### PR TITLE
Introduce ENABLE_PPCONVERT option and skip ppconvert compilation when cross compiling.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -342,6 +342,7 @@ the path to the source directory.
                            saving default use of symbolic links for test files. Useful
                            if the build is on a separate filesystem from the source, as
                            required on some HPC systems.
+    ENABLE_PPCONVERT       ON/OFF. Enable the ppconvert tool. If requirements are met, it is ON by default.
 
 - BLAS/LAPACK related
 

--- a/src/QMCTools/ppconvert/CMakeLists.txt
+++ b/src/QMCTools/ppconvert/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 string(REPLACE "-ffast-math" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 
 if(CMAKE_CROSSCOMPILING)
-  message(STATUS "Cannot run std::isnan tests when cross compiling. Set ISNAN_WORKS to FALSE.")
+  message(STATUS "Cannot run std::isnan tests when cross compiling. Setting ISNAN_WORKS to FALSE.")
   set(ISNAN_WORKS FALSE)
 else()
   # check if std::isnan works or not

--- a/src/QMCTools/ppconvert/CMakeLists.txt
+++ b/src/QMCTools/ppconvert/CMakeLists.txt
@@ -12,8 +12,7 @@ endif()
 string(REPLACE "-ffast-math" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 
 if(CMAKE_CROSSCOMPILING)
-  message(STATUS "Cannot run std::isnan tests when cross compiling. Assume std::isnan not working. "
-                 "Use -DQMC_ISNAN=ON to override.")
+  message(STATUS "Cannot run std::isnan tests when cross compiling. Set ISNAN_WORKS to FALSE.")
   set(ISNAN_WORKS FALSE)
 else()
   # check if std::isnan works or not
@@ -32,13 +31,13 @@ int main()
   ISNAN_WORKS)
 endif()
 
-option(QMC_ISNAN "Enable Code paths relying std::isnan" ${ISNAN_WORKS})
+option(ENABLE_PPCONVERT "Enable ppconvert" ${ISNAN_WORKS})
 
 # ppconvert only works when std::isnan works.
-if(QMC_ISNAN)
-  message(STATUS "std::isnan dependent code paths enabled. ppconvert enabled.")
+if(ENABLE_PPCONVERT)
+  message(STATUS "ppconvert enabled.")
   add_subdirectory(src)
   add_subdirectory(test)
 else()
-  message(STATUS "std::isnan dependent code paths disabled. ppconvert disabled.")
+  message(STATUS "ppconvert disabled.")
 endif()

--- a/src/QMCTools/ppconvert/CMakeLists.txt
+++ b/src/QMCTools/ppconvert/CMakeLists.txt
@@ -11,10 +11,15 @@ endif()
 
 string(REPLACE "-ffast-math" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 
-# check if std::isnan works or not
-# this check may fail when cross-compiling even if std::isnan actually functions properly.
-include(CheckCXXSourceRuns)
-check_cxx_source_runs(
+if(CMAKE_CROSSCOMPILING)
+  message(STATUS "Cannot run std::isnan tests when cross compiling. Assume std::isnan not working. "
+                 "Use -DQMC_ISNAN=ON to override.")
+  set(ISNAN_WORKS FALSE)
+else()
+  # check if std::isnan works or not
+  # this check may fail when cross-compiling even if std::isnan actually functions properly.
+  include(CheckCXXSourceRuns)
+  check_cxx_source_runs(
 "
 #include <cmath>
 int main()
@@ -24,13 +29,16 @@ int main()
   return 1;
 }
 "
-ISNAN_WORKS)
+  ISNAN_WORKS)
+endif()
+
+option(QMC_ISNAN "Enable Code paths relying std::isnan" ${ISNAN_WORKS})
 
 # ppconvert only works when std::isnan works.
-if(ISNAN_WORKS)
-  message(STATUS "ppconvert enabled. std:isnan support check passed.")
+if(QMC_ISNAN)
+  message(STATUS "std::isnan dependent code paths enabled. ppconvert enabled.")
   add_subdirectory(src)
   add_subdirectory(test)
 else()
-  message(STATUS "ppconvert disabled. std:isnan support check failed.")
+  message(STATUS "std::isnan dependent code paths disabled. ppconvert disabled.")
 endif()


### PR DESCRIPTION
## Proposed changes
CrayLinuxEnvironment is considered cross-compiling. Thus try_run requires user input and stop.
Consider ppconvert is not critical, simply turn it off by default.
QMC_ISNAN option can be used to override the detection.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Frontier/Crusher

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'