### PR TITLE
Free MKL reserved memory before the SYCL queue destruction.

### DIFF
--- a/config/build_alcf_sunspot_icpx.sh
+++ b/config/build_alcf_sunspot_icpx.sh
@@ -8,8 +8,8 @@
 # build_alcf_sunspot_icpx.sh <source_dir> <install_dir> # build all the variants with a given source directory <source_dir> and install to <install_dir>
 
 module load spack libxml2 cmake
-module load cray-hdf5/1.12.2.1
-module load oneapi/eng-compiler/2023.05.15.003
+module load cray-hdf5
+module load oneapi/eng-compiler/2023.05.15.007
 
 module list >& module_list.txt
 
@@ -23,7 +23,7 @@ echo "**********************************"
 
 TYPE=Release
 Machine=sunspot
-Compiler=icpx20230510
+Compiler=icpx20230613
 
 if [[ $# -eq 0 ]]; then
   source_folder=`pwd`
@@ -46,6 +46,7 @@ for name in offload_sycl_real_MP offload_sycl_real offload_sycl_cplx_MP offload_
 do
 
 CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=$TYPE -DMPIEXEC_PREFLAGS='--cpu-bind;depth;-d;8'"
+unset CMAKE_CXX_FLAGS
 
 if [[ $name == *"cplx"* ]]; then
   CMAKE_FLAGS="$CMAKE_FLAGS -DQMC_COMPLEX=ON"

--- a/src/Platforms/SYCL/syclSolver.hpp
+++ b/src/Platforms/SYCL/syclSolver.hpp
@@ -12,14 +12,17 @@
 #ifndef QMCPLUSPLUS_SYCL_MKL_SOLVER_H
 #define QMCPLUSPLUS_SYCL_MKL_SOLVER_H
 
-#include "oneapi/mkl/lapack.hpp"
+#include <oneapi/mkl/lapack.hpp>
+#include <mkl_service.h>
 
 namespace qmcplusplus
 {
 namespace syclSolver
 {
 using namespace oneapi::mkl::lapack;
-}
+
+inline void freeBuffer() { mkl_free_buffers(); }
+} // namespace syclSolver
 } // namespace qmcplusplus
 
 #endif

--- a/src/QMCWaveFunctions/Fermion/DelayedUpdateSYCL.h
+++ b/src/QMCWaveFunctions/Fermion/DelayedUpdateSYCL.h
@@ -22,6 +22,9 @@
 #include "PrefetchedRange.h"
 #include "syclSolverInverter.hpp"
 #include "DeviceManager.h"
+#if defined(HAVE_MKL)
+#include <mkl_service.h>
+#endif
 
 //#define SYCL_BLOCKING
 
@@ -73,7 +76,12 @@ public:
   /// default constructor
   DelayedUpdateSYCL() : delay_count(0) { m_queue_ = DeviceManager::getGlobal().getSYCLDM().createQueueDefaultDevice(); }
 
-  ~DelayedUpdateSYCL() {}
+  ~DelayedUpdateSYCL()
+  {
+#if defined(HAVE_MKL)
+    mkl_free_buffers();
+#endif
+  }
 
   /** resize the internal storage
    * @param norb number of electrons/orbitals

--- a/src/QMCWaveFunctions/Fermion/DelayedUpdateSYCL.h
+++ b/src/QMCWaveFunctions/Fermion/DelayedUpdateSYCL.h
@@ -22,9 +22,6 @@
 #include "PrefetchedRange.h"
 #include "syclSolverInverter.hpp"
 #include "DeviceManager.h"
-#if defined(HAVE_MKL)
-#include <mkl_service.h>
-#endif
 
 //#define SYCL_BLOCKING
 
@@ -76,12 +73,7 @@ public:
   /// default constructor
   DelayedUpdateSYCL() : delay_count(0) { m_queue_ = DeviceManager::getGlobal().getSYCLDM().createQueueDefaultDevice(); }
 
-  ~DelayedUpdateSYCL()
-  {
-#if defined(HAVE_MKL)
-    mkl_free_buffers();
-#endif
-  }
+  ~DelayedUpdateSYCL() { syclSolver::freeBuffer(); }
 
   /** resize the internal storage
    * @param norb number of electrons/orbitals


### PR DESCRIPTION
## Proposed changes
If we don't proactively poking MKL, memory free() happens when unloading the dynamic library and causes segfault.

PS: Update sunspot recipe.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
sunspot

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
