### PR TITLE
Remove xxx_unit cmake targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,11 +107,6 @@ if(IS_GIT_PROJECT)
   message("Git commit hash: ${GIT_CONFIG_COMMIT_HASH}")
 endif()
 
-# For unit tests, enable use for the fake RNG
-function(USE_FAKE_RNG TARGET)
-  target_compile_definitions(${TARGET} PRIVATE "USE_FAKE_RNG")
-endfunction()
-
 add_subdirectory(io)
 add_subdirectory(einspline)
 add_subdirectory(Containers)

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -50,6 +50,6 @@ use_fake_rng(qmcestimators_unit)
 target_include_directories(qmcestimators PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(qmcestimators_unit PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcestimators PUBLIC containers qmcham qmcparticle qmcutil)
-target_link_libraries(qmcestimators_unit PUBLIC containers qmcham_unit qmcparticle qmcutil)
+target_link_libraries(qmcestimators_unit PUBLIC containers qmcham qmcparticle qmcutil)
 
 add_subdirectory(tests)

--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -40,16 +40,11 @@ set(QMCEST_SRC
 ####################################
 if(USE_OBJECT_TARGET)
   add_library(qmcestimators OBJECT ${QMCEST_SRC})
-  add_library(qmcestimators_unit OBJECT ${QMCEST_SRC})
 else()
   add_library(qmcestimators ${QMCEST_SRC})
-  add_library(qmcestimators_unit ${QMCEST_SRC})
 endif()
-use_fake_rng(qmcestimators_unit)
 
 target_include_directories(qmcestimators PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-target_include_directories(qmcestimators_unit PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcestimators PUBLIC containers qmcham qmcparticle qmcutil)
-target_link_libraries(qmcestimators_unit PUBLIC containers qmcham qmcparticle qmcutil)
 
 add_subdirectory(tests)

--- a/src/Estimators/tests/CMakeLists.txt
+++ b/src/Estimators/tests/CMakeLists.txt
@@ -50,7 +50,7 @@ if(USE_OBJECT_TARGET)
     ${UTEST_EXE}
     qmcutil
     qmcestimators_unit
-    qmcham_unit
+    qmcham
     qmcwfs
     qmcparticle
     qmcwfs_omptarget
@@ -73,7 +73,7 @@ if(HAVE_MPI)
     target_link_libraries(
       ${UTEST_EXE}
       qmcestimators_unit
-      qmcham_unit
+      qmcham
       qmcdriver_unit
       qmcwfs
       qmcparticle

--- a/src/Estimators/tests/CMakeLists.txt
+++ b/src/Estimators/tests/CMakeLists.txt
@@ -73,7 +73,7 @@ if(HAVE_MPI)
       ${UTEST_EXE}
       qmcestimators
       qmcham
-      qmcdriver_unit
+      qmcdriver
       qmcwfs
       qmcparticle
       qmcwfs_omptarget

--- a/src/Estimators/tests/CMakeLists.txt
+++ b/src/Estimators/tests/CMakeLists.txt
@@ -43,13 +43,12 @@ set(SRCS
     test_MagnetizationDensity.cpp)
 
 add_executable(${UTEST_EXE} ${SRCS})
-use_fake_rng(${UTEST_EXE})
-target_link_libraries(${UTEST_EXE} catch_main qmcutil qmcestimators_unit utilities_for_test sposets_for_testing)
+target_link_libraries(${UTEST_EXE} catch_main qmcutil qmcestimators utilities_for_test sposets_for_testing)
 if(USE_OBJECT_TARGET)
   target_link_libraries(
     ${UTEST_EXE}
     qmcutil
-    qmcestimators_unit
+    qmcestimators
     qmcham
     qmcwfs
     qmcparticle
@@ -72,7 +71,7 @@ if(HAVE_MPI)
   if(USE_OBJECT_TARGET)
     target_link_libraries(
       ${UTEST_EXE}
-      qmcestimators_unit
+      qmcestimators
       qmcham
       qmcdriver_unit
       qmcwfs
@@ -83,7 +82,7 @@ if(HAVE_MPI)
       platform_omptarget_LA
       utilities_for_test)
   endif()
-  target_link_libraries(${UTEST_EXE} catch_main qmcestimators_unit)
+  target_link_libraries(${UTEST_EXE} catch_main qmcestimators)
   # Right now the unified driver mpi tests are hard coded for 3 MPI ranks
   add_unit_test(${UTEST_NAME} 3 1 $<TARGET_FILE:${UTEST_EXE}>)
 endif()

--- a/src/Estimators/tests/test_EstimatorManagerCrowd.cpp
+++ b/src/Estimators/tests/test_EstimatorManagerCrowd.cpp
@@ -145,7 +145,7 @@ TEST_CASE("EstimatorManagerCrowd PerParticleHamiltonianLogger integration", "[es
   emc.registerListeners(ham_list);
 
   //   Setup RNG
-  RandomGenerator rng;
+  FakeRandom<OHMMS_PRECISION_FULL> rng;
 
   // Without this QMCHamiltonian::mw_evaluate segfaults
   // Because the CoulombPBCAA hamiltonian component has PtclRhoK (StructFact) that is invalid.

--- a/src/Estimators/tests/test_MomentumDistribution.cpp
+++ b/src/Estimators/tests/test_MomentumDistribution.cpp
@@ -178,7 +178,7 @@ TEST_CASE("MomentumDistribution::accumulate", "[estimators]")
   auto ref_wfns    = convertUPtrToRefVector(wfns);
 
   //   Setup RNG
-  RandomGenerator rng;
+  FakeRandom<OHMMS_PRECISION_FULL> rng;
 
   //   Perform accumulate
   md.accumulate(ref_walkers, ref_psets, ref_wfns, rng);

--- a/src/Estimators/tests/test_PerParticleHamiltonianLogger.cpp
+++ b/src/Estimators/tests/test_PerParticleHamiltonianLogger.cpp
@@ -117,7 +117,7 @@ TEST_CASE("PerParticleHamiltonianLogger_sum", "[estimators]")
     for (auto& mwt : multi_walker_talkers)
       mwt.reportVector();
 
-    RandomGenerator rng;
+    FakeRandom<OHMMS_PRECISION_FULL> rng;
 
     int crowd_id = 0;
     long walker_id = 0;

--- a/src/Estimators/tests/test_SpinDensityNew.cpp
+++ b/src/Estimators/tests/test_SpinDensityNew.cpp
@@ -78,7 +78,7 @@ void accumulateFromPsets(int ncrowds, SpinDensityNew& sdn, UPtrVector<OperatorEs
     auto ref_psets   = makeRefVector<ParticleSet>(psets);
     auto ref_wfns    = makeRefVector<TrialWaveFunction>(wfns);
 
-    RandomGenerator rng;
+    FakeRandom<OHMMS_PRECISION_FULL> rng;
 
     crowd_sdn.accumulate(ref_walkers, ref_psets, ref_wfns, rng);
   }
@@ -116,7 +116,7 @@ void randomUpdateAccumulate(testing::RandomForTest<QMCT::RealType>& rft, UPtrVec
     auto ref_psets   = makeRefVector<ParticleSet>(psets);
     auto ref_wfns    = makeRefVector<TrialWaveFunction>(wfns);
 
-    RandomGenerator rng;
+    FakeRandom<OHMMS_PRECISION_FULL> rng;
 
     crowd_sdn.accumulate(ref_walkers, ref_psets, ref_wfns, rng);
   }
@@ -220,7 +220,7 @@ TEST_CASE("SpinDensityNew::accumulate", "[estimators]")
   auto ref_psets   = makeRefVector<ParticleSet>(psets);
   auto ref_wfns    = makeRefVector<TrialWaveFunction>(wfns);
 
-  RandomGenerator rng;
+  FakeRandom<OHMMS_PRECISION_FULL> rng;
 
   sdn.accumulate(ref_walkers, ref_psets, ref_wfns, rng);
 

--- a/src/Particle/ParticleBase/tests/CMakeLists.txt
+++ b/src/Particle/ParticleBase/tests/CMakeLists.txt
@@ -14,7 +14,6 @@ set(UTEST_EXE test_${SRC_DIR})
 set(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 
 add_executable(${UTEST_EXE} test_particle_attrib.cpp test_random_seq.cpp test_attrib_ops.cpp)
-use_fake_rng(${UTEST_EXE})
 target_link_libraries(${UTEST_EXE} catch_main qmcparticle)
 if(USE_OBJECT_TARGET)
   target_link_libraries(${UTEST_EXE} qmcutil qmcparticle_omptarget)

--- a/src/QMCDrivers/CMakeLists.txt
+++ b/src/QMCDrivers/CMakeLists.txt
@@ -106,7 +106,7 @@ target_include_directories(qmcdriver PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(qmcdriver_unit PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 target_link_libraries(qmcdriver PUBLIC qmcham qmcestimators)
-target_link_libraries(qmcdriver_unit PUBLIC qmcham qmcestimators_unit)
+target_link_libraries(qmcdriver_unit PUBLIC qmcham qmcestimators)
 
 target_link_libraries(qmcdriver PRIVATE platform_LA Boost::boost)
 target_link_libraries(qmcdriver_unit PRIVATE platform_LA Boost::boost)

--- a/src/QMCDrivers/CMakeLists.txt
+++ b/src/QMCDrivers/CMakeLists.txt
@@ -106,7 +106,7 @@ target_include_directories(qmcdriver PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(qmcdriver_unit PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 target_link_libraries(qmcdriver PUBLIC qmcham qmcestimators)
-target_link_libraries(qmcdriver_unit PUBLIC qmcham_unit qmcestimators_unit)
+target_link_libraries(qmcdriver_unit PUBLIC qmcham qmcestimators_unit)
 
 target_link_libraries(qmcdriver PRIVATE platform_LA Boost::boost)
 target_link_libraries(qmcdriver_unit PRIVATE platform_LA Boost::boost)

--- a/src/QMCDrivers/CMakeLists.txt
+++ b/src/QMCDrivers/CMakeLists.txt
@@ -95,24 +95,17 @@ endif(BUILD_LMYENGINE_INTERFACE)
 ####################################
 if(USE_OBJECT_TARGET)
   add_library(qmcdriver OBJECT ${QMCDRIVERS})
-  add_library(qmcdriver_unit OBJECT ${QMCDRIVERS})
 else()
   add_library(qmcdriver ${QMCDRIVERS})
-  add_library(qmcdriver_unit ${QMCDRIVERS})
 endif()
-use_fake_rng(qmcdriver_unit)
 
 target_include_directories(qmcdriver PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-target_include_directories(qmcdriver_unit PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 target_link_libraries(qmcdriver PUBLIC qmcham qmcestimators)
-target_link_libraries(qmcdriver_unit PUBLIC qmcham qmcestimators)
 
 target_link_libraries(qmcdriver PRIVATE platform_LA Boost::boost)
-target_link_libraries(qmcdriver_unit PRIVATE platform_LA Boost::boost)
 if(BUILD_LMYENGINE_INTERFACE)
   target_link_libraries(qmcdriver PRIVATE formic_utils)
-  target_link_libraries(qmcdriver_unit PRIVATE formic_utils)
 endif()
 
 if(BUILD_UNIT_TESTS)

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -28,7 +28,6 @@
 #include "Concurrency/OpenMP.h"
 #include "Utilities/Timer.h"
 #include "Utilities/RunTimeManager.h"
-#include "RandomNumberControl.h"
 #include "Utilities/ProgressReportEngine.h"
 #include "Utilities/qmc_common.h"
 #include "Utilities/FairDivide.h"
@@ -45,9 +44,11 @@ DMC::DMC(const ProjectData& project_data,
          MCWalkerConfiguration& w,
          TrialWaveFunction& psi,
          QMCHamiltonian& h,
+         UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs,
          Communicate* comm,
          bool enable_profiling)
     : QMCDriver(project_data, w, psi, h, comm, "DMC", enable_profiling),
+      rngs_(rngs),
       KillNodeCrossing(0),
       BranchInterval(-1),
       L2("no"),
@@ -129,12 +130,8 @@ void DMC::resetUpdateEngines()
 #if !defined(REMOVE_TRACEMANAGER)
       traceClones[ip] = Traces->makeClone();
 #endif
-#ifdef USE_FAKE_RNG
-      Rng[ip] = std::make_unique<FakeRandom<QMCTraits::FullPrecRealType>>();
-#else
-      Rng[ip] = RandomNumberControl::Children[ip]->makeClone();
+      Rng[ip] = rngs_[ip]->makeClone();
       hClones[ip]->setRandomGenerator(Rng[ip].get());
-#endif
       if (W.isSpinor())
       {
         spinor = true;
@@ -299,10 +296,8 @@ bool DMC::run()
     block++;
     if (DumpConfig && block % Period4CheckPoint == 0)
     {
-#ifndef USE_FAKE_RNG
       for (int ip = 0; ip < NumThreads; ip++)
-        RandomNumberControl::Children[ip] = Rng[ip]->makeClone();
-#endif
+        rngs_[ip] = Rng[ip]->makeClone();
     }
     recordBlock(block);
     dmc_loop.stop();
@@ -323,10 +318,8 @@ bool DMC::run()
 
   } while (block < nBlocks);
 
-#ifndef USE_FAKE_RNG
   for (int ip = 0; ip < NumThreads; ip++)
-    RandomNumberControl::Children[ip] = Rng[ip]->makeClone();
-#endif
+    rngs_[ip] = Rng[ip]->makeClone();
   Estimators->stop();
   for (int ip = 0; ip < NumThreads; ++ip)
     Movers[ip]->stopRun2();

--- a/src/QMCDrivers/DMC/DMC.h
+++ b/src/QMCDrivers/DMC/DMC.h
@@ -35,6 +35,7 @@ public:
       MCWalkerConfiguration& w,
       TrialWaveFunction& psi,
       QMCHamiltonian& h,
+      UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs,
       Communicate* comm,
       bool enable_profiling);
 
@@ -44,6 +45,8 @@ public:
   QMCRunType getRunType() override { return QMCRunType::DMC; }
 
 private:
+  //
+  UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs_;
   ///Index to determine what to do when node crossing is detected
   // does not appear to be used
   IndexType KillNodeCrossing;

--- a/src/QMCDrivers/DMC/DMCFactory.cpp
+++ b/src/QMCDrivers/DMC/DMCFactory.cpp
@@ -16,6 +16,7 @@
 #include "DMCFactory.h"
 #include "QMCDrivers/DMC/DMC.h"
 #include "Concurrency/OpenMP.h"
+#include "RandomNumberControl.h"
 
 //#define PETA_DMC_TEST
 namespace qmcplusplus
@@ -27,7 +28,7 @@ std::unique_ptr<QMCDriver> DMCFactory::create(const ProjectData& project_data,
                                               Communicate* comm,
                                               bool enable_profiling)
 {
-  auto qmc = std::make_unique<DMC>(project_data, w, psi, h, comm, enable_profiling);
+  auto qmc = std::make_unique<DMC>(project_data, w, psi, h, RandomNumberControl::Children, comm, enable_profiling);
   qmc->setUpdateMode(PbyPUpdate);
   return qmc;
 }

--- a/src/QMCDrivers/VMC/VMC.cpp
+++ b/src/QMCDrivers/VMC/VMC.cpp
@@ -21,7 +21,6 @@
 #include "QMCDrivers/VMC/VMCUpdateAll.h"
 #include "QMCDrivers/VMC/SOVMCUpdatePbyP.h"
 #include "QMCDrivers/VMC/SOVMCUpdateAll.h"
-#include "RandomNumberControl.h"
 #include "Concurrency/OpenMP.h"
 #include "Message/CommOperators.h"
 #include "Utilities/RunTimeManager.h"
@@ -41,9 +40,10 @@ VMC::VMC(const ProjectData& project_data,
          MCWalkerConfiguration& w,
          TrialWaveFunction& psi,
          QMCHamiltonian& h,
+         UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs,
          Communicate* comm,
          bool enable_profiling)
-    : QMCDriver(project_data, w, psi, h, comm, "VMC", enable_profiling), UseDrift("yes")
+    : QMCDriver(project_data, w, psi, h, comm, "VMC", enable_profiling), UseDrift("yes"), rngs_(rngs)
 {
   RootName = "vmc";
   qmc_driver_mode.set(QMC_UPDATE_MODE, 1);
@@ -132,10 +132,8 @@ bool VMC::run()
   Traces->stopRun();
 #endif
   //copy back the random states
-#ifndef USE_FAKE_RNG
   for (int ip = 0; ip < NumThreads; ++ip)
-    RandomNumberControl::Children[ip] = Rng[ip]->makeClone();
-#endif
+    rngs_[ip] = Rng[ip]->makeClone();
   ///write samples to a file
   bool wrotesamples = DumpConfig;
   if (DumpConfig)
@@ -182,11 +180,7 @@ void VMC::resetRun()
 #if !defined(REMOVE_TRACEMANAGER)
       traceClones[ip] = Traces->makeClone();
 #endif
-#ifdef USE_FAKE_RNG
-      Rng[ip] = std::make_unique<FakeRandom<double>>();
-#else
-      Rng[ip] = RandomNumberControl::Children[ip]->makeClone();
-#endif
+      Rng[ip] = rngs_[ip]->makeClone();
       hClones[ip]->setRandomGenerator(Rng[ip].get());
       if (W.isSpinor())
       {
@@ -287,7 +281,7 @@ void VMC::resetRun()
     qmc_common.memory_allocated += W.getActiveWalkers() * W[0]->DataSet.byteSize();
     qmc_common.print_memory_change("VMC::resetRun", before);
   }
-  
+
   for (int ip = 0; ip < NumThreads; ++ip)
     wClones[ip]->clearEnsemble();
   if (nSamplesPerThread)

--- a/src/QMCDrivers/VMC/VMC.h
+++ b/src/QMCDrivers/VMC/VMC.h
@@ -29,17 +29,21 @@ public:
       MCWalkerConfiguration& w,
       TrialWaveFunction& psi,
       QMCHamiltonian& h,
+      UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs,
       Communicate* comm,
       bool enable_profiling);
   bool run() override;
   bool put(xmlNodePtr cur) override;
   QMCRunType getRunType() override { return QMCRunType::VMC; }
+
 private:
   int prevSteps;
   int prevStepsBetweenSamples;
 
   ///option to enable/disable drift equation or RN for VMC
   std::string UseDrift;
+  //
+  UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs_;
   ///check the run-time environments
   void resetRun();
   ///copy constructor

--- a/src/QMCDrivers/VMC/VMCFactory.cpp
+++ b/src/QMCDrivers/VMC/VMCFactory.cpp
@@ -17,6 +17,7 @@
 #include "QMCDrivers/VMC/VMC.h"
 #include "QMCDrivers/QMCDriverInterface.h"
 #include "QMCDrivers/CorrelatedSampling/CSVMC.h"
+#include "RandomNumberControl.h"
 #if defined(QMC_BUILD_COMPLETE)
 //REMOVE Broken warping
 //#if !defined(QMC_COMPLEX)
@@ -40,7 +41,7 @@ std::unique_ptr<QMCDriverInterface> VMCFactory::create(const ProjectData& projec
   std::unique_ptr<QMCDriverInterface> qmc;
   if (VMCMode == 0 || VMCMode == 1) //(0,0,0) (0,0,1)
   {
-    qmc = std::make_unique<VMC>(project_data, w, psi, h, comm, enable_profiling);
+    qmc = std::make_unique<VMC>(project_data, w, psi, h, RandomNumberControl::Children, comm, enable_profiling);
   }
   else if (VMCMode == 2 || VMCMode == 3)
   {

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -19,6 +19,7 @@
 #include "Particle/HDFWalkerIO.h"
 #include "OhmmsData/AttributeSet.h"
 #include "Message/CommOperators.h"
+#include "RandomNumberControl.h"
 #include "QMCDrivers/WFOpt/QMCCostFunctionBase.h"
 #include "QMCDrivers/WFOpt/QMCCostFunction.h"
 #include "QMCDrivers/VMC/VMC.h"
@@ -647,7 +648,7 @@ bool QMCFixedSampleLinearOptimize::processOptXML(xmlNodePtr opt_xml, const std::
 
   // Destroy old object to stop timer to correctly order timer with object lifetime scope
   vmcEngine.reset(nullptr);
-  vmcEngine = std::make_unique<VMC>(project_data_, W, Psi, H, myComm, false);
+  vmcEngine = std::make_unique<VMC>(project_data_, W, Psi, H, RandomNumberControl::Children, myComm, false);
   vmcEngine->setUpdateMode(vmcMove[0] == 'p');
 
 

--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -42,8 +42,7 @@ if(HAVE_MPI)
 endif()
 add_executable(${UTEST_EXE} ${DRIVER_TEST_SRC})
 
-use_fake_rng(${UTEST_EXE})
-target_link_libraries(${UTEST_EXE} catch_main qmcdriver_unit)
+target_link_libraries(${UTEST_EXE} catch_main qmcdriver)
 if(USE_OBJECT_TARGET)
   target_link_libraries(
     ${UTEST_EXE}
@@ -84,8 +83,7 @@ set(DRIVER_TEST_SRC
     test_QMCCostFunctionBase.cpp
     test_WFOptDriverInput.cpp)
 add_executable(${UTEST_EXE} ${DRIVER_TEST_SRC})
-use_fake_rng(${UTEST_EXE})
-target_link_libraries(${UTEST_EXE} catch_main qmcdriver_unit)
+target_link_libraries(${UTEST_EXE} catch_main qmcdriver)
 if(USE_OBJECT_TARGET)
   target_link_libraries(
     ${UTEST_EXE}
@@ -107,8 +105,7 @@ if(HAVE_MPI)
   #this is dependent on the directory creation and sym linking of earlier driver tests
   set(DRIVER_TEST_SRC SetupPools.cpp test_WalkerControl.cpp test_QMCDriverNew.cpp)
   add_executable(${UTEST_EXE} ${DRIVER_TEST_SRC})
-  use_fake_rng(${UTEST_EXE})
-  target_link_libraries(${UTEST_EXE} catch_main qmcdriver_unit)
+  target_link_libraries(${UTEST_EXE} catch_main qmcdriver)
   if(USE_OBJECT_TARGET)
     target_link_libraries(
       ${UTEST_EXE}

--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -48,7 +48,7 @@ if(USE_OBJECT_TARGET)
   target_link_libraries(
     ${UTEST_EXE}
     qmcestimators_unit
-    qmcham_unit
+    qmcham
     qmcwfs
     qmcparticle
     qmcwfs_omptarget
@@ -90,7 +90,7 @@ if(USE_OBJECT_TARGET)
   target_link_libraries(
     ${UTEST_EXE}
     qmcestimators_unit
-    qmcham_unit
+    qmcham
     qmcwfs
     qmcparticle
     qmcwfs_omptarget
@@ -113,7 +113,7 @@ if(HAVE_MPI)
     target_link_libraries(
       ${UTEST_EXE}
       qmcestimators_unit
-      qmcham_unit
+      qmcham
       qmcwfs
       qmcparticle
       qmcwfs_omptarget

--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries(${UTEST_EXE} catch_main qmcdriver_unit)
 if(USE_OBJECT_TARGET)
   target_link_libraries(
     ${UTEST_EXE}
-    qmcestimators_unit
+    qmcestimators
     qmcham
     qmcwfs
     qmcparticle
@@ -89,7 +89,7 @@ target_link_libraries(${UTEST_EXE} catch_main qmcdriver_unit)
 if(USE_OBJECT_TARGET)
   target_link_libraries(
     ${UTEST_EXE}
-    qmcestimators_unit
+    qmcestimators
     qmcham
     qmcwfs
     qmcparticle
@@ -112,7 +112,7 @@ if(HAVE_MPI)
   if(USE_OBJECT_TARGET)
     target_link_libraries(
       ${UTEST_EXE}
-      qmcestimators_unit
+      qmcestimators
       qmcham
       qmcwfs
       qmcparticle

--- a/src/QMCDrivers/tests/test_clone_manager.cpp
+++ b/src/QMCDrivers/tests/test_clone_manager.cpp
@@ -38,7 +38,10 @@ namespace qmcplusplus
 class FakeUpdate : public QMCUpdateBase
 {
 public:
-  FakeUpdate(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator& rg)
+  FakeUpdate(MCWalkerConfiguration& w,
+             TrialWaveFunction& psi,
+             QMCHamiltonian& h,
+             FakeRandom<QMCTraits::FullPrecRealType>& rg)
       : QMCUpdateBase(w, psi, h, rg)
   {}
 

--- a/src/QMCDrivers/tests/test_dmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_dmc_driver.cpp
@@ -76,7 +76,10 @@ TEST_CASE("DMC", "[drivers][dmc]")
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();
 
-  FakeRandom rg;
+  using RNG = RandomBase<QMCTraits::FullPrecRealType>;
+  UPtrVector<RNG> rngs(omp_get_max_threads());
+  for (std::unique_ptr<RNG>& rng : rngs)
+    rng = std::make_unique<FakeRandom<QMCTraits::FullPrecRealType>>();
 
   QMCHamiltonian h;
   std::unique_ptr<BareKineticEnergy> p_bke = std::make_unique<BareKineticEnergy>(elec, psi);
@@ -85,7 +88,7 @@ TEST_CASE("DMC", "[drivers][dmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  DMC dmc_omp(project_data, elec, psi, h, c, false);
+  DMC dmc_omp(project_data, elec, psi, h, rngs, c, false);
 
   const char* dmc_input = R"(<qmc method="dmc" checkpoint="-1">
    <parameter name="steps">1</parameter>
@@ -157,7 +160,10 @@ TEST_CASE("SODMC", "[drivers][dmc]")
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();
 
-  FakeRandom rg;
+  using RNG = RandomBase<QMCTraits::FullPrecRealType>;
+  UPtrVector<RNG> rngs(omp_get_max_threads());
+  for (std::unique_ptr<RNG>& rng : rngs)
+    rng = std::make_unique<FakeRandom<QMCTraits::FullPrecRealType>>();
 
   QMCHamiltonian h;
   std::unique_ptr<BareKineticEnergy> p_bke = std::make_unique<BareKineticEnergy>(elec, psi);
@@ -166,7 +172,7 @@ TEST_CASE("SODMC", "[drivers][dmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  DMC dmc_omp(project_data, elec, psi, h, c, false);
+  DMC dmc_omp(project_data, elec, psi, h, rngs, c, false);
 
   const char* dmc_input = R"(<qmc method="dmc" checkpoint="-1">
    <parameter name="steps">1</parameter>

--- a/src/QMCDrivers/tests/test_vmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_vmc_driver.cpp
@@ -30,7 +30,6 @@
 #include "Estimators/TraceManager.h"
 #include "QMCDrivers/VMC/VMC.h"
 
-
 #include <stdio.h>
 #include <string>
 
@@ -76,7 +75,10 @@ TEST_CASE("VMC", "[drivers][vmc]")
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();
 
-  FakeRandom rg;
+  using RNG = RandomBase<QMCTraits::FullPrecRealType>;
+  UPtrVector<RNG> rngs(omp_get_max_threads());
+  for (std::unique_ptr<RNG>& rng : rngs)
+    rng = std::make_unique<FakeRandom<QMCTraits::FullPrecRealType>>();
 
   QMCHamiltonian h;
   h.addOperator(std::make_unique<BareKineticEnergy>(elec, psi), "Kinetic");
@@ -84,7 +86,7 @@ TEST_CASE("VMC", "[drivers][vmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  VMC vmc_omp(project_data, elec, psi, h, c, false);
+  VMC vmc_omp(project_data, elec, psi, h, rngs, c, false);
 
   const char* vmc_input = R"(<qmc method="vmc" move="pbyp" checkpoint="-1">
    <parameter name="substeps">1</parameter>
@@ -158,7 +160,10 @@ TEST_CASE("SOVMC", "[drivers][vmc]")
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();
 
-  FakeRandom rg;
+  using RNG = RandomBase<QMCTraits::FullPrecRealType>;
+  UPtrVector<RNG> rngs(omp_get_max_threads());
+  for (std::unique_ptr<RNG>& rng : rngs)
+    rng = std::make_unique<FakeRandom<QMCTraits::FullPrecRealType>>();
 
   QMCHamiltonian h;
   h.addOperator(std::make_unique<BareKineticEnergy>(elec, psi), "Kinetic");
@@ -166,7 +171,7 @@ TEST_CASE("SOVMC", "[drivers][vmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  VMC vmc_omp(project_data, elec, psi, h, c, false);
+  VMC vmc_omp(project_data, elec, psi, h, rngs, c, false);
 
   const char* vmc_input = R"(<qmc method="vmc" move="pbyp" checkpoint="-1">
    <parameter name="substeps">1</parameter>
@@ -245,7 +250,10 @@ TEST_CASE("SOVMC-alle", "[drivers][vmc]")
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();
 
-  FakeRandom rg;
+  using RNG = RandomBase<QMCTraits::FullPrecRealType>;
+  UPtrVector<RNG> rngs(omp_get_max_threads());
+  for (std::unique_ptr<RNG>& rng : rngs)
+    rng = std::make_unique<FakeRandom<QMCTraits::FullPrecRealType>>();
 
   QMCHamiltonian h;
   h.addOperator(std::make_unique<BareKineticEnergy>(elec, psi), "Kinetic");
@@ -253,7 +261,7 @@ TEST_CASE("SOVMC-alle", "[drivers][vmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  VMC vmc_omp(project_data, elec, psi, h, c, false);
+  VMC vmc_omp(project_data, elec, psi, h, rngs, c, false);
 
   const char* vmc_input = R"(<qmc method="vmc" move="alle" checkpoint="-1">
    <parameter name="substeps">1</parameter>

--- a/src/QMCHamiltonians/CMakeLists.txt
+++ b/src/QMCHamiltonians/CMakeLists.txt
@@ -81,22 +81,15 @@ endif(OHMMS_DIM MATCHES 3)
 
 if(USE_OBJECT_TARGET)
   add_library(qmcham OBJECT ${HAMSRCS})
-  add_library(qmcham_unit OBJECT ${HAMSRCS})
 else()
   add_library(qmcham ${HAMSRCS})
-  add_library(qmcham_unit ${HAMSRCS})
 endif()
 
-use_fake_rng(qmcham_unit)
-
 target_include_directories(qmcham PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-target_include_directories(qmcham_unit PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 target_link_libraries(qmcham PUBLIC qmcwfs)
-target_link_libraries(qmcham_unit PUBLIC qmcwfs)
 
 target_link_libraries(qmcham PRIVATE einspline platform_LA Math::FFTW3)
-target_link_libraries(qmcham_unit PRIVATE einspline platform_LA Math::FFTW3)
 
 if(BUILD_UNIT_TESTS)
   add_subdirectory(tests)

--- a/src/Utilities/RandomGenerator.h
+++ b/src/Utilities/RandomGenerator.h
@@ -52,17 +52,9 @@ public:
 extern template class RNGThreadSafe<FakeRandom<OHMMS_PRECISION_FULL>>;
 extern template class RNGThreadSafe<StdRandom<OHMMS_PRECISION_FULL>>;
 
-#if defined(USE_FAKE_RNG)
-// fake RNG redirection
-using RandomGenerator = FakeRandom<OHMMS_PRECISION_FULL>;
-extern RNGThreadSafe<RandomGenerator> fake_random_global;
-#define Random fake_random_global
-#else
-// real RNG redirection
 using RandomGenerator = StdRandom<OHMMS_PRECISION_FULL>;
 extern RNGThreadSafe<RandomGenerator> random_global;
 #define Random random_global
-#endif
 } // namespace qmcplusplus
 
 #endif


### PR DESCRIPTION
## Proposed changes
A big thank to @quantumsteve 
No more redundant compilation of qmcham qmcdriver qmcestimators.
Closes #3700.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
