### PR TITLE
HSPotential Helper replace ifdefs with const expr templates

### DIFF
--- a/src/AFQMC/Hamiltonians/FactorizedSparseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/FactorizedSparseHamiltonian.cpp
@@ -73,7 +73,7 @@ SpVType_shm_csr_matrix FactorizedSparseHamiltonian::calculateHSPotentials(double
   else
   {
     // you always need to count since some vectors might be empty
-    auto nnz_per_cv = HamHelper::count_nnz_per_cholvec(cut, TG, V2_fact, NMO);
+    auto nnz_per_cv = HamHelper::count_nnz_per_cholvec<SPValueType>(cut, TG, V2_fact, NMO);
 
     // count vectors and make mapping from 2*n/2*n+1 to actual value
     std::vector<int> map_;
@@ -126,7 +126,7 @@ SpVType_shm_csr_matrix FactorizedSparseHamiltonian::calculateHSPotentials(double
       }
     }
 
-    auto nnz_per_ik = HamHelper::count_nnz_per_ik(cut, TG, V2_fact, NMO, cv0, cvN);
+    auto nnz_per_ik = HamHelper::count_nnz_per_ik<SPValueType>(cut, TG, V2_fact, NMO, cv0, cvN);
 
     std::size_t nvec =
         std::count_if(nnz_per_cv.begin() + cv0, nnz_per_cv.begin() + cvN, [](std::size_t const& i) { return i > 0; });
@@ -138,7 +138,7 @@ SpVType_shm_csr_matrix FactorizedSparseHamiltonian::calculateHSPotentials(double
     // and can use emplace_back
     SpVType_shm_csr_matrix csr(tp_ul_ul{NMO * NMO, nvec}, tp_ul_ul{0, cv_origin}, nnz_per_ik, Alloc(TG.Node()));
 
-    HamHelper::generateHSPotential(csr, map_, cut, TG, V2_fact, NMO, cv0, cvN);
+    HamHelper::generateHSPotential<SPValueType>(csr, map_, cut, TG, V2_fact, NMO, cv0, cvN);
     TG.node_barrier();
 
     return csr;

--- a/src/AFQMC/Hamiltonians/HSPotential_Helpers.cpp
+++ b/src/AFQMC/Hamiltonians/HSPotential_Helpers.cpp
@@ -11,6 +11,7 @@
 #include "Configuration.h"
 
 #include "AFQMC/config.h"
+#include "type_traits/complex_help.hpp"
 #include "HSPotential_Helpers.h"
 #include "Utilities/FairDivide.h"
 #include "AFQMC/Utilities/taskgroup.h"
@@ -41,8 +42,8 @@ void count_over_cholvec(double cut,
                         std::vector<std::size_t>& count,
                         int c0,
                         int c1,
-                        SpVType_shm_csr_matrix::reference const& Lik,
-                        SpVType_shm_csr_matrix::reference const& Lki)
+                        CSRMtrxShared<T>::reference const& Lik,
+                        CSRMtrxShared<T>::reference const& Lki)
 {
   assert(c1 >= c0);
   if (c0 == c1)
@@ -79,7 +80,7 @@ void count_over_cholvec(double cut,
       if (abs(*vik) > cut)
       {
         count[2 * (*cik)] += size_t(2); // Lik + 0
-        if constexpr (is_complex_v<T>)
+        if constexpr (IsComplex_t_v<T>)
           count[2 * (*cik) + 1] += size_t(2); // Lik - 0
       }
       ++cik;
@@ -90,7 +91,7 @@ void count_over_cholvec(double cut,
       if (abs(*vki) > cut)
       {
         count[2 * (*cki)] += size_t(2); // Lki + 0
-        if constexpr (is_complex_v<T>)
+        if constexpr (IsComplex_t_v<T>)
           count[2 * (*cki) + 1] += size_t(2); // Lki - 0
       }
       ++cki;
@@ -103,7 +104,7 @@ void count_over_cholvec(double cut,
     if (abs(*vik) > cut)
     {
       count[2 * (*cik)] += size_t(2); // Lik + 0
-      if constexpr (is_complex_v<T>)
+      if constexpr (IsComplex_t_v<T>)
         count[2 * (*cik) + 1] += size_t(2); // Lik - 0
     }
     ++cik;
@@ -114,7 +115,7 @@ void count_over_cholvec(double cut,
     if (abs(*vki) > cut)
     {
       count[2 * (*cki)] += size_t(2); // Lki + 0
-      if constexpr (is_complex_v<T>)
+      if constexpr (IsComplex_t_v<T>)
         count[2 * (*cki) + 1] += size_t(2); // Lki - 0
     }
     ++cki;
@@ -127,8 +128,8 @@ void count_over_cholvec(double cut,
                           std::vector<std::size_t>& count, \
                           int c0, \
                           int c1, \
-                          SpVType_shm_csr_matrix::reference const& Lik, \
-                          SpVType_shm_csr_matrix::reference const& Lki);
+                          CSRMtrxShared<T>::reference const& Lik, \
+                          CSRMtrxShared<T>::reference const& Lki);
   QMC_FOREACH_TYPE(declare_type)
 #undef declare_type
 
@@ -137,7 +138,7 @@ void count_over_cholvec(double cut,
                         std::vector<std::size_t>& count,
                         int c0,
                         int c1,
-                        SpVType_shm_csr_matrix::reference const& Lii)
+                        CSRMtrxShared<T>::reference const& Lii)
 {
   assert(c1 >= c0);
   if (c0 == c1)
@@ -155,7 +156,7 @@ void count_over_cholvec(double cut,
   {
     if (abs(*vi + ma::conj(*vi)) > cut)
       ++count[2 * (*ci)]; // Lii + Lii*
-    if constexpr (is_complex_v<T>) {
+    if constexpr (IsComplex_t_v<T>) {
       if (abs(*vi - ma::conj(*vi)) > cut)
         ++count[2 * (*ci) + 1]; // Lii - Lii*
     }
@@ -170,7 +171,7 @@ void count_over_cholvec(double cut,
                           std::vector<std::size_t>& count, \
                           int c0, \
                           int c1, \
-                          SpVType_shm_csr_matrix::reference const& Lii);
+                          CSRMtrxShared<T>::reference const& Lii);
   QMC_FOREACH_TYPE(declare_type)
 #undef declare_type
 
@@ -181,8 +182,8 @@ void count_nnz(double cut,
                std::size_t& nki,
                int c0,
                int c1,
-               SpVType_shm_csr_matrix::reference const& Lik,
-               SpVType_shm_csr_matrix::reference const& Lki)
+               CSRMtrxShared<T>::reference const& Lik,
+               CSRMtrxShared<T>::reference const& Lki)
 {
   using ma::conj;
   using std::abs;
@@ -214,7 +215,7 @@ void count_nnz(double cut,
         nik++;
         nki++;
       }
-      if constexpr (is_complex_v<T>){
+      if constexpr (IsComplex_t_v<T>){
         if (abs(*vik - ma::conj(*vki)) > cut && // Lik - Lki* and Lki - Lik*
             2 * (*cik) + 1 >= c0 && 2 * (*cik) + 1 < c1)
         {
@@ -229,7 +230,7 @@ void count_nnz(double cut,
     }
     else if (*cik < *cki)
     { // not on the same chol vector, only operate on the smallest
-      if constexpr (is_complex_v<T>) {
+      if constexpr (IsComplex_t_v<T>) {
         if (abs(*vik) > cut)
         {
           if (2 * (*cik) >= c0 && 2 * (*cik) < c1)
@@ -255,7 +256,7 @@ void count_nnz(double cut,
     }
     else
     {
-      if constexpr (is_complex_v<T>) {
+      if constexpr (IsComplex_t_v<T>) {
         if (abs(*vki) > cut)
         {
           if (2 * (*cki) >= c0 && 2 * (*cki) < c1)
@@ -282,7 +283,7 @@ void count_nnz(double cut,
   }
   while (cik != cik_end)
   {
-    if constexpr (is_complex_v<T>) {
+    if constexpr (IsComplex_t_v<T>) {
       if (abs(*vik) > cut)
       {
         if (2 * (*cik) >= c0 && 2 * (*cik) < c1)
@@ -309,7 +310,7 @@ void count_nnz(double cut,
   }
   while (cki != cki_end)
   {
-    if constexpr (is_complex_v<T>) {
+    if constexpr (IsComplex_t_v<T>) {
       if (abs(*vki) > cut)
       {
         if (2 * (*cki) >= c0 && 2 * (*cki) < c1)
@@ -342,13 +343,13 @@ void count_nnz(double cut,
                 std::size_t& nki, \
                 int c0, \
                 int c1, \
-                SpVType_shm_csr_matrix::reference const& Lik, \
-                SpVType_shm_csr_matrix::reference const& Lki);
+                CSRMtrxShared<T>::reference const& Lik, \
+                CSRMtrxShared<T>::reference const& Lki);
   QMC_FOREACH_TYPE(declare_type)
 #undef declare_type
 
 template<class T>
-void count_nnz(double cut, size_t& ni, int c0, int c1, SpVType_shm_csr_matrix::reference const& Lii)
+void count_nnz(double cut, size_t& ni, int c0, int c1, CSRMtrxShared<T>::reference const& Lii)
 {
   using ma::conj;
   using std::abs;
@@ -368,7 +369,7 @@ void count_nnz(double cut, size_t& ni, int c0, int c1, SpVType_shm_csr_matrix::r
   {
     if (abs(*vi + ma::conj(*vi)) > cut && 2 * (*ci) >= c0 && 2 * (*ci) < c1)
       ++ni; // Lii + Lii*
-    if constexpr (is_complex_v<T>) {
+    if constexpr (IsComplex_t_v<T>) {
       if (abs(*vi - ma::conj(*vi)) > cut && 2 * (*ci) + 1 >= c0 && 2 * (*ci) + 1 < c1)
         ++ni; // Lii - Lii*
     }
@@ -378,13 +379,13 @@ void count_nnz(double cut, size_t& ni, int c0, int c1, SpVType_shm_csr_matrix::r
 }
 
 template<class T>
-void add_to_vn(SpVType_shm_csr_matrix& vn,
+void add_to_vn(CSRMtrxShared<T>& vn,
                std::vector<int> const& map_,
                double cut,
                int ik,
                int c0,
                int c1,
-               SpVType_shm_csr_matrix::reference const& Lii)
+               CSRMtrxShared<T>::reference const& Lii)
 {
   using ma::conj;
   using std::abs;
@@ -410,7 +411,7 @@ void add_to_vn(SpVType_shm_csr_matrix& vn,
       vn.emplace_back({ik, (map_[2 * (*ci)] - c_origin)},
                       static_cast<SPValueType>(half * (*vi + ma::conj(*vi)))); // Lii + Lii*
     }
-    if constexpr (is_complex_v<T>) {
+    if constexpr (IsComplex_t_v<T>) {
       if (abs(*vi - ma::conj(*vi)) > cut && 2 * (*ci) + 1 >= c0 && 2 * (*ci) + 1 < c1)
       {
         assert(map_[2 * (*ci) + 1] >= 0);
@@ -425,15 +426,15 @@ void add_to_vn(SpVType_shm_csr_matrix& vn,
 }
 
 template<class T>
-void add_to_vn(SpVType_shm_csr_matrix& vn,
+void add_to_vn(CSRMtrxShared<T>& vn,
                std::vector<int> const& map_,
                double cut,
                int ik,
                int ki,
                int c0,
                int c1,
-               SpVType_shm_csr_matrix::reference const& Lik,
-               SpVType_shm_csr_matrix::reference const& Lki)
+               CSRMtrxShared<T>::reference const& Lik,
+               CSRMtrxShared<T>::reference const& Lki)
 {
   using ma::conj;
   using std::abs;
@@ -472,7 +473,7 @@ void add_to_vn(SpVType_shm_csr_matrix& vn,
                           static_cast<SPValueType>(half * (*vki + ma::conj(*vik)))); // Lki + Lik*
         }
       }
-      if constexpr (is_complex_v<T>) {
+      if constexpr (IsComplex_t_v<T>) {
         if (abs(*vik - ma::conj(*vki)) > cut)
         { // Lik - Lki* and Lki - Lik*
           if (2 * (*cik) + 1 >= c0 && 2 * (*cik) + 1 < c1)
@@ -504,7 +505,7 @@ void add_to_vn(SpVType_shm_csr_matrix& vn,
           vn.emplace_back({ki, (map_[2 * (*cik)] - c_origin)},
                           static_cast<SPValueType>(half * ma::conj(*vik))); // Lik + 0
         }
-        if constexpr (is_complex_v<T>) {
+        if constexpr (IsComplex_t_v<T>) {
           if (2 * (*cik) + 1 >= c0 && 2 * (*cik) + 1 < c1)
           {
             assert(map_[2 * (*cik) + 1] >= 0);
@@ -532,7 +533,7 @@ void add_to_vn(SpVType_shm_csr_matrix& vn,
           vn.emplace_back({ki, (map_[2 * (*cki)] - c_origin)},
                           static_cast<SPValueType>(half * (*vki))); // Lki + 0
         }
-        if constexpr (is_complex_v<T>) {
+        if constexpr (IsComplex_t_v<T>) {
           if (2 * (*cki) + 1 >= c0 && 2 * (*cki) + 1 < c1)
           {
             assert(map_[2 * (*cki) + 1] >= 0);
@@ -561,7 +562,7 @@ void add_to_vn(SpVType_shm_csr_matrix& vn,
         vn.emplace_back({ki, (map_[2 * (*cik)] - c_origin)},
                         static_cast<SPValueType>(half * ma::conj(*vik))); // Lik + 0
       }
-      if constexpr (is_complex_v<T>) {
+      if constexpr (IsComplex_t_v<T>) {
         if (2 * (*cik) + 1 >= c0 && 2 * (*cik) + 1 < c1)
         {
           assert(map_[2 * (*cik) + 1] >= 0);
@@ -589,7 +590,7 @@ void add_to_vn(SpVType_shm_csr_matrix& vn,
         vn.emplace_back({ki, (map_[2 * (*cki)] - c_origin)},
                         static_cast<SPValueType>(half * (*vki))); // Lki + 0
       }
-      if constexpr (is_complex_v<T>) {
+      if constexpr (IsComplex_t_v<T>) {
         if (2 * (*cki) + 1 >= c0 && 2 * (*cki) + 1 < c1)
         {
           assert(map_[2 * (*cki) + 1] >= 0);
@@ -608,7 +609,7 @@ void add_to_vn(SpVType_shm_csr_matrix& vn,
 
 } // namespace
 template<class T>
-std::vector<std::size_t> count_nnz_per_cholvec(double cut, TaskGroup_& TG, SpVType_shm_csr_matrix& V2, int NMO)
+std::vector<std::size_t> count_nnz_per_cholvec(double cut, TaskGroup_& TG, CSRMtrxShared<T>& V2, int NMO)
 {
   if (TG.getNumberOfTGs() > 1)
     APP_ABORT("Error: count_nnz_per_cholvec is not designed for distributed CholMat. \n");
@@ -642,14 +643,14 @@ std::vector<std::size_t> count_nnz_per_cholvec(double cut, TaskGroup_& TG, SpVTy
 }
 
 #define declare_type(T) \
-  template std::vector<std::size_t> count_nnz_per_cholvec<T>(double cut, TaskGroup_& TG, SpVType_shm_csr_matrix& V2, int NMO);
+  template std::vector<std::size_t> count_nnz_per_cholvec<T>(double cut, TaskGroup_& TG, CSRMtrxShared<T>& V2, int NMO);
   QMC_FOREACH_TYPE(declare_type)
 #undef declare_type
 
 template<class T>
 std::vector<std::size_t> count_nnz_per_ik(double cut,
                                           TaskGroup_& TG,
-                                          SpVType_shm_csr_matrix& V2,
+                                          CSRMtrxShared<T>& V2,
                                           int NMO,
                                           int cv0,
                                           int cvN)
@@ -695,7 +696,7 @@ std::vector<std::size_t> count_nnz_per_ik(double cut,
   template \
   std::vector<std::size_t> count_nnz_per_ik<T>(double cut, \
                                             TaskGroup_& TG, \
-                                            SpVType_shm_csr_matrix& V2, \
+                                            CSRMtrxShared<T>& V2, \
                                             int NMO, \
                                             int cv0, \
                                             int cvN);
@@ -703,11 +704,11 @@ std::vector<std::size_t> count_nnz_per_ik(double cut,
 #undef declare_type
 
 template<class T>
-void generateHSPotential(SpVType_shm_csr_matrix& vn,
+void generateHSPotential(CSRMtrxShared<T>& vn,
                          std::vector<int> const& map_,
                          double cut,
                          TaskGroup_& TG,
-                         SpVType_shm_csr_matrix& V2,
+                         CSRMtrxShared<T>& V2,
                          int NMO,
                          int cv0,
                          int cvN)
@@ -746,11 +747,11 @@ void generateHSPotential(SpVType_shm_csr_matrix& vn,
 }
 
 #define declare_type(T) \
-  template void generateHSPotential<T>(SpVType_shm_csr_matrix& vn, \
+  template void generateHSPotential<T>(CSRMtrxShared<T>& vn, \
                          std::vector<int> const& map_, \
                          double cut, \
                          TaskGroup_& TG, \
-                         SpVType_shm_csr_matrix& V2, \
+                         CSRMtrxShared<T>& V2, \
                          int NMO, \
                          int cv0, \
                          int cvN);

--- a/src/AFQMC/Hamiltonians/HSPotential_Helpers.h
+++ b/src/AFQMC/Hamiltonians/HSPotential_Helpers.h
@@ -23,15 +23,17 @@ namespace afqmc
 {
 namespace HamHelper
 {
+template<class T>
 std::vector<std::size_t> count_nnz_per_cholvec(double cut, TaskGroup_& TG, SpVType_shm_csr_matrix& V2, int NMO);
 
+template<class T>
 std::vector<std::size_t> count_nnz_per_ik(double cut,
                                           TaskGroup_& TG,
                                           SpVType_shm_csr_matrix& V2,
                                           int NMO,
                                           int cv0,
                                           int cvN);
-
+template<class T>
 void generateHSPotential(SpVType_shm_csr_matrix& vn,
                          std::vector<int> const& map_,
                          double cut,

--- a/src/AFQMC/config.0.h
+++ b/src/AFQMC/config.0.h
@@ -60,12 +60,12 @@ using SPComplexType = std::complex<SPRealType>;
 
 template <class T>
 struct is_complex : std::false_type {};
-template <>
-struct is_complex<ComplexType> : std::true_type {};
-template <>
-struct is_complex<SPComplexType> : std::true_type {};
 
-{};
+template <class T>
+struct is_complex<std::complex<T>> : std::true_type {};
+
+template<class T>
+inline constexpr bool is_complex_v = is_complex<T>::value;
 
 
 } // namespace afqmc

--- a/src/AFQMC/config.0.h
+++ b/src/AFQMC/config.0.h
@@ -58,6 +58,16 @@ using SPValueType = SPRealType;
 using ComplexType   = std::complex<RealType>;
 using SPComplexType = std::complex<SPRealType>;
 
+template <class T>
+struct is_complex : std::false_type {};
+template <>
+struct is_complex<ComplexType> : std::true_type {};
+template <>
+struct is_complex<SPComplexType> : std::true_type {};
+
+{};
+
+
 } // namespace afqmc
 } // namespace qmcplusplus
 

--- a/src/AFQMC/config.0.h
+++ b/src/AFQMC/config.0.h
@@ -58,15 +58,6 @@ using SPValueType = SPRealType;
 using ComplexType   = std::complex<RealType>;
 using SPComplexType = std::complex<SPRealType>;
 
-template <class T>
-struct is_complex : std::false_type {};
-
-template <class T>
-struct is_complex<std::complex<T>> : std::true_type {};
-
-template<class T>
-inline constexpr bool is_complex_v = is_complex<T>::value;
-
 
 } // namespace afqmc
 } // namespace qmcplusplus

--- a/src/AFQMC/config.h
+++ b/src/AFQMC/config.h
@@ -218,6 +218,7 @@ using host_constructor     = std::allocator<T>;
 using host_memory_resource = boost::multi::memory::resource<>;
 
 // new types
+// DEPRECATED:  use CSRMtrxShared<T> instead
 using SpCType_shm_csr_matrix =
     ma::sparse::csr_matrix<SPComplexType, int, std::size_t, shared_allocator<SPComplexType>, ma::sparse::is_root>;
 using SpVType_shm_csr_matrix =
@@ -226,6 +227,9 @@ using CType_shm_csr_matrix =
     ma::sparse::csr_matrix<ComplexType, int, std::size_t, shared_allocator<ComplexType>, ma::sparse::is_root>;
 using VType_shm_csr_matrix =
     ma::sparse::csr_matrix<ValueType, int, std::size_t, shared_allocator<ValueType>, ma::sparse::is_root>;
+
+template<typename T>
+using CSRMtrxShared<T> = ma::sparse::csr_matrix<T, int, std::size_t, shared_allocator<T>, ma::sparse::is_root>;
 
 //#ifdef PsiT_IN_SHM
 template<typename T>

--- a/src/type_traits/QMCMacros.h
+++ b/src/type_traits/QMCMacros.h
@@ -1,0 +1,29 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2020 QMCPACK developers
+//
+// File developed by: William F Godoy, godoywf@ornl.gov, Oak Ridge National Lab
+//
+// File created by: William F Godoy, godoywf@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_QMC_MACROS_H
+#define QMCPLUSPLUS_QMC_MACROS_H
+
+
+#define QMC_FOREACH_REAL_TYPE(MACRO) \
+  MACRO(float)                       \
+  MACRO(double)
+
+#define QMC_FOREACH_COMPLEX_TYPE(MACRO) \
+  MACRO(std::complex<float>)            \
+  MACRO(std::complex<double>)
+
+#define QMC_FOREACH_TYPE(MACRO) \
+  QMC_FOREACH_REAL_TYPE(MACRO)  \
+  QMC_FOREACH_COMPLEX_TYPE(MACRO)
+
+#endif

--- a/src/type_traits/complex_help.hpp
+++ b/src/type_traits/complex_help.hpp
@@ -22,6 +22,9 @@ struct IsComplex_t<std::complex<T>> : public std::true_type
 {};
 
 template<typename T>
+inline constexpr bool IsComplex_t_v = IsComplex_t<T>::value;
+
+template<typename T>
 using IsComplex = std::enable_if_t<IsComplex_t<T>::value, bool>;
 template<typename T>
 using IsReal = std::enable_if_t<std::is_floating_point<T>::value, bool>;


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

This is a refactor of `HSPotential_Helpers.cpp` and `HSPotential_Helpers.h`  in accordance with this gist https://gist.github.com/williamfgc/28ffbd23f6888ed89530e3f68c992c93#refactoring-strategy
It removes the QMC_COMPLEX ifdefs and replaces them with templates and const expr as to generate complex/real versions in one compile.

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes/No. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
