### PR TITLE
Add tests for orbital rotation for Be

### DIFF
--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -71,7 +71,10 @@ set(FILES_TO_COPY
     C_diamond-twist-third.structure.xml
     C_diamond-twist-third.wfj.xml
     cartesian_order.wfnoj.xml
-    dirac_order.wfnoj.xml)
+    dirac_order.wfnoj.xml
+    rot_Be_STO.wfnoj.xml
+    rot_multi_1det_Be_STO.wfnoj.xml
+    rot_multi_2det_Be_STO.wfnoj.xml)
 
 foreach(fname ${FILES_TO_COPY})
   execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/${fname}" ${UTEST_DIR})

--- a/src/QMCWaveFunctions/tests/construct_rot.py
+++ b/src/QMCWaveFunctions/tests/construct_rot.py
@@ -1,0 +1,103 @@
+
+# Generate a constructor for a skew symmetric matrix from a list of parameters
+# Output is Python code to be used in further scripts
+
+# Autodiff expects matrices to be constructed and not updated.  This makes it
+# difficult to use autodiff with programmatically constructed rotation matrices.
+
+import numpy as np
+
+
+# Rotation indices for a ground state
+# This should produce the same list of indices as
+# QMCWaveFunctions/RotatedSPOs.cpp::createRotationIndices
+def get_rotation_indices(nel, nmo):
+    rot_ind = list()
+    for i in range(nel):
+        for j in range(nel,nmo):
+            rot_ind.append( (i,j) )
+
+    return rot_ind
+
+# Rotation indices including one excited state.
+# This implementation is specific to the first excited state being
+# included in one of the determinants.
+# Should produce the same list of indices as
+# QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp::buildOptVariables
+# for this problem.
+def get_rotation_indices_ex(nel, nmo):
+    rot_ind = list()
+    for i in range(nel+1):
+        for j in range(i+1,nmo):
+            rot_ind.append( (i,j) )
+
+    return rot_ind
+
+# Full rotation indices (for global rotation)
+# This should produce the same list of indices as
+# QMCWaveFunctions/RotatedSPOs.cpp::createRotationIndicesFull
+def get_full_rotation_indices(nel, nmo):
+    rot_ind = list()
+    for i in range(nel):
+        for j in range(nel,nmo):
+            rot_ind.append( (i,j) )
+
+    for i in range(nel):
+        for j in range(i+1,nel):
+            rot_ind.append( (i,j) )
+
+    for i in range(nel,nmo):
+        for j in range(i+1,nmo):
+            rot_ind.append( (i,j) )
+
+    return rot_ind
+
+
+# Populate a skew symmetric matrix with corresponding indices
+def construct_antisym(nmo,rot_ind):
+   rot = np.zeros((nmo,nmo),dtype=np.int64)
+   for idx in range(len(rot_ind)):
+        p,q = rot_ind[idx]
+        rot[q,p] = idx+1
+        rot[p,q] = -(idx+1)
+
+   return rot
+
+# Convert the output of construct_antisym to a numpy array constructor
+def print_anti(rot_mat):
+    print("np.array([")
+    for i in range(rot_mat.shape[0]):
+        print("[ ",end='')
+        for j in range(rot_mat.shape[1]):
+            idx = np.abs(rot_mat[i,j])
+            sign = ""
+            if rot_mat[i,j] < 0:
+                sign = "-"
+            if idx == 0:
+                print(" 0",end='')
+            else:
+                print(" {}p[{}]".format(sign,idx-1),end='')
+            if j != rot_mat.shape[1]-1:
+                print(",",end='')
+        print("]",end='')
+        if i != rot_mat.shape[0]-1:
+            print(",")
+    print("])")
+
+
+if __name__ == "__main__"
+    # For the Be problem
+    nel = 2
+    nmo = 7
+
+    # For rot_be_sto_wf.py
+    #rot_ind = get_rotation_indices(nel,nmo)
+
+    # For rot_multi_be_sto_wf.py
+    rot_ind = get_rotation_indices_ex(nel, nmo)
+
+    #rot_ind = get_full_rotation_indices(nel,nmo)
+    rot_mat = construct_antisym(nmo, rot_ind)
+    print_anti(rot_mat)
+
+

--- a/src/QMCWaveFunctions/tests/rot_Be_STO.wfnoj.xml
+++ b/src/QMCWaveFunctions/tests/rot_Be_STO.wfnoj.xml
@@ -1,0 +1,51 @@
+<qmcsystem>
+  <wavefunction name="psi0" target="e">
+    <!-- From Bunge, Barrientos, and Bunge, Atomic Data and Nuclear Data Tables 53, 113-162(1993) -->
+    <sposet_collection type="MolecularOrbital">
+      <basisset keyword="STO" transform="no">
+        <atomicBasisSet elementType="Be" normalized="no" type="STO">
+          <basisGroup l="0" m="0" rid="C0" type="Slater">
+             <radfunc n="1" exponent= "5.7531" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C1" type="Slater">
+             <radfunc n="1" exponent= "3.7156" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C2" type="Slater">
+             <radfunc n="3" exponent= "9.9670" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C3" type="Slater">
+             <radfunc n="3" exponent= "3.7128" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C4" type="Slater">
+             <radfunc n="2" exponent= "4.4661" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C5" type="Slater">
+             <radfunc n="2" exponent= "1.2919" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C6" type="Slater">
+             <radfunc n="2" exponent= "0.8555" />
+          </basisGroup>
+        </atomicBasisSet>
+      </basisset>
+      <rotated_sposet name="rot-spo-up" method="global">
+      <sposet basisset="LCAOBSet" name="spo-up">
+          <coefficient id="updetC" size="7" type="Array">
+-0.3203716272  -0.3404403028  -0.09736649354 -0.4377945266   0.02422331125 -0.7356371679   0.1963907521 
+ 0.6670416431   0.05589542384 -0.008824049451 0.008662699137 0.6847608591  -0.2754997442   0.08355057464 
+-0.07564611156 -0.02925862449  0.9855001816  -0.1207470799   0.08664604529 -0.01033460848 -0.004097813485 
+ 0.1073578588   0.7549795709  -0.0300084091  -0.6086077017  -0.1715415418  -0.06645371134 -0.1154716512 
+ 0.6371603738  -0.4486557886   0.04882715285 -0.2885587972  -0.5478377162   0.06267642488 -0.05504428678 
+-0.1551054775  -0.2897122992  -0.1210613174  -0.5804289448   0.4111220408   0.6019922521   0.09507611705 
+ 0.07168243573  0.1577993958   0.03592848464  0.05580124477 -0.1563146302   0.1099633686   0.963862095 
+          </coefficient>
+      </sposet>
+    </rotated_sposet>
+    </sposet_collection>
+    <determinantset key="STO" source="ion0" transform="no" type="MO">
+      <slaterdeterminant batch="no">
+        <determinant id="rot-spo-up"/>
+        <determinant id="rot-spo-up"/>
+      </slaterdeterminant>
+    </determinantset>
+ </wavefunction>
+</qmcsystem>

--- a/src/QMCWaveFunctions/tests/rot_be_sto_wf.py
+++ b/src/QMCWaveFunctions/tests/rot_be_sto_wf.py
@@ -1,0 +1,181 @@
+import autograd.numpy as np
+from autograd import hessian, grad
+from run_qmc import run_qmc
+import read_qmcpack
+from slater_orbitals import STO
+
+import scipy.linalg
+
+# From construct_rot.py
+def construct_antisym(p):
+    return np.array(
+        [
+            [0, 0, -p[0], -p[1], -p[2], -p[3], -p[4]],
+            [0, 0, -p[5], -p[6], -p[7], -p[8], -p[9]],
+            [p[0], p[5], 0, 0, 0, 0, 0],
+            [p[1], p[6], 0, 0, 0, 0, 0],
+            [p[2], p[7], 0, 0, 0, 0, 0],
+            [p[3], p[8], 0, 0, 0, 0, 0],
+            [p[4], p[9], 0, 0, 0, 0, 0],
+        ]
+    )
+
+
+def det2(phi):
+    return phi[0, 0] * phi[1, 1] - phi[1, 0] * phi[0, 1]
+
+
+def mat_exp(m):
+    # Simple approximation good enough for derivatives at zero rotation
+    # Might only need to go up to the linear term
+    return np.eye(m.shape[0]) + m + np.dot(m, m) / 2
+
+
+class Wavefunction_Be_STO:
+    def __init__(self, basis, mo_coeff):
+        self.sto = STO()
+        self.sto.set_basis(basis)
+        self.mo_coeff = mo_coeff
+        self.hess = list()
+        for i in range(4):
+            self.hess.append(hessian(self.psi_internal, i))
+
+        self.nmo = 7
+
+        self.param_size = 10
+
+        self.dpsi = grad(self.psi, 1)
+
+        self.dlocal_energy = grad(self.local_energy, 1)
+
+    def mag(self, r):
+        return np.sqrt(r[0] * r[0] + r[1] * r[1] + r[2] * r[2])
+
+    def psi_internal(self, r1, r2, r3, r4, VP):
+
+        param = VP[0 : self.param_size]
+        rot = construct_antisym(param)
+        # Could use this if not doing autodiff
+        # rot_mat = scipy.linalg.expm(-rot)
+        rot_mat = mat_exp(-rot)
+        rot_mo = np.dot(rot_mat, self.mo_coeff)
+
+        mo_size = self.mo_coeff.shape[0]
+        phi0_1 = [self.sto.eval_v2(i, r1) for i in range(mo_size)]
+        phi0_2 = [self.sto.eval_v2(i, r2) for i in range(mo_size)]
+        phi0_a = np.array([phi0_1, phi0_2])
+        phi0 = np.dot(rot_mo, phi0_a.T)
+
+        phi1_1 = [self.sto.eval_v2(i, r3) for i in range(mo_size)]
+        phi1_2 = [self.sto.eval_v2(i, r4) for i in range(mo_size)]
+        phi1_a = np.array([phi1_1, phi1_2])
+        phi1 = np.dot(rot_mo, phi1_a.T)
+
+        d1 = det2(phi0)
+        d2 = det2(phi1)
+        return d1 * d2
+
+    def psi(self, r, VP):
+        r1 = r[0, :]
+        r2 = r[1, :]
+        r3 = r[2, :]
+        r4 = r[3, :]
+        return self.psi_internal(r1, r2, r3, r4, VP)
+
+    def dpsi(self, r, VP):
+        r1 = r[0, :]
+        r2 = r[1, :]
+        r3 = r[2, :]
+        r4 = r[3, :]
+        return self.dpsi_internal(r1, r2, r3, r4, VP)
+
+    def en_pot(self, r):
+        Z = 4.0
+        total = 0.0
+        for i in range(r.shape[0]):
+            r_mag = self.mag(r[i, :])
+            total += -Z / r_mag
+        return total
+
+    def ee_pot(self, r):
+        total = 0.0
+        for i in range(r.shape[0]):
+            for j in range(i):
+                rij = r[j, :] - r[i, :]
+                rij_mag = self.mag(rij)
+                total += 1.0 / rij_mag
+        return total
+
+    def lap(self, r1, r2, r3, r4, VP):
+        h = 0.0
+        for i in range(4):
+            h += np.sum(np.diag(self.hess[i](r1, r2, r3, r4, VP)))
+        return h
+
+    def local_energy(self, r, VP):
+        r1 = r[0, :]
+        r2 = r[1, :]
+        r3 = r[2, :]
+        r4 = r[3, :]
+        pot = self.en_pot(r) + self.ee_pot(r)
+        psi_val = self.psi_internal(r1, r2, r3, r4, VP)
+        lapl = self.lap(r1, r2, r3, r4, VP)
+        h = -0.5 * lapl / psi_val + pot
+        return h
+
+    def dlocal_energy(self, r, VP):
+        r1 = r[0, :]
+        r2 = r[1, :]
+        r3 = r[2, :]
+        r4 = r[3, :]
+        pot = self.en_pot(r) + self.ee_pot(r)
+        psi_val = self.psi_internal(r1, r2, r3, r4, VP)
+        lapl = self.lap(r1, r2, r3, r4, VP)
+        h = -0.5 * lapl / psi_val + pot
+        return h
+
+# Create reference values for
+# "Rotated LCAO Be single determinant" and "Rotated LCAO Be multi determinant with one determinant"
+# in test_RotatedSPOs_LCAO.cpp
+def generate_point_values():
+    fname = "rot_Be_STO.wfnoj.xml"
+    basis, mo = read_qmcpack.parse_qmc_wf(fname, ["Be"])
+    wf = Wavefunction_Be_STO(basis["Be"], mo)
+
+    r = np.array([[0.7, 2.0, 3.0], [1.2, 1.5, 0.5], [1.5, 1.6, 1.5], [0.7, 1.0, 1.2]])
+
+    VP = np.zeros(wf.param_size)
+    p = wf.psi(r, VP)
+    print("psi = ", p)
+    print("log psi = ", np.log(abs(p)))
+
+    dp = wf.dpsi(r, VP)
+    print("dpsi = ", dp)
+
+    print("dlogpsi = ", dp / p)
+    dlogpsi = dp / p
+    for i in range(dlogpsi.shape[0]):
+        print("    CHECK(dlogpsi[{}] == ValueApprox({}));".format(i, dlogpsi[i]))
+
+    en = wf.local_energy(r, VP)
+    print("en = ", en)
+
+    den = wf.dlocal_energy(r, VP)
+    print("den = ", den)
+
+    for i in range(den.shape[0]):
+        print("    CHECK(dhpsioverpsi[{}] == ValueApprox({}));".format(i, den[i]))
+
+
+def run():
+    fname = "rot_Be_STO.wfnoj.xml"
+    basis, mo = read_qmcpack.parse_qmc_wf(fname, ["Be"])
+    wf = Wavefunction_Be_STO(basis["Be"], mo)
+    VP = np.zeros(wf.param_size)
+    r = np.array([[0.7, 2.0, 3.0], [1.2, 1.5, 0.5], [1.5, 1.6, 1.5], [0.7, 1.0, 1.2]])
+    run_qmc(r, wf, VP, nstep=100, nblock=10)
+
+
+if __name__ == "__main__":
+    generate_point_values()
+    #run()

--- a/src/QMCWaveFunctions/tests/rot_be_sto_wf.py
+++ b/src/QMCWaveFunctions/tests/rot_be_sto_wf.py
@@ -1,3 +1,7 @@
+
+# Compute wavefunction values and parameter derivatives
+# for a wavefunction with STO Be orbitals, single determinant, and orbital rotation
+
 import autograd.numpy as np
 from autograd import hessian, grad
 from run_qmc import run_qmc

--- a/src/QMCWaveFunctions/tests/rot_multi_1det_Be_STO.wfnoj.xml
+++ b/src/QMCWaveFunctions/tests/rot_multi_1det_Be_STO.wfnoj.xml
@@ -1,0 +1,52 @@
+<qmcsystem>
+  <wavefunction name="psi0" target="e">
+    <!-- From Bunge, Barrientos, and Bunge, Atomic Data and Nuclear Data Tables 53, 113-162(1993) -->
+    <sposet_collection type="MolecularOrbital">
+      <basisset keyword="STO" transform="no">
+        <atomicBasisSet elementType="Be" normalized="no" type="STO">
+          <basisGroup l="0" m="0" rid="C0" type="Slater">
+             <radfunc n="1" exponent= "5.7531" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C1" type="Slater">
+             <radfunc n="1" exponent= "3.7156" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C2" type="Slater">
+             <radfunc n="3" exponent= "9.9670" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C3" type="Slater">
+             <radfunc n="3" exponent= "3.7128" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C4" type="Slater">
+             <radfunc n="2" exponent= "4.4661" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C5" type="Slater">
+             <radfunc n="2" exponent= "1.2919" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C6" type="Slater">
+             <radfunc n="2" exponent= "0.8555" />
+          </basisGroup>
+        </atomicBasisSet>
+      </basisset>
+      <rotated_sposet name="rot-spo-up" method="global">
+      <sposet basisset="LCAOBSet" name="spo-up">
+          <coefficient id="updetC" size="7" type="Array">
+-0.3203716272  -0.3404403028  -0.09736649354 -0.4377945266   0.02422331125 -0.7356371679   0.1963907521 
+ 0.6670416431   0.05589542384 -0.008824049451 0.008662699137 0.6847608591  -0.2754997442   0.08355057464 
+-0.07564611156 -0.02925862449  0.9855001816  -0.1207470799   0.08664604529 -0.01033460848 -0.004097813485 
+ 0.1073578588   0.7549795709  -0.0300084091  -0.6086077017  -0.1715415418  -0.06645371134 -0.1154716512 
+ 0.6371603738  -0.4486557886   0.04882715285 -0.2885587972  -0.5478377162   0.06267642488 -0.05504428678 
+-0.1551054775  -0.2897122992  -0.1210613174  -0.5804289448   0.4111220408   0.6019922521   0.09507611705 
+ 0.07168243573  0.1577993958   0.03592848464  0.05580124477 -0.1563146302   0.1099633686   0.963862095 
+          </coefficient>
+      </sposet>
+    </rotated_sposet>
+    </sposet_collection>
+    <determinantset>
+      <multideterminant optimize="no" spo_0="rot-spo-up" spo_1="rot-spo-up" algorithm="precomputed_table_method">
+        <detlist size="1" type="DETS" nc0="0" ne0="2" nc1="0" ne1="2" nstates="4" cutoff="1e-20">
+          <ci id="CI0" coeff="1.0" occ0="1100" occ1="1100"/>
+        </detlist>
+       </multideterminant>
+    </determinantset>
+ </wavefunction>
+</qmcsystem>

--- a/src/QMCWaveFunctions/tests/rot_multi_2det_Be_STO.wfnoj.xml
+++ b/src/QMCWaveFunctions/tests/rot_multi_2det_Be_STO.wfnoj.xml
@@ -1,0 +1,54 @@
+<qmcsystem>
+  <wavefunction name="psi0" target="e">
+    <!-- From Bunge, Barrientos, and Bunge, Atomic Data and Nuclear Data Tables 53, 113-162(1993) -->
+    <sposet_collection type="MolecularOrbital">
+      <basisset keyword="STO" transform="no">
+        <atomicBasisSet elementType="Be" normalized="no" type="STO">
+          <basisGroup l="0" m="0" rid="C0" type="Slater">
+             <radfunc n="1" exponent= "5.7531" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C1" type="Slater">
+             <radfunc n="1" exponent= "3.7156" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C2" type="Slater">
+             <radfunc n="3" exponent= "9.9670" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C3" type="Slater">
+             <radfunc n="3" exponent= "3.7128" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C4" type="Slater">
+             <radfunc n="2" exponent= "4.4661" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C5" type="Slater">
+             <radfunc n="2" exponent= "1.2919" />
+          </basisGroup>
+          <basisGroup l="0" m="0" rid="C6" type="Slater">
+             <radfunc n="2" exponent= "0.8555" />
+          </basisGroup>
+        </atomicBasisSet>
+      </basisset>
+      <rotated_sposet name="rot-spo-up" method="global">
+      <sposet basisset="LCAOBSet" name="spo-up">
+          <coefficient id="updetC" size="7" type="Array">
+-0.3203716272  -0.3404403028  -0.09736649354 -0.4377945266   0.02422331125 -0.7356371679   0.1963907521 
+ 0.6670416431   0.05589542384 -0.008824049451 0.008662699137 0.6847608591  -0.2754997442   0.08355057464 
+-0.07564611156 -0.02925862449  0.9855001816  -0.1207470799   0.08664604529 -0.01033460848 -0.004097813485 
+ 0.1073578588   0.7549795709  -0.0300084091  -0.6086077017  -0.1715415418  -0.06645371134 -0.1154716512 
+ 0.6371603738  -0.4486557886   0.04882715285 -0.2885587972  -0.5478377162   0.06267642488 -0.05504428678 
+-0.1551054775  -0.2897122992  -0.1210613174  -0.5804289448   0.4111220408   0.6019922521   0.09507611705 
+ 0.07168243573  0.1577993958   0.03592848464  0.05580124477 -0.1563146302   0.1099633686   0.963862095 
+          </coefficient>
+      </sposet>
+    </rotated_sposet>
+    </sposet_collection>
+    <determinantset>
+      <multideterminant optimize="yes" spo_0="rot-spo-up" spo_1="rot-spo-up" algorithm="precomputed_table_method">
+        <detlist size="2" type="DETS" nc0="0" ne0="2" nc1="0" ne1="2" nstates="4" cutoff="1e-20">
+          <ci id="CI0" coeff="1.0" occ0="1100" occ1="1100"/>
+          <ci id="CI1" coeff="0.1" occ0="1010" occ1="1010"/>
+        </detlist>
+       </multideterminant>
+    </determinantset>
+
+ </wavefunction>
+</qmcsystem>

--- a/src/QMCWaveFunctions/tests/rot_multi_be_sto_wf.py
+++ b/src/QMCWaveFunctions/tests/rot_multi_be_sto_wf.py
@@ -1,3 +1,7 @@
+
+# Compute wavefunction values and parameter derivatives
+# for a wavefunction with STO Be orbitals, two determinants, and orbital rotation
+
 import autograd.numpy as np
 from autograd import hessian, grad
 

--- a/src/QMCWaveFunctions/tests/rot_multi_be_sto_wf.py
+++ b/src/QMCWaveFunctions/tests/rot_multi_be_sto_wf.py
@@ -1,0 +1,194 @@
+import autograd.numpy as np
+from autograd import hessian, grad
+
+from run_qmc import run_qmc
+import read_qmcpack
+from slater_orbitals import STO
+
+import scipy.linalg
+
+# From construct_rot.py
+def construct_antisym_ex(p):
+    return np.array(
+        [
+            [0, -p[0], -p[1], -p[2], -p[3], -p[4], -p[5]],
+            [p[0], 0, -p[6], -p[7], -p[8], -p[9], -p[10]],
+            [p[1], p[6], 0, -p[11], -p[12], -p[13], -p[14]],
+            [p[2], p[7], p[11], 0, 0, 0, 0],
+            [p[3], p[8], p[12], 0, 0, 0, 0],
+            [p[4], p[9], p[13], 0, 0, 0, 0],
+            [p[5], p[10], p[14], 0, 0, 0, 0],
+        ]
+    )
+
+
+# 2x2 determinant between two states
+def det2_ex(phi, i, j):
+    return phi[i, 0] * phi[j, 1] - phi[j, 0] * phi[i, 1]
+
+
+def mat_exp(m):
+    # Simple approximation good enough for derivatives at zero rotation
+    # Might only need to go up to the linear term
+    return np.eye(m.shape[0]) + m + np.dot(m, m) / 2
+
+
+class Wavefunction_Be_STO:
+    def __init__(self, basis, mo_coeff):
+        self.sto = STO()
+        self.sto.set_basis(basis)
+        self.mo_coeff = mo_coeff
+        self.hess = list()
+        for i in range(4):
+            self.hess.append(hessian(self.psi_internal, i))
+
+        self.nmo = 7
+
+        self.rot_param_size = 15  # size of p in construct_antisym_ex
+
+        self.dpsi = grad(self.psi, 1)
+
+        self.dlocal_energy = grad(self.local_energy, 1)
+
+    def mag(self, r):
+        return np.sqrt(r[0] * r[0] + r[1] * r[1] + r[2] * r[2])
+
+    def psi_internal(self, r1, r2, r3, r4, VP):
+
+        param = VP[1 : self.rot_param_size + 1]
+
+        rot = construct_antisym_ex(param)
+        # Can use this line if not doing autodiff
+        # rot_mat = scipy.linalg.expm(-rot)
+        rot_mat = mat_exp(-rot)
+        rot_mo = np.dot(rot_mat, self.mo_coeff)
+
+        mo_size = self.mo_coeff.shape[0]
+        phi0_1 = [self.sto.eval_v2(i, r1) for i in range(mo_size)]
+        phi0_2 = [self.sto.eval_v2(i, r2) for i in range(mo_size)]
+        phi0_a = np.array([phi0_1, phi0_2])
+        phi0 = np.dot(rot_mo, phi0_a.T)
+
+        phi1_1 = [self.sto.eval_v2(i, r3) for i in range(mo_size)]
+        phi1_2 = [self.sto.eval_v2(i, r4) for i in range(mo_size)]
+        phi1_a = np.array([phi1_1, phi1_2])
+        phi1 = np.dot(rot_mo, phi1_a.T)
+
+        d1 = det2_ex(phi0, 0, 1)
+        d2 = det2_ex(phi1, 0, 1)
+        c1 = 1.0
+
+        d3 = det2_ex(phi0, 0, 2)
+        d4 = det2_ex(phi1, 0, 2)
+        c2 = VP[0]
+
+        return c1 * d1 * d2 + c2 * d3 * d4
+
+    def psi(self, r, VP):
+        r1 = r[0, :]
+        r2 = r[1, :]
+        r3 = r[2, :]
+        r4 = r[3, :]
+        return self.psi_internal(r1, r2, r3, r4, VP)
+
+    def dpsi(self, r, VP):
+        r1 = r[0, :]
+        r2 = r[1, :]
+        r3 = r[2, :]
+        r4 = r[3, :]
+        return self.dpsi_internal(r1, r2, r3, r4, VP)
+
+    def en_pot(self, r):
+        Z = 4.0
+        total = 0.0
+        for i in range(r.shape[0]):
+            r_mag = self.mag(r[i, :])
+            total += -Z / r_mag
+        return total
+
+    def ee_pot(self, r):
+        total = 0.0
+        for i in range(r.shape[0]):
+            for j in range(i):
+                rij = r[j, :] - r[i, :]
+                rij_mag = self.mag(rij)
+                total += 1.0 / rij_mag
+        return total
+
+    def lap(self, r1, r2, r3, r4, VP):
+        h = 0.0
+        for i in range(4):
+            h += np.sum(np.diag(self.hess[i](r1, r2, r3, r4, VP)))
+        return h
+
+    def local_energy(self, r, VP):
+        r1 = r[0, :]
+        r2 = r[1, :]
+        r3 = r[2, :]
+        r4 = r[3, :]
+        pot = self.en_pot(r) + self.ee_pot(r)
+        psi_val = self.psi_internal(r1, r2, r3, r4, VP)
+        lapl = self.lap(r1, r2, r3, r4, VP)
+        h = -0.5 * lapl / psi_val + pot
+        return h
+
+    def dlocal_energy(self, r, VP):
+        r1 = r[0, :]
+        r2 = r[1, :]
+        r3 = r[2, :]
+        r4 = r[3, :]
+        pot = self.en_pot(r) + self.ee_pot(r)
+        psi_val = self.psi_internal(r1, r2, r3, r4, VP)
+        lapl = self.lap(r1, r2, r3, r4, VP)
+        h = -0.5 * lapl / psi_val + pot
+        return h
+
+
+# Create reference values for
+# "Rotated LCAO Be two determinant" in test_RotatedSPOs_LCAO.cpp
+def gen_point_derivatives():
+    # only uses the basis set
+    fname = "rot_multi_2det_Be_STO.wfnoj.xml"
+    basis, mo = read_qmcpack.parse_qmc_wf(fname, ["Be"])
+    wf = Wavefunction_Be_STO(basis["Be"], mo)
+
+    r = np.array([[0.7, 2.0, 3.0], [1.2, 1.5, 0.5], [1.5, 1.6, 1.5], [0.7, 1.0, 1.2]])
+
+    VP = np.zeros(wf.rot_param_size + 1)
+    VP[0] = 0.1
+    p = wf.psi(r, VP)
+    print("psi = ", p)
+    print("log psi = ", np.log(abs(p)))
+
+    dp = wf.dpsi(r, VP)
+    print("dpsi = ", dp)
+
+    print("dlogpsi = ", dp / p)
+    dlogpsi = dp / p
+    for i in range(dlogpsi.shape[0]):
+        print("    CHECK(dlogpsi[{}] == ValueApprox({}));".format(i, dlogpsi[i]))
+
+    en = wf.local_energy(r, VP)
+    print("en = ", en)
+
+    den = wf.dlocal_energy(r, VP)
+    print("den = ", den)
+
+    for i in range(den.shape[0]):
+        print("   CHECK(dhpsioverpsi[{}] == ValueApprox({}));".format(i, den[i]))
+
+
+def run():
+    fname = "rot_multi_2det_Be_STO.wfnoj.xml"
+    basis, mo = read_qmcpack.parse_qmc_wf(fname, ["Be"])
+    wf = Wavefunction_Be_STO(basis["Be"], mo)
+
+    r = np.array([[0.7, 2.0, 3.0], [1.2, 1.5, 0.5], [1.5, 1.6, 1.5], [0.7, 1.0, 1.2]])
+    VP = np.zeros(wf.rot_param_size + 1)
+    VP[0] = 0.1
+    run_qmc(r, wf, VP, nstep=10, nblock=10)
+
+
+if __name__ == "__main__":
+    gen_point_derivatives()
+    #run()

--- a/src/QMCWaveFunctions/tests/slater_orbitals.py
+++ b/src/QMCWaveFunctions/tests/slater_orbitals.py
@@ -1,0 +1,69 @@
+from sympy import *
+from sympy.utilities.lambdify import lambdastr
+from collections import namedtuple, defaultdict
+
+# import numpy as np
+from autograd import grad
+import autograd.numpy as np
+import math
+
+
+# n, zeta, and contraction_coeff are lists of size nbasis
+CG_basis = namedtuple(
+    "CG_basis", ["orbtype", "nbasis", "n", "zeta", "contraction_coeff"]
+)
+
+
+class STO:
+    def __init__(self):
+        x, y, z = symbols("x y z", real=True)
+        zeta = Symbol("zeta", positive=True, real=True)
+        r = Symbol("r", real=True, nonnegative=True)
+        N = Symbol("N")
+        self.N = N
+        n = Symbol("n", integer=True, positive=True)
+        norm = (2 * zeta) ** n * sqrt(2 * zeta / factorial(2 * n))
+
+        sto_sym_raw = N * r ** (n - 1) * exp(-zeta * r)
+
+        stosym = sto_sym_raw.subs(N, norm)
+
+        nmax = 3
+        self.sto = dict()
+        self.sto_dr = dict()
+        for nval in range(1, nmax + 1):
+            subs_list = {n: nval}
+            csto = stosym.subs(subs_list).evalf()
+
+            sto_str = lambdastr((r, zeta), csto).replace("math", "np")
+            self.sto[nval] = eval(sto_str)
+            # print('s',sto_str)
+
+    def set_basis(self, basis):
+        self.basis = basis
+
+    def eval_v(self, x, y, z):
+        r = np.sqrt(x * x + y * y + z * z)
+        ang_norm = 1 / np.sqrt(4 * np.pi)
+        v = 0.0
+        for basis in self.basis:
+            for i in range(basis.nbasis):
+                v += (
+                    ang_norm
+                    * basis.contraction_coeff[i]
+                    * self.sto[basis.n[i]](r, basis.zeta[i])
+                )
+        return v
+
+    def eval_v2(self, basis_idx, r):
+        r = np.sqrt(r[0] * r[0] + r[1] * r[1] + r[2] * r[2])
+        ang_norm = 1 / np.sqrt(4 * np.pi)
+        v = 0.0
+        basis = self.basis[basis_idx]
+        for i in range(basis.nbasis):
+            v += (
+                ang_norm
+                * basis.contraction_coeff[i]
+                * self.sto[basis.n[i]](r, basis.zeta[i])
+            )
+        return v

--- a/src/QMCWaveFunctions/tests/slater_orbitals.py
+++ b/src/QMCWaveFunctions/tests/slater_orbitals.py
@@ -1,3 +1,6 @@
+
+# Evaluate STO's starting from a symbolic representation
+
 from sympy import *
 from sympy.utilities.lambdify import lambdastr
 from collections import namedtuple, defaultdict

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
@@ -74,6 +74,56 @@ void setupParticleSetPool(ParticleSetPool& pp)
   pp.put(part_elec);
 }
 
+// Set particles for Be atom
+void setupParticleSetPoolBe(ParticleSetPool& pp)
+{
+  // See ParticleIO/tests/test_xml_io.cpp for particle parsing
+  const char* particles = R"(<qmcsystem>
+  <particleset name="ion0" size="1">
+    <group name="Be">
+      <parameter name="charge">4</parameter>
+      <parameter name="valence">4</parameter>
+      <parameter name="atomicnumber">4</parameter>
+    </group>
+    <attrib name="position" datatype="posArray">
+  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00
+</attrib>
+    <attrib name="ionid" datatype="stringArray">
+ Be
+</attrib>
+  </particleset>
+
+  <particleset name="e" random="no">
+    <group name="u" size="2">
+      <parameter name="charge">-1</parameter>
+    <attrib name="position" datatype="posArray">
+      0.7 2.0 3.0
+      1.2 1.5 0.5
+    </attrib>
+    </group>
+    <group name="d" size="2">
+      <parameter name="charge">-1</parameter>
+    <attrib name="position" datatype="posArray">
+      1.5 1.6 1.5
+      0.7 1.0 1.2
+    </attrib>
+    </group>
+  </particleset>
+</qmcsystem>)";
+
+  Libxml2Document doc;
+
+  bool okay = doc.parseFromString(particles);
+  REQUIRE(okay);
+
+  xmlNodePtr root = doc.getRoot();
+
+  xmlNodePtr part_ion = xmlFirstElementChild(root);
+  pp.put(part_ion);
+  xmlNodePtr part_elec = xmlNextElementSibling(part_ion);
+  pp.put(part_elec);
+}
+
 std::string setupRotationXML(const std::string& rot_angle_up,
                              const std::string& rot_angle_down,
                              const std::string& coeff_up,
@@ -688,6 +738,221 @@ TEST_CASE("Rotated LCAO rotation consistency", "[qmcapp]")
   std::vector<ValueType> expected_param = {0.3998099017676912, 0.34924318065960236, -0.02261313113492491};
   for (int i = 0; i < expected_param.size(); i++)
     CHECK(new_params2[i] == Approx(expected_param[i]));
+}
+
+// Reference values from rot_be_sto_wf.py
+// Uses single determinant code path
+TEST_CASE("Rotated LCAO Be single determinant", "[qmcapp]")
+{
+  ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
+  Communicate* c;
+  c = OHMMS::Controller;
+
+  ParticleSetPool pp(c);
+  setupParticleSetPoolBe(pp);
+
+  WaveFunctionPool wp(test_project.getRuntimeOptions(), pp, c);
+
+  REQUIRE(wp.empty() == true);
+
+  Libxml2Document doc;
+  bool okay = doc.parse("rot_Be_STO.wfnoj.xml");
+  REQUIRE(okay);
+  xmlNodePtr root = doc.getRoot();
+
+  wp.put(xmlFirstElementChild(root));
+
+
+  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
+  REQUIRE(psi != nullptr);
+  REQUIRE(psi->getOrbitals().size() == 1);
+
+  opt_variables_type opt_vars;
+  psi->checkInVariables(opt_vars);
+  opt_vars.resetIndex();
+  psi->checkOutVariables(opt_vars);
+  psi->resetParameters(opt_vars);
+
+  ParticleSet* elec = pp.getParticleSet("e");
+  elec->update();
+
+
+  double logval = psi->evaluateLog(*elec);
+  CHECK(logval == Approx(-17.768474132175342));
+
+  using ValueType = QMCTraits::ValueType;
+  Vector<ValueType> dlogpsi(10);
+  Vector<ValueType> dhpsioverpsi(10);
+  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+
+  CHECK(dlogpsi[0] == ValueApprox(0.24797938203759148));
+  CHECK(dlogpsi[1] == ValueApprox(0.41454059122930453));
+  CHECK(dlogpsi[2] == ValueApprox(0.7539626161586822));
+  CHECK(dlogpsi[3] == ValueApprox(3.13489394217799));
+  CHECK(dlogpsi[4] == ValueApprox(8.47176722646749));
+  CHECK(dlogpsi[5] == ValueApprox(-0.48182453464906033));
+  CHECK(dlogpsi[6] == ValueApprox(2.269206401396164));
+  CHECK(dlogpsi[7] == ValueApprox(-1.883221269688377));
+  CHECK(dlogpsi[8] == ValueApprox(-19.450964163527598));
+  CHECK(dlogpsi[9] == ValueApprox(-47.28198556252034));
+
+  CHECK(dhpsioverpsi[0] == ValueApprox(0.3662586398420111));
+  CHECK(dhpsioverpsi[1] == ValueApprox(-5.544323554018982));
+  CHECK(dhpsioverpsi[2] == ValueApprox(-0.7790656028274846));
+  CHECK(dhpsioverpsi[3] == ValueApprox(24.930187483208087));
+  CHECK(dhpsioverpsi[4] == ValueApprox(71.30301022344871));
+  CHECK(dhpsioverpsi[5] == ValueApprox(-1.1614358798793771));
+  CHECK(dhpsioverpsi[6] == ValueApprox(17.678711245652913));
+  CHECK(dhpsioverpsi[7] == ValueApprox(2.491238469662668));
+  CHECK(dhpsioverpsi[8] == ValueApprox(-79.37464297365679));
+  CHECK(dhpsioverpsi[9] == ValueApprox(-227.0976672502695));
+}
+
+// Reference values from rot_be_sto_wf.py
+// Uses multi-determinant code path with one determinant
+TEST_CASE("Rotated LCAO Be multi determinant with one determinant", "[qmcapp]")
+{
+  ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
+  Communicate* c;
+  c = OHMMS::Controller;
+
+  ParticleSetPool pp(c);
+  setupParticleSetPoolBe(pp);
+
+  WaveFunctionPool wp(test_project.getRuntimeOptions(), pp, c);
+
+  REQUIRE(wp.empty() == true);
+
+  Libxml2Document doc;
+  bool okay = doc.parse("rot_multi_1det_Be_STO.wfnoj.xml");
+  REQUIRE(okay);
+  xmlNodePtr root = doc.getRoot();
+
+  wp.put(xmlFirstElementChild(root));
+
+  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
+  REQUIRE(psi != nullptr);
+  REQUIRE(psi->getOrbitals().size() == 1);
+
+  opt_variables_type opt_vars;
+  psi->checkInVariables(opt_vars);
+  opt_vars.resetIndex();
+  psi->checkOutVariables(opt_vars);
+  psi->resetParameters(opt_vars);
+
+  ParticleSet* elec = pp.getParticleSet("e");
+  elec->update();
+
+
+  double logval = psi->evaluateLog(*elec);
+  CHECK(logval == Approx(-17.768474132175342));
+
+  using ValueType = QMCTraits::ValueType;
+  Vector<ValueType> dlogpsi(10);
+  Vector<ValueType> dhpsioverpsi(10);
+  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+
+  CHECK(dlogpsi[0] == ValueApprox(0.24797938203759148));
+  CHECK(dlogpsi[1] == ValueApprox(0.41454059122930453));
+  CHECK(dlogpsi[2] == ValueApprox(0.7539626161586822));
+  CHECK(dlogpsi[3] == ValueApprox(3.13489394217799));
+  CHECK(dlogpsi[4] == ValueApprox(8.47176722646749));
+  CHECK(dlogpsi[5] == ValueApprox(-0.48182453464906033));
+  CHECK(dlogpsi[6] == ValueApprox(2.269206401396164));
+  CHECK(dlogpsi[7] == ValueApprox(-1.883221269688377));
+  CHECK(dlogpsi[8] == ValueApprox(-19.450964163527598));
+  CHECK(dlogpsi[9] == ValueApprox(-47.28198556252034));
+
+  CHECK(dhpsioverpsi[0] == ValueApprox(0.3662586398420111));
+  CHECK(dhpsioverpsi[1] == ValueApprox(-5.544323554018982));
+  CHECK(dhpsioverpsi[2] == ValueApprox(-0.7790656028274846));
+  CHECK(dhpsioverpsi[3] == ValueApprox(24.930187483208087));
+  CHECK(dhpsioverpsi[4] == ValueApprox(71.30301022344871));
+  CHECK(dhpsioverpsi[5] == ValueApprox(-1.1614358798793771));
+  CHECK(dhpsioverpsi[6] == ValueApprox(17.678711245652913));
+  CHECK(dhpsioverpsi[7] == ValueApprox(2.491238469662668));
+  CHECK(dhpsioverpsi[8] == ValueApprox(-79.37464297365679));
+  CHECK(dhpsioverpsi[9] == ValueApprox(-227.0976672502695));
+}
+
+// Reference values from rot_multi_be_sto_wf.py
+// Uses multi-determinant code path with two determinants
+TEST_CASE("Rotated LCAO Be two determinant", "[qmcapp]")
+{
+  ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
+  Communicate* c;
+  c = OHMMS::Controller;
+
+  ParticleSetPool pp(c);
+  setupParticleSetPoolBe(pp);
+
+  WaveFunctionPool wp(test_project.getRuntimeOptions(), pp, c);
+
+  REQUIRE(wp.empty() == true);
+
+  Libxml2Document doc;
+  bool okay = doc.parse("rot_multi_2det_Be_STO.wfnoj.xml");
+  REQUIRE(okay);
+  xmlNodePtr root = doc.getRoot();
+
+  wp.put(xmlFirstElementChild(root));
+
+  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
+  REQUIRE(psi != nullptr);
+  REQUIRE(psi->getOrbitals().size() == 1);
+
+  opt_variables_type opt_vars;
+  psi->checkInVariables(opt_vars);
+  opt_vars.resetIndex();
+  psi->checkOutVariables(opt_vars);
+  psi->resetParameters(opt_vars);
+
+  ParticleSet* elec = pp.getParticleSet("e");
+  elec->update();
+
+
+  double logval = psi->evaluateLog(*elec);
+  CHECK(logval == Approx(-17.762687110866413));
+
+  using ValueType = QMCTraits::ValueType;
+  Vector<ValueType> dlogpsi(16);
+  Vector<ValueType> dhpsioverpsi(16);
+  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+
+  CHECK(dlogpsi[0] == ValueApprox(0.05770308755290168));
+  CHECK(dlogpsi[1] == ValueApprox(0.00593995768443123));
+  CHECK(dlogpsi[2] == ValueApprox(0.24654846443828843));
+  CHECK(dlogpsi[3] == ValueApprox(0.4214539468865001));
+  CHECK(dlogpsi[4] == ValueApprox(0.7484015451192123));
+  CHECK(dlogpsi[5] == ValueApprox(3.076586144487743));
+  CHECK(dlogpsi[6] == ValueApprox(8.329621106110908));
+  CHECK(dlogpsi[7] == ValueApprox(-0.4311398324864351));
+  CHECK(dlogpsi[8] == ValueApprox(2.2561123798306273));
+  CHECK(dlogpsi[9] == ValueApprox(-1.8723545015077454));
+  CHECK(dlogpsi[10] == ValueApprox(-19.33872609471596));
+  CHECK(dlogpsi[11] == ValueApprox(-47.00915390726143));
+  CHECK(dlogpsi[12] == ValueApprox(-0.05463186141658209));
+  CHECK(dlogpsi[13] == ValueApprox(0.045055811131004785));
+  CHECK(dlogpsi[14] == ValueApprox(0.46675941272234));
+  CHECK(dlogpsi[15] == ValueApprox(1.1352711502777513));
+
+
+  CHECK(dhpsioverpsi[0] == ValueApprox(0.2761674423047662));
+  CHECK(dhpsioverpsi[1] == ValueApprox(0.022999975062422046));
+  CHECK(dhpsioverpsi[2] == ValueApprox(0.3572968312376671));
+  CHECK(dhpsioverpsi[3] == ValueApprox(-5.459873357259045));
+  CHECK(dhpsioverpsi[4] == ValueApprox(-0.792225084691375));
+  CHECK(dhpsioverpsi[5] == ValueApprox(24.453138754349123));
+  CHECK(dhpsioverpsi[6] == ValueApprox(70.0280297306038));
+  CHECK(dhpsioverpsi[7] == ValueApprox(-1.0272848501840672));
+  CHECK(dhpsioverpsi[8] == ValueApprox(17.514031530576368));
+  CHECK(dhpsioverpsi[9] == ValueApprox(2.52887169464403));
+  CHECK(dhpsioverpsi[10] == ValueApprox(-78.37945447401765));
+  CHECK(dhpsioverpsi[11] == ValueApprox(-224.4814690906403));
+  CHECK(dhpsioverpsi[12] == ValueApprox(-0.6346957697642424));
+  CHECK(dhpsioverpsi[13] == ValueApprox(0.03270289146243591));
+  CHECK(dhpsioverpsi[14] == ValueApprox(3.263830358386392));
+  CHECK(dhpsioverpsi[15] == ValueApprox(8.944714289946793));
 }
 
 } // namespace qmcplusplus


### PR DESCRIPTION
Test case is a Be atom with an STO basis set.  Basis set and MO matrix are taken from https://github.com/QMCPACK/qmcpack/blob/develop/tests/molecules/Be_STO/partial_opt_Be_STO.wfnoj.xml

Python scripts compute reference values for the test cases:
 1. single determinant
 2. multi-determinant code path with one determinant (same values as 1)
 3. multi-determinant code path with two determinants

For ease of using autodiff, the skew-symmetric matrix that goes into the rotation matrix is constructed by a separate script (construct_rot.py) and hard-coded into the wavefunction scripts.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
