### PR TITLE
Fix Nexus rtd configuration

### DIFF
--- a/nexus/.readthedocs.yaml
+++ b/nexus/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+sphinx:
+   configuration: nexus/sphinx_docs/conf.py
+
+python:
+   install:
+   - requirements: nexus/sphinx_docs/requirements.txt  

--- a/nexus/sphinx_docs/requirements.txt
+++ b/nexus/sphinx_docs/requirements.txt
@@ -1,0 +1,6 @@
+# Specify exact versions for reproducible builds, e.g. in readthedocs
+sphinx==3.2.0
+sphinx_rtd_theme==0.5.2
+sphinxcontrib-bibtex==2.2.0
+
+


### PR DESCRIPTION
## Proposed changes

Fix the Nexus configuration on rtd so that the Nexus documentation and not QMCPACK documentation is produced. https://nexus-workflows.readthedocs.io/en/latest/

rtd configuration updated online to read nexus/.readthedocs.yaml

## What type(s) of changes does this code introduce?

- Bugfix
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None. Will need checking in CI, may require merge.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
