### PR TITLE
Introduce QMC_DISABLE_HIP_HOST_REGISTER. ON by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -842,6 +842,7 @@ if(ENABLE_ROCM)
     target_link_libraries(ROCM::libraries INTERFACE roc::rocsolver roc::rocrand)
   endif()
   message("Project HIP_FLAGS: ${CMAKE_HIP_FLAGS}")
+  option(QMC_DISABLE_HIP_HOST_REGISTER "Disable hipHostRegister for pinning host memory" ON)
 endif(ENABLE_ROCM)
 
 #-------------------------------------------------------------------

--- a/src/Platforms/ROCm/cuda2hip.h
+++ b/src/Platforms/ROCm/cuda2hip.h
@@ -109,8 +109,13 @@
 #define cudaMalloc                      hipMalloc
 #define cudaMallocArray                 hipMallocArray
 #define cudaMallocHost                  hipHostMalloc
+#if defined(QMC_DISABLE_HIP_HOST_REGISTER)
+#define cudaHostRegister(ptr, size, flags) hipSuccess
+#define cudaHostUnregister(ptr) hipSuccess
+#else
 #define cudaHostRegister                hipHostRegister
 #define cudaHostUnregister              hipHostUnregister
+#endif
 #define cudaHostRegisterDefault         hipHostRegisterDefault
 #define cudaMallocManaged               hipMallocManaged
 #define cudaMemAdvise                   hipMemAdvise

--- a/src/Platforms/tests/CUDA/test_CUDAallocator.cpp
+++ b/src/Platforms/tests/CUDA/test_CUDAallocator.cpp
@@ -50,6 +50,7 @@ TEST_CASE("CUDA_allocators", "[CUDA]")
     REQUIRE(attr.type == cudaMemoryTypeHost);
 #endif
   }
+#if !defined(QMC_DISABLE_HIP_HOST_REGISTER)
   { // CUDALockedPageAllocator
     Vector<double, CUDALockedPageAllocator<double>> vec(1024);
     cudaPointerAttributes attr;
@@ -61,6 +62,7 @@ TEST_CASE("CUDA_allocators", "[CUDA]")
 #endif
     Vector<double, CUDALockedPageAllocator<double>> vecb(vec);
   }
+#endif
   { // CUDALockedPageAllocator zero size and copy constructor
     Vector<double, CUDALockedPageAllocator<double>> vec;
     Vector<double, CUDALockedPageAllocator<double>> vecb(vec);

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -102,6 +102,9 @@
 /* Using translation of CUDA to HIP for GPU execution */
 #cmakedefine QMC_CUDA2HIP @QMC_CUDA2HIP@
 
+/* Disable hipHostRegister/hipHostUnregister */
+#cmakedefine QMC_DISABLE_HIP_HOST_REGISTER @QMC_DISABLE_HIP_HOST_REGISTER@
+
 /* Using CUDA for GPU execution, next generation */
 #cmakedefine ENABLE_CUDA @ENABLE_CUDA@
 


### PR DESCRIPTION
## Proposed changes
Since rocm 5.6. hipHostRegister becomes terribly slow https://github.com/ye-luo/miniqmc/wiki/hip-hsa-issues.
Introduce QMC_DISABLE_HIP_HOST_REGISTER. which can be used to make hipHostRegister no-op.
I set it ON by default for now. Will go through a few nights of performance test runs.

My guess is that it makes runs slower because we lose more from not using pinned memory than slower hipHostRegister in close  to production benchmarks.

## What type(s) of changes does this code introduce?
- Other (please describe):

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
