### PR TITLE
uninitcopy for device pointer

### DIFF
--- a/src/AFQMC/Memory/device_pointers.hpp
+++ b/src/AFQMC/Memory/device_pointers.hpp
@@ -887,6 +887,12 @@ device_pointer<T> uninitialized_copy(T* Abeg, T* Aend, device_pointer<Q> B)
   return copy_n(Abeg, std::distance(Abeg, Aend), B);
 }
 
+template<class It, typename Q>
+device_pointer<Q> uninitialized_copy(It Abeg, It Aend, device_pointer<Q> B)
+{
+  return copy_n(Abeg, std::distance(Abeg, Aend), B);
+}
+
 template<typename T>
 T* uninitialized_copy(device_pointer<T> const Abeg, device_pointer<T> const Aend, T* B)
 {


### PR DESCRIPTION
## Proposed changes

This change is necessary for multi to be able to call `uninitialized_copy` generically from subarray -> array construction

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
