### PR TITLE
apply_rotation timer

### DIFF
--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -25,7 +25,7 @@ RotatedSPOs::RotatedSPOs(const std::string& my_name, std::unique_ptr<SPOSet>&& s
       Phi(std::move(spos)),
       nel_major_(0),
       params_supplied(false),
-      rotation_timer_(createGlobalTimer("RotatedSPOs::apply_rotation", timer_level_fine))
+      apply_rotation_timer_(createGlobalTimer("RotatedSPOs::apply_rotation", timer_level_fine))
 {
   OrbitalSetSize = Phi->getOrbitalSetSize();
 }
@@ -414,7 +414,7 @@ void RotatedSPOs::apply_rotation(const std::vector<RealType>& param, bool use_st
   */
   exponentiate_antisym_matrix(rot_mat);
   {
-    ScopedTimer local(rotation_timer_);
+    ScopedTimer local(apply_rotation_timer_);
     Phi->applyRotation(rot_mat, use_stored_copy);
   }
 }
@@ -428,7 +428,7 @@ void RotatedSPOs::applyDeltaRotation(const std::vector<RealType>& delta_param,
   constructDeltaRotation(delta_param, old_param, m_act_rot_inds, m_full_rot_inds, new_param, new_rot_mat);
 
   {
-    ScopedTimer local(rotation_timer_);
+    ScopedTimer local(apply_rotation_timer_);
     Phi->applyRotation(new_rot_mat, true);
   }
 }

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -427,7 +427,10 @@ void RotatedSPOs::applyDeltaRotation(const std::vector<RealType>& delta_param,
   ValueMatrix new_rot_mat(nmo, nmo);
   constructDeltaRotation(delta_param, old_param, m_act_rot_inds, m_full_rot_inds, new_param, new_rot_mat);
 
-  Phi->applyRotation(new_rot_mat, true);
+  {
+    ScopedTimer local(rotation_timer_);
+    Phi->applyRotation(new_rot_mat, true);
+  }
 }
 
 void RotatedSPOs::constructDeltaRotation(const std::vector<RealType>& delta_param,

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -20,7 +20,12 @@
 namespace qmcplusplus
 {
 RotatedSPOs::RotatedSPOs(const std::string& my_name, std::unique_ptr<SPOSet>&& spos)
-    : SPOSet(my_name), OptimizableObject(my_name), Phi(std::move(spos)), nel_major_(0), params_supplied(false)
+    : SPOSet(my_name),
+      OptimizableObject(my_name),
+      Phi(std::move(spos)),
+      nel_major_(0),
+      params_supplied(false),
+      rotation_timer_(createGlobalTimer("RotatedSPOs::apply_rotation", timer_level_fine))
 {
   OrbitalSetSize = Phi->getOrbitalSetSize();
 }
@@ -408,7 +413,10 @@ void RotatedSPOs::apply_rotation(const std::vector<RealType>& param, bool use_st
     Finally, apply unitary matrix to orbs.
   */
   exponentiate_antisym_matrix(rot_mat);
-  Phi->applyRotation(rot_mat, use_stored_copy);
+  {
+    ScopedTimer local(rotation_timer_);
+    Phi->applyRotation(rot_mat, use_stored_copy);
+  }
 }
 
 void RotatedSPOs::applyDeltaRotation(const std::vector<RealType>& delta_param,

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -381,7 +381,7 @@ private:
   opt_variables_type myVarsFull;
 
   /// timer for apply_rotation
-  NewTimer& rotation_timer_;
+  NewTimer& apply_rotation_timer_;
 
   /// List of previously applied parameters
   std::vector<std::vector<RealType>> history_params_;

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -380,6 +380,9 @@ private:
   /// Full set of rotation matrix parameters for use in global rotation method
   opt_variables_type myVarsFull;
 
+  /// timer for apply_rotation
+  NewTimer& rotation_timer_;
+
   /// List of previously applied parameters
   std::vector<std::vector<RealType>> history_params_;
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

adding a timer to the Phi->apply_rotation calls. Useful as we are testing some of the performance of orbital optimization

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature

### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
macOS

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
