### PR TITLE
Use 'python3' as python exectable name when using pyscf from Nexus

### DIFF
--- a/nexus/lib/pyscf_input.py
+++ b/nexus/lib/pyscf_input.py
@@ -138,7 +138,7 @@ class PyscfInput(SimulationInputTemplateDev):
                  calculation = None,     # obj w/ Calculation variables
                  chkfile     = None,     # obj w/ Calculation variables
                  twist_num   = None,     # Twist index
-                 python_exe  = 'python', # Python executable
+                 python_exe  = 'python3', # Python executable
                  ):
         if filepath is None and template is not None:
             filepath = template

--- a/nexus/lib/pyscf_sim.py
+++ b/nexus/lib/pyscf_sim.py
@@ -31,7 +31,7 @@ class Pyscf(Simulation):
     analyzer_type      = PyscfAnalyzer
     generic_identifier = 'pyscf'
     infile_extension   = '.py'
-    application        = 'python'
+    application        = 'python3'
     application_properties = set(['serial','mpi'])
     application_results    = set(['orbitals','wavefunction'])
 

--- a/nexus/tests/unit/test_pyscf_input.py
+++ b/nexus/tests/unit/test_pyscf_input.py
@@ -251,7 +251,7 @@ def test_generate():
         ### end generated pyscfimport text ###
         '''.format("'''")
                     
-    ref_python_exe = 'python'
+    ref_python_exe = 'python3'
 
     assert(len(pi.values)==4 and 'system' in pi.values)
     assert(len(pi.values)==4 and 'calculation' in pi.values)


### PR DESCRIPTION
Found on a Ubuntu 22.04 system where the 'python' executable doesn't exist, only 'python3'.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
