### PR TITLE
Use SYCL in-order queue.

### DIFF
--- a/config/build_alcf_sunspot_icpx.sh
+++ b/config/build_alcf_sunspot_icpx.sh
@@ -9,7 +9,7 @@
 
 module load spack libxml2 cmake
 module load cray-hdf5/1.12.2.1
-module load oneapi/eng-compiler/2022.12.30.005
+module load oneapi/eng-compiler/2023.05.15.003
 
 module list >& module_list.txt
 
@@ -23,7 +23,7 @@ echo "**********************************"
 
 TYPE=Release
 Machine=sunspot
-Compiler=icpx20230321
+Compiler=icpx20230510
 
 if [[ $# -eq 0 ]]; then
   source_folder=`pwd`

--- a/src/Platforms/SYCL/SYCLDeviceManager.cpp
+++ b/src/Platforms/SYCL/SYCLDeviceManager.cpp
@@ -33,7 +33,7 @@ syclDeviceInfo::syclDeviceInfo(const sycl::context& context, const sycl::device&
 syclDeviceInfo::~syclDeviceInfo()
 {
 #if defined(ENABLE_OFFLOAD)
-  #pragma omp interop destroy(interop_)
+#pragma omp interop destroy(interop_)
 #endif
 }
 
@@ -128,7 +128,8 @@ SYCLDeviceManager::SYCLDeviceManager(int& default_device_num, int& num_devices, 
     else if (default_device_num != sycl_default_device_num)
       throw std::runtime_error("Inconsistent assigned SYCL devices with the previous record!");
     default_device_queue = std::make_unique<sycl::queue>(visible_devices[sycl_default_device_num].get_context(),
-                                                         visible_devices[sycl_default_device_num].get_device());
+                                                         visible_devices[sycl_default_device_num].get_device(),
+                                                         sycl::property::queue::in_order());
   }
 }
 
@@ -141,7 +142,8 @@ sycl::queue& SYCLDeviceManager::getDefaultDeviceDefaultQueue()
 
 sycl::queue SYCLDeviceManager::createQueueDefaultDevice() const
 {
-  return sycl::queue(visible_devices[sycl_default_device_num].get_context(), visible_devices[sycl_default_device_num].get_device());
+  return sycl::queue(visible_devices[sycl_default_device_num].get_context(),
+                     visible_devices[sycl_default_device_num].get_device(), sycl::property::queue::in_order());
 }
 
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes
It seems that matrix inversion in MKL fails when using default out-of-order queue. Switching to in-order queues makes `test_syclSolverInverter.cpp` to pass reliably. In-order queues add less burden on GPU runtime and should have lower latency. QMCPACK uses multiple queues and doesn't really need out-of-order queue to gain kernel parallelism.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
sunspot

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
