### PR TITLE
Fix Nexus GPU jobs for NERSC/Perlmutter

### DIFF
--- a/nexus/lib/machines.py
+++ b/nexus/lib/machines.py
@@ -2314,7 +2314,7 @@ class Perlmutter(NerscMachine):
 echo $SLURM_SUBMIT_DIR
 cd $SLURM_SUBMIT_DIR
 '''
-        if job.threads>1:
+        if (job.threads>1) and ('cpu' in job.constraint):
             c+='''
 export OMP_PROC_BIND=true
 export OMP_PLACES=threads


### PR DESCRIPTION
## Proposed changes

`OMP_PROC_BIND` and `OMP_PLACES` environment variables should not be set for GPU jobs. With this change, Nexus GPU jobs are running for me on Perlmutter.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

NERSC/Perlmutter (Nexus tests are passing)

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
