### PR TITLE
Simplify checkpointing, change defaults, fix legacy, implement in batched

### DIFF
--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -36,7 +36,7 @@ Quantum Monte Carlo Methods
   +----------------+--------------+--------------+-------------+---------------------------------+
   | ``profiling``  | text         | yes/no       | no          | Activate resume/pause control   |
   +----------------+--------------+--------------+-------------+---------------------------------+
-  | ``checkpoint`` | integer      | -1, 0, n     | -1          | Checkpoint frequency            |
+  | ``checkpoint`` | integer      | -1, 0, n     | 0           | Checkpoint frequency            |
   +----------------+--------------+--------------+-------------+---------------------------------+
   | ``record``     | integer      | n            | 0           | Save configuration ever n steps |
   +----------------+--------------+--------------+-------------+---------------------------------+
@@ -69,9 +69,9 @@ Additional information:
 -  ``checkpoint``: This enables and disables checkpointing and
    specifying the frequency of output. Possible values are:
 
-   - **[-1]** No checkpoint (default setting).
+   - **[-1]** No checkpoint files are written.
 
-   - **[0]** Write the checkpoint files after the completion of the QMC section.
+   - **[0]** Write the checkpoint files after the completion of the QMC section (default).
 
    - **[n]** Write the checkpoint files after every :math:`n` blocks, and also at the end of the QMC section.
 

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -184,8 +184,6 @@ Variational Monte Carlo
   +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
   | ``samplesperthread``           | integer      | :math:`\geq 0`          | 0           | Number of samples per thread                  |
   +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
-  | ``storeconfigs``               | integer      | all values              | 0           | Write configurations to files                 |
-  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
   | ``blocks_between_recompute``   | integer      | :math:`\geq 0`          | dep.        | Wavefunction recompute frequency              |
   +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
   | ``spinMass``                   | real         | :math:`> 0`             | 1.0         | Effective mass for spin sampling              |
@@ -257,9 +255,6 @@ Additional information:
   than 1 can be used to reduces that correlation. In practice, using larger substeps is cheaper than using ``stepsbetweensamples``
   to decorrelate samples.
   
-- ``storeconfigs`` If ``storeconfigs`` is set to a nonzero value, then electron configurations during the VMC run are saved to
-  files.
-
 - ``blocks_between_recompute`` Recompute the accuracy critical determinant part of the wavefunction from scratch: =1 by
   default when using mixed precision. =10 by default when not using mixed precision. 0 can be set for no recomputation
   and higher performance, but numerical errors will accumulate over time. Recomputing introduces a performance penalty
@@ -334,8 +329,6 @@ Batched ``vmc`` driver (experimental)
   +--------------------------------+--------------+-------------------------+-------------+-------------------------------------------------+
   | ``samples`` (not ready)        | integer      | :math:`\geq 0`          | 0           | Number of walker samples for in this VMC run    |
   +--------------------------------+--------------+-------------------------+-------------+-------------------------------------------------+
-  | ``storeconfigs`` (not ready)   | integer      | all values              | 0           | Write configurations to files                   |
-  +--------------------------------+--------------+-------------------------+-------------+-------------------------------------------------+
   | ``blocks_between_recompute``   | integer      | :math:`\geq 0`          | dep.        | Wavefunction recompute frequency                |
   +--------------------------------+--------------+-------------------------+-------------+-------------------------------------------------+
   | ``crowd_serialize_walkers``    | integer      | yes, no                 | no          | Force use of single walker APIs (for testing)   |
@@ -399,9 +392,6 @@ Additional information:
   simulation.
 
 - ``samples`` (not ready)
-
-- ``storeconfigs`` If ``storeconfigs`` is set to a nonzero value, then electron configurations during the VMC run are saved to
-  files.
 
 - ``blocks_between_recompute`` Recompute the accuracy critical determinant part of the wavefunction from scratch: =1 by
   default when using mixed precision. =10 by default when not using mixed precision. 0 can be set for no recomputation
@@ -1426,10 +1416,6 @@ parameters:
   +-----------------------------+--------------+-------------------------+-------------+-----------------------------------------+
   | ``checkproperties``         | integer      | :math:`\geq 0`          | 100         | Number of steps between walker updates  |
   +-----------------------------+--------------+-------------------------+-------------+-----------------------------------------+
-  | ``fastgrad``                | text         | yes/other               | yes         | Fast gradients                          |
-  +-----------------------------+--------------+-------------------------+-------------+-----------------------------------------+
-  | ``storeconfigs``            | integer      | all values              | 0           | Store configurations                    |
-  +-----------------------------+--------------+-------------------------+-------------+-----------------------------------------+
   | ``use_nonblocking``         | string       | yes/no                  | yes         | Using nonblocking send/recv             |
   +-----------------------------+--------------+-------------------------+-------------+-----------------------------------------+
   | ``debug_disable_branching`` | string       | yes/no                  | no          | Disable branching for debugging         |
@@ -1568,9 +1554,6 @@ where :math:`E_\text{ref}` is the :math:`E_\text{pop\_avg}` average over all the
 -  ``MaxCopy``: When determining the number of copies of a walker to
    branch, set the number of copies equal to min(Multiplicity,MaxCopy).
 
--  ``fastgrad``: This calculates gradients with either the fast version
-   or the full-ratio version.
-
 -  ``maxDisplSq``: When running a DMC calculation with particle by
    particle, this sets the maximum displacement allowed for a single
    particle move. All distance displacements larger than the max are
@@ -1579,10 +1562,6 @@ where :math:`E_\text{ref}` is the :math:`E_\text{pop\_avg}` average over all the
 
 -  ``sigmaBound``: This determines the branch cutoff to limit wild
    weights based on the sigma and ``sigmaBound``.
-
--  ``storeconfigs``: If ``storeconfigs`` is set to a nonzero value, then
-   electron configurations during the DMC run will be saved. This option
-   is disabled for the OpenMP version of DMC.
 
 -  ``blocks_between_recompute``: See details in :ref:`vmc`.
 
@@ -1718,8 +1697,6 @@ Batched ``dmc`` driver (experimental)
   | ``sigmaBound``                 | 10           | :math:`\geq 0`          | 10          | Parameter to cutoff large weights               |
   +--------------------------------+--------------+-------------------------+-------------+-------------------------------------------------+
   | ``reconfiguration``            | string       | yes/pure/other          | no          | Fixed population technique                      |
-  +--------------------------------+--------------+-------------------------+-------------+-------------------------------------------------+
-  | ``storeconfigs``               | integer      | all values              | 0           | Store configurations                            |
   +--------------------------------+--------------+-------------------------+-------------+-------------------------------------------------+
   | ``use_nonblocking``            | string       | yes/no                  | yes         | Using nonblocking send/recv                     |
   +--------------------------------+--------------+-------------------------+-------------+-------------------------------------------------+

--- a/src/Particle/HDFWalkerOutput.h
+++ b/src/Particle/HDFWalkerOutput.h
@@ -43,8 +43,6 @@ class HDFWalkerOutput
   ///rootname
   std::string RootName;
   std::string prevFile;
-  //     ///handle for the storeConfig.h5
-  //     hdf_archive fw_out;
 public:
   ///constructor
   HDFWalkerOutput(size_t num_ptcls, const std::string& fname, Communicate* c);

--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
@@ -184,8 +184,7 @@ bool CSVMC::run()
 #if !defined(REMOVE_TRACEMANAGER)
     Traces->write_buffers(traceClones, block);
 #endif
-    if (storeConfigs)
-      recordBlock(block);
+    recordBlock(block);
   } //block
   Estimators->stop(estimatorClones);
   for (int ip = 0; ip < NumThreads; ++ip)

--- a/src/QMCDrivers/DMC/DMC.h
+++ b/src/QMCDrivers/DMC/DMC.h
@@ -61,8 +61,6 @@ private:
   std::string Reconfiguration;
   ///input std::string to determine to use nonlocal move
   std::string NonLocalMove;
-  ///input std::string to use fast gradient
-  std::string UseFastGrad;
   ///input to control maximum age allowed for walkers.
   IndexType mover_MaxAge;
 

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -492,6 +492,7 @@ bool DMCBatched::run()
     if (qmcdriver_input_.get_measure_imbalance())
       measureImbalance("Block " + std::to_string(block));
     endBlock();
+    recordBlock(block);
     dmc_loop.stop();
 
     bool stop_requested = false;

--- a/src/QMCDrivers/DMC/DMCDriverInput.h
+++ b/src/QMCDrivers/DMC/DMCDriverInput.h
@@ -61,8 +61,6 @@ private:
   bool reconfiguration_ = true;
   ///input std::string to determine to use nonlocal move
   std::string NonLocalMove;
-  ///input std::string to use fast gradient
-  std::string UseFastGrad;
   ///input to control maximum age allowed for walkers.
   IndexType max_age_ = 10;
   /// reserved walkers for population growth

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -67,7 +67,7 @@ QMCDriver::QMCDriver(const ProjectData& project_data,
   //<parameter name=" "> value </parameter>
   //accept multiple names for the same value
   //recommend using all lower cases for a new parameter
-  Period4CheckPoint = -1;
+  Period4CheckPoint = 0;
   Period4CheckProperties = 100;
   m_param.add(Period4CheckProperties, "checkProperties");
   m_param.add(Period4CheckProperties, "checkproperties");
@@ -401,7 +401,7 @@ bool QMCDriver::putQMCInfo(xmlNodePtr cur)
   //int oldSteps=nSteps;
 
   //set the default walker to the number of threads times 10
-  Period4CheckPoint = -1;
+  Period4CheckPoint = 0;
   int defaultw      = omp_get_max_threads();
   OhmmsAttributeSet aAttrib;
   aAttrib.add(Period4CheckPoint, "checkpoint");

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -68,10 +68,6 @@ QMCDriver::QMCDriver(const ProjectData& project_data,
   //accept multiple names for the same value
   //recommend using all lower cases for a new parameter
   Period4CheckPoint = -1;
-  storeConfigs      = 0;
-  //m_param.add(storeConfigs,"storeConfigs");
-  m_param.add(storeConfigs, "storeconfigs");
-  m_param.add(storeConfigs, "store_configs");
   Period4CheckProperties = 100;
   m_param.add(Period4CheckProperties, "checkProperties");
   m_param.add(Period4CheckProperties, "checkproperties");

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -229,7 +229,6 @@ protected:
   *
   * The unit is in steps.
   */
-  int storeConfigs;
 
   ///Period to recalculate the walker properties from scratch.
   int Period4CheckProperties;

--- a/src/QMCDrivers/QMCDriverInput.cpp
+++ b/src/QMCDrivers/QMCDriverInput.cpp
@@ -39,7 +39,7 @@ void QMCDriverInput::readXML(xmlNodePtr cur)
   std::string serialize_walkers;
   std::string debug_checks_str;
   std::string measure_imbalance_str;
-  int Period4CheckPoint{-1};
+  int Period4CheckPoint{0};
 
   ParameterSet parameter_set;
   parameter_set.add(recalculate_properties_period_, "checkProperties");

--- a/src/QMCDrivers/QMCDriverInput.cpp
+++ b/src/QMCDrivers/QMCDriverInput.cpp
@@ -42,8 +42,6 @@ void QMCDriverInput::readXML(xmlNodePtr cur)
   int Period4CheckPoint{-1};
 
   ParameterSet parameter_set;
-  parameter_set.add(store_config_period_, "storeconfigs");
-  parameter_set.add(store_config_period_, "store_configs");
   parameter_set.add(recalculate_properties_period_, "checkProperties");
   parameter_set.add(recalculate_properties_period_, "checkproperties");
   parameter_set.add(recalculate_properties_period_, "check_properties");

--- a/src/QMCDrivers/QMCDriverInput.h
+++ b/src/QMCDrivers/QMCDriverInput.h
@@ -58,8 +58,6 @@ protected:
 
   /// if true, batched operations are serialized over walkers
   bool crowd_serialize_walkers_ = false;
-  /// period of dumping walker positions and IDs for Forward Walking (steps)
-  int store_config_period_ = 0;
   /// period to recalculate the walker properties from scratch.
   int recalculate_properties_period_ = 100;
   /// period of recording walker positions and IDs for forward walking afterwards
@@ -109,7 +107,6 @@ protected:
    */
 
 public:
-  int get_store_config_period() const { return store_config_period_; }
   int get_recalculate_properties_period() const { return recalculate_properties_period_; }
   input::PeriodStride get_config_dump_period() const { return config_dump_period_; }
   IndexType get_starting_step() const { return starting_step_; }

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -235,6 +235,8 @@ void QMCDriverNew::recordBlock(int block)
   if (qmcdriver_input_.get_dump_config() && block % qmcdriver_input_.get_check_point_period().period == 0)
   {
     ScopedTimer local_timer(timers_.checkpoint_timer);
+    population_.saveWalkerConfigurations(walker_configs_ref_);
+    setWalkerOffsets(walker_configs_ref_, myComm);
     wOut->dump(walker_configs_ref_, block);
 #ifndef USE_FAKE_RNG
     RandomNumberControl::write(getRngRefs(), get_root_name(), myComm);

--- a/src/QMCDrivers/RMC/RMC.cpp
+++ b/src/QMCDrivers/RMC/RMC.cpp
@@ -114,9 +114,7 @@ bool RMC::run()
     } //end-of-parallel for
     CurrentStep += nSteps;
     Estimators->stopBlock(estimatorClones);
-    //why was this commented out? Are checkpoints stored some other way?
-    if (storeConfigs)
-      recordBlock(block);
+    recordBlock(block);
     rmc_loop.stop();
 
     bool stop_requested = false;

--- a/src/QMCDrivers/VMC/VMC.cpp
+++ b/src/QMCDrivers/VMC/VMC.cpp
@@ -109,8 +109,7 @@ bool VMC::run()
 #if !defined(REMOVE_TRACEMANAGER)
     Traces->write_buffers(traceClones, block);
 #endif
-    if (storeConfigs)
-      recordBlock(block);
+    recordBlock(block);
     vmc_loop.stop();
 
     bool stop_requested = false;

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -382,6 +382,7 @@ bool VMCBatched::run()
     if (qmcdriver_input_.get_measure_imbalance())
       measureImbalance("Block " + std::to_string(block));
     endBlock();
+    recordBlock(block);
     vmc_loop.stop();
 
     bool stop_requested = false;

--- a/src/QMCDrivers/tests/test_dmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_dmc_driver.cpp
@@ -87,7 +87,7 @@ TEST_CASE("DMC", "[drivers][dmc]")
 
   DMC dmc_omp(project_data, elec, psi, h, c, false);
 
-  const char* dmc_input = R"(<qmc method="dmc">
+  const char* dmc_input = R"(<qmc method="dmc" checkpoint="-1">
    <parameter name="steps">1</parameter>
    <parameter name="blocks">1</parameter>
    <parameter name="timestep">0.1</parameter>
@@ -168,7 +168,7 @@ TEST_CASE("SODMC", "[drivers][dmc]")
 
   DMC dmc_omp(project_data, elec, psi, h, c, false);
 
-  const char* dmc_input = R"(<qmc method="dmc">
+  const char* dmc_input = R"(<qmc method="dmc" checkpoint="-1">
    <parameter name="steps">1</parameter>
    <parameter name="blocks">1</parameter>
    <parameter name="timestep">0.1</parameter>

--- a/src/QMCDrivers/tests/test_vmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_vmc_driver.cpp
@@ -86,7 +86,7 @@ TEST_CASE("VMC", "[drivers][vmc]")
 
   VMC vmc_omp(project_data, elec, psi, h, c, false);
 
-  const char* vmc_input = R"(<qmc method="vmc" move="pbyp">
+  const char* vmc_input = R"(<qmc method="vmc" move="pbyp" checkpoint="-1">
    <parameter name="substeps">1</parameter>
    <parameter name="steps">1</parameter>
    <parameter name="blocks">1</parameter>
@@ -168,7 +168,7 @@ TEST_CASE("SOVMC", "[drivers][vmc]")
 
   VMC vmc_omp(project_data, elec, psi, h, c, false);
 
-  const char* vmc_input = R"(<qmc method="vmc" move="pbyp">
+  const char* vmc_input = R"(<qmc method="vmc" move="pbyp" checkpoint="-1">
    <parameter name="substeps">1</parameter>
    <parameter name="steps">1</parameter>
    <parameter name="blocks">1</parameter>
@@ -255,7 +255,7 @@ TEST_CASE("SOVMC-alle", "[drivers][vmc]")
 
   VMC vmc_omp(project_data, elec, psi, h, c, false);
 
-  const char* vmc_input = R"(<qmc method="vmc" move="alle">
+  const char* vmc_input = R"(<qmc method="vmc" move="alle" checkpoint="-1">
    <parameter name="substeps">1</parameter>
    <parameter name="steps">1</parameter>
    <parameter name="blocks">1</parameter>


### PR DESCRIPTION
## Proposed changes

This PR aims to simplify and improve the checkpointing process.

As mentioned in https://github.com/QMCPACK/qmcpack/issues/4633 the documented every N blocks checkpointing feature was not working as expected. In legacy, this required storeconfigs to also be specified to work (undocumented/unexpected).  Checkpointing was also not implemented in the batched drivers.

Here:

- checkpoint={-1,0,N} driver parameter option sufficient to control checkpointing
- Default changed to checkpoint=0. Configs will be written at the end of each QMC section by default. -1 disables. N sets write period in addition to end of section write.
- Removed storeconfigs option completely.
- Implemented checkpointing in batched code.
- Updated docs appropriately

Have verified by eye that the checkpoints look sensible and are updated periodically. Open to testing suggestions.

Batched code does not create a info.xml as part of checkpoint.

Also remove unused FastGrad option.

## What type(s) of changes does this code introduce?

- Bugfix
- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

sulfur gcc build only. PR for CI.

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes/ This PR is up to date with current the current state of 'develop'
- Yes/ Code added or changed in the PR has been clang-formatted
- (Existing restart tests use code paths). This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
