### PR TITLE
Nexus: Use simplices in convex_hull

### DIFF
--- a/nexus/lib/numerics.py
+++ b/nexus/lib/numerics.py
@@ -1386,7 +1386,11 @@ def convex_hull(points,dimension=None,tol=None):
             i = ns.index(-1)
             inds = all_inds.copy()
             inds[i] = False
-            v = tri.simplices[ni]
+            try:
+                v = tri.simplices[ni]
+            except:
+                v = tri.vertices[ni]
+            #end try
             if have_tol:
                 iv = list(range(d1))
                 iv.pop(i)

--- a/nexus/lib/numerics.py
+++ b/nexus/lib/numerics.py
@@ -1386,7 +1386,7 @@ def convex_hull(points,dimension=None,tol=None):
             i = ns.index(-1)
             inds = all_inds.copy()
             inds[i] = False
-            v = tri.vertices[ni]
+            v = tri.simplices[ni]
             if have_tol:
                 iv = list(range(d1))
                 iv.pop(i)


### PR DESCRIPTION
## Proposed changes

Closes #4670 

This looks to be a trivial fix ; vertices was removed in scipy 1.11.0 https://docs.scipy.org/doc/scipy/release/1.11.0-notes.html#expired-deprecations . However I did not yet find the version when simplices was introduced - is it old enough?

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

sulfur, nightly config

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
