### PR TITLE
Add evaluateDerivativesWF for J3

### DIFF
--- a/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
@@ -174,7 +174,7 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
   dlogpsiWF.resize(NumOptimizables);
   j3->evaluateDerivativesWF(elec_, optvars, dlogpsiWF);
   for (int i = 0; i < NumOptimizables; i++)
-    CHECK(dlogpsi[i] == Approx(dlogpsiWF[i]));
+    CHECK(dlogpsi[i] == ValueApprox(dlogpsiWF[i]));
 
   VirtualParticleSet VP(elec_, 2);
   std::vector<PosType> newpos2(2);

--- a/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
@@ -151,7 +151,6 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
 
   opt_variables_type optvars;
   Vector<WaveFunctionComponent::ValueType> dlogpsi;
-  Vector<WaveFunctionComponent::ValueType> dlogpsiWF;
   Vector<WaveFunctionComponent::ValueType> dhpsioverpsi;
 
   for (OptimizableObject& obj : opt_obj_refs)
@@ -160,7 +159,6 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
   const int NumOptimizables(optvars.size());
   j3->checkOutVariables(optvars);
   dlogpsi.resize(NumOptimizables);
-  dlogpsiWF.resize(NumOptimizables);
   dhpsioverpsi.resize(NumOptimizables);
   j3->evaluateDerivatives(elec_, optvars, dlogpsi, dhpsioverpsi);
 
@@ -172,6 +170,8 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
   CHECK(std::real(dlogpsi[43]) == Approx(1.3358726814e+05));
   CHECK(std::real(dhpsioverpsi[43]) == Approx(-2.3246270644e+05));
 
+  Vector<WaveFunctionComponent::ValueType> dlogpsiWF;
+  dlogpsiWF.resize(NumOptimizables);
   j3->evaluateDerivativesWF(elec_, optvars, dlogpsiWF);
   for (int i = 0; i < NumOptimizables; i++)
     CHECK(dlogpsi[i] == Approx(dlogpsiWF[i]));

--- a/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
@@ -151,6 +151,7 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
 
   opt_variables_type optvars;
   Vector<WaveFunctionComponent::ValueType> dlogpsi;
+  Vector<WaveFunctionComponent::ValueType> dlogpsiWF;
   Vector<WaveFunctionComponent::ValueType> dhpsioverpsi;
 
   for (OptimizableObject& obj : opt_obj_refs)
@@ -159,6 +160,7 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
   const int NumOptimizables(optvars.size());
   j3->checkOutVariables(optvars);
   dlogpsi.resize(NumOptimizables);
+  dlogpsiWF.resize(NumOptimizables);
   dhpsioverpsi.resize(NumOptimizables);
   j3->evaluateDerivatives(elec_, optvars, dlogpsi, dhpsioverpsi);
 
@@ -169,6 +171,10 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
 
   CHECK(std::real(dlogpsi[43]) == Approx(1.3358726814e+05));
   CHECK(std::real(dhpsioverpsi[43]) == Approx(-2.3246270644e+05));
+
+  j3->evaluateDerivativesWF(elec_, optvars, dlogpsiWF);
+  for (int i = 0; i < NumOptimizables; i++)
+    CHECK(dlogpsi[i] == Approx(dlogpsiWF[i]));
 
   VirtualParticleSet VP(elec_, 2);
   std::vector<PosType> newpos2(2);


### PR DESCRIPTION
Add the function `evaluateDerivativesWF` for the three-body Jastrow.  It's a copy of `evaluateDerivatives` with the code to compute `dhpsioverpsi` removed.

This function is needed for orbital rotation with psuedopotentials and J3.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- No. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
