### PR TITLE
Nexus: fix namelist read for Projwfc input

### DIFF
--- a/nexus/lib/pwscf_postprocessors.py
+++ b/nexus/lib/pwscf_postprocessors.py
@@ -217,6 +217,10 @@ class Namelist(DevBase):
         for line in lines:
             tokens = line.split(',')
             for t in tokens:
+                t = t.strip()
+                if len(t)==0:
+                    continue
+                #end if
                 name,value = t.split('=')
                 name  = name.strip()
                 value = value.strip()


### PR DESCRIPTION
## Proposed changes

Small fix to properly read namelist input.  Previously failed if there was a dangling comma.

## What type(s) of changes does this code introduce?

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Workstation

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
