### PR TITLE
Cleanup snprintf calls with lessons learned

### DIFF
--- a/src/Estimators/EstimatorManagerBase.cpp
+++ b/src/Estimators/EstimatorManagerBase.cpp
@@ -16,8 +16,6 @@
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 
-#include <functional>
-
 #include "Particle/MCWalkerConfiguration.h"
 #include "EstimatorManagerBase.h"
 #include "QMCHamiltonians/QMCHamiltonian.h"
@@ -34,6 +32,10 @@
 #include "hdf/HDFVersion.h"
 #include "OhmmsData/AttributeSet.h"
 #include "Estimators/CSEnergyEstimator.h"
+
+#include <array>
+#include <functional>
+
 //leave it for serialization debug
 //#define DEBUG_ESTIMATOR_ARCHIVE
 
@@ -180,10 +182,10 @@ void EstimatorManagerBase::start(int blocks, bool record)
 #if defined(DEBUG_ESTIMATOR_ARCHIVE)
   if (record && !DebugArchive)
   {
-    char fname[128];
-    if (snprintf(fname, 128, "%s.p%03d.scalar.dat", myComm->getName().c_str(), myComm->rank()) < 0)
+    std::array<char, 128> fname;
+    if (std::snprintf(fname.data(), fname.size(), "%s.p%03d.scalar.dat", myComm->getName().c_str(), myComm->rank()) < 0)
       throw std::runtime_error("Error generating filename");
-    DebugArchive = std::make_unique<std::ofstream>(fname);
+    DebugArchive = std::make_unique<std::ofstream>(fname.data());
     addHeader(*DebugArchive);
   }
 #endif

--- a/src/Estimators/EstimatorManagerNew.cpp
+++ b/src/Estimators/EstimatorManagerNew.cpp
@@ -207,7 +207,8 @@ void EstimatorManagerNew::startDriverRun()
   if (!DebugArchive)
   {
     std::array<char, 128> fname;
-    if (snprintf(fname.data(), fname.size(), "%s.p%03d.scalar.dat", my_comm_->getName().c_str(), my_comm_->rank()) < 0)
+    if (std::snprintf(fname.data(), fname.size(), "%s.p%03d.scalar.dat", my_comm_->getName().c_str(),
+                      my_comm_->rank()) < 0)
       throw std::runtime_error("Error generating filename");
     DebugArchive = std::make_unique<std::ofstream>(fname.data());
     addHeader(*DebugArchive);

--- a/src/Estimators/TraceManager.h
+++ b/src/Estimators/TraceManager.h
@@ -33,11 +33,12 @@
 #include "Message/Communicate.h"
 #include "hdf/hdf_archive.h"
 #include "Concurrency/OpenMP.h"
+
+#include <algorithm>
 #include <array>
 #include <map>
 #include <memory>
 #include <set>
-#include <algorithm>
 
 namespace qmcplusplus
 {
@@ -2071,13 +2072,16 @@ public:
     std::string file_name = file_root;
     if (nprocs > 1)
     {
+      int length{0};
       if (nprocs > 10000)
-        snprintf(ptoken.data(), ptoken.size(), ".p%05d", rank);
+        length = std::snprintf(ptoken.data(), ptoken.size(), ".p%05d", rank);
       else if (nprocs > 1000)
-        snprintf(ptoken.data(), ptoken.size(), ".p%04d", rank);
+        length = std::snprintf(ptoken.data(), ptoken.size(), ".p%04d", rank);
       else
-        snprintf(ptoken.data(), ptoken.size(), ".p%03d", rank);
-      file_name += ptoken.data();
+        length = std::snprintf(ptoken.data(), ptoken.size(), ".p%03d", rank);
+      if (length < 0)
+        throw std::runtime_error("Error generating filename");
+      file_name.append(ptoken.data(), length);
     }
     file_name += ".traces.h5";
     if (verbose)

--- a/src/Particle/HDFWalkerInput_0_4.cpp
+++ b/src/Particle/HDFWalkerInput_0_4.cpp
@@ -19,6 +19,8 @@
 #include "mpi/collectives.h"
 #include "Utilities/FairDivide.h"
 
+#include <array>
+
 namespace qmcplusplus
 {
 HDFWalkerInput_0_4::HDFWalkerInput_0_4(WalkerConfigurations& wc_list,
@@ -72,7 +74,8 @@ void HDFWalkerInput_0_4::checkOptions(xmlNodePtr cur)
         {
           // 2 chars for '.p', 11 chars for pid, 1 char for \0
           std::array<char, 14> h5name;
-          snprintf(h5name.data(), h5name.size(), ".p%03d", pid++);
+          if (std::snprintf(h5name.data(), h5name.size(), ".p%03d", pid++) < 0)
+            throw std::runtime_error("Error generating filename");
           auto fname = std::filesystem::path(froot).concat(h5name.data());
           FileStack.push(std::move(fname));
           pid += nprocs_now;
@@ -83,7 +86,8 @@ void HDFWalkerInput_0_4::checkOptions(xmlNodePtr cur)
         int pid = myComm->rank() % i_info.nprocs;
         // 2 chars for '.p', 11 chars for pid, 1 char for \0
         std::array<char, 14> h5name;
-        snprintf(h5name.data(), h5name.size(), ".p%03d", pid);
+        if (std::snprintf(h5name.data(), h5name.size(), ".p%03d", pid) < 0)
+          throw std::runtime_error("Error generating filename");
         auto fname = std::filesystem::path(froot).concat(h5name.data());
         FileStack.push(std::move(fname));
       }

--- a/src/QMCApp/qmcapp.cpp
+++ b/src/QMCApp/qmcapp.cpp
@@ -29,6 +29,8 @@
 #include "QMCApp/QMCMain.h"
 #include "Utilities/qmc_common.h"
 
+#include <array>
+
 void output_hardware_info(Communicate* comm, Libxml2Document& doc, xmlNodePtr root);
 
 /** @file qmcapp.cpp
@@ -183,10 +185,10 @@ int main(int argc, char** argv)
     }
     if (inputs.size() > 1 && qmcComm->rank() == 0)
     {
-      char fn[128];
-      snprintf(fn, 127, "%s.g%03d.qmc", logname.str().c_str(), qmcComm->getGroupID());
-      fn[127] = '\0';
-      infoSummary.redirectToFile(fn);
+      std::array<char, 128> fn;
+      if (std::snprintf(fn.data(), fn.size(), "%s.g%03d.qmc", logname.str().c_str(), qmcComm->getGroupID()) < 0)
+        throw std::runtime_error("Error generating filename");
+      infoSummary.redirectToFile(fn.data());
       infoLog.redirectToSameStream(infoSummary);
       infoError.redirectToSameStream(infoSummary);
     }

--- a/src/QMCHamiltonians/MPC.cpp
+++ b/src/QMCHamiltonians/MPC.cpp
@@ -25,6 +25,9 @@
 #include <fftw3.h>
 #endif
 
+#include <array>
+#include <string_view>
+
 namespace qmcplusplus
 {
 void MPC::resetTargetParticleSet(ParticleSet& ptcl) {}
@@ -206,13 +209,15 @@ void MPC::init_f_G()
     // std::cerr << "f_G = " << f_G[iG]/volInv << std::endl;
     // std::cerr << "f_G - 4*pi/G2= " << f_G[iG]/volInv - 4.0*M_PI/G2 << std::endl;
   }
-  char buff[1000];
-  snprintf(buff, 1000,
-           "    Worst MPC discrepancy:\n"
-           "      Linear Extrap   : %18.14e\n"
-           "      Quadratic Extrap: %18.14e\n",
-           worstLin, worstQuad);
-  app_log() << buff;
+  std::array<char, 1000> buff;
+  int length = std::snprintf(buff.data(), buff.size(),
+                             "    Worst MPC discrepancy:\n"
+                             "      Linear Extrap   : %18.14e\n"
+                             "      Quadratic Extrap: %18.14e\n",
+                             worstLin, worstQuad);
+  if (length < 0)
+    throw std::runtime_error("Error generating buffer string");
+  app_log() << std::string_view(buff.data(), length);
 }
 
 

--- a/src/QMCTools/ppconvert/src/NLPPClass.cc
+++ b/src/QMCTools/ppconvert/src/NLPPClass.cc
@@ -18,9 +18,10 @@
 #include "XMLWriterClass2.h"
 #include "ParserClass.h"
 #include "ParseCommand.h"
+
+#include <array>
 #include <sstream>
 #include <ctime>
-#include <stdlib.h>
 #include <cstdlib>
 
 void
@@ -1047,9 +1048,10 @@ PseudoClass::ReadBFD_PP (std::string fileName)
   assert (parser.FindToken ("Non-local component:"));
   assert (parser.FindToken ("Proj."));
   for (int l=0; l<numProjectors; l++) {
-    char fname[100];
-    snprintf (fname, 100, "V_%d.dat", l);
-    FILE *fout = fopen (fname, "w");
+    std::array<char, 100> fname;
+    if (std::snprintf(fname.data(), fname.size(), "V_%d.dat", l) < 0)
+      throw std::runtime_error("Error generating filename");
+    FILE* fout = fopen(fname.data(), "w");
     double c0, exp0;
     int power, channel;
     assert (parser.ReadDouble (c0));

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineReaderBase.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineReaderBase.cpp
@@ -221,9 +221,9 @@ void BsplineReaderBase::initialize_spo2band(int spin,
     double e  = bigspace[i].Energy;
     int nd    = (bigspace[i].MakeTwoCopies) ? 2 : 1;
     PosType k = mybuilder->PrimCell.k_cart(mybuilder->TwistAngles[ti]);
-    int s_size = snprintf(s.data(), s.size(), "%8d %8d %8d %8d %12.6f %7.4f %7.4f %7.4f %7.4f %7.4f %7.4f %6d\n", i, ns,
-                          ti, bi, e, k[0], k[1], k[2], mybuilder->TwistAngles[ti][0], mybuilder->TwistAngles[ti][1],
-                          mybuilder->TwistAngles[ti][2], nd);
+    int s_size = std::snprintf(s.data(), s.size(), "%8d %8d %8d %8d %12.6f %7.4f %7.4f %7.4f %7.4f %7.4f %7.4f %6d\n",
+                               i, ns, ti, bi, e, k[0], k[1], k[2], mybuilder->TwistAngles[ti][0],
+                               mybuilder->TwistAngles[ti][1], mybuilder->TwistAngles[ti][2], nd);
     if (s_size < 0)
       throw std::runtime_error("Error generating bandinfo");
     o << s.data();

--- a/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
@@ -28,6 +28,9 @@
 #include "QMCWaveFunctions/BsplineFactory/BsplineReaderBase.h"
 #include "Particle/DistanceTable.h"
 
+#include <array>
+#include <string_view>
+
 namespace qmcplusplus
 {
 //std::map<H5OrbSet,SPOSet*,H5OrbSet>  EinsplineSetBuilder::SPOSetMap;
@@ -453,10 +456,12 @@ void EinsplineSetBuilder::AnalyzeTwists2(const int twist_num_inp, const TinyVect
       int n_tot_irred(0);
       for (int si = 0; si < numSuperTwists; si++)
       {
-        char buf[1000];
-        snprintf(buf, 1000, "Super twist #%d:  [ %9.5f %9.5f %9.5f ]\n", si, superFracs[si][0], superFracs[si][1],
-                 superFracs[si][2]);
-        app_log() << buf;
+        std::array<char, 1000> buf;
+        int length = std::snprintf(buf.data(), buf.size(), "Super twist #%d:  [ %9.5f %9.5f %9.5f ]\n", si,
+                                   superFracs[si][0], superFracs[si][1], superFracs[si][2]);
+        if (length < 0)
+          throw std::runtime_error("Error converting Super twist to a string");
+        app_log() << std::string_view(buf.data(), length);
         app_log().flush();
       }
     }
@@ -477,11 +482,14 @@ void EinsplineSetBuilder::AnalyzeTwists2(const int twist_num_inp, const TinyVect
 
       if (twist_num < 0)
       {
-        char buf[1000];
-        snprintf(buf, 1000,
-                 "AnalyzeTwists2. Input twist [ %9.5f %9.5f %9.5f] not found in the list of super twists above.\n",
-                 twist[0], twist[1], twist[2]);
-        throw UniformCommunicateError(buf);
+        std::array<char, 1000> buf;
+        int length = std::
+            snprintf(buf.data(), buf.size(),
+                     "AnalyzeTwists2. Input twist [ %9.5f %9.5f %9.5f] not found in the list of super twists above.\n",
+                     twist[0], twist[1], twist[2]);
+        if (length < 0)
+          throw std::runtime_error("Error generating error message");
+        throw UniformCommunicateError(buf.data());
       }
       return twist_num;
     };
@@ -516,10 +524,12 @@ void EinsplineSetBuilder::AnalyzeTwists2(const int twist_num_inp, const TinyVect
 
     assert(twist_num_ >= 0 && twist_num_ < numSuperTwists);
 
-    char buf[1000];
-    snprintf(buf, 1000, "  Using supercell twist %d:  [ %9.5f %9.5f %9.5f]", twist_num_, superFracs[twist_num_][0],
-             superFracs[twist_num_][1], superFracs[twist_num_][2]);
-    app_log() << buf << std::endl;
+    std::array<char, 1000> buf;
+    int length = std::snprintf(buf.data(), buf.size(), "  Using supercell twist %d:  [ %9.5f %9.5f %9.5f]", twist_num_,
+                               superFracs[twist_num_][0], superFracs[twist_num_][1], superFracs[twist_num_][2]);
+    if (length < 0)
+      throw std::runtime_error("Error converting supercell twist to a string");
+    app_log() << std::string_view(buf.data(), length) << std::endl;
   }
 
   TargetPtcl.setTwist(superFracs[twist_num_]);
@@ -545,10 +555,12 @@ void EinsplineSetBuilder::AnalyzeTwists2(const int twist_num_inp, const TinyVect
     // First make sure we have enough points
     if (superSets[si].size() != numTwistsNeeded)
     {
-      char buf[1000];
-      snprintf(buf, 1000, "Super twist %d should own %d k-points, but owns %d.\n", si, numTwistsNeeded,
-               static_cast<int>(superSets[si].size()));
-      app_error() << buf;
+      std::array<char, 1000> buf;
+      int length = std::snprintf(buf.data(), buf.size(), "Super twist %d should own %d k-points, but owns %d.\n", si,
+                                 numTwistsNeeded, static_cast<int>(superSets[si].size()));
+      if (length < 0)
+        throw std::runtime_error("Error generating Super twist string");
+      app_error() << std::string_view(buf.data(), length);
       if (si == twist_num_)
       {
         APP_ABORT("EinsplineSetBuilder::AnalyzeTwists2");
@@ -621,11 +633,12 @@ void EinsplineSetBuilder::AnalyzeTwists2(const int twist_num_inp, const TinyVect
     }
     if (myComm->rank() == 0)
     {
-      char buf[1000];
-
-      snprintf(buf, 1000, "Using %d copies of twist angle [%6.3f, %6.3f, %6.3f]\n", MakeTwoCopies[i] ? 2 : 1,
-               twist_i[0], twist_i[1], twist_i[2]);
-      app_log() << buf;
+      std::array<char, 1000> buf;
+      int length = std::snprintf(buf.data(), buf.size(), "Using %d copies of twist angle [%6.3f, %6.3f, %6.3f]\n",
+                                 MakeTwoCopies[i] ? 2 : 1, twist_i[0], twist_i[1], twist_i[2]);
+      if (length < 0)
+        throw std::runtime_error("Error generating string");
+      app_log() << std::string_view(buf.data(), length);
       app_log().flush();
     }
   }

--- a/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
@@ -22,6 +22,9 @@
 #include "ParticleBase/RandomSeqGenerator.h"
 #include "Utilities/qmc_common.h"
 
+#include <array>
+#include <string_view>
+
 namespace qmcplusplus
 {
 bool sortByIndex(BandInfo leftB, BandInfo rightB)
@@ -46,21 +49,26 @@ bool EinsplineSetBuilder::ReadOrbitalInfo_ESHDF(bool skipChecks)
   H5File.read(Lattice, "/supercell/primitive_vectors");
   RecipLattice = 2.0 * M_PI * inverse(Lattice);
   SuperLattice = dot(TileMatrix, Lattice);
-  char buff[1000];
-  snprintf(buff, 1000,
-           "  Lattice = \n    [ %9.6f %9.6f %9.6f\n"
-           "      %9.6f %9.6f %9.6f\n"
-           "      %9.6f %9.6f %9.6f ]\n",
-           Lattice(0, 0), Lattice(0, 1), Lattice(0, 2), Lattice(1, 0), Lattice(1, 1), Lattice(1, 2), Lattice(2, 0),
-           Lattice(2, 1), Lattice(2, 2));
-  app_log() << buff;
-  snprintf(buff, 1000,
-           "  SuperLattice = \n    [ %9.6f %9.6f %9.6f\n"
-           "      %9.6f %9.6f %9.6f\n"
-           "      %9.6f %9.6f %9.6f ]\n",
-           SuperLattice(0, 0), SuperLattice(0, 1), SuperLattice(0, 2), SuperLattice(1, 0), SuperLattice(1, 1),
-           SuperLattice(1, 2), SuperLattice(2, 0), SuperLattice(2, 1), SuperLattice(2, 2));
-  app_log() << buff << std::endl;
+  std::array<char, 1000> buff;
+  int length = std::snprintf(buff.data(), buff.size(),
+                             "  Lattice = \n    [ %9.6f %9.6f %9.6f\n"
+                             "      %9.6f %9.6f %9.6f\n"
+                             "      %9.6f %9.6f %9.6f ]\n",
+                             Lattice(0, 0), Lattice(0, 1), Lattice(0, 2), Lattice(1, 0), Lattice(1, 1), Lattice(1, 2),
+                             Lattice(2, 0), Lattice(2, 1), Lattice(2, 2));
+  if (length < 0)
+    throw std::runtime_error("Error converting lattice to a string");
+  app_log() << std::string_view(buff.data(), length);
+  length =
+      std::snprintf(buff.data(), buff.size(),
+                    "  SuperLattice = \n    [ %9.6f %9.6f %9.6f\n"
+                    "      %9.6f %9.6f %9.6f\n"
+                    "      %9.6f %9.6f %9.6f ]\n",
+                    SuperLattice(0, 0), SuperLattice(0, 1), SuperLattice(0, 2), SuperLattice(1, 0), SuperLattice(1, 1),
+                    SuperLattice(1, 2), SuperLattice(2, 0), SuperLattice(2, 1), SuperLattice(2, 2));
+  if (length < 0)
+    throw std::runtime_error("Error converting SuperLattice to a string");
+  app_log() << std::string_view(buff.data(), length) << std::endl;
   if (!CheckLattice())
     throw std::runtime_error("CheckLattice failed");
   PrimCell.set(Lattice);

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -36,6 +36,9 @@
 #include "QMCWaveFunctions/BsplineFactory/BsplineSet.h"
 #include "QMCWaveFunctions/BsplineFactory/createBsplineReader.h"
 
+#include <array>
+#include <string_view>
+
 namespace qmcplusplus
 {
 void EinsplineSetBuilder::set_metadata(int numOrbs,
@@ -64,13 +67,16 @@ void EinsplineSetBuilder::set_metadata(int numOrbs,
     for (int i = 0; i < 3; i++)
       for (int j = 0; j < 3; j++)
         TileMatrix(i, j) = (i == j) ? TileFactor[i] : 0;
-  char buff[1000];
   if (myComm->rank() == 0)
   {
-    snprintf(buff, 1000, "  TileMatrix = \n [ %2d %2d %2d\n   %2d %2d %2d\n   %2d %2d %2d ]\n", TileMatrix(0, 0),
-             TileMatrix(0, 1), TileMatrix(0, 2), TileMatrix(1, 0), TileMatrix(1, 1), TileMatrix(1, 2), TileMatrix(2, 0),
-             TileMatrix(2, 1), TileMatrix(2, 2));
-    app_log() << buff;
+    std::array<char, 1000> buff;
+    int length =
+        std::snprintf(buff.data(), buff.size(), "  TileMatrix = \n [ %2d %2d %2d\n   %2d %2d %2d\n   %2d %2d %2d ]\n",
+                      TileMatrix(0, 0), TileMatrix(0, 1), TileMatrix(0, 2), TileMatrix(1, 0), TileMatrix(1, 1),
+                      TileMatrix(1, 2), TileMatrix(2, 0), TileMatrix(2, 1), TileMatrix(2, 2));
+    if (length < 0)
+      throw std::runtime_error("Error converting TileMatrix to a string");
+    app_log() << std::string_view(buff.data(), length);
   }
   if (numOrbs == 0)
     myComm->barrier_and_abort(

--- a/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
@@ -36,6 +36,8 @@
 #include "OhmmsData/ParameterSet.h"
 #include "Numerics/LinearFit.h"
 
+#include <array>
+
 namespace qmcplusplus
 {
 BackflowBuilder::BackflowBuilder(ParticleSet& els, const PSetMap& pool) : cutOff(1.0), targetPtcl(els), ptclPool(pool)
@@ -550,20 +552,18 @@ void BackflowBuilder::makeLongRange_twoBody(xmlNodePtr cur, Backflow_ee_kSpace* 
       offsets.push_back(tbfks->numParams);
       if (OHMMS::Controller->rank() == 0)
       {
-        const int max_size{16};
-        char fname[max_size];
-        if (snprintf(fname, max_size, "RPABFee-LR.%s.dat", (spA + spB).c_str()) < 0)
+        std::array<char, 16> fname;
+        if (std::snprintf(fname.data(), fname.size(), "RPABFee-LR.%s.dat", (spA + spB).c_str()) < 0)
           throw std::runtime_error("Error generating filename");
 
-        std::ofstream fout(fname);
+        std::ofstream fout(fname.data());
         fout.setf(std::ios::scientific, std::ios::floatfield);
         fout << "# Backflow longrange  \n";
         for (int i = 0; i < tbfks->NumKShells; i++)
         {
-          fout << std::pow(targetPtcl.getSimulationCell()
-                               .getKLists()
-                               .ksq[targetPtcl.getSimulationCell().getKLists().kshell[i]],
-                           0.5)
+          fout << std::sqrt(targetPtcl.getSimulationCell()
+                                .getKLists()
+                                .ksq[targetPtcl.getSimulationCell().getKLists().kshell[i]])
                << " " << yk[i] << std::endl;
         }
         fout.close();

--- a/src/Sandbox/ParticleIOUtility.cpp
+++ b/src/Sandbox/ParticleIOUtility.cpp
@@ -14,6 +14,10 @@
 
 #include "ParticleIOUtility.h"
 #include "Utilities/ProgressReportEngine.h"
+
+#include <array>
+#include <string_view>
+
 namespace qmcplusplus
 {
 
@@ -29,10 +33,12 @@ void expandSuperCell(const ParticleSet& in, const Tensor<int, OHMMS_DIM>& tmat, 
 {
   app_log() << "  Expanding a simulation cell from " << in.getName() << " to " << out.getName() << std::endl;
   {
-    char buff[500];
-    snprintf(buff, 500, "   tilematrix= %4d %4d %4d %4d %4d %4d %4d %4d %4d\n", tmat[0], tmat[1], tmat[2], tmat[3],
-             tmat[4], tmat[5], tmat[6], tmat[7], tmat[8]);
-    app_log() << buff << std::endl;
+    std::array<char, 500> buff;
+    int length = std::snprintf(buff.data(), buff.size(), "   tilematrix= %4d %4d %4d %4d %4d %4d %4d %4d %4d\n",
+                               tmat[0], tmat[1], tmat[2], tmat[3], tmat[4], tmat[5], tmat[6], tmat[7], tmat[8]);
+    if (length < 0)
+      throw std::runtime_error("Error converting tilematrix to string");
+    app_log() << std::string_view(buff.data(), length) << std::endl;
   }
 
   if (in.R.InUnit != PosUnit::Lattice)
@@ -68,10 +74,13 @@ void expandSuperCell(const ParticleSet& in, const Tensor<int, OHMMS_DIM>& tmat, 
             if ((uSuper[0] >= -1.0e-6) && (uSuper[0] < 0.9999) && (uSuper[1] >= -1.0e-6) && (uSuper[1] < 0.9999) &&
                 (uSuper[2] >= -1.0e-6) && (uSuper[2] < 0.9999))
             {
-              char buff[500];
-              snprintf(buff, 500, "  %10.4f  %10.4f %10.4f   %12.6f %12.6f %12.6f %d\n", uSuper[0], uSuper[1],
-                       uSuper[2], r[0], r[1], r[2], ns);
-              app_log() << buff;
+              std::array<char, 500> buff;
+              int length =
+                  std::snprintf(buff.data(), buff.size(), "  %10.4f  %10.4f %10.4f   %12.6f %12.6f %12.6f %d\n",
+                                uSuper[0], uSuper[1], uSuper[2], r[0], r[1], r[2], ns);
+              if (length < 0)
+                throw std::runtime_error("Error converting coordinates to strings");
+              app_log() << std::string_view(buff.data(), length);
               out.R[index]       = r;
               out.GroupID[index] = ns; //primTypes[iat];
               index++;

--- a/src/Utilities/SimpleParser.cpp
+++ b/src/Utilities/SimpleParser.cpp
@@ -15,6 +15,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
+#include <array>
 #include <cstdio>
 #include <cstring>
 #include <iterator>
@@ -178,9 +179,8 @@ int getwords(std::vector<std::string>& slist,std::istream& fpos, const char* fie
 int getwords(std::vector<std::string>& slist, std::istream& fpos, const char* field, const char* terminate)
 {
   slist.clear();
-  const int max = 128;
-  char end_key[max];
-  if (snprintf(end_key, max, "</%s>", field) < 0)
+  std::array<char, 128> end_key;
+  if (std::snprintf(end_key.data(), end_key.size(), "</%s>", field) < 0)
     throw std::runtime_error("Error extract end_key from field.");
 
   std::vector<std::string> vlist;
@@ -188,7 +188,7 @@ int getwords(std::vector<std::string>& slist, std::istream& fpos, const char* fi
   {
     if (getwords(vlist, fpos) == 0)
       continue;
-    if (vlist[0] == terminate || vlist[0] == end_key)
+    if (vlist[0] == terminate || vlist[0] == end_key.data())
       break;
     slist.insert(slist.end(), std::make_move_iterator(vlist.begin()), std::make_move_iterator(vlist.end()));
   };

--- a/src/io/OhmmsData/Libxml2Doc.cpp
+++ b/src/io/OhmmsData/Libxml2Doc.cpp
@@ -42,7 +42,7 @@ OhmmsXPathObject::OhmmsXPathObject(const char* expression, xmlNodePtr cur)
   else
   {
     std::array<char, 128> local;
-    if (snprintf(local.data(), local.size(), ".%s", expression) < 0)
+    if (std::snprintf(local.data(), local.size(), ".%s", expression) < 0)
       throw std::runtime_error("Error generating expression");
     put(local.data(), m_context);
   }


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Cleaning up earlier attempts to use `std::snprintf` with lessons learned through completing #4438. Mostly using `std::array` instead of a c-style array and a separate size variable and checking the return value from the function. Also found a few places where `std::string_view` may avoid a call to `strlen`

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
