### PR TITLE
Reduce restart_batch memory consumption when running 8r-2t.

### DIFF
--- a/tests/io/restart_batch/qmc_short_batch.in.xml
+++ b/tests/io/restart_batch/qmc_short_batch.in.xml
@@ -82,7 +82,7 @@
       </hamiltonian>
    </qmcsystem>
    <qmc method="vmc_batch" move="pbyp" checkpoint="0">
-      <parameter name="walkers_per_rank"    >    16              </parameter>
+      <parameter name="total_walkers"       >    16              </parameter>
       <parameter name="blocks"              >    3               </parameter>
       <parameter name="steps"               >    8               </parameter>
       <parameter name="subSteps"            >    2               </parameter>
@@ -90,7 +90,7 @@
       <parameter name="warmupSteps"         >    10              </parameter>
    </qmc>
    <qmc method="vmc_batch" move="pbyp" checkpoint="-1">
-      <parameter name="walkers_per_rank"    >    16              </parameter>
+      <parameter name="total_walkers"       >    16              </parameter>
       <parameter name="blocks"              >    1               </parameter>
       <parameter name="steps"               >    1               </parameter>
       <parameter name="subSteps"            >    1               </parameter>

--- a/tests/io/restart_batch/qmc_short_batch.restart.xml
+++ b/tests/io/restart_batch/qmc_short_batch.restart.xml
@@ -85,7 +85,7 @@
    <mcwalkerset fileroot="qmc_short_batch.s000" node="-1" nprocs="1" version="0 4" collected="yes"/>
 
    <qmc method="vmc_batch" move="pbyp" checkpoint="-1">
-      <parameter name="walkers_per_rank"> 16            </parameter>	   
+      <parameter name="total_walkers">    16            </parameter>
       <parameter name="blocks">           1             </parameter>
       <parameter name="steps">            1             </parameter>
       <parameter name="subSteps">         1             </parameter>


### PR DESCRIPTION
## Proposed changes
Restrict to total_walkers=16 which avoids memory pressure when running 8 ranks.

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
