### PR TITLE
RandomBase: use type alias FullPrecRealType instead of double.

### DIFF
--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -90,7 +90,7 @@ public:
                       Wavefunction& wfn_,
                       stdCMatrix&& h1_,
                       CVector&& vmf_,
-                      RandomBase<double>& r)
+                      RandomBase<RealType>& r)
       : AFQMCInfo(info),
         TG(tg_),
         buffer_manager(),
@@ -190,7 +190,7 @@ protected:
 
   CVector vMF;
 
-  RandomBase<double>& rng;
+  RandomBase<RealType>& rng;
 
   SlaterDetOperations* SDetOp;
 

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagator.h
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagator.h
@@ -56,7 +56,7 @@ public:
                              Wavefunction& wfn_,
                              stdCMatrix&& h1_,
                              CVector&& vmf_,
-                             RandomBase<double>& r)
+                             RandomBase<RealType>& r)
       : base(info, cur, tg_, wfn_, std::move(h1_), std::move(vmf_), r),
         core_comm(tg_.TG().split(tg_.getLocalTGRank(), tg_.TG().rank()))
   //            ,core_comm()

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.h
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.h
@@ -56,7 +56,7 @@ public:
                                    Wavefunction& wfn_,
                                    stdCMatrix&& h1_,
                                    CVector&& vmf_,
-                                   RandomBase<double>& r)
+                                   RandomBase<RealType>& r)
       : base(info, cur, tg_, wfn_, std::move(h1_), std::move(vmf_), r),
         bpX(iextensions<1u>{1}, shared_allocator<ComplexType>{TG.TG_local()}),
         req_Gsend(MPI_REQUEST_NULL),

--- a/src/AFQMC/Propagators/PropagatorFactory.cpp
+++ b/src/AFQMC/Propagators/PropagatorFactory.cpp
@@ -23,7 +23,7 @@ namespace afqmc
 Propagator PropagatorFactory::buildAFQMCPropagator(TaskGroup_& TG,
                                                    xmlNodePtr cur,
                                                    Wavefunction& wfn,
-                                                   RandomBase<double>& rng)
+                                                   RandomBase<RealType>& rng)
 {
   // allocator for local memory
   using allocator = device_allocator<ComplexType>;

--- a/src/AFQMC/Propagators/PropagatorFactory.h
+++ b/src/AFQMC/Propagators/PropagatorFactory.h
@@ -54,7 +54,7 @@ public:
   }
 
   // returns a pointer to the base Propagator class associated with a given ID
-  Propagator& getPropagator(TaskGroup_& TG, const std::string& ID, Wavefunction& wfn, RandomBase<double>& rng)
+  Propagator& getPropagator(TaskGroup_& TG, const std::string& ID, Wavefunction& wfn, RandomBase<RealType>& rng)
   {
     auto xml = xmlBlocks.find(ID);
     if (xml == xmlBlocks.end())
@@ -94,7 +94,7 @@ protected:
   std::map<std::string, AFQMCInfo>& InfoMap;
 
   // generates a new Propagator and returns the pointer to the base class
-  Propagator buildPropagator(TaskGroup_& TG, xmlNodePtr cur, Wavefunction& wfn, RandomBase<double>& rng)
+  Propagator buildPropagator(TaskGroup_& TG, xmlNodePtr cur, Wavefunction& wfn, RandomBase<RealType>& rng)
   {
     std::string type("afqmc");
     OhmmsAttributeSet oAttrib;
@@ -116,7 +116,7 @@ protected:
     return Propagator{};
   }
 
-  Propagator buildAFQMCPropagator(TaskGroup_& TG, xmlNodePtr cur, Wavefunction& wfn, RandomBase<double>& r);
+  Propagator buildAFQMCPropagator(TaskGroup_& TG, xmlNodePtr cur, Wavefunction& wfn, RandomBase<RealType>& r);
 
   std::map<std::string, xmlNodePtr> xmlBlocks;
 

--- a/src/AFQMC/Propagators/store/AFQMCDistributedPropagatorDistCV.h
+++ b/src/AFQMC/Propagators/store/AFQMCDistributedPropagatorDistCV.h
@@ -59,7 +59,7 @@ public:
                                    Wavefunction& wfn_,
                                    CMatrix&& h1_,
                                    CVector&& vmf_,
-                                   RandomBase<double>* r)
+                                   RandomBase<RealType>& r)
       : base(info, cur, tg_, wfn_, std::move(h1_), std::move(vmf_), r),
         req_Gsend(MPI_REQUEST_NULL),
         req_Grecv(MPI_REQUEST_NULL),

--- a/src/AFQMC/Walkers/SerialWalkerSet.hpp
+++ b/src/AFQMC/Walkers/SerialWalkerSet.hpp
@@ -44,7 +44,7 @@ class SerialWalkerSet : public WalkerSetBase<device_allocator<ComplexType>, devi
 
 public:
   /// constructor
-  SerialWalkerSet(afqmc::TaskGroup_& tg_, xmlNodePtr cur, AFQMCInfo& info, RandomBase<double>& r)
+  SerialWalkerSet(afqmc::TaskGroup_& tg_, xmlNodePtr cur, AFQMCInfo& info, RandomBase<RealType>& r)
       : Base(tg_, cur, info, r, device_allocator<ComplexType>{}, shared_allocator<ComplexType>{tg_.TG_local()})
   {}
 

--- a/src/AFQMC/Walkers/SharedWalkerSet.hpp
+++ b/src/AFQMC/Walkers/SharedWalkerSet.hpp
@@ -43,7 +43,7 @@ public:
   using Base = WalkerSetBase<shared_allocator<ComplexType>, ComplexType*>;
 
   /// constructor
-  SharedWalkerSet(afqmc::TaskGroup_& tg_, xmlNodePtr cur, AFQMCInfo& info, RandomBase<double>& r)
+  SharedWalkerSet(afqmc::TaskGroup_& tg_, xmlNodePtr cur, AFQMCInfo& info, RandomBase<RealType>& r)
       : Base(tg_,
              cur,
              info,

--- a/src/AFQMC/Walkers/WalkerSetBase.h
+++ b/src/AFQMC/Walkers/WalkerSetBase.h
@@ -90,7 +90,7 @@ public:
   WalkerSetBase(afqmc::TaskGroup_& tg_,
                 xmlNodePtr cur,
                 AFQMCInfo& info,
-                RandomBase<double>& r,
+                RandomBase<RealType>& r,
                 Allocator alloc_,
                 BPAllocator bpalloc_)
       : AFQMCInfo(info),
@@ -744,7 +744,7 @@ public:
 protected:
   afqmc::TaskGroup_& TG;
 
-  RandomBase<double>& rng;
+  RandomBase<RealType>& rng;
 
   int walker_size, walker_memory_usage;
   int bp_walker_size, bp_walker_memory_usage;

--- a/src/AFQMC/Walkers/WalkerSetFactory.hpp
+++ b/src/AFQMC/Walkers/WalkerSetFactory.hpp
@@ -46,7 +46,7 @@ public:
       return true;
   }
 
-  WalkerSet& getWalkerSet(TaskGroup_& TG, const std::string& ID, RandomBase<double>& rng)
+  WalkerSet& getWalkerSet(TaskGroup_& TG, const std::string& ID, RandomBase<RealType>& rng)
   {
     auto xml = xmlBlocks.find(ID);
     if (xml == xmlBlocks.end())
@@ -86,7 +86,7 @@ protected:
   std::map<std::string, AFQMCInfo>& InfoMap;
 
   // generates a new WalkerSet and returns the pointer to the base class
-  WalkerSet buildHandler(TaskGroup_& TG, xmlNodePtr cur, RandomBase<double>& rng)
+  WalkerSet buildHandler(TaskGroup_& TG, xmlNodePtr cur, RandomBase<RealType>& rng)
   {
     std::string type("shared");
     std::string info("info0");

--- a/src/Estimators/EstimatorManagerCrowd.cpp
+++ b/src/Estimators/EstimatorManagerCrowd.cpp
@@ -25,7 +25,7 @@ EstimatorManagerCrowd::EstimatorManagerCrowd(EstimatorManagerNew& em)
 void EstimatorManagerCrowd::accumulate(const RefVector<MCPWalker>& walkers,
                                        const RefVector<ParticleSet>& psets,
                                        const RefVector<TrialWaveFunction>& wfns,
-                                       RandomBase<double>& rng)
+                                       RandomBase<FullPrecRealType>& rng)
 {
   block_num_samples_ += walkers.size();
   for (MCPWalker& awalker : walkers)

--- a/src/Estimators/EstimatorManagerCrowd.h
+++ b/src/Estimators/EstimatorManagerCrowd.h
@@ -40,6 +40,7 @@ class EstimatorManagerCrowd
 public:
   using MCPWalker = Walker<QMCTraits, PtclOnLatticeTraits>;
   using RealType  = EstimatorManagerNew::RealType;
+  using FullPrecRealType = EstimatorManagerNew::FullPrecRealType;
 
   /** EstimatorManagerCrowd are always spawn of an EstimatorManagerNew
    */
@@ -77,7 +78,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
-                  RandomBase<double>& rng);
+                  RandomBase<FullPrecRealType>& rng);
 
   ScalarEstimatorBase& get_main_estimator() { return *main_estimator_; }
   RefVector<ScalarEstimatorBase> get_scalar_estimators() { return convertUPtrToRefVector(scalar_estimators_); }

--- a/src/Estimators/MagnetizationDensity.cpp
+++ b/src/Estimators/MagnetizationDensity.cpp
@@ -49,7 +49,7 @@ size_t MagnetizationDensity::getFullDataSize() { return npoints_ * DIM; }
 void MagnetizationDensity::accumulate(const RefVector<MCPWalker>& walkers,
                                       const RefVector<ParticleSet>& psets,
                                       const RefVector<TrialWaveFunction>& wfns,
-                                      RandomBase<double>& rng)
+                                      RandomBase<FullPrecReal>& rng)
 {
   for (int iw = 0; iw < walkers.size(); ++iw)
   {
@@ -241,7 +241,7 @@ MagnetizationDensity::Value MagnetizationDensity::integrateMagnetizationDensity(
 }
 
 void MagnetizationDensity::generateRandomGrid(std::vector<Real>& sgrid,
-                                              RandomBase<double>& rng,
+                                              RandomBase<FullPrecReal>& rng,
                                               Real start,
                                               Real stop) const
 {

--- a/src/Estimators/MagnetizationDensity.h
+++ b/src/Estimators/MagnetizationDensity.h
@@ -60,7 +60,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
-                  RandomBase<double>& rng) override;
+                  RandomBase<FullPrecReal>& rng) override;
 
   void collect(const RefVector<OperatorEstBase>& operator_estimators) override;
   /**
@@ -146,7 +146,7 @@ private:
   * @param[in] stop end of grid interval
   */
 
-  void generateRandomGrid(std::vector<Real>& sgrid, RandomBase<double>& rng, Real start, Real stop) const;
+  void generateRandomGrid(std::vector<Real>& sgrid, RandomBase<FullPrecReal>& rng, Real start, Real stop) const;
 
   /**
   * For a given spatial position r and spin component s, this returns the bin for accumulating the observable.

--- a/src/Estimators/MomentumDistribution.cpp
+++ b/src/Estimators/MomentumDistribution.cpp
@@ -234,7 +234,7 @@ void MomentumDistribution::startBlock(int steps)
 void MomentumDistribution::accumulate(const RefVector<MCPWalker>& walkers,
                                       const RefVector<ParticleSet>& psets,
                                       const RefVector<TrialWaveFunction>& wfns,
-                                      RandomBase<double>& rng)
+                                      RandomBase<FullPrecRealType>& rng)
 {
   for (int iw = 0; iw < walkers.size(); ++iw)
   {

--- a/src/Estimators/MomentumDistribution.h
+++ b/src/Estimators/MomentumDistribution.h
@@ -98,7 +98,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
-                  RandomBase<double>& rng) override;
+                  RandomBase<FullPrecRealType>& rng) override;
 
   /** this allows the EstimatorManagerNew to reduce without needing to know the details
    *  of MomentumDistribution's data.

--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -396,7 +396,7 @@ void OneBodyDensityMatrices::calcDensityDrift(const Position& r, Real& dens, Pos
 void OneBodyDensityMatrices::accumulate(const RefVector<MCPWalker>& walkers,
                                         const RefVector<ParticleSet>& psets,
                                         const RefVector<TrialWaveFunction>& wfns,
-                                        RandomBase<double>& rng)
+                                        RandomBase<FullPrecReal>& rng)
 {
   implAccumulate(walkers, psets, wfns, rng);
 }

--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -166,7 +166,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
-                  RandomBase<double>& rng) override;
+                  RandomBase<FullPrecReal>& rng) override;
 
   void startBlock(int steps) override;
 

--- a/src/Estimators/OperatorEstBase.h
+++ b/src/Estimators/OperatorEstBase.h
@@ -40,6 +40,7 @@ class OperatorEstBase
 {
 public:
   using QMCT      = QMCTraits;
+  using FullPrecRealType = QMCT::FullPrecRealType;
   using MCPWalker = Walker<QMCTraits, PtclOnLatticeTraits>;
 
   using Data = std::vector<QMCT::RealType>;
@@ -73,7 +74,7 @@ public:
   virtual void accumulate(const RefVector<MCPWalker>& walkers,
                           const RefVector<ParticleSet>& psets,
                           const RefVector<TrialWaveFunction>& wfns,
-                          RandomBase<double>& rng) = 0;
+                          RandomBase<FullPrecRealType>& rng) = 0;
 
   /** Reduce estimator result data from crowds to rank
    *

--- a/src/Estimators/PerParticleHamiltonianLogger.cpp
+++ b/src/Estimators/PerParticleHamiltonianLogger.cpp
@@ -59,7 +59,7 @@ void PerParticleHamiltonianLogger::write(CrowdLogValues& cl_values, const std::v
 void PerParticleHamiltonianLogger::accumulate(const RefVector<MCPWalker>& walkers,
                                               const RefVector<ParticleSet>& psets,
                                               const RefVector<TrialWaveFunction>& wfns,
-                                              RandomBase<double>& rng)
+                                              RandomBase<FullPrecRealType>& rng)
 
 {
   // The hamiltonian doesn't know the walker ID only its index in the walker elements of the crowd

--- a/src/Estimators/PerParticleHamiltonianLogger.h
+++ b/src/Estimators/PerParticleHamiltonianLogger.h
@@ -38,7 +38,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
-                  RandomBase<double>& rng) override;
+                  RandomBase<FullPrecRealType>& rng) override;
 
   UPtr<OperatorEstBase> spawnCrowdClone() const override;
   void startBlock(int steps) override;

--- a/src/Estimators/SpinDensityNew.cpp
+++ b/src/Estimators/SpinDensityNew.cpp
@@ -117,7 +117,7 @@ void SpinDensityNew::startBlock(int steps)
 void SpinDensityNew::accumulate(const RefVector<MCPWalker>& walkers,
                                 const RefVector<ParticleSet>& psets,
                                 const RefVector<TrialWaveFunction>& wfns,
-                                RandomBase<double>& rng)
+                                RandomBase<FullPrecRealType>& rng)
 {
   auto& dp_ = derived_parameters_;
   for (int iw = 0; iw < walkers.size(); ++iw)

--- a/src/Estimators/SpinDensityNew.h
+++ b/src/Estimators/SpinDensityNew.h
@@ -38,6 +38,7 @@ public:
   using POLT    = PtclOnLatticeTraits;
   using Lattice = POLT::ParticleLayout;
   using QMCT    = QMCTraits;
+  using FullPrecRealType = QMCT::FullPrecRealType;
 
   /** Constructor for SpinDensityNew that contains an explicitly defined cell
    *  part of legacy input handling, Deprecated
@@ -84,7 +85,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
-                  RandomBase<double>& rng) override;
+                  RandomBase<FullPrecRealType>& rng) override;
 
   /** this allows the EstimatorManagerNew to reduce without needing to know the details
    *  of SpinDensityNew's data.

--- a/src/Estimators/tests/FakeOperatorEstimator.h
+++ b/src/Estimators/tests/FakeOperatorEstimator.h
@@ -32,7 +32,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
-                  RandomBase<double>& rng) override
+                  RandomBase<FullPrecRealType>& rng) override
   {}
 
   void registerOperatorEstimator(hdf_archive& file) override {}

--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -280,7 +280,7 @@ TEST_CASE("OneBodyDensityMatrices::OneBodyDensityMatrices", "[estimators]")
   // make sure there is something in obdm's data
   OEBAccessor oeba(obdm);
   oeba[0] = 1.0;
-  testing::OneBodyDensityMatricesTests<double> obdmt;
+  testing::OneBodyDensityMatricesTests<QMCTraits::FullPrecRealType> obdmt;
   obdmt.testCopyConstructor(obdm);
 
   species_set = testing::makeSpeciesSet(SpeciesCases::NO_MEMBERSIZE);
@@ -317,10 +317,10 @@ TEST_CASE("OneBodyDensityMatrices::generateSamples", "[estimators]")
 
     OneBodyDensityMatrices obDenMat(std::move(obdmi), pset_target.getLattice(), species_set, spo_map, pset_target);
 
-    OneBodyDensityMatricesTests<double> obdmt;
+    OneBodyDensityMatricesTests<QMCTraits::FullPrecRealType> obdmt;
     //Get control over which rng is used.
     //we don't want FakeRandom.
-    StdRandom<double> rng;
+    StdRandom<OneBodyDensityMatrices::FullPrecRealType> rng;
     obdmt.testGenerateSamples(test_case, obDenMat, pset_target, rng);
   };
 
@@ -428,7 +428,7 @@ TEST_CASE("OneBodyDensityMatrices::accumulate", "[estimators]")
   for (int iw = 0; iw < nwalkers; ++iw)
     twfcs[iw] = trial_wavefunction.makeClone(psets[iw]);
 
-  StdRandom<double> rng;
+  StdRandom<OneBodyDensityMatrices::FullPrecRealType> rng;
   rng.init(101);
 
   auto updateWalker = [](auto& walker, auto& pset_target, auto& trial_wavefunction) {
@@ -445,7 +445,7 @@ TEST_CASE("OneBodyDensityMatrices::accumulate", "[estimators]")
   auto ref_psets(makeRefVector<ParticleSet>(psets));
   auto ref_twfcs(convertUPtrToRefVector(twfcs));
 
-  OneBodyDensityMatricesTests<double> obdmt;
+  OneBodyDensityMatricesTests<QMCTraits::FullPrecRealType> obdmt;
   obdmt.testAccumulate(obdm, ref_walkers, ref_psets, ref_twfcs, rng);
 
   if constexpr (dump_obdm)
@@ -493,7 +493,7 @@ TEST_CASE("OneBodyDensityMatrices::evaluateMatrix", "[estimators]")
         {3.173382998, 3.651777267, 2.970916748},  {1.576967478, 2.874752045, 3.687536716},
     };
 
-    StdRandom<double> rng;
+    StdRandom<OneBodyDensityMatrices::FullPrecRealType> rng;
     rng.init(101);
     MCPWalker walker;
     // Now we have to bring the pset, trial_wavefunction and walker to valid state.
@@ -502,7 +502,7 @@ TEST_CASE("OneBodyDensityMatrices::evaluateMatrix", "[estimators]")
     pset_target.donePbyP();
     trial_wavefunction.evaluateLog(pset_target);
     pset_target.saveWalker(walker);
-    OneBodyDensityMatricesTests<double> obdmt;
+    OneBodyDensityMatricesTests<QMCTraits::FullPrecRealType> obdmt;
     obdmt.testEvaluateMatrix(obdm, pset_target, trial_wavefunction, walker, rng);
     if constexpr (dump_obdm)
       obdmt.dumpData(obdm);
@@ -539,7 +539,7 @@ TEST_CASE("OneBodyDensityMatrices::registerAndWrite", "[estimators]")
   auto& species_set = pset_target.getSpeciesSet();
   OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, spomap, pset_target);
 
-  OneBodyDensityMatricesTests<double> obdmt;
+  OneBodyDensityMatricesTests<QMCTraits::FullPrecRealType> obdmt;
   obdmt.testRegisterAndWrite(obdm);
 }
 

--- a/src/Particle/ParticleBase/tests/test_random_seq.cpp
+++ b/src/Particle/ParticleBase/tests/test_random_seq.cpp
@@ -110,7 +110,7 @@ TEST_CASE("makeGaussRandomWithEngine(MCCoords...)", "[particle_base]")
   int size_test = 7;
   std::vector<double> gauss_random_vals(size_test * 3 + (size_test * 3) % 2 + size_test);
   {
-    StdRandom<double> rng;
+    StdRandom<QMCTraits::FullPrecRealType> rng;
     makeGaussRandomWithEngine(gauss_random_vals, rng);
   }
 
@@ -125,13 +125,13 @@ TEST_CASE("makeGaussRandomWithEngine(MCCoords...)", "[particle_base]")
 
   MCCoords<CoordsType::POS> mc_coords_rs(size_test);
   {
-    StdRandom<double> rng;
+    StdRandom<QMCTraits::FullPrecRealType> rng;
     makeGaussRandomWithEngine(mc_coords_rs, rng);
     checkRs(mc_coords_rs.positions);
   }
   MCCoords<CoordsType::POS_SPIN> mc_coords_rsspins(size_test);
   {
-    StdRandom<double> rng;
+    StdRandom<QMCTraits::FullPrecRealType> rng;
     makeGaussRandomWithEngine(mc_coords_rsspins, rng);
     checkRs(mc_coords_rsspins.positions);
     // Mod 2 is result of how gaussianDistribution is generated.

--- a/src/QMCDrivers/ContextForSteps.cpp
+++ b/src/QMCDrivers/ContextForSteps.cpp
@@ -14,6 +14,6 @@
 
 namespace qmcplusplus
 {
-ContextForSteps::ContextForSteps(RandomBase<double>& random_gen) : random_gen_(random_gen) {}
+ContextForSteps::ContextForSteps(RandomBase<FullPrecRealType>& random_gen) : random_gen_(random_gen) {}
 
 } // namespace qmcplusplus

--- a/src/QMCDrivers/ContextForSteps.h
+++ b/src/QMCDrivers/ContextForSteps.h
@@ -33,12 +33,13 @@ namespace qmcplusplus
 class ContextForSteps
 {
 public:
-  ContextForSteps(RandomBase<double>& random_gen);
+  using FullPrecRealType = QMCTraits::FullPrecRealType;
+  ContextForSteps(RandomBase<FullPrecRealType>& random_gen);
 
-  RandomBase<double>& get_random_gen() { return random_gen_; }
+  RandomBase<FullPrecRealType>& get_random_gen() { return random_gen_; }
 
 protected:
-  RandomBase<double>& random_gen_;
+  RandomBase<FullPrecRealType>& random_gen_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCDrivers/CorrelatedSampling/CSUpdateBase.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSUpdateBase.cpp
@@ -29,7 +29,7 @@ using WP = WalkerProperties::Indexes;
 CSUpdateBase::CSUpdateBase(MCWalkerConfiguration& w,
                            std::vector<TrialWaveFunction*>& psipool,
                            std::vector<QMCHamiltonian*>& hpool,
-                           RandomBase<double>& rg)
+                           RandomBase<FullPrecRealType>& rg)
     : QMCUpdateBase(w, *psipool[0], *hpool[0], rg), nPsi(0), useDriftOption("no"), H1(hpool), Psi1(psipool)
 {
   myParams.add(useDriftOption, "useDrift");

--- a/src/QMCDrivers/CorrelatedSampling/CSUpdateBase.h
+++ b/src/QMCDrivers/CorrelatedSampling/CSUpdateBase.h
@@ -30,7 +30,7 @@ public:
   CSUpdateBase(MCWalkerConfiguration& w,
                std::vector<TrialWaveFunction*>& psi,
                std::vector<QMCHamiltonian*>& h,
-               RandomBase<double>& rg);
+               RandomBase<FullPrecRealType>& rg);
 
   ~CSUpdateBase() override;
 

--- a/src/QMCDrivers/CorrelatedSampling/CSVMCUpdateAll.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMCUpdateAll.cpp
@@ -33,7 +33,7 @@ using WP = WalkerProperties::Indexes;
 CSVMCUpdateAll::CSVMCUpdateAll(MCWalkerConfiguration& w,
                                std::vector<TrialWaveFunction*>& psi,
                                std::vector<QMCHamiltonian*>& h,
-                               RandomBase<double>& rg)
+                               RandomBase<FullPrecRealType>& rg)
     : CSUpdateBase(w, psi, h, rg)
 {
   UpdatePbyP = false;
@@ -120,7 +120,7 @@ void CSVMCUpdateAll::advanceWalker(Walker_t& thisWalker, bool recompute)
 CSVMCUpdateAllWithDrift::CSVMCUpdateAllWithDrift(MCWalkerConfiguration& w,
                                                  std::vector<TrialWaveFunction*>& psi,
                                                  std::vector<QMCHamiltonian*>& h,
-                                                 RandomBase<double>& rg)
+                                                 RandomBase<FullPrecRealType>& rg)
     : CSUpdateBase(w, psi, h, rg)
 {
   UpdatePbyP = false;

--- a/src/QMCDrivers/CorrelatedSampling/CSVMCUpdateAll.h
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMCUpdateAll.h
@@ -36,7 +36,7 @@ public:
   CSVMCUpdateAll(MCWalkerConfiguration& w,
                  std::vector<TrialWaveFunction*>& psi,
                  std::vector<QMCHamiltonian*>& h,
-                 RandomBase<double>& rg);
+                 RandomBase<FullPrecRealType>& rg);
 
   void advanceWalker(Walker_t& thisWalker, bool recompute) override;
 
@@ -51,7 +51,7 @@ public:
   CSVMCUpdateAllWithDrift(MCWalkerConfiguration& w,
                           std::vector<TrialWaveFunction*>& psi,
                           std::vector<QMCHamiltonian*>& h,
-                          RandomBase<double>& rg);
+                          RandomBase<FullPrecRealType>& rg);
 
   void advanceWalker(Walker_t& thisWalker, bool recompute) override;
 

--- a/src/QMCDrivers/CorrelatedSampling/CSVMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMCUpdatePbyP.cpp
@@ -30,7 +30,7 @@ using WP = WalkerProperties::Indexes;
 CSVMCUpdatePbyP::CSVMCUpdatePbyP(MCWalkerConfiguration& w,
                                  std::vector<TrialWaveFunction*>& psi,
                                  std::vector<QMCHamiltonian*>& h,
-                                 RandomBase<double>& rg)
+                                 RandomBase<FullPrecRealType>& rg)
     : CSUpdateBase(w, psi, h, rg)
 {}
 
@@ -150,7 +150,7 @@ void CSVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
 CSVMCUpdatePbyPWithDriftFast::CSVMCUpdatePbyPWithDriftFast(MCWalkerConfiguration& w,
                                                            std::vector<TrialWaveFunction*>& psi,
                                                            std::vector<QMCHamiltonian*>& h,
-                                                           RandomBase<double>& rg)
+                                                           RandomBase<FullPrecRealType>& rg)
     : CSUpdateBase(w, psi, h, rg){APP_ABORT("CSVMCUpdatePbyPWithDriftFast currently not working.  Please eliminate \
              drift option, or choose all electron moves instead.")}
 

--- a/src/QMCDrivers/CorrelatedSampling/CSVMCUpdatePbyP.h
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMCUpdatePbyP.h
@@ -28,7 +28,7 @@ public:
   CSVMCUpdatePbyP(MCWalkerConfiguration& w,
                   std::vector<TrialWaveFunction*>& psi,
                   std::vector<QMCHamiltonian*>& h,
-                  RandomBase<double>& rg);
+                  RandomBase<FullPrecRealType>& rg);
 
   ~CSVMCUpdatePbyP() override;
 
@@ -47,7 +47,7 @@ public:
   CSVMCUpdatePbyPWithDriftFast(MCWalkerConfiguration& w,
                                std::vector<TrialWaveFunction*>& psi,
                                std::vector<QMCHamiltonian*>& h,
-                               RandomBase<double>& rg);
+                               RandomBase<FullPrecRealType>& rg);
 
   ~CSVMCUpdatePbyPWithDriftFast() override;
 

--- a/src/QMCDrivers/Crowd.cpp
+++ b/src/QMCDrivers/Crowd.cpp
@@ -68,7 +68,7 @@ void Crowd::addWalker(MCPWalker& walker, ParticleSet& elecs, TrialWaveFunction& 
   walker_hamiltonians_.push_back(hamiltonian);
 };
 
-void Crowd::setRNGForHamiltonian(RandomBase<double>& rng)
+void Crowd::setRNGForHamiltonian(RandomBase<FullPrecRealType>& rng)
 {
   for (QMCHamiltonian& ham : walker_hamiltonians_)
     ham.setRandomGenerator(&rng);

--- a/src/QMCDrivers/Crowd.h
+++ b/src/QMCDrivers/Crowd.h
@@ -76,14 +76,14 @@ public:
    */
   void clearWalkers();
 
-  void accumulate(RandomBase<double>& rng)
+  void accumulate(RandomBase<FullPrecRealType>& rng)
   {
     if (this->size() == 0)
       return;
     estimator_manager_crowd_.accumulate(mcp_walkers_, walker_elecs_, walker_twfs_, rng);
   }
 
-  void setRNGForHamiltonian(RandomBase<double>& rng);
+  void setRNGForHamiltonian(RandomBase<FullPrecRealType>& rng);
 
   auto beginWalkers() { return mcp_walkers_.begin(); }
   auto endWalkers() { return mcp_walkers_.end(); }

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -130,7 +130,7 @@ void DMC::resetUpdateEngines()
       traceClones[ip] = Traces->makeClone();
 #endif
 #ifdef USE_FAKE_RNG
-      Rng[ip] = std::make_unique<FakeRandom<double>>();
+      Rng[ip] = std::make_unique<FakeRandom<QMCTraits::FullPrecRealType>>();
 #else
       Rng[ip] = RandomNumberControl::Children[ip]->clone();
       hClones[ip]->setRandomGenerator(Rng[ip].get());

--- a/src/QMCDrivers/DMC/DMCUpdateAll.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdateAll.cpp
@@ -26,7 +26,7 @@ using WP = WalkerProperties::Indexes;
 DMCUpdateAllWithRejection::DMCUpdateAllWithRejection(MCWalkerConfiguration& w,
                                                      TrialWaveFunction& psi,
                                                      QMCHamiltonian& h,
-                                                     RandomBase<double>& rg)
+                                                     RandomBase<FullPrecRealType>& rg)
     : QMCUpdateBase(w, psi, h, rg)
 {
   UpdatePbyP = false;
@@ -138,7 +138,7 @@ void DMCUpdateAllWithRejection::advanceWalker(Walker_t& thisWalker, bool recompu
 DMCUpdateAllWithKill::DMCUpdateAllWithKill(MCWalkerConfiguration& w,
                                            TrialWaveFunction& psi,
                                            QMCHamiltonian& h,
-                                           RandomBase<double>& rg)
+                                           RandomBase<FullPrecRealType>& rg)
     : QMCUpdateBase(w, psi, h, rg)
 {
   UpdatePbyP = false;

--- a/src/QMCDrivers/DMC/DMCUpdateAll.h
+++ b/src/QMCDrivers/DMC/DMCUpdateAll.h
@@ -23,7 +23,7 @@ public:
   DMCUpdateAllWithRejection(MCWalkerConfiguration& w,
                             TrialWaveFunction& psi,
                             QMCHamiltonian& h,
-                            RandomBase<double>& rg);
+                            RandomBase<FullPrecRealType>& rg);
   ///destructor
   ~DMCUpdateAllWithRejection() override;
 
@@ -39,7 +39,10 @@ class DMCUpdateAllWithKill : public QMCUpdateBase
 {
 public:
   /// Constructor.
-  DMCUpdateAllWithKill(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomBase<double>& rg);
+  DMCUpdateAllWithKill(MCWalkerConfiguration& w,
+                       TrialWaveFunction& psi,
+                       QMCHamiltonian& h,
+                       RandomBase<FullPrecRealType>& rg);
   ///destructor
   ~DMCUpdateAllWithKill() override;
 

--- a/src/QMCDrivers/DMC/DMCUpdatePbyP.h
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyP.h
@@ -26,7 +26,7 @@ public:
   DMCUpdatePbyPWithRejectionFast(MCWalkerConfiguration& w,
                                  TrialWaveFunction& psi,
                                  QMCHamiltonian& h,
-                                 RandomBase<double>& rg);
+                                 RandomBase<FullPrecRealType>& rg);
   ///destructor
   ~DMCUpdatePbyPWithRejectionFast() override;
 

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
@@ -42,7 +42,7 @@ TimerNameList_t<DMCTimers> DMCTimerNames = {{DMC_buffer, "DMCUpdatePbyP::Buffer"
 DMCUpdatePbyPWithRejectionFast::DMCUpdatePbyPWithRejectionFast(MCWalkerConfiguration& w,
                                                                TrialWaveFunction& psi,
                                                                QMCHamiltonian& h,
-                                                               RandomBase<double>& rg)
+                                                               RandomBase<FullPrecRealType>& rg)
     : QMCUpdateBase(w, psi, h, rg), myTimers(getGlobalTimerManager(), DMCTimerNames, timer_level_medium)
 {}
 

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPL2.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPL2.cpp
@@ -36,7 +36,7 @@ using WP = WalkerProperties::Indexes;
 DMCUpdatePbyPL2::DMCUpdatePbyPL2(MCWalkerConfiguration& w,
                                  TrialWaveFunction& psi,
                                  QMCHamiltonian& h,
-                                 RandomBase<double>& rg)
+                                 RandomBase<FullPrecRealType>& rg)
     : QMCUpdateBase(w, psi, h, rg), myTimers(getGlobalTimerManager(), DMCTimerNames, timer_level_medium)
 {}
 

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPL2.h
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPL2.h
@@ -24,7 +24,10 @@ class DMCUpdatePbyPL2 : public QMCUpdateBase
 {
 public:
   /// Constructor.
-  DMCUpdatePbyPL2(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomBase<double>& rg);
+  DMCUpdatePbyPL2(MCWalkerConfiguration& w,
+                  TrialWaveFunction& psi,
+                  QMCHamiltonian& h,
+                  RandomBase<FullPrecRealType>& rg);
   ///destructor
   ~DMCUpdatePbyPL2() override;
 

--- a/src/QMCDrivers/DMC/SODMCUpdatePbyP.h
+++ b/src/QMCDrivers/DMC/SODMCUpdatePbyP.h
@@ -23,7 +23,7 @@ public:
   SODMCUpdatePbyPWithRejectionFast(MCWalkerConfiguration& w,
                                    TrialWaveFunction& psi,
                                    QMCHamiltonian& h,
-                                   RandomBase<double>& rg);
+                                   RandomBase<FullPrecRealType>& rg);
   ///destructor
   ~SODMCUpdatePbyPWithRejectionFast() override;
 

--- a/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
@@ -39,7 +39,7 @@ const TimerNameList_t<SODMCTimers> SODMCTimerNames = {{SODMC_buffer, "SODMCUpdat
 SODMCUpdatePbyPWithRejectionFast::SODMCUpdatePbyPWithRejectionFast(MCWalkerConfiguration& w,
                                                                    TrialWaveFunction& psi,
                                                                    QMCHamiltonian& h,
-                                                                   RandomBase<double>& rg)
+                                                                   RandomBase<FullPrecRealType>& rg)
     : QMCUpdateBase(w, psi, h, rg), myTimers(getGlobalTimerManager(), SODMCTimerNames, timer_level_medium)
 
 {}

--- a/src/QMCDrivers/DMC/WalkerControl.cpp
+++ b/src/QMCDrivers/DMC/WalkerControl.cpp
@@ -54,7 +54,7 @@ TimerNameList_t<WC_Timers> WalkerControlTimerNames = {{WC_branch, "WalkerControl
                                                       {WC_send, "WalkerControl::send"},
                                                       {WC_recv, "WalkerControl::recv"}};
 
-WalkerControl::WalkerControl(Communicate* c, RandomBase<double>& rng, bool use_fixed_pop)
+WalkerControl::WalkerControl(Communicate* c, RandomBase<FullPrecRealType>& rng, bool use_fixed_pop)
     : MPIObjectBase(c),
       rng_(rng),
       use_fixed_pop_(use_fixed_pop),

--- a/src/QMCDrivers/DMC/WalkerControl.h
+++ b/src/QMCDrivers/DMC/WalkerControl.h
@@ -53,7 +53,7 @@ public:
    *
    * Set the SwapMode to zero so that instantiation can be done
    */
-  WalkerControl(Communicate* c, RandomBase<double>& rng, bool use_fixed_pop = false);
+  WalkerControl(Communicate* c, RandomBase<FullPrecRealType>& rng, bool use_fixed_pop = false);
 
   /** empty destructor to clean up the derived classes */
   ~WalkerControl();
@@ -141,7 +141,7 @@ private:
   };
 
   ///random number generator
-  RandomBase<double>& rng_;
+  RandomBase<FullPrecRealType>& rng_;
   ///if true, use fixed population
   bool use_fixed_pop_;
   ///minimum number of walkers

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -81,6 +81,8 @@ public:
 
   using Walker_t = MCWalkerConfiguration::Walker_t;
   using Buffer_t = Walker_t::Buffer_t;
+  using FullPrecRealType = QMCTraits::FullPrecRealType;
+
   /** bits to classify QMCDriver
    *
    * - qmc_driver_mode[QMC_UPDATE_MODE]? particle-by-particle: walker-by-walker
@@ -183,16 +185,16 @@ public:
   std::unique_ptr<TraceManager> Traces;
 
   ///return the random generators
-  inline RefVector<RandomBase<double>> getRngRefs() const
+  inline RefVector<RandomBase<FullPrecRealType>> getRngRefs() const
   {
-    RefVector<RandomBase<double>> RngRefs;
+    RefVector<RandomBase<FullPrecRealType>> RngRefs;
     for (int i = 0; i < Rng.size(); ++i)
       RngRefs.push_back(*Rng[i]);
     return RngRefs;
   }
 
   ///return the i-th random generator
-  inline RandomBase<double>& getRng(int i) override { return (*Rng[i]); }
+  inline RandomBase<FullPrecRealType>& getRng(int i) override { return (*Rng[i]); }
 
   unsigned long getDriverMode() override { return qmc_driver_mode.to_ulong(); }
 
@@ -323,7 +325,7 @@ protected:
   std::vector<QMCHamiltonian*> H1;
 
   ///Random number generators
-  UPtrVector<RandomBase<double>> Rng;
+  UPtrVector<RandomBase<FullPrecRealType>> Rng;
 
   ///a list of mcwalkerset element
   std::vector<xmlNodePtr> mcwalkerNodePtr;

--- a/src/QMCDrivers/QMCDriverInterface.h
+++ b/src/QMCDrivers/QMCDriverInterface.h
@@ -34,13 +34,13 @@ class QMCDriverInterface
 {
 public:
   using BranchEngineType = SimpleFixedNodeBranch;
-
+  using FullPrecRealType              = QMCTraits::FullPrecRealType;
   virtual bool run()                  = 0;
   virtual bool put(xmlNodePtr cur)    = 0;
   virtual void recordBlock(int block) = 0;
 
   ///return the i-th random generator
-  virtual RandomBase<double>& getRng(int i) = 0;
+  virtual RandomBase<FullPrecRealType>& getRng(int i) = 0;
 
   virtual void setStatus(const std::string& aname, const std::string& h5name, bool append) = 0;
 

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -192,16 +192,16 @@ public:
 
   void putWalkers(std::vector<xmlNodePtr>& wset) override;
 
-  inline RefVector<RandomBase<double>> getRngRefs() const
+  inline RefVector<RandomBase<FullPrecRealType>> getRngRefs() const
   {
-    RefVector<RandomBase<double>> RngRefs;
+    RefVector<RandomBase<FullPrecRealType>> RngRefs;
     for (int i = 0; i < Rng.size(); ++i)
       RngRefs.push_back(*Rng[i]);
     return RngRefs;
   }
 
   ///return the i-th random generator
-  inline RandomBase<double>& getRng(int i) override { return (*Rng[i]); }
+  inline RandomBase<FullPrecRealType>& getRng(int i) override { return (*Rng[i]); }
 
   /** intended for logging output and debugging
    *  you should base behavior on type preferably at compile time or if
@@ -426,7 +426,7 @@ protected:
   std::vector<std::unique_ptr<ContextForSteps>> step_contexts_;
 
   ///Random number generators
-  UPtrVector<RandomBase<double>> Rng;
+  UPtrVector<RandomBase<FullPrecRealType>> Rng;
 
   ///a list of mcwalkerset element
   std::vector<xmlNodePtr> mcwalkerNodePtr;

--- a/src/QMCDrivers/QMCUpdateBase.cpp
+++ b/src/QMCDrivers/QMCUpdateBase.cpp
@@ -34,7 +34,7 @@ QMCUpdateBase::QMCUpdateBase(MCWalkerConfiguration& w,
                              TrialWaveFunction& psi,
                              TrialWaveFunction& guide,
                              QMCHamiltonian& h,
-                             RandomBase<double>& rg)
+                             RandomBase<FullPrecRealType>& rg)
     : csoffset(0),
       Traces(0),
       W(w),
@@ -54,7 +54,7 @@ QMCUpdateBase::QMCUpdateBase(MCWalkerConfiguration& w,
 QMCUpdateBase::QMCUpdateBase(MCWalkerConfiguration& w,
                              TrialWaveFunction& psi,
                              QMCHamiltonian& h,
-                             RandomBase<double>& rg)
+                             RandomBase<FullPrecRealType>& rg)
     : csoffset(0),
       Traces(0),
       W(w),

--- a/src/QMCDrivers/QMCUpdateBase.h
+++ b/src/QMCDrivers/QMCUpdateBase.h
@@ -78,13 +78,13 @@ public:
   bool UseDrift;
 
   /// Constructor.
-  QMCUpdateBase(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomBase<double>& rg);
+  QMCUpdateBase(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomBase<FullPrecRealType>& rg);
   ///Alt Constructor.
   QMCUpdateBase(MCWalkerConfiguration& w,
                 TrialWaveFunction& psi,
                 TrialWaveFunction& guide,
                 QMCHamiltonian& h,
-                RandomBase<double>& rg);
+                RandomBase<FullPrecRealType>& rg);
   ///destructor
   virtual ~QMCUpdateBase();
 
@@ -263,7 +263,7 @@ protected:
   ///Hamiltonian
   QMCHamiltonian& H;
   ///random number generator
-  RandomBase<double>& RandomGen;
+  RandomBase<FullPrecRealType>& RandomGen;
   ///branch engine, stateless reference to the one in QMCDriver
   const BranchEngineType* branchEngine;
   ///drift modifer, stateless reference to the one in QMCDriver

--- a/src/QMCDrivers/RMC/RMCUpdateAll.cpp
+++ b/src/QMCDrivers/RMC/RMCUpdateAll.cpp
@@ -40,7 +40,7 @@ using WP = WalkerProperties::Indexes;
 RMCUpdateAllWithDrift::RMCUpdateAllWithDrift(MCWalkerConfiguration& w,
                                              TrialWaveFunction& psi,
                                              QMCHamiltonian& h,
-                                             RandomBase<double>& rg,
+                                             RandomBase<FullPrecRealType>& rg,
                                              std::vector<int> act,
                                              std::vector<int> tp)
     : QMCUpdateBase(w, psi, h, rg), Action(act), TransProb(tp)

--- a/src/QMCDrivers/RMC/RMCUpdateAll.h
+++ b/src/QMCDrivers/RMC/RMCUpdateAll.h
@@ -34,7 +34,7 @@ public:
   RMCUpdateAllWithDrift(MCWalkerConfiguration& w,
                         TrialWaveFunction& psi,
                         QMCHamiltonian& h,
-                        RandomBase<double>& rg,
+                        RandomBase<FullPrecRealType>& rg,
                         std::vector<int> act,
                         std::vector<int> tp);
   ~RMCUpdateAllWithDrift() override;

--- a/src/QMCDrivers/RMC/RMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/RMC/RMCUpdatePbyP.cpp
@@ -40,7 +40,7 @@ using WP = WalkerProperties::Indexes;
 RMCUpdatePbyPWithDrift::RMCUpdatePbyPWithDrift(MCWalkerConfiguration& w,
                                                TrialWaveFunction& psi,
                                                QMCHamiltonian& h,
-                                               RandomBase<double>& rg,
+                                               RandomBase<FullPrecRealType>& rg,
                                                std::vector<int> act,
                                                std::vector<int> tp)
     : QMCUpdateBase(w, psi, h, rg),

--- a/src/QMCDrivers/RMC/RMCUpdatePbyP.h
+++ b/src/QMCDrivers/RMC/RMCUpdatePbyP.h
@@ -28,7 +28,7 @@ public:
   RMCUpdatePbyPWithDrift(MCWalkerConfiguration& w,
                          TrialWaveFunction& psi,
                          QMCHamiltonian& h,
-                         RandomBase<double>& rg,
+                         RandomBase<FullPrecRealType>& rg,
                          std::vector<int> act,
                          std::vector<int> tp);
   ~RMCUpdatePbyPWithDrift() override;

--- a/src/QMCDrivers/VMC/SOVMCUpdateAll.cpp
+++ b/src/QMCDrivers/VMC/SOVMCUpdateAll.cpp
@@ -24,7 +24,7 @@ using WP = WalkerProperties::Indexes;
 SOVMCUpdateAll::SOVMCUpdateAll(MCWalkerConfiguration& w,
                                TrialWaveFunction& psi,
                                QMCHamiltonian& h,
-                               RandomBase<double>& rg)
+                               RandomBase<FullPrecRealType>& rg)
     : QMCUpdateBase(w, psi, h, rg)
 {
   UpdatePbyP = false;

--- a/src/QMCDrivers/VMC/SOVMCUpdateAll.h
+++ b/src/QMCDrivers/VMC/SOVMCUpdateAll.h
@@ -20,7 +20,7 @@ class SOVMCUpdateAll : public QMCUpdateBase
 {
 public:
   /// Constructor.
-  SOVMCUpdateAll(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomBase<double>& rg);
+  SOVMCUpdateAll(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomBase<FullPrecRealType>& rg);
 
   ~SOVMCUpdateAll() override;
 

--- a/src/QMCDrivers/VMC/SOVMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/VMC/SOVMCUpdatePbyP.cpp
@@ -26,7 +26,7 @@ namespace qmcplusplus
 SOVMCUpdatePbyP::SOVMCUpdatePbyP(MCWalkerConfiguration& w,
                                  TrialWaveFunction& psi,
                                  QMCHamiltonian& h,
-                                 RandomBase<double>& rg)
+                                 RandomBase<FullPrecRealType>& rg)
     : QMCUpdateBase(w, psi, h, rg),
       buffer_timer_(createGlobalTimer("SOVMCUpdatePbyP::Buffer", timer_level_medium)),
       movepbyp_timer_(createGlobalTimer("SOVMCUpdatePbyP::MovePbyP", timer_level_medium)),

--- a/src/QMCDrivers/VMC/SOVMCUpdatePbyP.h
+++ b/src/QMCDrivers/VMC/SOVMCUpdatePbyP.h
@@ -23,7 +23,10 @@ class SOVMCUpdatePbyP : public QMCUpdateBase
 {
 public:
   /// Constructor.
-  SOVMCUpdatePbyP(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomBase<double>& rg);
+  SOVMCUpdatePbyP(MCWalkerConfiguration& w,
+                  TrialWaveFunction& psi,
+                  QMCHamiltonian& h,
+                  RandomBase<FullPrecRealType>& rg);
 
   ~SOVMCUpdatePbyP() override;
 

--- a/src/QMCDrivers/VMC/VMCUpdateAll.cpp
+++ b/src/QMCDrivers/VMC/VMCUpdateAll.cpp
@@ -21,7 +21,10 @@ namespace qmcplusplus
 {
 using WP = WalkerProperties::Indexes;
 
-VMCUpdateAll::VMCUpdateAll(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomBase<double>& rg)
+VMCUpdateAll::VMCUpdateAll(MCWalkerConfiguration& w,
+                           TrialWaveFunction& psi,
+                           QMCHamiltonian& h,
+                           RandomBase<FullPrecRealType>& rg)
     : QMCUpdateBase(w, psi, h, rg)
 {
   UpdatePbyP = false;

--- a/src/QMCDrivers/VMC/VMCUpdateAll.h
+++ b/src/QMCDrivers/VMC/VMCUpdateAll.h
@@ -25,7 +25,7 @@ class VMCUpdateAll : public QMCUpdateBase
 {
 public:
   /// Constructor.
-  VMCUpdateAll(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomBase<double>& rg);
+  VMCUpdateAll(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomBase<FullPrecRealType>& rg);
 
   ~VMCUpdateAll() override;
 

--- a/src/QMCDrivers/VMC/VMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/VMC/VMCUpdatePbyP.cpp
@@ -30,7 +30,7 @@ namespace qmcplusplus
 VMCUpdatePbyP::VMCUpdatePbyP(MCWalkerConfiguration& w,
                              TrialWaveFunction& psi,
                              QMCHamiltonian& h,
-                             RandomBase<double>& rg)
+                             RandomBase<FullPrecRealType>& rg)
     : QMCUpdateBase(w, psi, h, rg),
       buffer_timer_(createGlobalTimer("VMCUpdatePbyP::Buffer", timer_level_medium)),
       movepbyp_timer_(createGlobalTimer("VMCUpdatePbyP::MovePbyP", timer_level_medium)),

--- a/src/QMCDrivers/VMC/VMCUpdatePbyP.h
+++ b/src/QMCDrivers/VMC/VMCUpdatePbyP.h
@@ -26,7 +26,7 @@ class VMCUpdatePbyP : public QMCUpdateBase
 {
 public:
   /// Constructor.
-  VMCUpdatePbyP(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomBase<double>& rg);
+  VMCUpdatePbyP(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomBase<FullPrecRealType>& rg);
 
   ~VMCUpdatePbyP() override;
 

--- a/src/QMCDrivers/WFOpt/CostFunctionCrowdData.cpp
+++ b/src/QMCDrivers/WFOpt/CostFunctionCrowdData.cpp
@@ -19,7 +19,7 @@ CostFunctionCrowdData::CostFunctionCrowdData(int crowd_size,
                                              ParticleSet& P,
                                              TrialWaveFunction& Psi,
                                              QMCHamiltonian& H,
-                                             RandomBase<double>& Rng)
+                                             RandomBase<FullPrecRealType>& Rng)
     : h0_res_("h0 resource"), e0_(0.0), e2_(0.0), wgt_(0.0), wgt2_(0.0)
 {
   P.createResource(driverwalker_resource_collection_.pset_res);

--- a/src/QMCDrivers/WFOpt/CostFunctionCrowdData.h
+++ b/src/QMCDrivers/WFOpt/CostFunctionCrowdData.h
@@ -29,13 +29,13 @@ class CostFunctionCrowdData
 {
 public:
   using Return_rt = qmcplusplus::QMCTraits::RealType;
-
+  using FullPrecRealType = QMCTraits::FullPrecRealType;
   /// Create the arrays of crowd_size and create object copies
   CostFunctionCrowdData(int crowd_size,
                         ParticleSet& P,
                         TrialWaveFunction& Psi,
                         QMCHamiltonian& H,
-                        RandomBase<double>& Rng);
+                        RandomBase<FullPrecRealType>& Rng);
 
   /// Set the log_psi_* arrays to zero
   void zero_log_psi();
@@ -48,8 +48,8 @@ public:
   std::vector<Return_rt>& get_log_psi_fixed() { return log_psi_fixed_; }
   std::vector<Return_rt>& get_log_psi_opt() { return log_psi_opt_; }
 
-  UPtrVector<RandomBase<double>>& get_rng_ptr_list() { return rng_ptr_list_; }
-  RandomBase<double>& get_rng_save() { return *rng_save_ptr_; }
+  UPtrVector<RandomBase<FullPrecRealType>>& get_rng_ptr_list() { return rng_ptr_list_; }
+  RandomBase<FullPrecRealType>& get_rng_save() { return *rng_save_ptr_; }
 
   UPtrVector<TrialWaveFunction>& get_wf_ptr_list() { return wf_ptr_list_; }
 
@@ -72,7 +72,7 @@ private:
   UPtrVector<ParticleSet> p_ptr_list_;
   UPtrVector<QMCHamiltonian> h_ptr_list_;
   UPtrVector<QMCHamiltonian> h0_ptr_list_;
-  UPtrVector<RandomBase<double>> rng_ptr_list_;
+  UPtrVector<RandomBase<FullPrecRealType>> rng_ptr_list_;
 
   // proivides multi walker resource
   DriverWalkerResourceCollection driverwalker_resource_collection_;
@@ -81,7 +81,7 @@ private:
   ResourceCollection h0_res_;
 
   // Saved RNG state to reset to before correlated sampling
-  std::unique_ptr<RandomBase<double>> rng_save_ptr_;
+  std::unique_ptr<RandomBase<FullPrecRealType>> rng_save_ptr_;
 
   // Crowd-local accumulator variables
   Return_rt e0_;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -83,7 +83,7 @@ QMCCostFunctionBase::~QMCCostFunctionBase()
   debug_stream.reset();
 }
 
-void QMCCostFunctionBase::setRng(RefVector<RandomBase<double>> r)
+void QMCCostFunctionBase::setRng(RefVector<RandomBase<FullPrecRealType>> r)
 {
   if (MoverRng.size() < r.size())
   {

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -69,7 +69,7 @@ public:
   };
 
   using EffectiveWeight = QMCTraits::QTFull::RealType;
-
+  using FullPrecRealType = QMCTraits::FullPrecRealType;
   ///Constructor.
   QMCCostFunctionBase(ParticleSet& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm);
 
@@ -154,7 +154,7 @@ public:
 
 #endif
 
-  void setRng(RefVector<RandomBase<double>> r);
+  void setRng(RefVector<RandomBase<FullPrecRealType>> r);
 
   inline bool getneedGrads() const { return needGrads; }
 
@@ -262,7 +262,7 @@ protected:
   xmlNodePtr m_wfPtr;
   ///document node to be dumped
   xmlDocPtr m_doc_out;
-  ///parameters to be updated
+  ///parameters to be updated`
   std::map<std::string, xmlNodePtr> paramNodes;
   ///coefficients to be updated
   std::map<std::string, xmlNodePtr> coeffNodes;
@@ -272,8 +272,8 @@ protected:
   std::string RootName;
 
   ///Random number generators
-  UPtrVector<RandomBase<double>> RngSaved;
-  std::vector<RandomBase<double>*> MoverRng;
+  UPtrVector<RandomBase<FullPrecRealType>> RngSaved;
+  std::vector<RandomBase<FullPrecRealType>*> MoverRng;
 
   /// optimized parameter names
   std::vector<std::string> variational_subset_names;

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -516,7 +516,7 @@ void DensityMatrices1B::getRequiredTraces(TraceManager& tm)
 }
 
 
-void DensityMatrices1B::setRandomGenerator(RandomBase<double>* rng) { uniform_random = rng; }
+void DensityMatrices1B::setRandomGenerator(RandomBase<FullPrecRealType>* rng) { uniform_random = rng; }
 
 
 void DensityMatrices1B::addObservables(PropertySetType& plist, BufferType& collectables)
@@ -959,7 +959,7 @@ inline void DensityMatrices1B::generate_samples(RealType weight, int steps)
 }
 
 
-inline void DensityMatrices1B::generate_uniform_grid(RandomBase<double>& rng)
+inline void DensityMatrices1B::generate_uniform_grid(RandomBase<FullPrecRealType>& rng)
 {
   PosType rp;
   PosType ushift = 0.0;
@@ -981,7 +981,7 @@ inline void DensityMatrices1B::generate_uniform_grid(RandomBase<double>& rng)
 }
 
 
-inline void DensityMatrices1B::generate_uniform_samples(RandomBase<double>& rng)
+inline void DensityMatrices1B::generate_uniform_samples(RandomBase<FullPrecRealType>& rng)
 {
   PosType rp;
   for (int s = 0; s < samples; ++s)
@@ -993,7 +993,7 @@ inline void DensityMatrices1B::generate_uniform_samples(RandomBase<double>& rng)
 }
 
 
-inline void DensityMatrices1B::generate_density_samples(bool save, int steps, RandomBase<double>& rng)
+inline void DensityMatrices1B::generate_density_samples(bool save, int steps, RandomBase<FullPrecRealType>& rng)
 {
   RealType sqt = std::sqrt(timestep);
   RealType ot  = 1.0 / timestep;

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -140,7 +140,7 @@ public:
   PosType dpcur;
   RealType rhocur;
 
-  RandomBase<double>* uniform_random;
+  RandomBase<FullPrecRealType>* uniform_random;
 
 
   //constructor/destructor
@@ -157,7 +157,7 @@ public:
 
   //optional standard interface
   void getRequiredTraces(TraceManager& tm) override;
-  void setRandomGenerator(RandomBase<double>* rng) override;
+  void setRandomGenerator(RandomBase<FullPrecRealType>* rng) override;
 
   //required for Collectables interface
   void addObservables(PropertySetType& plist, BufferType& olist) override;
@@ -188,9 +188,9 @@ public:
   //  sample generation
   void warmup_sampling();
   void generate_samples(RealType weight, int steps = 0);
-  void generate_uniform_grid(RandomBase<double>& rng);
-  void generate_uniform_samples(RandomBase<double>& rng);
-  void generate_density_samples(bool save, int steps, RandomBase<double>& rng);
+  void generate_uniform_grid(RandomBase<FullPrecRealType>& rng);
+  void generate_uniform_samples(RandomBase<FullPrecRealType>& rng);
+  void generate_density_samples(bool save, int steps, RandomBase<FullPrecRealType>& rng);
   void diffusion(RealType sqt, PosType& diff);
   void density_only(const PosType& r, RealType& dens);
   void density_drift(const PosType& r, RealType& dens, PosType& drift);

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -449,7 +449,7 @@ void MomentumEstimator::resize(const std::vector<PosType>& kin, const int Min)
     phases_vPos[im].resize(kPoints.size());
 }
 
-void MomentumEstimator::setRandomGenerator(RandomBase<double>* rng)
+void MomentumEstimator::setRandomGenerator(RandomBase<FullPrecRealType>* rng)
 {
   //simply copy it
   myRNG = rng->clone();

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -36,7 +36,7 @@ public:
   bool put(xmlNodePtr cur) override { return false; };
   bool get(std::ostream& os) const override;
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
-  void setRandomGenerator(RandomBase<double>* rng) override;
+  void setRandomGenerator(RandomBase<FullPrecRealType>* rng) override;
   //resize the internal data by input k-point list
   void resize(const std::vector<PosType>& kin, const int Min);
   ///number of samples
@@ -48,7 +48,7 @@ public:
   ///normalization factor for n(k)
   RealType norm_nofK;
   ///random generator
-  std::unique_ptr<RandomBase<double>> myRNG;
+  std::unique_ptr<RandomBase<FullPrecRealType>> myRNG;
   ///sample positions
   std::vector<PosType> vPos;
   ///wavefunction ratios

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -151,7 +151,7 @@ public:
   /** set the internal RNG pointer as the given pointer
    * @param rng input RNG pointer
    */
-  void setRandomGenerator(RandomBase<double>* rng) override { myRNG = rng; }
+  void setRandomGenerator(RandomBase<FullPrecRealType>* rng) override { myRNG = rng; }
 
   void addObservables(PropertySetType& plist, BufferType& collectables) override;
 
@@ -183,7 +183,7 @@ protected:
                               bool keepGrid = false);
 
   ///random number generator
-  RandomBase<double>* myRNG;
+  RandomBase<FullPrecRealType>* myRNG;
   ///the set of local-potentials (one for each ion)
   std::vector<NonLocalECPComponent*> PP;
   ///unique NonLocalECPComponent to remove

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -210,7 +210,7 @@ void OperatorBase::releaseResource(ResourceCollection& collection,
                                    const RefVectorWithLeader<OperatorBase>& o_list) const
 {}
 
-void OperatorBase::setRandomGenerator(RandomBase<double>* rng) {}
+void OperatorBase::setRandomGenerator(RandomBase<FullPrecRealType>* rng) {}
 
 void OperatorBase::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& targetH)
 {

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -446,7 +446,7 @@ public:
    * TODO: add docs
    * @param rng 
    */
-  virtual void setRandomGenerator(RandomBase<double>* rng);
+  virtual void setRandomGenerator(RandomBase<FullPrecRealType>* rng);
 
   /**
    * @brief TODO: add docs

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -1036,7 +1036,7 @@ void QMCHamiltonian::resetTargetParticleSet(ParticleSet& P)
     auxH[i]->resetTargetParticleSet(P);
 }
 
-void QMCHamiltonian::setRandomGenerator(RandomBase<double>* rng)
+void QMCHamiltonian::setRandomGenerator(RandomBase<FullPrecRealType>* rng)
 {
   for (int i = 0; i < H.size(); i++)
     H[i]->setRandomGenerator(rng);

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -408,7 +408,7 @@ public:
 
   RealType get_LocalEnergy() const { return LocalEnergy; }
 
-  void setRandomGenerator(RandomBase<double>* rng);
+  void setRandomGenerator(RandomBase<FullPrecRealType>* rng);
 
   static void updateNonKinetic(OperatorBase& op, QMCHamiltonian& ham, ParticleSet& pset);
   static void updateKinetic(OperatorBase& op, QMCHamiltonian& ham, ParticleSet& pset);

--- a/src/QMCHamiltonians/RandomRotationMatrix.h
+++ b/src/QMCHamiltonians/RandomRotationMatrix.h
@@ -22,7 +22,7 @@ namespace qmcplusplus
 {
 
 /// Create a random 3D rotation matrix using a random generator
-inline QMCTraits::TensorType generateRandomRotationMatrix(RandomBase<double>& rng)
+inline QMCTraits::TensorType generateRandomRotationMatrix(RandomBase<QMCTraits::FullPrecRealType>& rng)
 {
   auto rng1 = rng();
   auto rng2 = rng();

--- a/src/QMCHamiltonians/SOECPotential.h
+++ b/src/QMCHamiltonians/SOECPotential.h
@@ -68,7 +68,7 @@ public:
 
   void addComponent(int groupID, std::unique_ptr<SOECPComponent>&& pp);
 
-  void setRandomGenerator(RandomBase<double>* rng) override { my_rng_ = rng; }
+  void setRandomGenerator(RandomBase<FullPrecRealType>* rng) override { my_rng_ = rng; }
 
   //initialize shared resource and hand to collection
   void createResource(ResourceCollection& collection) const override;
@@ -80,7 +80,7 @@ public:
   void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const override;
 
 protected:
-  RandomBase<double>* my_rng_;
+  RandomBase<FullPrecRealType>* my_rng_;
   std::vector<SOECPComponent*> pp_;
   std::vector<std::unique_ptr<SOECPComponent>> ppset_;
   ParticleSet& ion_config_;

--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -137,7 +137,7 @@ int main(int argc, char** argv)
   tile_cell(ions, tmat);
 
   RandomNumberControl::make_seeds();
-  UPtrVector<RandomBase<double>> myRNG(NumThreads);
+  UPtrVector<RandomBase<FullPrecRealType>> myRNG(NumThreads);
   std::vector<uint_type> mt(Random.state_size(), 0);
   std::vector<MCWalkerConfiguration> elecs(NumThreads, MCWalkerConfiguration(super_lattice));
 

--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -53,14 +53,15 @@ int main(int argc, char** argv)
   qmcplusplus::hdf_error_suppression hide_hdf_errors;
 
   Communicate* myComm = OHMMS::Controller;
-  
-  using RealType    = QMCTraits::RealType;
-  using ParticlePos = ParticleSet::ParticlePos;
-  using LatticeType = ParticleSet::ParticleLayout;
-  using TensorType  = ParticleSet::TensorType;
-  using PosType     = ParticleSet::PosType;
-  using uint_type   = RandomGenerator::uint_type;
-  using Walker_t    = MCWalkerConfiguration::Walker_t;
+
+  using RealType         = QMCTraits::RealType;
+  using FullPrecRealType = QMCTraits::FullPrecRealType;
+  using ParticlePos      = ParticleSet::ParticlePos;
+  using LatticeType      = ParticleSet::ParticleLayout;
+  using TensorType       = ParticleSet::TensorType;
+  using PosType          = ParticleSet::PosType;
+  using uint_type        = RandomGenerator::uint_type;
+  using Walker_t         = MCWalkerConfiguration::Walker_t;
 
   //use the global generator
 

--- a/src/Utilities/RandomNumberControl.cpp
+++ b/src/Utilities/RandomNumberControl.cpp
@@ -28,9 +28,9 @@
 namespace qmcplusplus
 {
 ///initialize the static data members
-PrimeNumberSet<RandomBase<double>::uint_type> RandomNumberControl::PrimeNumbers;
-std::vector<std::unique_ptr<RandomBase<double>>> RandomNumberControl::Children;
-RandomBase<double>::uint_type RandomNumberControl::Offset = 11u;
+PrimeNumberSet<RandomBase<QMCTraits::FullPrecRealType>::uint_type> RandomNumberControl::PrimeNumbers;
+std::vector<std::unique_ptr<RandomBase<QMCTraits::FullPrecRealType>>> RandomNumberControl::Children;
+RandomBase<QMCTraits::FullPrecRealType>::uint_type RandomNumberControl::Offset = 11u;
 
 /// constructors and destructors
 RandomNumberControl::RandomNumberControl(const char* aname)
@@ -220,7 +220,9 @@ void RandomNumberControl::write(const std::string& fname, Communicate* comm)
 }
 
 //switch between write functions
-void RandomNumberControl::write(const RefVector<RandomBase<double>>& rng, const std::string& fname, Communicate* comm)
+void RandomNumberControl::write(const RefVector<RandomBase<FullPrecRealType>>& rng,
+                                const std::string& fname,
+                                Communicate* comm)
 {
   std::string h5name = fname + ".random.h5";
   hdf_archive hout(comm, true); //attempt to write in parallel
@@ -289,7 +291,9 @@ void RandomNumberControl::read_parallel(hdf_archive& hin, Communicate* comm)
 }
 
 //Parallel write
-void RandomNumberControl::write_parallel(const RefVector<RandomBase<double>>& rng, hdf_archive& hout, Communicate* comm)
+void RandomNumberControl::write_parallel(const RefVector<RandomBase<FullPrecRealType>>& rng,
+                                         hdf_archive& hout,
+                                         Communicate* comm)
 {
   // cast integer to size_t
   const size_t nthreads  = static_cast<size_t>(omp_get_max_threads());
@@ -402,7 +406,9 @@ void RandomNumberControl::read_rank_0(hdf_archive& hin, Communicate* comm)
 }
 
 //scatter write
-void RandomNumberControl::write_rank_0(const RefVector<RandomBase<double>>& rng, hdf_archive& hout, Communicate* comm)
+void RandomNumberControl::write_rank_0(const RefVector<RandomBase<FullPrecRealType>>& rng,
+                                       hdf_archive& hout,
+                                       Communicate* comm)
 {
   // cast integer to size_t
   const size_t nthreads  = static_cast<size_t>(omp_get_max_threads());

--- a/src/Utilities/RandomNumberControl.h
+++ b/src/Utilities/RandomNumberControl.h
@@ -11,16 +11,19 @@
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 
-
 #ifndef OHMMS_RANDOMNUMBERCONTROL_H__
 #define OHMMS_RANDOMNUMBERCONTROL_H__
-#include <memory>
-#include <libxml/xpath.h>
+
+#include "Configuration.h"
 #include "OhmmsData/OhmmsElementBase.h"
 #include "Utilities/RandomGenerator.h"
 #include "Utilities/PrimeNumberSet.h"
 #include "hdf/hdf_archive.h"
 #include "type_traits/template_types.hpp"
+
+#include <libxml/xpath.h>
+
+#include <memory>
 
 class Communicate;
 
@@ -36,10 +39,11 @@ namespace qmcplusplus
 class RandomNumberControl : public OhmmsElementBase
 {
 public:
-  using uint_type = RandomBase<double>::uint_type;
+  using FullPrecRealType = QMCTraits::FullPrecRealType;
+  using uint_type        = RandomBase<FullPrecRealType>::uint_type;
   static PrimeNumberSet<uint_type> PrimeNumbers;
   //children random number generator
-  static std::vector<std::unique_ptr<RandomBase<double>>> Children;
+  static std::vector<std::unique_ptr<RandomBase<FullPrecRealType>>> Children;
 
   /// constructors and destructors
   RandomNumberControl(const char* aname = "random");
@@ -70,7 +74,7 @@ public:
    * @param fname file name
    * @param comm communicator
    */
-  static void write(const RefVector<RandomBase<double>>& rng, const std::string& fname, Communicate* comm);
+  static void write(const RefVector<RandomBase<FullPrecRealType>>& rng, const std::string& fname, Communicate* comm);
   /** read random state from a hdf file in parallel
    * @param hin hdf_archive set to parallel
    * @param comm communicator
@@ -80,7 +84,7 @@ public:
    * @param hdf_archive set to parallel
    * @param comm communicator
    */
-  static void write_parallel(const RefVector<RandomBase<double>>& rng, hdf_archive& hout, Communicate* comm);
+  static void write_parallel(const RefVector<RandomBase<FullPrecRealType>>& rng, hdf_archive& hout, Communicate* comm);
   /** rank 0 reads random states from a hdf file
    * and distributes them to all the other ranks
    * @param hin hdf_archive set to serial
@@ -92,7 +96,7 @@ public:
    * @param hin hdf_archive object set to serial
    * @param comm communicator
    */
-  static void write_rank_0(const RefVector<RandomBase<double>>& rng, hdf_archive& hout, Communicate* comm);
+  static void write_rank_0(const RefVector<RandomBase<FullPrecRealType>>& rng, hdf_archive& hout, Communicate* comm);
 
 private:
   bool NeverBeenInitialized;


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Use type alias `QMCTraits::FullPrecRealType` instead of `double`.
This is part of #3700.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
