### PR TITLE
add mw_ APIs to RotatedSPO

### DIFF
--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -1603,7 +1603,7 @@ void RotatedSPOs::mw_evaluateDetRatios(const RefVectorWithLeader<SPOSet>& spo_li
                                        std::vector<std::vector<ValueType>>& ratios_list) const
 {
   auto phi_list = extractPhiRefList(spo_list);
-  auto& leader = phi_list.getLeader();
+  auto& leader  = phi_list.getLeader();
   leader.mw_evaluateDetRatios(phi_list, vp_list, psi_list, invRow_ptr_list, ratios_list);
 }
 
@@ -1613,7 +1613,7 @@ void RotatedSPOs::mw_evaluateValue(const RefVectorWithLeader<SPOSet>& spo_list,
                                    const RefVector<ValueVector>& psi_v_list) const
 {
   auto phi_list = extractPhiRefList(spo_list);
-  auto& leader = phi_list.getLeader();
+  auto& leader  = phi_list.getLeader();
   leader.mw_evaluateValue(phi_list, P_list, iat, psi_v_list);
 }
 
@@ -1625,7 +1625,7 @@ void RotatedSPOs::mw_evaluateVGL(const RefVectorWithLeader<SPOSet>& spo_list,
                                  const RefVector<ValueVector>& d2psi_v_list) const
 {
   auto phi_list = extractPhiRefList(spo_list);
-  auto& leader = phi_list.getLeader();
+  auto& leader  = phi_list.getLeader();
   leader.mw_evaluateVGL(phi_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list);
 }
 
@@ -1638,7 +1638,7 @@ void RotatedSPOs::mw_evaluateVGLWithSpin(const RefVectorWithLeader<SPOSet>& spo_
                                          OffloadMatrix<ComplexType>& mw_dspin) const
 {
   auto phi_list = extractPhiRefList(spo_list);
-  auto& leader = phi_list.getLeader();
+  auto& leader  = phi_list.getLeader();
   leader.mw_evaluateVGLWithSpin(phi_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list, mw_dspin);
 }
 
@@ -1651,7 +1651,7 @@ void RotatedSPOs::mw_evaluateVGLandDetRatioGrads(const RefVectorWithLeader<SPOSe
                                                  std::vector<GradType>& grads) const
 {
   auto phi_list = extractPhiRefList(spo_list);
-  auto& leader = phi_list.getLeader();
+  auto& leader  = phi_list.getLeader();
   leader.mw_evaluateVGLandDetRatioGrads(phi_list, P_list, iat, invRow_ptr_list, phi_vgl_v, ratios, grads);
 }
 
@@ -1665,9 +1665,9 @@ void RotatedSPOs::mw_evaluateVGLandDetRatioGradsWithSpin(const RefVectorWithLead
                                                          std::vector<ValueType>& spingrads) const
 {
   auto phi_list = extractPhiRefList(spo_list);
-  auto& leader = phi_list.getLeader();
+  auto& leader  = phi_list.getLeader();
   leader.mw_evaluateVGLandDetRatioGradsWithSpin(phi_list, P_list, iat, invRow_ptr_list, phi_vgl_v, ratios, grads,
-                                              spingrads);
+                                                spingrads);
 }
 
 void RotatedSPOs::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_list,
@@ -1679,7 +1679,7 @@ void RotatedSPOs::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo
                                           const RefVector<ValueMatrix>& d2logdet_list) const
 {
   auto phi_list = extractPhiRefList(spo_list);
-  auto& leader = phi_list.getLeader();
+  auto& leader  = phi_list.getLeader();
   leader.mw_evaluate_notranspose(phi_list, P_list, first, last, logdet_list, dlogdet_list, d2logdet_list);
 }
 
@@ -1688,28 +1688,27 @@ void RotatedSPOs::createResource(ResourceCollection& collection) const { Phi->cr
 void RotatedSPOs::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const
 {
   auto phi_list = extractPhiRefList(spo_list);
-  auto& leader = phi_list.getLeader();
+  auto& leader  = phi_list.getLeader();
   leader.acquireResource(collection, phi_list);
 }
 
 void RotatedSPOs::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const
 {
   auto phi_list = extractPhiRefList(spo_list);
-  auto& leader = phi_list.getLeader();
+  auto& leader  = phi_list.getLeader();
   leader.releaseResource(collection, phi_list);
 }
 
-RefVectorWithLeader<SPOSet> RotatedSPOs::extractPhiRefList(const RefVectorWithLeader<SPOSet>& spo_list) const
+static RefVectorWithLeader<SPOSet> extractPhiRefList(const RefVectorWithLeader<SPOSet>& spo_list)
 {
-  auto& spo_leader      = spo_list.getCastedLeader<RotatedSPOs>();
-  IndexType nw          = spo_list.size();
-  SPOSet& phi_leader = *(spo_leader.Phi);
-  RefVectorWithLeader<SPOSet> phi_list(phi_leader);
+  auto& spo_leader = spo_list.getCastedLeader<RotatedSPOs>();
+  const auto nw    = spo_list.size();
+  RefVectorWithLeader<SPOSet> phi_list(*spo_leader.Phi);
   phi_list.reserve(nw);
   for (int iw = 0; iw < nw; iw++)
   {
     RotatedSPOs& rot = spo_list.getCastedElement<RotatedSPOs>(iw);
-    phi_list.emplace_back(*(rot.Phi));
+    phi_list.emplace_back(*rot.Phi);
   }
   return phi_list;
 }

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -1669,7 +1669,7 @@ void RotatedSPOs::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo
   Phi->mw_evaluate_notranspose(spo_list, P_list, first, last, logdet_list, dlogdet_list, d2logdet_list);
 }
 
-void RotatedSPOSs::createResource(ResourceCollection& collection) const { Phi->createResource(collection); }
+void RotatedSPOs::createResource(ResourceCollection& collection) const { Phi->createResource(collection); }
 
 void RotatedSPOs::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const
 {

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -1602,7 +1602,9 @@ void RotatedSPOs::mw_evaluateDetRatios(const RefVectorWithLeader<SPOSet>& spo_li
                                        const std::vector<const ValueType*>& invRow_ptr_list,
                                        std::vector<std::vector<ValueType>>& ratios_list) const
 {
-  Phi->mw_evaluateDetRatios(spo_list, vp_list, psi_list, invRow_ptr_list, ratios_list);
+  auto phi_list = extractPhiRefList(spo_list);
+  auto& leader = phi_list.getLeader();
+  leader.mw_evaluateDetRatios(phi_list, vp_list, psi_list, invRow_ptr_list, ratios_list);
 }
 
 void RotatedSPOs::mw_evaluateValue(const RefVectorWithLeader<SPOSet>& spo_list,
@@ -1610,7 +1612,9 @@ void RotatedSPOs::mw_evaluateValue(const RefVectorWithLeader<SPOSet>& spo_list,
                                    int iat,
                                    const RefVector<ValueVector>& psi_v_list) const
 {
-  Phi->mw_evaluateValue(spo_list, P_list, iat, psi_v_list);
+  auto phi_list = extractPhiRefList(spo_list);
+  auto& leader = phi_list.getLeader();
+  leader.mw_evaluateValue(phi_list, P_list, iat, psi_v_list);
 }
 
 void RotatedSPOs::mw_evaluateVGL(const RefVectorWithLeader<SPOSet>& spo_list,
@@ -1620,7 +1624,9 @@ void RotatedSPOs::mw_evaluateVGL(const RefVectorWithLeader<SPOSet>& spo_list,
                                  const RefVector<GradVector>& dpsi_v_list,
                                  const RefVector<ValueVector>& d2psi_v_list) const
 {
-  Phi->mw_evaluateVGL(spo_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list);
+  auto phi_list = extractPhiRefList(spo_list);
+  auto& leader = phi_list.getLeader();
+  leader.mw_evaluateVGL(phi_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list);
 }
 
 void RotatedSPOs::mw_evaluateVGLWithSpin(const RefVectorWithLeader<SPOSet>& spo_list,
@@ -1631,7 +1637,9 @@ void RotatedSPOs::mw_evaluateVGLWithSpin(const RefVectorWithLeader<SPOSet>& spo_
                                          const RefVector<ValueVector>& d2psi_v_list,
                                          OffloadMatrix<ComplexType>& mw_dspin) const
 {
-  Phi->mw_evaluateVGLWithSpin(spo_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list, mw_dspin);
+  auto phi_list = extractPhiRefList(spo_list);
+  auto& leader = phi_list.getLeader();
+  leader.mw_evaluateVGLWithSpin(phi_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list, mw_dspin);
 }
 
 void RotatedSPOs::mw_evaluateVGLandDetRatioGrads(const RefVectorWithLeader<SPOSet>& spo_list,
@@ -1642,7 +1650,9 @@ void RotatedSPOs::mw_evaluateVGLandDetRatioGrads(const RefVectorWithLeader<SPOSe
                                                  std::vector<ValueType>& ratios,
                                                  std::vector<GradType>& grads) const
 {
-  Phi->mw_evaluateVGLandDetRatioGrads(spo_list, P_list, iat, invRow_ptr_list, phi_vgl_v, ratios, grads);
+  auto phi_list = extractPhiRefList(spo_list);
+  auto& leader = phi_list.getLeader();
+  leader.mw_evaluateVGLandDetRatioGrads(phi_list, P_list, iat, invRow_ptr_list, phi_vgl_v, ratios, grads);
 }
 
 void RotatedSPOs::mw_evaluateVGLandDetRatioGradsWithSpin(const RefVectorWithLeader<SPOSet>& spo_list,
@@ -1654,7 +1664,9 @@ void RotatedSPOs::mw_evaluateVGLandDetRatioGradsWithSpin(const RefVectorWithLead
                                                          std::vector<GradType>& grads,
                                                          std::vector<ValueType>& spingrads) const
 {
-  Phi->mw_evaluateVGLandDetRatioGradsWithSpin(spo_list, P_list, iat, invRow_ptr_list, phi_vgl_v, ratios, grads,
+  auto phi_list = extractPhiRefList(spo_list);
+  auto& leader = phi_list.getLeader();
+  leader.mw_evaluateVGLandDetRatioGradsWithSpin(phi_list, P_list, iat, invRow_ptr_list, phi_vgl_v, ratios, grads,
                                               spingrads);
 }
 
@@ -1666,19 +1678,40 @@ void RotatedSPOs::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo
                                           const RefVector<GradMatrix>& dlogdet_list,
                                           const RefVector<ValueMatrix>& d2logdet_list) const
 {
-  Phi->mw_evaluate_notranspose(spo_list, P_list, first, last, logdet_list, dlogdet_list, d2logdet_list);
+  auto phi_list = extractSPORefList(spo_list);
+  auto& leader = phi_list.getLeader();
+  leader.mw_evaluate_notranspose(phi_list, P_list, first, last, logdet_list, dlogdet_list, d2logdet_list);
 }
 
 void RotatedSPOs::createResource(ResourceCollection& collection) const { Phi->createResource(collection); }
 
 void RotatedSPOs::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const
 {
-  Phi->acquireResource(collection, spo_list);
+  auto phi_list = extractPhiRefList(spo_list);
+  auto& leader = phi_list.getLeader();
+  leader.acquireResource(collection, phi_list);
 }
 
 void RotatedSPOs::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const
 {
-  Phi->releaseResource(collection, spo_list);
+  auto phi_list = extractPhiRefList(spo_list);
+  auto& leader = phi_list.getLeader();
+  leader.releaseResource(collection, phi_list);
+}
+
+RefVectorWithLeader<SPOSet> RotatedSPOs::extractPhiRefList(const RefVectorWithLeader<SPOSet>& spo_list) const
+{
+  auto& spo_leader      = spo_list.getCastedLeader<RotatedSPOs>();
+  IndexType nw          = spo_list.size();
+  SPOSet& phi_leader = *(spo_leader->Phi);
+  RefVectorWithLeader<SPOSet> phi_list(phi_leader);
+  phi_list.reserve(nw);
+  for (int iw = 0; iw < nw; iw++)
+  {
+    RotatedSPOs& rot = spo_list.getCastedElement<RotatedSPOs>(iw);
+    phi_list.emplace_back(*(rot->Phi));
+  }
+  return phi_list;
 }
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -1669,4 +1669,16 @@ void RotatedSPOs::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo
   Phi->mw_evaluate_notranspose(spo_list, P_list, first, last, logdet_list, dlogdet_list, d2logdet_list);
 }
 
+void RotatedSPOSs::createResource(ResourceCollection& collection) const { Phi->createResource(collection); }
+
+void RotatedSPOs::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const
+{
+  Phi->acquireResource(collection, spo_list);
+}
+
+void RotatedSPOs::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const
+{
+  Phi->releaseResource(collection, spo_list);
+}
+
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -1678,7 +1678,7 @@ void RotatedSPOs::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo
                                           const RefVector<GradMatrix>& dlogdet_list,
                                           const RefVector<ValueMatrix>& d2logdet_list) const
 {
-  auto phi_list = extractSPORefList(spo_list);
+  auto phi_list = extractPhiRefList(spo_list);
   auto& leader = phi_list.getLeader();
   leader.mw_evaluate_notranspose(phi_list, P_list, first, last, logdet_list, dlogdet_list, d2logdet_list);
 }

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -1703,13 +1703,13 @@ RefVectorWithLeader<SPOSet> RotatedSPOs::extractPhiRefList(const RefVectorWithLe
 {
   auto& spo_leader      = spo_list.getCastedLeader<RotatedSPOs>();
   IndexType nw          = spo_list.size();
-  SPOSet& phi_leader = *(spo_leader->Phi);
+  SPOSet& phi_leader = *(spo_leader.Phi);
   RefVectorWithLeader<SPOSet> phi_list(phi_leader);
   phi_list.reserve(nw);
   for (int iw = 0; iw < nw; iw++)
   {
     RotatedSPOs& rot = spo_list.getCastedElement<RotatedSPOs>(iw);
-    phi_list.emplace_back(*(rot->Phi));
+    phi_list.emplace_back(*(rot.Phi));
   }
   return phi_list;
 }

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -1596,5 +1596,77 @@ std::unique_ptr<SPOSet> RotatedSPOs::makeClone() const
   return myclone;
 }
 
+void RotatedSPOs::mw_evaluateDetRatios(const RefVectorWithLeader<SPOSet>& spo_list,
+                                       const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+                                       const RefVector<ValueVector>& psi_list,
+                                       const std::vector<const ValueType*>& invRow_ptr_list,
+                                       std::vector<std::vector<ValueType>>& ratios_list) const
+{
+  Phi->mw_evaluateDetRatios(spo_list, vp_list, psi_list, invRow_ptr_list, ratios_list);
+}
+
+void RotatedSPOs::mw_evaluateValue(const RefVectorWithLeader<SPOSet>& spo_list,
+                                   const RefVectorWithLeader<ParticleSet>& P_list,
+                                   int iat,
+                                   const RefVector<ValueVector>& psi_v_list) const
+{
+  Phi->mw_evaluateValue(spo_list, P_list, iat, psi_v_list);
+}
+
+void RotatedSPOs::mw_evaluateVGL(const RefVectorWithLeader<SPOSet>& spo_list,
+                                 const RefVectorWithLeader<ParticleSet>& P_list,
+                                 int iat,
+                                 const RefVector<ValueVector>& psi_v_list,
+                                 const RefVector<GradVector>& dpsi_v_list,
+                                 const RefVector<ValueVector>& d2psi_v_list) const
+{
+  Phi->mw_evaluateVGL(spo_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list);
+}
+
+void RotatedSPOs::mw_evaluateVGLWithSpin(const RefVectorWithLeader<SPOSet>& spo_list,
+                                         const RefVectorWithLeader<ParticleSet>& P_list,
+                                         int iat,
+                                         const RefVector<ValueVector>& psi_v_list,
+                                         const RefVector<GradVector>& dpsi_v_list,
+                                         const RefVector<ValueVector>& d2psi_v_list,
+                                         OffloadMatrix<ComplexType>& mw_dspin) const
+{
+  Phi->mw_evaluateVGLWithSpin(spo_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list, mw_dspin);
+}
+
+void RotatedSPOs::mw_evaluateVGLandDetRatioGrads(const RefVectorWithLeader<SPOSet>& spo_list,
+                                                 const RefVectorWithLeader<ParticleSet>& P_list,
+                                                 int iat,
+                                                 const std::vector<const ValueType*>& invRow_ptr_list,
+                                                 OffloadMWVGLArray& phi_vgl_v,
+                                                 std::vector<ValueType>& ratios,
+                                                 std::vector<GradType>& grads) const
+{
+  Phi->mw_evaluateVGLandDetRatioGrads(spo_list, P_list, iat, invRow_ptr_list, phi_vgl_v, ratios, grads);
+}
+
+void RotatedSPOs::mw_evaluateVGLandDetRatioGradsWithSpin(const RefVectorWithLeader<SPOSet>& spo_list,
+                                                         const RefVectorWithLeader<ParticleSet>& P_list,
+                                                         int iat,
+                                                         const std::vector<const ValueType*>& invRow_ptr_list,
+                                                         OffloadMWVGLArray& phi_vgl_v,
+                                                         std::vector<ValueType>& ratios,
+                                                         std::vector<GradType>& grads,
+                                                         std::vector<ValueType>& spingrads) const
+{
+  Phi->mw_evaluateVGLandDetRatioGradsWithSpin(spo_list, P_list, iat, invRow_ptr_list, phi_vgl_v, ratios, grads,
+                                              spingrads);
+}
+
+void RotatedSPOs::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_list,
+                                          const RefVectorWithLeader<ParticleSet>& P_list,
+                                          int first,
+                                          int last,
+                                          const RefVector<ValueMatrix>& logdet_list,
+                                          const RefVector<GradMatrix>& dlogdet_list,
+                                          const RefVector<ValueMatrix>& d2logdet_list) const
+{
+  Phi->mw_evaluate_notranspose(spo_list, P_list, first, last, logdet_list, dlogdet_list, d2logdet_list);
+}
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -1699,7 +1699,7 @@ void RotatedSPOs::releaseResource(ResourceCollection& collection, const RefVecto
   leader.releaseResource(collection, phi_list);
 }
 
-static RefVectorWithLeader<SPOSet> extractPhiRefList(const RefVectorWithLeader<SPOSet>& spo_list)
+RefVectorWithLeader<SPOSet> RotatedSPOs::extractPhiRefList(const RefVectorWithLeader<SPOSet>& spo_list)
 {
   auto& spo_leader = spo_list.getCastedLeader<RotatedSPOs>();
   const auto nw    = spo_list.size();

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -421,6 +421,12 @@ public:
                                const RefVector<ValueMatrix>& logdet_list,
                                const RefVector<GradMatrix>& dlogdet_list,
                                const RefVector<ValueMatrix>& d2logdet_list) const override;
+  
+  void createResource(ResourceCollection& collection) const override;
+
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override;
+
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override;
 
 private:
   /// true if SPO parameters (orbital rotation parameters) have been supplied by input

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -371,6 +371,57 @@ public:
   /// Use history list (false) or global rotation (true)
   void set_use_global_rotation(bool use_global_rotation) { use_global_rot_ = use_global_rotation; }
 
+  void mw_evaluateDetRatios(const RefVectorWithLeader<SPOSet>& spo_list,
+                            const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+                            const RefVector<ValueVector>& psi_list,
+                            const std::vector<const ValueType*>& invRow_ptr_list,
+                            std::vector<std::vector<ValueType>>& ratios_list) const override;
+
+  void mw_evaluateValue(const RefVectorWithLeader<SPOSet>& spo_list,
+                        const RefVectorWithLeader<ParticleSet>& P_list,
+                        int iat,
+                        const RefVector<ValueVector>& psi_v_list) const override;
+
+  void mw_evaluateVGL(const RefVectorWithLeader<SPOSet>& spo_list,
+                      const RefVectorWithLeader<ParticleSet>& P_list,
+                      int iat,
+                      const RefVector<ValueVector>& psi_v_list,
+                      const RefVector<GradVector>& dpsi_v_list,
+                      const RefVector<ValueVector>& d2psi_v_list) const override;
+
+  void mw_evaluateVGLWithSpin(const RefVectorWithLeader<SPOSet>& spo_list,
+                              const RefVectorWithLeader<ParticleSet>& P_list,
+                              int iat,
+                              const RefVector<ValueVector>& psi_v_list,
+                              const RefVector<GradVector>& dpsi_v_list,
+                              const RefVector<ValueVector>& d2psi_v_list,
+                              OffloadMatrix<ComplexType>& mw_dspin) const override;
+
+  void mw_evaluateVGLandDetRatioGrads(const RefVectorWithLeader<SPOSet>& spo_list,
+                                      const RefVectorWithLeader<ParticleSet>& P_list,
+                                      int iat,
+                                      const std::vector<const ValueType*>& invRow_ptr_list,
+                                      OffloadMWVGLArray& phi_vgl_v,
+                                      std::vector<ValueType>& ratios,
+                                      std::vector<GradType>& grads) const override;
+
+  void mw_evaluateVGLandDetRatioGradsWithSpin(const RefVectorWithLeader<SPOSet>& spo_list,
+                                              const RefVectorWithLeader<ParticleSet>& P_list,
+                                              int iat,
+                                              const std::vector<const ValueType*>& invRow_ptr_list,
+                                              OffloadMWVGLArray& phi_vgl_v,
+                                              std::vector<ValueType>& ratios,
+                                              std::vector<GradType>& grads,
+                                              std::vector<ValueType>& spingrads) const override;
+
+  void mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_list,
+                               const RefVectorWithLeader<ParticleSet>& P_list,
+                               int first,
+                               int last,
+                               const RefVector<ValueMatrix>& logdet_list,
+                               const RefVector<GradMatrix>& dlogdet_list,
+                               const RefVector<ValueMatrix>& d2logdet_list) const override;
+
 private:
   /// true if SPO parameters (orbital rotation parameters) have been supplied by input
   bool params_supplied;

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -440,6 +440,8 @@ private:
   /// List of previously applied parameters
   std::vector<std::vector<RealType>> history_params_;
 
+  static RefVectorWithLeader<SPOSet> extractPhiRefList(const RefVectorWithLeader<SPOSet>& spo_list);
+
   /// Use global rotation or history list
   bool use_global_rot_ = true;
 
@@ -447,7 +449,6 @@ private:
   friend std::vector<std::vector<RealType>>& testing::getHistoryParams(RotatedSPOs& rot);
 };
 
-static RefVectorWithLeader<SPOSet> extractPhiRefList(const RefVectorWithLeader<SPOSet>& spo_list);
 
 } //namespace qmcplusplus
 

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -421,7 +421,7 @@ public:
                                const RefVector<ValueMatrix>& logdet_list,
                                const RefVector<GradMatrix>& dlogdet_list,
                                const RefVector<ValueMatrix>& d2logdet_list) const override;
-  
+
   void createResource(ResourceCollection& collection) const override;
 
   void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override;
@@ -440,14 +440,14 @@ private:
   /// List of previously applied parameters
   std::vector<std::vector<RealType>> history_params_;
 
-  RefVectorWithLeader<SPOSet> extractPhiRefList(const RefVectorWithLeader<SPOSet>& spo_list) const;
-
   /// Use global rotation or history list
   bool use_global_rot_ = true;
 
   friend opt_variables_type& testing::getMyVarsFull(RotatedSPOs& rot);
   friend std::vector<std::vector<RealType>>& testing::getHistoryParams(RotatedSPOs& rot);
 };
+
+static RefVectorWithLeader<SPOSet> extractPhiRefList(const RefVectorWithLeader<SPOSet>& spo_list);
 
 } //namespace qmcplusplus
 

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -440,6 +440,8 @@ private:
   /// List of previously applied parameters
   std::vector<std::vector<RealType>> history_params_;
 
+  RefVectorWithLeader<SPOSet> extractPhiRefList(const RefVectorWithLeader<SPOSet>& spo_list) const;
+
   /// Use global rotation or history list
   bool use_global_rot_ = true;
 

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -756,7 +756,7 @@ public:
   void setOrbitalSetSize(int norbs) override {}
   void evaluateValue(const ParticleSet& P, int iat, SPOSet::ValueVector& psi) override
   {
-    assert(psi.get().size() == 3);
+    assert(psi.size() == 3);
     psi[0] = 123;
     psi[1] = 456;
     psi[2] = 789;

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -838,7 +838,7 @@ TEST_CASE("RotatedSPOs mw_ APIs", "[wavefunction]")
     //loops over single walker APIs (which have different values enforced in
     // DummySPOSetWithoutMW
 
-    RotatedSPOs rot_spo0("rotated0", std::move(std::make_unique<DummySPOSetWithMW>("mw 0")));
+    RotatedSPOs rot_spo0("rotated0", std::make_unique<DummySPOSetWithMW>("mw 0"));
     RotatedSPOs rot_spo1("rotated1", std::make_unique<DummySPOSetWithMW>("mw 1"));
     RefVectorWithLeader<SPOSet> spo_list(rot_spo0, {rot_spo0, rot_spo1});
 

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -802,10 +802,10 @@ TEST_CASE("RotatedSPOs mw_ APIs", "[wavefunction]")
     //In the case that the underlying SPOSet doesn't specialize the mw_ API,
     //the underlying SPOSet will fall back to the default SPOSet mw_, which is
     //just a loop over the single walker API.
-    RotatedSPOs rot_spo0("rotated0", std::move(std::make_unique<DummySPOSetWithoutMW>("no mw 0")));
-    RotatedSPOs rot_spo1("rotated1", std::move(std::make_unique<DummySPOSetWithoutMW>("no mw 1")));
-
+    RotatedSPOs rot_spo0("rotated0", std::make_unique<DummySPOSetWithoutMW>("no mw 0"));
+    RotatedSPOs rot_spo1("rotated1", std::make_unique<DummySPOSetWithoutMW>("no mw 1"));
     RefVectorWithLeader<SPOSet> spo_list(rot_spo0, {rot_spo0, rot_spo1});
+
     ResourceCollection spo_res("test_rot_res");
     rot_spo0.createResource(spo_res);
     ResourceCollectionTeamLock<SPOSet> mw_sposet_lock(spo_res, spo_list);
@@ -813,7 +813,6 @@ TEST_CASE("RotatedSPOs mw_ APIs", "[wavefunction]")
     const SimulationCell simulation_cell;
     ParticleSet elec0(simulation_cell);
     ParticleSet elec1(simulation_cell);
-
     RefVectorWithLeader<ParticleSet> p_list(elec0, {elec0, elec1});
 
     SPOSet::ValueVector psi0(3);
@@ -838,28 +837,23 @@ TEST_CASE("RotatedSPOs mw_ APIs", "[wavefunction]")
     //in the underlying SPO and not using the default SPOSet implementation which
     //loops over single walker APIs (which have different values enforced in
     // DummySPOSetWithoutMW
-    auto spo_ptr0 = std::make_unique<DummySPOSetWithMW>("mw 0");
-    RotatedSPOs rot_spo0("rotated0", std::move(spo_ptr0));
-    auto spo_ptr1 = std::make_unique<DummySPOSetWithMW>("mw 1");
-    RotatedSPOs rot_spo1("rotated1", std::move(spo_ptr1));
 
-    RefVectorWithLeader<SPOSet> spo_list(rot_spo0);
-    spo_list.push_back(rot_spo0);
-    spo_list.push_back(rot_spo1);
+    RotatedSPOs rot_spo0("rotated0", std::move(std::make_unique<DummySPOSetWithMW>("mw 0")));
+    RotatedSPOs rot_spo1("rotated1", std::make_unique<DummySPOSetWithMW>("mw 1"));
+    RefVectorWithLeader<SPOSet> spo_list(rot_spo0, {rot_spo0, rot_spo1});
+
+    ResourceCollection spo_res("test_rot_res");
+    rot_spo0.createResource(spo_res);
+    ResourceCollectionTeamLock<SPOSet> mw_sposet_lock(spo_res, spo_list);
 
     const SimulationCell simulation_cell;
     ParticleSet elec0(simulation_cell);
     ParticleSet elec1(simulation_cell);
-
-    RefVectorWithLeader<ParticleSet> p_list(elec0);
-    p_list.push_back(elec0);
-    p_list.push_back(elec1);
+    RefVectorWithLeader<ParticleSet> p_list(elec0, {elec0, elec1});
 
     SPOSet::ValueVector psi0(3);
     SPOSet::ValueVector psi1(3);
-    RefVector<SPOSet::ValueVector> psi_v_list;
-    psi_v_list.push_back(psi0);
-    psi_v_list.push_back(psi1);
+    RefVector<SPOSet::ValueVector> psi_v_list{psi0, psi1};
 
     rot_spo0.mw_evaluateValue(spo_list, p_list, 0, psi_v_list);
     for (int iw = 0; iw < spo_list.size(); iw++)

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -22,6 +22,7 @@
 #include "QMCWaveFunctions/RotatedSPOs.h"
 #include "checkMatrix.hpp"
 #include "FakeSPO.h"
+#include "ConstantSPOSet.h"
 
 #include <stdio.h>
 #include <string>
@@ -747,6 +748,132 @@ TEST_CASE("RotatedSPOs read and write parameters history", "[wavefunction]")
   auto hist = testing::getHistoryParams(rot2);
   REQUIRE(hist.size() == 1);
   REQUIRE(hist[0].size() == 4);
+}
+
+class DummySPOSetWithoutMW : public SPOSet
+{
+public:
+  DummySPOSetWithoutMW(const std::string& my_name) : SPOSet(my_name) {}
+  void setOrbitalSetSize(int norbs) override {}
+  void evaluateValue(const ParticleSet& P, int iat, SPOSet::ValueVector& psi) override
+  {
+    assert(psi.size() == 3);
+    psi[0] = 123;
+    psi[1] = 456;
+    psi[2] = 789;
+  }
+  void evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi) override {}
+  void evaluate_notranspose(const ParticleSet& P,
+                            int first,
+                            int last,
+                            ValueMatrix& logdet,
+                            GradMatrix& dlogdet,
+                            ValueMatrix& d2logdet) override
+  {}
+  std::string getClassName() const override { return my_name_; }
+};
+
+class DummySPOSetWithMW : public DummySPOSetWithoutMW
+{
+public:
+  DummySPOSetWithMW(const std::string& my_name) : DummySPOSetWithoutMW(my_name) {}
+  void mw_evaluateValue(const RefVectorWithLeader<SPOSet>& spo_list,
+                        const RefVectorWithLeader<ParticleSet>& P_list,
+                        int iat,
+                        const RefVector<ValueVector>& psi_v_list) const override
+  {
+    for (auto& psi : psi_v_list)
+    {
+      assert(psi.size() == 3);
+      psi.get()[0] = 321;
+      psi.get()[1] = 654;
+      psi.get()[2] = 987;
+    }
+  }
+};
+
+TEST_CASE("RotatedSPOs mw_ APIs", "[wavefunction]")
+{
+  //checking that mw_ API works in RotatedSPOs and is not defaulting to
+  //SPOSet default implementation
+  {
+    //First check calling the mw_ APIs for RotatedSPOs, for which the
+    //underlying implementation just calls the underlying SPOSet mw_ API
+    //In the case that the underlying SPOSet doesn't specialize the mw_ API,
+    //the underlying SPOSet will fall back to the default SPOSet mw_, which is
+    //just a loop over the single walker API.
+    auto spo_ptr0 = std::make_unique<DummySPOSetWithoutMW>("no mw 0");
+    RotatedSPOs rot_spo0("rotated0", std::move(spo_ptr0));
+    auto spo_ptr1 = std::make_unique<DummySPOSetWithoutMW>("no mw 1");
+    RotatedSPOs rot_spo1("rotated1", std::move(spo_ptr1));
+
+    RefVectorWithLeader<SPOSet> spo_list(rot_spo0);
+    spo_list.push_back(rot_spo0);
+    spo_list.push_back(rot_spo1);
+
+    const SimulationCell simulation_cell;
+    ParticleSet elec0(simulation_cell);
+    ParticleSet elec1(simulation_cell);
+
+    RefVectorWithLeader<ParticleSet> p_list(elec0);
+    p_list.push_back(elec0);
+    p_list.push_back(elec1);
+
+    SPOSet::ValueVector psi0(3);
+    SPOSet::ValueVector psi1(3);
+    RefVector<SPOSet::ValueVector> psi_v_list;
+    psi_v_list.push_back(psi0);
+    psi_v_list.push_back(psi1);
+
+    rot_spo0.mw_evaluateValue(spo_list, p_list, 0, psi_v_list);
+    for (int iw = 0; iw < spo_list.size(); iw++)
+    {
+      CHECK(psi_v_list[iw].get()[0] == Approx(123));
+      CHECK(psi_v_list[iw].get()[1] == Approx(456));
+      CHECK(psi_v_list[iw].get()[2] == Approx(789));
+    }
+  }
+  {
+    //In the case that the underlying SPOSet DOES have mw_ specializations,
+    //we want to make sure that RotatedSPOs are triggering that appropriately
+    //This will mean that the underlying SPOSets will do the appropriate offloading
+    //To check this, DummySPOSetWithMW has an explicit mw_evaluateValue which sets
+    //different values than what gets set in evaluateValue. By doing this,
+    //we are ensuring that RotatedSPOs->mw_evaluaeValue is calling the specialization
+    //in the underlying SPO and not using the default SPOSet implementation which
+    //loops over single walker APIs (which have different values enforced in
+    // DummySPOSetWithoutMW
+    auto spo_ptr0 = std::make_unique<DummySPOSetWithMW>("mw 0");
+    RotatedSPOs rot_spo0("rotated0", std::move(spo_ptr0));
+    auto spo_ptr1 = std::make_unique<DummySPOSetWithMW>("mw 1");
+    RotatedSPOs rot_spo1("rotated1", std::move(spo_ptr1));
+
+    RefVectorWithLeader<SPOSet> spo_list(rot_spo0);
+    spo_list.push_back(rot_spo0);
+    spo_list.push_back(rot_spo1);
+
+    const SimulationCell simulation_cell;
+    ParticleSet elec0(simulation_cell);
+    ParticleSet elec1(simulation_cell);
+
+    RefVectorWithLeader<ParticleSet> p_list(elec0);
+    p_list.push_back(elec0);
+    p_list.push_back(elec1);
+
+    SPOSet::ValueVector psi0(3);
+    SPOSet::ValueVector psi1(3);
+    RefVector<SPOSet::ValueVector> psi_v_list;
+    psi_v_list.push_back(psi0);
+    psi_v_list.push_back(psi1);
+
+    rot_spo0.mw_evaluateValue(spo_list, p_list, 0, psi_v_list);
+    for (int iw = 0; iw < spo_list.size(); iw++)
+    {
+      CHECK(psi_v_list[iw].get()[0] == Approx(321));
+      CHECK(psi_v_list[iw].get()[1] == Approx(654));
+      CHECK(psi_v_list[iw].get()[2] == Approx(789));
+    }
+  }
 }
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -756,7 +756,7 @@ public:
   void setOrbitalSetSize(int norbs) override {}
   void evaluateValue(const ParticleSet& P, int iat, SPOSet::ValueVector& psi) override
   {
-    assert(psi.size() == 3);
+    assert(psi.get().size() == 3);
     psi[0] = 123;
     psi[1] = 456;
     psi[2] = 789;
@@ -783,7 +783,7 @@ public:
   {
     for (auto& psi : psi_v_list)
     {
-      assert(psi.size() == 3);
+      assert(psi.get().size() == 3);
       psi.get()[0] = 321;
       psi.get()[1] = 654;
       psi.get()[2] = 987;

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -22,7 +22,6 @@
 #include "QMCWaveFunctions/RotatedSPOs.h"
 #include "checkMatrix.hpp"
 #include "FakeSPO.h"
-#include "ConstantSPOSet.h"
 
 #include <stdio.h>
 #include <string>

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -870,7 +870,7 @@ TEST_CASE("RotatedSPOs mw_ APIs", "[wavefunction]")
     {
       CHECK(psi_v_list[iw].get()[0] == Approx(321));
       CHECK(psi_v_list[iw].get()[1] == Approx(654));
-      CHECK(psi_v_list[iw].get()[2] == Approx(789));
+      CHECK(psi_v_list[iw].get()[2] == Approx(987));
     }
   }
 }


### PR DESCRIPTION
## Proposed changes

In the case where we go straight from an optimization into a VMC/DMC in the same run, or with WF evaluation during optimization we want to be able to utilize mw_ APIs and  offload when using RotatedSPOs. Currently, since RotatedSPOs inherits from SPOSet and doesn't have any mw_ APIs defined, it will just fall back to the single walker APIs. This PR adds the resource management and mw_ APIs to RotatedSPOs, which simply call its underlying SPOSet's resource and mw_ APIs. 

I made a unit test to check that these mw_ APIs have the correct behavior by introducing two "dummy" SPOSets, one that has mw_ APIs defined and one that doesn't. A RotatedSPO for the dummy SPO which doesn't have any mw_ specialization does RotatedSPOs::mw_XXX which calls underlying SPO::mw_XXX. Since it isn't defined, it defaults to loop over single walker APIs. But in the case where the underlying SPOSet does have mw_ defined, we want it to have the appropriate behavior. The dummy test SPOSets I created set different values in different APIs to ensure that the appropriate code paths are being followed for mw_evaluateValue. I assumed it would be sufficient to test only that one, but can add more if needed. 

Also, if there is a better way to test this, let me know and I can make some changes. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
macOS

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
