### PR TITLE
Automatically apply additional clang offload optimization flags.

### DIFF
--- a/CMake/ClangCompilers.cmake
+++ b/CMake/ClangCompilers.cmake
@@ -46,6 +46,18 @@ if(QMC_OMP)
       set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstandalone-debug")
     endif()
 
+    check_cxx_compiler_flag(-fopenmp-assume-no-thread-state OPENMP_ASSUME_NO_THREAD_STATE_WORKS)
+    option(OMPTARGET_ASSUME_NO_THREAD_STATE "Use -fopenmp-assume-no-thread-state compile option" ${OPENMP_ASSUME_NO_THREAD_STATE_WORKS})
+    if(OMPTARGET_ASSUME_NO_THREAD_STATE)
+      set(OPENMP_OFFLOAD_COMPILE_OPTIONS "${OPENMP_OFFLOAD_COMPILE_OPTIONS} -fopenmp-assume-no-thread-state")
+    endif()
+
+    check_cxx_compiler_flag(-fopenmp-assume-no-nested-parallelism OPENMP_ASSUME_NO_NESTED_PAR_WORKS)
+    option(OMPTARGET_ASSUME_NO_NESTED_PAR "Use -fopenmp-assume-no-nested-parallelism compile option" ${OPENMP_ASSUME_NO_NESTED_PAR_WORKS})
+    if(OMPTARGET_ASSUME_NO_NESTED_PAR)
+      set(OPENMP_OFFLOAD_COMPILE_OPTIONS "${OPENMP_OFFLOAD_COMPILE_OPTIONS} -fopenmp-assume-no-nested-parallelism")
+    endif()
+
     # AOMP/ROCM special option -fdisable-host-devmem to disable unecessary data transfers
     # The down side of using this option is that it disables printf from offload regions.
     # see https://github.com/ROCm-Developer-Tools/aomp/issues/526


### PR DESCRIPTION
## Proposed changes
`-fopenmp-assume-no-nested-parallelism` and `-fopenmp-assume-no-thread-state` reduce shared memory and register usage. I don't see performance impact on NVIDIA but they do seem to get AMD a bit better.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Summit

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
