### PR TITLE
Fix orbital images code

### DIFF
--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -156,7 +156,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
 
   //second pass parameter read to get orbital indices
   //  each parameter is named after the corresponding sposet
-  sposet_indices->resize(sposet_names.size());
+  sposet_indices.resize(sposet_names.size());
   for (int n = 0; n < other_elements.size(); ++n)
   {
     xmlNodePtr element = other_elements[n];
@@ -166,7 +166,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
       const std::string name(getXMLAttributeValue(element, "name"));
       for (int i = 0; i < sposet_names.size(); ++i)
         if (name == sposet_names[i])
-          putContent((*sposet_indices)[i], element);
+          putContent(sposet_indices[i], element);
     }
   }
 
@@ -219,7 +219,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
 
     sposets.push_back(spo_it->second->makeClone());
     auto& sposet = sposets.back();
-    std::vector<int>& sposet_inds = (*sposet_indices)[i];
+    std::vector<int>& sposet_inds = sposet_indices[i];
     if (sposet_inds.size() == 0)
       for (int n = 0; n < sposet->size(); ++n)
         sposet_inds.push_back(n);
@@ -277,10 +277,10 @@ void OrbitalImages::report(const std::string& pad)
   app_log() << pad << "OrbitalImages report" << std::endl;
   app_log() << pad << "  derivatives = " << derivatives << std::endl;
   app_log() << pad << "  nsposets    = " << sposets.size() << " " << sposet_names.size() << " "
-            << sposet_indices->size() << std::endl;
+            << sposet_indices.size() << std::endl;
   for (int i = 0; i < sposet_names.size(); ++i)
   {
-    std::vector<int>& sposet_inds = (*sposet_indices)[i];
+    std::vector<int>& sposet_inds = sposet_indices[i];
     SPOSet& sposet                = *sposets[i];
     if (sposet_inds.size() == sposet.size())
       app_log() << pad << "  " << sposet_names[i] << " = all " << sposet.size() << " orbitals" << std::endl;
@@ -342,7 +342,7 @@ OrbitalImages::Return_t OrbitalImages::evaluate(ParticleSet& P)
       //get sposet information
       const std::string& sposet_name = sposet_names[i];
       app_log() << "  evaluating orbitals in " + sposet_name + " on the grid" << std::endl;
-      std::vector<int>& sposet_inds = (*sposet_indices)[i];
+      std::vector<int>& sposet_inds = sposet_indices[i];
       SPOSet& sposet                = *sposets[i];
       int nspo                      = sposet_inds.size();
 

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -166,7 +166,8 @@ public:
   std::vector<std::string> sposet_names;
 
   ///indices of orbitals within each sposet to evaluate
-  const std::shared_ptr<std::vector<std::vector<int>>> sposet_indices;
+  //const std::shared_ptr<std::vector<std::vector<int>>> sposet_indices;
+  std::vector<std::vector<int>> sposet_indices;
 
   ///sposets obtained by name from SPOMap
   std::vector<std::unique_ptr<SPOSet>> sposets;

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -166,7 +166,6 @@ public:
   std::vector<std::string> sposet_names;
 
   ///indices of orbitals within each sposet to evaluate
-  //const std::shared_ptr<std::vector<std::vector<int>>> sposet_indices;
   std::vector<std::vector<int>> sposet_indices;
 
   ///sposets obtained by name from SPOMap


### PR DESCRIPTION
## Proposed changes

Replace odd usage of shared_ptr in OrbitalImages with a regular vector.  In the code prior to this change, the shared_ptr was uninitialized, causing a crash.  This update restores the functionality of the OrbitalImages code.

## What type(s) of changes does this code introduce?

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Andes

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'

