### PR TITLE
Update device manager

### DIFF
--- a/src/Platforms/CUDA/CMakeLists.txt
+++ b/src/Platforms/CUDA/CMakeLists.txt
@@ -9,11 +9,13 @@
 #// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 #//////////////////////////////////////////////////////////////////////////////////////
 
-set(CUDA_RT_SRCS CUDAfill.cpp CUDAallocator.cpp CUDAruntime.cpp)
+set(CUDA_RT_SRCS CUDAfill.cpp CUDAallocator.cpp CUDAruntime.cpp CUDADeviceManager.cpp)
 set(CUDA_LA_SRCS cuBLAS_missing_functions.cu)
 
 add_library(platform_cuda_runtime ${CUDA_RT_SRCS})
 add_library(platform_cuda_LA ${CUDA_LA_SRCS})
+
+target_link_libraries(platform_cuda_runtime PRIVATE platform_host_runtime)
 
 if(NOT QMC_CUDA2HIP)
   target_link_libraries(platform_cuda_runtime PUBLIC CUDA::cudart)

--- a/src/Platforms/CUDA/CUDADeviceManager.cpp
+++ b/src/Platforms/CUDA/CUDADeviceManager.cpp
@@ -1,0 +1,50 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2023 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "CUDADeviceManager.h"
+#include <stdexcept>
+#include "CUDAruntime.hpp"
+#include "OutputManager.h"
+#include "determineDefaultDeviceNum.h"
+
+namespace qmcplusplus
+{
+CUDADeviceManager::CUDADeviceManager(int& default_device_num, int& num_devices, int local_rank, int local_size)
+    : cuda_default_device_num(-1), cuda_device_count(0)
+{
+  cudaErrorCheck(cudaGetDeviceCount(&cuda_device_count), "cudaGetDeviceCount failed!");
+  if (num_devices == 0)
+    num_devices = cuda_device_count;
+  else if (num_devices != cuda_device_count)
+    throw std::runtime_error("Inconsistent number of CUDA devices with the previous record!");
+  if (cuda_device_count > local_size)
+    app_warning() << "More CUDA devices than the number of MPI ranks. "
+                  << "Some devices will be left idle.\n"
+                  << "There is potential performance issue with the GPU affinity. "
+                  << "Use CUDA_VISIBLE_DEVICE or MPI launcher to expose desired devices.\n";
+  if (num_devices > 0)
+  {
+    cuda_default_device_num = determineDefaultDeviceNum(cuda_device_count, local_rank, local_size);
+    if (default_device_num < 0)
+      default_device_num = cuda_default_device_num;
+    else if (default_device_num != cuda_default_device_num)
+      throw std::runtime_error("Inconsistent assigned CUDA devices with the previous record!");
+
+#pragma omp parallel
+    {
+      cudaErrorCheck(cudaSetDevice(cuda_default_device_num), "cudaSetDevice failed!");
+      cudaErrorCheck(cudaFree(0), "cudaFree failed!");
+    }
+  }
+}
+} // namespace qmcplusplus

--- a/src/Platforms/CUDA/CUDADeviceManager.h
+++ b/src/Platforms/CUDA/CUDADeviceManager.h
@@ -14,11 +14,6 @@
 #ifndef QMCPLUSPLUS_CUDADEVICEMANAGER_H
 #define QMCPLUSPLUS_CUDADEVICEMANAGER_H
 
-#include <stdexcept>
-#include "CUDAruntime.hpp"
-#include "Host/OutputManager.h"
-#include "determineDefaultDeviceNum.h"
-
 namespace qmcplusplus
 {
 
@@ -30,34 +25,7 @@ class CUDADeviceManager
   int cuda_device_count;
 
 public:
-  CUDADeviceManager(int& default_device_num, int& num_devices, int local_rank, int local_size)
-      : cuda_default_device_num(-1), cuda_device_count(0)
-  {
-    cudaErrorCheck(cudaGetDeviceCount(&cuda_device_count), "cudaGetDeviceCount failed!");
-    if (num_devices == 0)
-      num_devices = cuda_device_count;
-    else if (num_devices != cuda_device_count)
-      throw std::runtime_error("Inconsistent number of CUDA devices with the previous record!");
-    if (cuda_device_count > local_size)
-      app_warning() << "More CUDA devices than the number of MPI ranks. "
-                    << "Some devices will be left idle.\n"
-                    << "There is potential performance issue with the GPU affinity. "
-                    << "Use CUDA_VISIBLE_DEVICE or MPI launcher to expose desired devices.\n";
-    if (num_devices > 0)
-    {
-      cuda_default_device_num = determineDefaultDeviceNum(cuda_device_count, local_rank, local_size);
-      if (default_device_num < 0)
-        default_device_num = cuda_default_device_num;
-      else if (default_device_num != cuda_default_device_num)
-        throw std::runtime_error("Inconsistent assigned CUDA devices with the previous record!");
-
-#pragma omp parallel
-      {
-        cudaErrorCheck(cudaSetDevice(cuda_default_device_num), "cudaSetDevice failed!");
-        cudaErrorCheck(cudaFree(0), "cudaFree failed!");
-      }
-    }
-  }
+  CUDADeviceManager(int& default_device_num, int& num_devices, int local_rank, int local_size);
 };
 } // namespace qmcplusplus
 

--- a/src/Platforms/MemoryUsage.cpp
+++ b/src/Platforms/MemoryUsage.cpp
@@ -20,6 +20,10 @@
 #include "CUDA/CUDAallocator.hpp"
 #include "CUDA/CUDAruntime.hpp"
 #endif
+#ifdef ENABLE_SYCL
+#include "SYCL/SYCLallocator.hpp"
+#include "SYCL/SYCLruntime.hpp"
+#endif
 
 namespace qmcplusplus
 {
@@ -38,6 +42,12 @@ void print_mem(const std::string& title, std::ostream& log)
   log << "Device memory allocated via CUDA allocator : " << std::setw(7) << (getCUDAdeviceMemAllocated() >> 20)
       << " MiB" << std::endl;
   log << "Free memory available on default device    : " << std::setw(7) << (getCUDAdeviceFreeMem() >> 20) << " MiB"
+      << std::endl;
+#endif
+#ifdef ENABLE_SYCL
+  log << "Device memory allocated via SYCL allocator : " << std::setw(7) << (getSYCLdeviceMemAllocated() >> 20)
+      << " MiB" << std::endl;
+  log << "Free memory available on default device    : " << std::setw(7) << (getSYCLdeviceFreeMem() >> 20) << " MiB"
       << std::endl;
 #endif
 #ifdef ENABLE_OFFLOAD

--- a/src/Platforms/MemoryUsage.cpp
+++ b/src/Platforms/MemoryUsage.cpp
@@ -38,20 +38,20 @@ void print_mem(const std::string& title, std::ostream& log)
   log << std::right;
   log << "Available memory on node 0, free + buffers : " << std::setw(7) << (freemem() >> 20) << " MiB" << std::endl;
   log << "Memory footprint by rank 0 on node 0       : " << std::setw(7) << (memusage() >> 10) << " MiB" << std::endl;
+#ifdef ENABLE_OFFLOAD
+  log << "Device memory allocated via OpenMP offload : " << std::setw(7) << (getOMPdeviceMemAllocated() >> 20) << " MiB"
+      << std::endl;
+#endif
 #ifdef ENABLE_CUDA
   log << "Device memory allocated via CUDA allocator : " << std::setw(7) << (getCUDAdeviceMemAllocated() >> 20)
       << " MiB" << std::endl;
-  log << "Free memory available on default device    : " << std::setw(7) << (getCUDAdeviceFreeMem() >> 20) << " MiB"
+  log << "Free memory on the default device          : " << std::setw(7) << (getCUDAdeviceFreeMem() >> 20) << " MiB"
       << std::endl;
 #endif
 #ifdef ENABLE_SYCL
   log << "Device memory allocated via SYCL allocator : " << std::setw(7) << (getSYCLdeviceMemAllocated() >> 20)
       << " MiB" << std::endl;
-  log << "Free memory available on default device    : " << std::setw(7) << (getSYCLdeviceFreeMem() >> 20) << " MiB"
-      << std::endl;
-#endif
-#ifdef ENABLE_OFFLOAD
-  log << "Device memory allocated via OpenMP offload : " << std::setw(7) << (getOMPdeviceMemAllocated() >> 20) << " MiB"
+  log << "Free memory on the default device          : " << std::setw(7) << (getSYCLdeviceFreeMem() >> 20) << " MiB"
       << std::endl;
 #endif
   log << line_separator << std::endl;

--- a/src/Platforms/OMPTarget/CMakeLists.txt
+++ b/src/Platforms/OMPTarget/CMakeLists.txt
@@ -2,14 +2,14 @@
 #// This file is distributed under the University of Illinois/NCSA Open Source License.
 #// See LICENSE file in top directory for details.
 #//
-#// Copyright (c) 2021 QMCPACK developers.
+#// Copyright (c) 2023 QMCPACK developers.
 #//
 #// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 #//
 #// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 #//////////////////////////////////////////////////////////////////////////////////////
 
-set(OMP_RT_SRCS OMPallocator.cpp)
+set(OMP_RT_SRCS OMPallocator.cpp OMPDeviceManager.cpp)
 set(OMP_LA_SRCS ompBLAS.cpp)
 
 add_library(platform_omptarget_runtime ${OMP_RT_SRCS})
@@ -18,6 +18,7 @@ if(USE_OBJECT_TARGET)
 else()
   add_library(platform_omptarget_LA ${OMP_LA_SRCS})
 endif()
+target_link_libraries(platform_omptarget_runtime PRIVATE platform_host_runtime)
 target_link_libraries(platform_omptarget_LA PUBLIC platform_omptarget_runtime)
 
 target_compile_options(platform_omptarget_LA PRIVATE "$<$<BOOL:${ENABLE_OFFLOAD_CLANG_DEBUG_O3}>:$<$<CONFIG:DEBUG>:-O3>>")

--- a/src/Platforms/OMPTarget/CMakeLists.txt
+++ b/src/Platforms/OMPTarget/CMakeLists.txt
@@ -21,7 +21,8 @@ endif()
 target_link_libraries(platform_omptarget_runtime PRIVATE platform_host_runtime)
 target_link_libraries(platform_omptarget_LA PUBLIC platform_omptarget_runtime)
 
-target_compile_options(platform_omptarget_LA PRIVATE "$<$<BOOL:${ENABLE_OFFLOAD_CLANG_DEBUG_O3}>:$<$<CONFIG:DEBUG>:-O3>>")
+target_compile_options(platform_omptarget_LA
+                       PRIVATE "$<$<BOOL:${ENABLE_OFFLOAD_CLANG_DEBUG_O3}>:$<$<CONFIG:DEBUG>:-O3>>")
 
 if(ENABLE_CUDA AND QMC_OFFLOAD_MEM_ASSOCIATED)
   target_link_libraries(platform_omptarget_runtime PUBLIC platform_cuda_runtime)

--- a/src/Platforms/OMPTarget/OMPDeviceManager.cpp
+++ b/src/Platforms/OMPTarget/OMPDeviceManager.cpp
@@ -1,0 +1,44 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2023 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "OMPDeviceManager.h"
+#include <stdexcept>
+#include <omp.h>
+#include "OutputManager.h"
+#include "determineDefaultDeviceNum.h"
+
+namespace qmcplusplus
+{
+
+OMPDeviceManager::OMPDeviceManager(int& default_device_num, int& num_devices, int local_rank, int local_size)
+    : omp_default_device_num(-1), omp_device_count(omp_get_num_devices())
+{
+  if (num_devices == 0)
+    num_devices = omp_device_count;
+  else if (num_devices != omp_device_count)
+    throw std::runtime_error("Inconsistent number of OpenMP devices with the previous record!");
+  if (omp_device_count > local_size)
+    app_warning() << "More OpenMP devices than the number of MPI ranks. "
+                  << "Some devices will be left idle.\n"
+                  << "There is potential performance issue with the GPU affinity.\n";
+  if (num_devices > 0)
+  {
+    omp_default_device_num = determineDefaultDeviceNum(omp_device_count, local_rank, local_size);
+    if (default_device_num < 0)
+      default_device_num = omp_default_device_num;
+    else if (default_device_num != omp_default_device_num)
+      throw std::runtime_error("Inconsistent assigned OpenMP devices with the previous record!");
+    omp_set_default_device(omp_default_device_num);
+  }
+}
+} // namespace qmcplusplus

--- a/src/Platforms/OMPTarget/OMPDeviceManager.h
+++ b/src/Platforms/OMPTarget/OMPDeviceManager.h
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2021 QMCPACK developers.
+// Copyright (c) 2023 QMCPACK developers.
 //
 // File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //
@@ -13,11 +13,6 @@
 
 #ifndef QMCPLUSPLUS_OMPDEVICEMANAGER_H
 #define QMCPLUSPLUS_OMPDEVICEMANAGER_H
-
-#include <stdexcept>
-#include <omp.h>
-#include "Host/OutputManager.h"
-#include "determineDefaultDeviceNum.h"
 
 namespace qmcplusplus
 {
@@ -30,27 +25,7 @@ class OMPDeviceManager
   const int omp_device_count;
 
 public:
-  OMPDeviceManager(int& default_device_num, int& num_devices, int local_rank, int local_size)
-      : omp_default_device_num(-1), omp_device_count(omp_get_num_devices())
-  {
-    if (num_devices == 0)
-      num_devices = omp_device_count;
-    else if (num_devices != omp_device_count)
-      throw std::runtime_error("Inconsistent number of OpenMP devices with the previous record!");
-    if (omp_device_count > local_size)
-      app_warning() << "More OpenMP devices than the number of MPI ranks. "
-                    << "Some devices will be left idle.\n"
-                    << "There is potential performance issue with the GPU affinity.\n";
-    if (num_devices > 0)
-    {
-      omp_default_device_num = determineDefaultDeviceNum(omp_device_count, local_rank, local_size);
-      if (default_device_num < 0)
-        default_device_num = omp_default_device_num;
-      else if (default_device_num != omp_default_device_num)
-        throw std::runtime_error("Inconsistent assigned OpenMP devices with the previous record!");
-      omp_set_default_device(omp_default_device_num);
-    }
-  }
+  OMPDeviceManager(int& default_device_num, int& num_devices, int local_rank, int local_size);
 };
 } // namespace qmcplusplus
 

--- a/src/Platforms/SYCL/CMakeLists.txt
+++ b/src/Platforms/SYCL/CMakeLists.txt
@@ -9,14 +9,17 @@
 #// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 #//////////////////////////////////////////////////////////////////////////////////////
 
-
 set(SYCL_RT_SRCS SYCLDeviceManager.cpp SYCLallocator.cpp SYCLruntime.cpp)
 set(SYCL_LA_SRCS syclBLAS.cpp)
 
 add_library(platform_sycl_runtime ${SYCL_RT_SRCS})
-target_link_libraries(platform_sycl_runtime PUBLIC SYCL::host
-                                            PRIVATE platform_host_runtime)
+target_link_libraries(
+  platform_sycl_runtime
+  PUBLIC SYCL::host
+  PRIVATE platform_host_runtime)
 
 add_library(platform_sycl_LA ${SYCL_LA_SRCS})
-target_link_libraries(platform_sycl_LA PUBLIC platform_sycl_runtime MKL::sycl
-                                       PRIVATE SYCL::device platform_sycl_runtime)
+target_link_libraries(
+  platform_sycl_LA
+  PUBLIC platform_sycl_runtime MKL::sycl
+  PRIVATE SYCL::device platform_sycl_runtime)

--- a/src/Platforms/SYCL/SYCLDeviceManager.cpp
+++ b/src/Platforms/SYCL/SYCLDeviceManager.cpp
@@ -130,9 +130,10 @@ SYCLDeviceManager::SYCLDeviceManager(int& default_device_num, int& num_devices, 
     default_device_queue = std::make_unique<sycl::queue>(visible_devices[sycl_default_device_num].get_context(),
                                                          visible_devices[sycl_default_device_num].get_device(),
                                                          sycl::property::queue::in_order());
-    if(!visible_devices[sycl_default_device_num].get_device().has(sycl::aspect::ext_intel_free_memory))
-      app_warning() << "Free memory queries always return 0 due to inactive 'oneAPI' System Resource Management (sysman). "
-	            << "Set environment variable ZES_ENABLE_SYSMAN to 1 to activate the query feature." << std::endl;
+    if (!visible_devices[sycl_default_device_num].get_device().has(sycl::aspect::ext_intel_free_memory))
+      app_warning()
+          << "Free memory queries always return 0 due to inactive 'oneAPI' System Resource Management (sysman). "
+          << "Set environment variable ZES_ENABLE_SYSMAN to 1 to activate the query feature." << std::endl;
   }
 }
 

--- a/src/Platforms/SYCL/SYCLDeviceManager.cpp
+++ b/src/Platforms/SYCL/SYCLDeviceManager.cpp
@@ -130,6 +130,9 @@ SYCLDeviceManager::SYCLDeviceManager(int& default_device_num, int& num_devices, 
     default_device_queue = std::make_unique<sycl::queue>(visible_devices[sycl_default_device_num].get_context(),
                                                          visible_devices[sycl_default_device_num].get_device(),
                                                          sycl::property::queue::in_order());
+    if(!visible_devices[sycl_default_device_num].get_device().has(sycl::aspect::ext_intel_free_memory))
+      app_warning() << "Free memory queries always return 0 due to inactive 'oneAPI' System Resource Management (sysman). "
+	            << "Set environment variable ZES_ENABLE_SYSMAN to 1 to activate the query feature." << std::endl;
   }
 }
 

--- a/src/Platforms/SYCL/SYCLruntime.cpp
+++ b/src/Platforms/SYCL/SYCLruntime.cpp
@@ -18,6 +18,10 @@ namespace qmcplusplus
 sycl::queue& getSYCLDefaultDeviceDefaultQueue() { return SYCLDeviceManager::getDefaultDeviceDefaultQueue(); }
 size_t getSYCLdeviceFreeMem()
 {
-  return getSYCLDefaultDeviceDefaultQueue().get_device().get_info<sycl::info::device::global_mem_size>();
+	auto device = getSYCLDefaultDeviceDefaultQueue().get_device();
+	if(device.has(sycl::aspect::ext_intel_free_memory))
+  return getSYCLDefaultDeviceDefaultQueue().get_device().get_info<sycl::ext::intel::info::device::free_memory>();
+	else
+		return 0;
 }
 } // namespace qmcplusplus

--- a/src/Platforms/SYCL/SYCLruntime.cpp
+++ b/src/Platforms/SYCL/SYCLruntime.cpp
@@ -18,10 +18,10 @@ namespace qmcplusplus
 sycl::queue& getSYCLDefaultDeviceDefaultQueue() { return SYCLDeviceManager::getDefaultDeviceDefaultQueue(); }
 size_t getSYCLdeviceFreeMem()
 {
-	auto device = getSYCLDefaultDeviceDefaultQueue().get_device();
-	if(device.has(sycl::aspect::ext_intel_free_memory))
-  return getSYCLDefaultDeviceDefaultQueue().get_device().get_info<sycl::ext::intel::info::device::free_memory>();
-	else
-		return 0;
+  auto device = getSYCLDefaultDeviceDefaultQueue().get_device();
+  if (device.has(sycl::aspect::ext_intel_free_memory))
+    return getSYCLDefaultDeviceDefaultQueue().get_device().get_info<sycl::ext::intel::info::device::free_memory>();
+  else
+    return 0;
 }
 } // namespace qmcplusplus

--- a/src/Platforms/SYCL/SYCLruntime.cpp
+++ b/src/Platforms/SYCL/SYCLruntime.cpp
@@ -16,4 +16,8 @@
 namespace qmcplusplus
 {
 sycl::queue& getSYCLDefaultDeviceDefaultQueue() { return SYCLDeviceManager::getDefaultDeviceDefaultQueue(); }
+size_t getSYCLdeviceFreeMem()
+{
+  return getSYCLDefaultDeviceDefaultQueue().get_device().get_info<sycl::info::device::global_mem_size>();
+}
 } // namespace qmcplusplus

--- a/src/Platforms/SYCL/SYCLruntime.hpp
+++ b/src/Platforms/SYCL/SYCLruntime.hpp
@@ -17,6 +17,9 @@
 namespace qmcplusplus
 {
 sycl::queue& getSYCLDefaultDeviceDefaultQueue();
+
+size_t getSYCLdeviceFreeMem();
+
 } // namespace qmcplusplus
 
 #endif


### PR DESCRIPTION
## Proposed changes
1) Break header files into h/cpp in OMPTarget and CUDA.
2) Enable SYCL free device memory reporting. There is a catch. Need to enable environment variable ZES_ENABLE_SYSMAN=1

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
sunspot

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'