### PR TITLE
Disable Estimator tests if BUILD_UNIT_TESTS is set to OFF.

### DIFF
--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -47,4 +47,6 @@ endif()
 target_include_directories(qmcestimators PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcestimators PUBLIC containers qmcham qmcparticle qmcutil)
 
-add_subdirectory(tests)
+if(BUILD_UNIT_TESTS)
+  add_subdirectory(tests)
+endif()


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
The 'test_estimators' binary is build independent of the setting of BUILD_UNIT_TESTS. This causes a linker error as 'sposets_for_testing' library is not available. Disable tests for Estimators if BUILD_UNIT_TESTS is OFF.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
