### PR TITLE
Make Intel LLVM compiler to pass qmcplusplus::isnan tests.

### DIFF
--- a/CMake/IntelCompilers.cmake
+++ b/CMake/IntelCompilers.cmake
@@ -36,6 +36,10 @@ endif(QMC_OMP)
 if(CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
   # oneAPI compiler options
 
+  # Set extra optimization specific flags
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffast-math")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math")
+
   # Set clang specific flags (which we always want)
   add_compile_definitions(restrict=__restrict__)
 

--- a/src/Platforms/CPU/CMakeLists.txt
+++ b/src/Platforms/CPU/CMakeLists.txt
@@ -10,7 +10,9 @@
 #//////////////////////////////////////////////////////////////////////////////////////
 
 # To enable a custom qmcplusplus::isnan, remove fast-math. Only the file scope CMAKE_CXX_FLAGS gets affected.
-string(REPLACE " -ffast-math" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+if(CMAKE_CXX_FLAGS MATCHES " -ffast-math")
+  string(REPLACE " -ffast-math" " -fno-fast-math" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+endif()
 
 add_library(platform_cpu_runtime math.cpp)
 target_link_libraries(platform_cpu_runtime INTERFACE Math::scalar_vector_functions)

--- a/src/QMCTools/ppconvert/CMakeLists.txt
+++ b/src/QMCTools/ppconvert/CMakeLists.txt
@@ -9,7 +9,9 @@ if(CMAKE_CXX_FLAGS_RELEASE)
   string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
 endif()
 
-string(REPLACE " -ffast-math" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+if(CMAKE_CXX_FLAGS MATCHES " -ffast-math")
+  string(REPLACE " -ffast-math" " -fno-fast-math" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+endif()
 
 if(CMAKE_CROSSCOMPILING)
   message(STATUS "Cannot run std::isnan tests when cross compiling. Setting ISNAN_WORKS to FALSE.")


### PR DESCRIPTION
## Proposed changes
icpx has `-ffast-math` on by default. There's no harm adding it and it helps aligning behaviors with Clang and GNU.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
sunspot

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'