### PR TITLE
Fix sposet_indices missing construction in OrbitalImages.

### DIFF
--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -19,11 +19,8 @@
 
 namespace qmcplusplus
 {
-OrbitalImages::OrbitalImages(ParticleSet& P,
-                             const PSPool& PSP,
-                             Communicate* mpicomm,
-                             const SPOMap& spomap)
-    : psetpool(PSP), spomap_(spomap)
+OrbitalImages::OrbitalImages(ParticleSet& P, const PSPool& PSP, Communicate* mpicomm, const SPOMap& spomap)
+    : psetpool(PSP), sposet_indices(std::make_shared<std::vector<std::vector<int>>>()), spomap_(spomap)
 {
   //keep the electron particle to get the cell later, if necessary
   Peln = &P;
@@ -219,8 +216,8 @@ bool OrbitalImages::put(xmlNodePtr cur)
       throw std::runtime_error("OrbitalImages::put  sposet " + sposet_names[i] + " does not exist.");
 
     sposets.push_back(spo_it->second->makeClone());
-    auto& sposet = sposets.back();
-    std::vector<int>& sposet_inds = (*sposet_indices)[i];
+    auto& sposet      = sposets.back();
+    auto& sposet_inds = (*sposet_indices)[i];
     if (sposet_inds.size() == 0)
       for (int n = 0; n < sposet->size(); ++n)
         sposet_inds.push_back(n);


### PR DESCRIPTION
## Proposed changes
A simpler alternative to https://github.com/QMCPACK/qmcpack/pull/4617

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
