### PR TITLE
pin clang and gcc versions for ubuntu22-openmpi

### DIFF
--- a/config/docker/dependencies/ubuntu22/openmpi/Dockerfile
+++ b/config/docker/dependencies/ubuntu22/openmpi/Dockerfile
@@ -11,8 +11,8 @@ RUN wget https://apt.kitware.com/kitware-archive.sh &&\
     sh kitware-archive.sh
 
 RUN export DEBIAN_FRONTEND=noninteractive &&\
-    apt-get install gcc g++ \ 
-    clang \
+    apt-get install gcc-9 g++-9 \ 
+    clang-14 \
     clang-format \
     clang-tidy \
     libomp-dev \
@@ -48,6 +48,13 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
 
 RUN export DEBIAN_FRONTEND=noninteractive &&\
     pip3 install cif2cell
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 100
+
+# add clang-14 as clang
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 100
 
 # must add a user different from root 
 # to run MPI executables

--- a/config/docker/dependencies/ubuntu22/openmpi/Dockerfile
+++ b/config/docker/dependencies/ubuntu22/openmpi/Dockerfile
@@ -13,9 +13,9 @@ RUN wget https://apt.kitware.com/kitware-archive.sh &&\
 RUN export DEBIAN_FRONTEND=noninteractive &&\
     apt-get install gcc-9 g++-9 \ 
     clang-14 \
-    clang-format \
-    clang-tidy \
-    libomp-dev \
+    clang-format-14 \
+    clang-tidy-14 \
+    libomp-14-dev \
     gcovr \
     python3 \
     cmake \
@@ -55,6 +55,11 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 && \
 # add clang-14 as clang
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 100 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 100
+
+# add clang-format and clang-tidy as well as libomp
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 100 && \
+    update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 100 && \
+    update-alternatives --install /usr/bin/clang-tidy-diff.py clang-tidy-diff.py /usr/bin/clang-tidy-diff-14.py 100
 
 # must add a user different from root 
 # to run MPI executables


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

This is updating the dockerfile for the changes I'm about to push for the `ubuntu22-openmpi:latest` image.
GCC9 tests have not been using gcc9, this should set gcc9 as the default and thus fix this.
In addition, I've also done this for clang just in case.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- CI

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- N/A This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A Documentation has been added (if appropriate)
