### PR TITLE
fix type mismatch of multi array in AFQMC

### DIFF
--- a/src/AFQMC/Hamiltonians/Hamiltonian.hpp
+++ b/src/AFQMC/Hamiltonians/Hamiltonian.hpp
@@ -70,7 +70,7 @@ public:
   boost::multi::array<SPComplexType, 1> halfRotatedHij(WALKER_TYPES type, PsiT_Matrix* Alpha, PsiT_Matrix* Beta)
   {
     throw std::runtime_error("calling visitor on dummy object");
-    return boost::multi::array<ComplexType, 1>(iextensions<1u>{1});
+    return boost::multi::array<SPComplexType, 1>(iextensions<1u>{1});
   }
 
   SpCType_shm_csr_matrix halfRotatedHijkl(WALKER_TYPES type,


### PR DESCRIPTION
## Proposed changes

Multi is more picky now for implicit conversions.
There is no impact at runtime, since it was unreachable code.

## What type(s) of changes does this code introduce?

- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
