### PR TITLE
Fix parameters for real-complex dot product

### DIFF
--- a/src/Containers/OhmmsPETE/TinyVectorOps.h
+++ b/src/Containers/OhmmsPETE/TinyVectorOps.h
@@ -355,11 +355,11 @@ struct OTDot<TinyVector<T1, 4>, TinyVector<T2, 4>>
 };
 
 /** specialization for real-complex TinyVector */
-template<class T1>
-struct OTDot<TinyVector<T1, 3>, TinyVector<std::complex<T1>, 3>>
+template<class T1, class T2>
+struct OTDot<TinyVector<T1, 3>, TinyVector<std::complex<T2>, 3>>
 {
   using Type_t = T1;
-  inline static Type_t apply(const TinyVector<T1, 3>& lhs, const TinyVector<std::complex<T1>, 3>& rhs)
+  inline static Type_t apply(const TinyVector<T1, 3>& lhs, const TinyVector<std::complex<T2>, 3>& rhs)
   {
     return lhs[0] * rhs[0].real() + lhs[1] * rhs[1].real() + lhs[2] * rhs[2].real();
   }


### PR DESCRIPTION
## Proposed changes
Template parameters did not allow for a real type other than the underlying type of the complex type.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Ubuntu 22.04

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
