### PR TITLE
[AFQMC] Add customized uninitialized_copy for device_pointer

### DIFF
--- a/src/AFQMC/Memory/device_pointers.hpp
+++ b/src/AFQMC/Memory/device_pointers.hpp
@@ -379,6 +379,14 @@ struct device_pointer : base_device_pointer
   }
   T* impl_;
 
+
+  template<class It>
+  static auto uninitialized_copy(It Abeg, It Aend, device_pointer B)
+  {
+    static_assert(std::is_trivially_copyable_v<T>);
+    return copy_n(Abeg, std::distance(Abeg, Aend), B);
+  }
+
 private:
   device_pointer(T* impl__) : impl_(impl__) {}
 };


### PR DESCRIPTION
## Proposed changes

to fight ADL-unfriendly types used in AFQMC

This change is necessary for multi to be able to call `uninitialized_copy` generically from subarray -> array construction

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
