### PR TITLE
Use snprintf or std::cout instead of sprintf.

### DIFF
--- a/src/Estimators/EstimatorManagerBase.cpp
+++ b/src/Estimators/EstimatorManagerBase.cpp
@@ -181,7 +181,8 @@ void EstimatorManagerBase::start(int blocks, bool record)
   if (record && !DebugArchive)
   {
     char fname[128];
-    sprintf(fname, "%s.p%03d.scalar.dat", myComm->getName().c_str(), myComm->rank());
+    if (snprintf(fname, 128, "%s.p%03d.scalar.dat", myComm->getName().c_str(), myComm->rank()) < 0)
+      throw std::runtime_error("Error generating filename");
     DebugArchive = std::make_unique<std::ofstream>(fname);
     addHeader(*DebugArchive);
   }

--- a/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
@@ -332,17 +332,6 @@ std::unique_ptr<BackflowFunctionBase> BackflowBuilder::addTwoBody(xmlNodePtr cur
         offsets.push_back(tbf->numParams);
         tbf->numParams += bsp->NumParams;
         tbf->addFunc(ia, ib, std::move(bsp));
-
-        //            if(OHMMS::Controller->rank()==0)
-        //            {
-        //              char fname[64];
-        //              sprintf(fname,"BFe-e.%s.dat",(spA+spB).c_str());
-        //              std::ofstream fout(fname);
-        //              fout.setf(std::ios::scientific, std::ios::floatfield);
-        //              fout << "# Backflow radial function \n";
-        //              bsp->print(fout);
-        //              fout.close();
-        //            }
       }
       cur = cur->next;
     }
@@ -561,8 +550,11 @@ void BackflowBuilder::makeLongRange_twoBody(xmlNodePtr cur, Backflow_ee_kSpace* 
       offsets.push_back(tbfks->numParams);
       if (OHMMS::Controller->rank() == 0)
       {
-        char fname[16];
-        sprintf(fname, "RPABFee-LR.%s.dat", (spA + spB).c_str());
+        const int max_size{16};
+        char fname[max_size];
+        if (snprintf(fname, max_size, "RPABFee-LR.%s.dat", (spA + spB).c_str()) < 0)
+          throw std::runtime_error("Error generating filename");
+
         std::ofstream fout(fname);
         fout.setf(std::ios::scientific, std::ios::floatfield);
         fout << "# Backflow longrange  \n";
@@ -690,16 +682,6 @@ void BackflowBuilder::makeShortRange_twoBody(xmlNodePtr cur,
       tbf->addFunc(ia, ib, std::move(bsp));
       offsets.push_back(tbf->numParams);
       tbf->numParams += bsp->NumParams;
-      //            if(OHMMS::Controller->rank()==0)
-      //            {
-      //              char fname[64];
-      //              sprintf(fname,"RPABFee-SR.%s.dat",(spA+spB).c_str());
-      //              std::ofstream fout(fname);
-      //              fout.setf(std::ios::scientific, std::ios::floatfield);
-      //              fout << "# Backflow radial function \n";
-      //              bsp->print(fout);
-      //              fout.close();
-      //            }
     }
     xmlCoefs = xmlCoefs->next;
   }

--- a/src/Utilities/ProgressReportEngine.cpp
+++ b/src/Utilities/ProgressReportEngine.cpp
@@ -28,7 +28,7 @@ void ReportEngine::echo(xmlNodePtr cur, bool recursive)
     app_debug() << "  " << (const char*)(att->name) << R"(=")" << (const char*)(att->children->content) << '"';
     att = att->next;
   }
-  app_debug() << R"(>\n)";
+  app_debug() << R"(/>\n)";
 }
 
 bool ReportEngine::DoOutput = false;

--- a/src/Utilities/ProgressReportEngine.cpp
+++ b/src/Utilities/ProgressReportEngine.cpp
@@ -19,18 +19,16 @@ namespace qmcplusplus
 {
 void ReportEngine::echo(xmlNodePtr cur, bool recursive)
 {
-  if (cur == NULL)
+  if (cur == nullptr)
     return;
-  app_debug() << "<input node=\"" << (const char*)(cur->name) << "\"";
+  app_debug() << R"(<input node=")" << (const char*)(cur->name) << '"';
   xmlAttrPtr att = cur->properties;
-  char atext[1024];
-  while (att != NULL)
+  while (att != nullptr)
   {
-    sprintf(atext, "  %s=\"%s\"", (const char*)(att->name), (const char*)(att->children->content));
-    app_debug() << atext;
+    app_debug() << "  " << (const char*)(att->name) << R"(=")" << (const char*)(att->children->content) << '"';
     att = att->next;
   }
-  app_debug() << "/>\n";
+  app_debug() << R"(>\n)";
 }
 
 bool ReportEngine::DoOutput = false;

--- a/src/Utilities/ProgressReportEngine.h
+++ b/src/Utilities/ProgressReportEngine.h
@@ -38,7 +38,7 @@ public:
   {
     if (DoOutput)
     {
-      LogBuffer << "  " << ClassName << "::" << FuncName << "\n";
+      LogBuffer << "  " << ClassName << "::" << FuncName << '\n';
       LogBuffer.flush(); //always flush
     }
   }
@@ -57,11 +57,11 @@ public:
     }
   }
 
-  inline void warning(const std::string& msg) { LogBuffer << ("WARNING: " + msg + "\n"); }
+  inline void warning(const std::string& msg) { LogBuffer << ("WARNING: " + msg + '\n'); }
 
   inline void error(const std::string& msg, bool fatal = false)
   {
-    app_error() << ("ERROR: " + msg + "\n");
+    app_error() << ("ERROR: " + msg + '\n');
     if (fatal)
       APP_ABORT(ClassName + "::" + FuncName);
   }

--- a/src/Utilities/SimpleParser.cpp
+++ b/src/Utilities/SimpleParser.cpp
@@ -184,41 +184,14 @@ int getwords(std::vector<std::string>& slist, std::istream& fpos, const char* fi
     throw std::runtime_error("Error extract end_key from field.");
 
   std::vector<std::string> vlist;
-  bool start = true;
-  while (start)
+  while (true)
   {
     if (getwords(vlist, fpos) == 0)
       continue;
-    if (vlist[0] == terminate)
+    if (vlist[0] == terminate || vlist[0] == end_key)
       break;
-    if (vlist[0] == end_key)
-      start = false;
-    else
-      slist.insert(slist.end(), std::make_move_iterator(vlist.begin()), std::make_move_iterator(vlist.end()));
+    slist.insert(slist.end(), std::make_move_iterator(vlist.begin()), std::make_move_iterator(vlist.end()));
   };
-  return slist.size();
-}
-
-/////////////////////////////////////////////////////////////
-// insert parsed strings of std::istream until terminate is encountered
-/////////////////////////////////////////////////////////////
-int getwords(std::vector<std::string>& slist, std::istream& fpos, const char* terminate)
-{
-  // first check if the input list already contains "terminate"
-  if (std::find(slist.cbegin(), slist.cend(), terminate) != slist.cend())
-    return slist.size();
-
-  std::vector<std::string> vlist;
-  bool start = true;
-  while (start)
-  {
-    if (getwords(vlist, fpos) == 0)
-      continue;
-    if (vlist[0] == terminate)
-      break;
-    else
-      slist.insert(slist.end(), std::make_move_iterator(vlist.begin()), std::make_move_iterator(vlist.end()));
-  }
   return slist.size();
 }
 
@@ -250,29 +223,4 @@ int getXwords(std::vector<std::string>& slist, std::istream& fp)
     return parseXwords(s, slist);
   else
     return -1;
-}
-
-
-/////////////////////////////////////////////////////////////
-// insert parsed strings of std::istream until terminate is encountered
-/////////////////////////////////////////////////////////////
-int getXwords(std::vector<std::string>& slist, std::istream& fpos, const char* terminate)
-{
-  // first check if the input list already contains "terminate"
-  if (std::find(slist.cbegin(), slist.cend(), terminate) != slist.cend())
-    return slist.size();
-
-  std::vector<std::string> vlist;
-  bool start = true;
-  while (start)
-  {
-    int nw = getXwords(vlist, fpos);
-    if (nw == 0)
-      continue;
-    if (vlist[0] == terminate)
-      break;
-    else
-      slist.insert(slist.end(), std::make_move_iterator(vlist.begin()), std::make_move_iterator(vlist.end()));
-  }
-  return slist.size();
 }

--- a/src/Utilities/SimpleParser.cpp
+++ b/src/Utilities/SimpleParser.cpp
@@ -17,6 +17,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <iterator>
 #include <regex>
 #include <string>
 
@@ -55,7 +56,7 @@ char* readLine(char* s, int max, std::istream& fp)
   if (max > 0)
     s[i] = '\0'; // add terminating NULL
   if (!(ch == '\n' || ch == ';'))
-    return NULL; // return NULL for end of file
+    return nullptr; // return NULL for end of file
   return s;
 }
 
@@ -176,40 +177,25 @@ int getwords(std::vector<std::string>& slist,std::istream& fpos, const char* fie
 
 int getwords(std::vector<std::string>& slist, std::istream& fpos, const char* field, const char* terminate)
 {
-  slist.erase(slist.begin(), slist.end());
+  slist.clear();
+  const int max = 128;
+  char end_key[max];
+  if (snprintf(end_key, max, "</%s>", field) < 0)
+    throw std::runtime_error("Error extract end_key from field.");
+
   std::vector<std::string> vlist;
-  //char start_key[128];
-  char end_key[128];
-  //sprintf(start_key,"<%s>",field);
-  sprintf(end_key, "</%s>", field);
-  //   bool start = false;
-  //   do {
-  //     int nw =getwords(vlist,fpos);
-  //     if(nw == 0) continue;
-  //     if(vlist[0] == terminate)
-  //       return slist.size();
-  //     if(vlist[0] == start_key) {
-  //       slist.insert(slist.end(), vlist.begin()+1, vlist.end());
-  //       start = true;
-  //     }
-  //   } while(!start);
   bool start = true;
-  do
+  while (start)
   {
-    int nw = getwords(vlist, fpos);
-    if (nw == 0)
+    if (getwords(vlist, fpos) == 0)
       continue;
     if (vlist[0] == terminate)
-      return slist.size();
+      break;
     if (vlist[0] == end_key)
-    {
       start = false;
-    }
     else
-    {
-      slist.insert(slist.end(), vlist.begin(), vlist.end());
-    }
-  } while (start);
+      slist.insert(slist.end(), std::make_move_iterator(vlist.begin()), std::make_move_iterator(vlist.end()));
+  };
   return slist.size();
 }
 
@@ -218,34 +204,33 @@ int getwords(std::vector<std::string>& slist, std::istream& fpos, const char* fi
 /////////////////////////////////////////////////////////////
 int getwords(std::vector<std::string>& slist, std::istream& fpos, const char* terminate)
 {
-  std::vector<std::string> vlist;
   // first check if the input list already contains "terminate"
-  std::vector<std::string>::iterator it = find(slist.begin(), slist.end(), terminate);
-  if (it != slist.end())
+  if (std::find(slist.cbegin(), slist.cend(), terminate) != slist.cend())
     return slist.size();
-  //slist.erase(slist.begin(), slist.end()); // remove input number
+
+  std::vector<std::string> vlist;
   bool start = true;
-  do
+  while (start)
   {
-    int nw = getwords(vlist, fpos);
-    if (nw == 0)
+    if (getwords(vlist, fpos) == 0)
       continue;
     if (vlist[0] == terminate)
-      return slist.size();
+      break;
     else
-      slist.insert(slist.end(), vlist.begin(), vlist.end());
-  } while (start);
+      slist.insert(slist.end(), std::make_move_iterator(vlist.begin()), std::make_move_iterator(vlist.end()));
+  }
   return slist.size();
 }
 
 ////////////////////////////////////////////////////////
 // simple parser to get around XML parser problem
 ////////////////////////////////////////////////////////
-unsigned parseXwords(char* inbuf, std::vector<std::string>& slist)
+unsigned parseXwords(const char* inbuf, std::vector<std::string>& slist)
 {
+  slist.clear();
+
   const char* token = "=, <>\"\t\n";
   std::string tmpstr(inbuf);
-  slist.clear();
   unsigned num = 0;
   char* tokenp = strtok(tmpstr.data(), token);
   while (tokenp && tokenp[0] != '#')
@@ -273,22 +258,21 @@ int getXwords(std::vector<std::string>& slist, std::istream& fp)
 /////////////////////////////////////////////////////////////
 int getXwords(std::vector<std::string>& slist, std::istream& fpos, const char* terminate)
 {
-  std::vector<std::string> vlist;
   // first check if the input list already contains "terminate"
-  std::vector<std::string>::iterator it = find(slist.begin(), slist.end(), terminate);
-  if (it != slist.end())
+  if (std::find(slist.cbegin(), slist.cend(), terminate) != slist.cend())
     return slist.size();
-  //slist.erase(slist.begin(), slist.end()); // remove input number
+
+  std::vector<std::string> vlist;
   bool start = true;
-  do
+  while (start)
   {
     int nw = getXwords(vlist, fpos);
     if (nw == 0)
       continue;
     if (vlist[0] == terminate)
-      return slist.size();
+      break;
     else
-      slist.insert(slist.end(), vlist.begin(), vlist.end());
-  } while (start);
+      slist.insert(slist.end(), std::make_move_iterator(vlist.begin()), std::make_move_iterator(vlist.end()));
+  }
   return slist.size();
 }

--- a/src/Utilities/SimpleParser.h
+++ b/src/Utilities/SimpleParser.h
@@ -35,9 +35,7 @@ int getwordsWithMergedNumbers(std::vector<std::string>& slist,
                               const std::string& extra_tokens = "");
 int getwords(std::vector<std::string>& slist, std::istream& fp, std::string& aline);
 int getwords(std::vector<std::string>& slist, std::istream& fpos, const char* field, const char* terminate);
-int getwords(std::vector<std::string>& slist, std::istream& fpos, const char* terminate);
 int getXwords(std::vector<std::string>& slist, std::istream& fp);
-int getXwords(std::vector<std::string>& slist, std::istream& fpos, const char* terminate);
 
 unsigned parsewords(const char* inbuf, std::vector<std::string>& slist, const std::string& extra_tokens = "");
 unsigned parsewords(const char* inbuf, std::list<std::string>& slist);


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Replace the unsafe function `sprintf` with `snprintf` or streams. 

This is part of #4438.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

my laptop, Ubuntu 20.04

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
