### PR TITLE
Fix checkMatrix usage in some tests

### DIFF
--- a/src/QMCWaveFunctions/tests/test_ConstantSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/test_ConstantSPOSet.cpp
@@ -114,8 +114,10 @@ TEST_CASE("ConstantSPOSet", "[wavefunction]")
   const int last_index  = 2;
   sposet->evaluate_notranspose(elec, first_index, last_index, phimat, gphimat, lphimat);
 
-  checkMatrix(phimat, spomat);
-  checkMatrix(lphimat, laplspomat);
+  auto check = checkMatrix(phimat, spomat);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
+  check = checkMatrix(lphimat, laplspomat);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   //Test of makeClone()
   auto sposet_vgl2 = sposet->makeClone();
@@ -125,8 +127,10 @@ TEST_CASE("ConstantSPOSet", "[wavefunction]")
 
   sposet_vgl2->evaluate_notranspose(elec, first_index, last_index, phimat, gphimat, lphimat);
 
-  checkMatrix(phimat, spomat);
-  checkMatrix(lphimat, laplspomat);
+  check = checkMatrix(phimat, spomat);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
+  check = checkMatrix(lphimat, laplspomat);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   //Lastly, check if name is correct.
   std::string myname = sposet_vgl2->getClassName();

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -66,7 +66,7 @@ void test_DiracDeterminantBatched_first()
   b(2, 1) = -0.04586322768;
   b(2, 2) = 0.3927890292;
 
-  auto check = checkMatrix(ddb.get_det_engine().get_ref_psiMinv(), b);
+  auto check = checkMatrix(b, ddb.get_det_engine().get_ref_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   ParticleSet::GradType grad;
@@ -86,7 +86,7 @@ void test_DiracDeterminantBatched_first()
   b(2, 1) = 0.7119205298;
   b(2, 2) = 0.9105960265;
 
-  check = checkMatrix(ddb.get_det_engine().get_ref_psiMinv(), b);
+  check = checkMatrix(b, ddb.get_det_engine().get_ref_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // set virtutal particle position
@@ -261,7 +261,7 @@ void test_DiracDeterminantBatched_second()
   app_log() << ddb.getPsiMinv() << std::endl;
 #endif
 
-  auto check = checkMatrix(ddb.get_det_engine().get_ref_psiMinv(), orig_a);
+  auto check = checkMatrix(orig_a, ddb.get_det_engine().get_ref_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 }
 
@@ -359,7 +359,7 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   // force update Ainv in ddc using SM-1 code path
   ddc.completeUpdates();
 
-  auto check = checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), a_update1);
+  auto check = checkMatrix(a_update1, ddc.get_det_engine().get_ref_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   grad = ddc.evalGrad(elec, 1);
@@ -415,7 +415,7 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
 #endif
 
   // compare all the elements of get_ref_psiMinv() in ddc and orig_a
-  check = checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), orig_a);
+  check = checkMatrix(orig_a, ddc.get_det_engine().get_ref_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // testing batched interfaces
@@ -451,10 +451,10 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   ddc.mw_accept_rejectMove(ddc_ref_list, p_ref_list, 0, isAccepted, true);
   ddc.mw_completeUpdates(ddc_ref_list);
 
-  check = checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), a_update1);
+  check = checkMatrix(a_update1, ddc.get_det_engine().get_ref_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
-  check = checkMatrix(ddc_clone_ref.get_det_engine().get_ref_psiMinv(), a_update1);
+  check = checkMatrix(a_update1, ddc_clone_ref.get_det_engine().get_ref_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   ddc.mw_evalGrad(ddc_ref_list, p_ref_list, 1, grad_new);
@@ -473,10 +473,10 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   ddc.mw_accept_rejectMove(ddc_ref_list, p_ref_list, 2, isAccepted, true);
   ddc.mw_completeUpdates(ddc_ref_list);
 
-  check = checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), orig_a);
+  check = checkMatrix(orig_a, ddc.get_det_engine().get_ref_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
-  check = checkMatrix(ddc_clone_ref.get_det_engine().get_ref_psiMinv(), orig_a);
+  check = checkMatrix(orig_a, ddc_clone_ref.get_det_engine().get_ref_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 }
 

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -66,7 +66,8 @@ void test_DiracDeterminantBatched_first()
   b(2, 1) = -0.04586322768;
   b(2, 2) = 0.3927890292;
 
-  checkMatrix(ddb.get_det_engine().get_ref_psiMinv(), b);
+  auto check = checkMatrix(ddb.get_det_engine().get_ref_psiMinv(), b);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   ParticleSet::GradType grad;
   PsiValueType det_ratio  = ddb.ratioGrad(elec, 0, grad);
@@ -85,7 +86,8 @@ void test_DiracDeterminantBatched_first()
   b(2, 1) = 0.7119205298;
   b(2, 2) = 0.9105960265;
 
-  checkMatrix(ddb.get_det_engine().get_ref_psiMinv(), b);
+  check = checkMatrix(ddb.get_det_engine().get_ref_psiMinv(), b);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // set virtutal particle position
   PosType newpos(0.3, 0.2, 0.5);
@@ -259,7 +261,8 @@ void test_DiracDeterminantBatched_second()
   app_log() << ddb.getPsiMinv() << std::endl;
 #endif
 
-  checkMatrix(ddb.get_det_engine().get_ref_psiMinv(), orig_a);
+  auto check = checkMatrix(ddb.get_det_engine().get_ref_psiMinv(), orig_a);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 }
 
 TEST_CASE("DiracDeterminantBatched_second", "[wavefunction][fermion]")
@@ -356,7 +359,8 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   // force update Ainv in ddc using SM-1 code path
   ddc.completeUpdates();
 
-  checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), a_update1);
+  auto check = checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), a_update1);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   grad = ddc.evalGrad(elec, 1);
 
@@ -411,7 +415,8 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
 #endif
 
   // compare all the elements of get_ref_psiMinv() in ddc and orig_a
-  checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), orig_a);
+  check = checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), orig_a);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // testing batched interfaces
   ResourceCollection pset_res("test_pset_res");
@@ -446,8 +451,11 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   ddc.mw_accept_rejectMove(ddc_ref_list, p_ref_list, 0, isAccepted, true);
   ddc.mw_completeUpdates(ddc_ref_list);
 
-  checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), a_update1);
-  checkMatrix(ddc_clone_ref.get_det_engine().get_ref_psiMinv(), a_update1);
+  check = checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), a_update1);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
+
+  check = checkMatrix(ddc_clone_ref.get_det_engine().get_ref_psiMinv(), a_update1);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   ddc.mw_evalGrad(ddc_ref_list, p_ref_list, 1, grad_new);
   ddc.mw_ratioGrad(ddc_ref_list, p_ref_list, 1, ratios, grad_new);
@@ -465,8 +473,11 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   ddc.mw_accept_rejectMove(ddc_ref_list, p_ref_list, 2, isAccepted, true);
   ddc.mw_completeUpdates(ddc_ref_list);
 
-  checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), orig_a);
-  checkMatrix(ddc_clone_ref.get_det_engine().get_ref_psiMinv(), orig_a);
+  check = checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), orig_a);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
+
+  check = checkMatrix(ddc_clone_ref.get_det_engine().get_ref_psiMinv(), orig_a);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 }
 
 TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")

--- a/src/QMCWaveFunctions/tests/test_spline_applyrotation.cpp
+++ b/src/QMCWaveFunctions/tests/test_spline_applyrotation.cpp
@@ -123,7 +123,8 @@ TEST_CASE("Spline applyRotation zero rotation", "[wavefunction]")
       for (int k = 0; k < orbitalsetsize; k++)
         psiM_rot_manual[i][j] += psiM_bare[i][k] * rot_mat[k][j];
     }
-  checkMatrix(psiM_rot_manual, psiM_rot);
+  auto check = checkMatrix(psiM_rot_manual, psiM_rot);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // Check grad
   SPOSet::GradMatrix dpsiM_rot_manual(elec_.R.size(), orbitalsetsize);
@@ -157,7 +158,8 @@ TEST_CASE("Spline applyRotation zero rotation", "[wavefunction]")
         d2psiM_rot_manual[i][j] += d2psiM_bare[i][k] * rot_mat[k][j];
     }
 
-  checkMatrix(d2psiM_rot_manual, d2psiM_rot);
+  check = checkMatrix(d2psiM_rot_manual, d2psiM_rot);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
 } // TEST_CASE
 
@@ -329,7 +331,8 @@ TEST_CASE("Spline applyRotation one rotation", "[wavefunction]")
       for (int k = 0; k < orbitalsetsize; k++)
         psiM_rot_manual[i][j] += psiM_bare[i][k] * rot_mat[k][j];
     }
-  checkMatrix(psiM_rot_manual, psiM_rot);
+  auto check = checkMatrix(psiM_rot_manual, psiM_rot);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // Check grad
   SPOSet::GradMatrix dpsiM_rot_manual(elec_.R.size(), orbitalsetsize);
@@ -363,7 +366,8 @@ TEST_CASE("Spline applyRotation one rotation", "[wavefunction]")
         d2psiM_rot_manual[i][j] += d2psiM_bare[i][k] * rot_mat[k][j];
     }
 
-  checkMatrix(d2psiM_rot_manual, d2psiM_rot);
+  check = checkMatrix(d2psiM_rot_manual, d2psiM_rot);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
 } // TEST_CASE
 
@@ -630,7 +634,8 @@ TEST_CASE("Spline applyRotation two rotations", "[wavefunction]")
       for (int k = 0; k < orbitalsetsize; k++)
         psiM_rot_manual[i][j] += psiM_bare[i][k] * rot_mat_tot[k][j];
     }
-  checkMatrix(psiM_rot_manual, psiM_rot);
+  auto check = checkMatrix(psiM_rot_manual, psiM_rot);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // Check grad
   SPOSet::GradMatrix dpsiM_rot_manual(elec_.R.size(), orbitalsetsize);
@@ -663,7 +668,8 @@ TEST_CASE("Spline applyRotation two rotations", "[wavefunction]")
       for (int k = 0; k < orbitalsetsize; k++)
         d2psiM_rot_manual[i][j] += d2psiM_bare[i][k] * rot_mat_tot[k][j];
     }
-  checkMatrix(d2psiM_rot_manual, d2psiM_rot);
+  check = checkMatrix(d2psiM_rot_manual, d2psiM_rot);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
 } // TEST_CASE
 
@@ -771,7 +777,8 @@ TEST_CASE("Spline applyRotation complex rotation", "[wavefunction]")
       for (int k = 0; k < orbitalsetsize; k++)
         psiM_rot_manual[i][j] += psiM_bare[i][k] * rot_mat[k][j];
     }
-  checkMatrix(psiM_rot_manual, psiM_rot);
+  auto check = checkMatrix(psiM_rot_manual, psiM_rot);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // Check grad
   SPOSet::GradMatrix dpsiM_rot_manual(elec_.R.size(), orbitalsetsize);
@@ -804,7 +811,8 @@ TEST_CASE("Spline applyRotation complex rotation", "[wavefunction]")
       for (int k = 0; k < orbitalsetsize; k++)
         d2psiM_rot_manual[i][j] += d2psiM_bare[i][k] * rot_mat[k][j];
     }
-  checkMatrix(d2psiM_rot_manual, d2psiM_rot);
+  check = checkMatrix(d2psiM_rot_manual, d2psiM_rot);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 } // TEST_CASE
 #endif
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_spline_applyrotation.cpp
+++ b/src/QMCWaveFunctions/tests/test_spline_applyrotation.cpp
@@ -123,7 +123,7 @@ TEST_CASE("Spline applyRotation zero rotation", "[wavefunction]")
       for (int k = 0; k < orbitalsetsize; k++)
         psiM_rot_manual[i][j] += psiM_bare[i][k] * rot_mat[k][j];
     }
-  auto check = checkMatrix(psiM_rot_manual, psiM_rot);
+  auto check = checkMatrix(psiM_rot_manual, psiM_rot, true);
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // Check grad
@@ -158,7 +158,7 @@ TEST_CASE("Spline applyRotation zero rotation", "[wavefunction]")
         d2psiM_rot_manual[i][j] += d2psiM_bare[i][k] * rot_mat[k][j];
     }
 
-  check = checkMatrix(d2psiM_rot_manual, d2psiM_rot);
+  check = checkMatrix(d2psiM_rot_manual, d2psiM_rot, true, 2e-4);
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
 } // TEST_CASE
@@ -331,7 +331,7 @@ TEST_CASE("Spline applyRotation one rotation", "[wavefunction]")
       for (int k = 0; k < orbitalsetsize; k++)
         psiM_rot_manual[i][j] += psiM_bare[i][k] * rot_mat[k][j];
     }
-  auto check = checkMatrix(psiM_rot_manual, psiM_rot);
+  auto check = checkMatrix(psiM_rot_manual, psiM_rot, true);
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // Check grad
@@ -366,7 +366,7 @@ TEST_CASE("Spline applyRotation one rotation", "[wavefunction]")
         d2psiM_rot_manual[i][j] += d2psiM_bare[i][k] * rot_mat[k][j];
     }
 
-  check = checkMatrix(d2psiM_rot_manual, d2psiM_rot);
+  check = checkMatrix(d2psiM_rot_manual, d2psiM_rot, true, 2e-4);
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
 } // TEST_CASE
@@ -634,7 +634,7 @@ TEST_CASE("Spline applyRotation two rotations", "[wavefunction]")
       for (int k = 0; k < orbitalsetsize; k++)
         psiM_rot_manual[i][j] += psiM_bare[i][k] * rot_mat_tot[k][j];
     }
-  auto check = checkMatrix(psiM_rot_manual, psiM_rot);
+  auto check = checkMatrix(psiM_rot_manual, psiM_rot, true);
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // Check grad
@@ -668,7 +668,7 @@ TEST_CASE("Spline applyRotation two rotations", "[wavefunction]")
       for (int k = 0; k < orbitalsetsize; k++)
         d2psiM_rot_manual[i][j] += d2psiM_bare[i][k] * rot_mat_tot[k][j];
     }
-  check = checkMatrix(d2psiM_rot_manual, d2psiM_rot);
+  check = checkMatrix(d2psiM_rot_manual, d2psiM_rot, true, 2e-4);
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
 } // TEST_CASE
@@ -777,7 +777,7 @@ TEST_CASE("Spline applyRotation complex rotation", "[wavefunction]")
       for (int k = 0; k < orbitalsetsize; k++)
         psiM_rot_manual[i][j] += psiM_bare[i][k] * rot_mat[k][j];
     }
-  auto check = checkMatrix(psiM_rot_manual, psiM_rot);
+  auto check = checkMatrix(psiM_rot_manual, psiM_rot, true);
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // Check grad
@@ -811,7 +811,7 @@ TEST_CASE("Spline applyRotation complex rotation", "[wavefunction]")
       for (int k = 0; k < orbitalsetsize; k++)
         d2psiM_rot_manual[i][j] += d2psiM_bare[i][k] * rot_mat[k][j];
     }
-  check = checkMatrix(d2psiM_rot_manual, d2psiM_rot);
+  check = checkMatrix(d2psiM_rot_manual, d2psiM_rot, true, 2e-4);
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 } // TEST_CASE
 #endif

--- a/src/Utilities/for_testing/checkMatrix.cpp
+++ b/src/Utilities/for_testing/checkMatrix.cpp
@@ -13,12 +13,12 @@
 
 namespace qmcplusplus
 {
-template bool approxEquality<float>(float val_a, float val_b, double eps);
+template bool approxEquality<float>(float val_a, float val_b, std::optional<double> eps);
 template bool approxEquality<std::complex<float>>(std::complex<float> val_a,
                                                   std::complex<float> val_b,
-                                                  double eps);
-template bool approxEquality<double>(double val_a, double val_b, double eps);
+                                                  std::optional<double> eps);
+template bool approxEquality<double>(double val_a, double val_b, std::optional<double> eps);
 template bool approxEquality<std::complex<double>>(std::complex<double> val_a,
                                                    std::complex<double> val_b,
-                                                   double eps);
+                                                   std::optional<double> eps);
 } // namespace qmcplusplus

--- a/src/Utilities/for_testing/checkMatrix.cpp
+++ b/src/Utilities/for_testing/checkMatrix.cpp
@@ -13,8 +13,12 @@
 
 namespace qmcplusplus
 {
-template bool approxEquality<float>(float val_a, float val_b);
-template bool approxEquality<std::complex<float>>(std::complex<float> val_a, std::complex<float> val_b);
-template bool approxEquality<double>(double val_a, double val_b);
-template bool approxEquality<std::complex<double>>(std::complex<double> val_a, std::complex<double> val_b);
+template bool approxEquality<float>(float val_a, float val_b, double eps);
+template bool approxEquality<std::complex<float>>(std::complex<float> val_a,
+                                                  std::complex<float> val_b,
+                                                  double eps);
+template bool approxEquality<double>(double val_a, double val_b, double eps);
+template bool approxEquality<std::complex<double>>(std::complex<double> val_a,
+                                                   std::complex<double> val_b,
+                                                   double eps);
 } // namespace qmcplusplus

--- a/src/Utilities/for_testing/checkMatrix.hpp
+++ b/src/Utilities/for_testing/checkMatrix.hpp
@@ -17,20 +17,21 @@
 #include <string>
 #include <complex>
 #include <type_traits>
+#include <limits>
 #include "type_traits/complex_help.hpp"
 namespace qmcplusplus
 {
 
 template<typename T, IsComplex<T> = true>
-bool approxEquality(T val_a, T val_b)
+bool approxEquality(T val_a, T val_b, double eps)
 {
-  return val_a == ComplexApprox(val_b);
+  return val_a == ComplexApprox(val_b).epsilon(eps);
 }
 
 template<typename T, IsReal<T> = true>
-bool approxEquality(T val_a, T val_b)
+bool approxEquality(T val_a, T val_b, double eps)
 {
-  return val_a == Approx(val_b);
+  return val_a == Approx(val_b).epsilon(eps);
 }
 
 struct CheckMatrixResult
@@ -50,9 +51,13 @@ struct CheckMatrixResult
  *                         left block of b_mat.
  *  \param[in] b_mat     - the matrix to check
  *  \param[in] check_all - if true continue to check matrix elements after failure
+ *  \param[in] eps       - add a tolerance for Catch Approx checks. Default to same as in Approx. 
  */
 template<class M1, class M2>
-CheckMatrixResult checkMatrix(M1& a_mat, M2& b_mat, const bool check_all = false)
+CheckMatrixResult checkMatrix(M1& a_mat,
+                              M2& b_mat,
+                              const bool check_all              = false,
+                              const double eps = std::numeric_limits<float>::epsilon() * 100)
 {
   // This allows use to check a padded b matrix with a nonpadded a
   if (a_mat.rows() > b_mat.rows() || a_mat.cols() > b_mat.cols())
@@ -66,7 +71,7 @@ CheckMatrixResult checkMatrix(M1& a_mat, M2& b_mat, const bool check_all = false
   for (int i = 0; i < a_mat.rows(); i++)
     for (int j = 0; j < a_mat.cols(); j++)
     {
-      bool approx_equality = approxEquality<typename M1::value_type>(a_mat(i, j), b_mat(i, j));
+      bool approx_equality = approxEquality<typename M1::value_type>(a_mat(i, j), b_mat(i, j), eps);
       if (!approx_equality)
       {
         matrixElementError(i, j, a_mat, b_mat);
@@ -78,9 +83,13 @@ CheckMatrixResult checkMatrix(M1& a_mat, M2& b_mat, const bool check_all = false
   return {all_elements_match, error_msg.str()};
 }
 
-extern template bool approxEquality<float>(float val_a, float val_b);
-extern template bool approxEquality<std::complex<float>>(std::complex<float> val_a, std::complex<float> val_b);
-extern template bool approxEquality<double>(double val_a, double val_b);
-extern template bool approxEquality<std::complex<double>>(std::complex<double> val_a, std::complex<double> val_b);
+extern template bool approxEquality<float>(float val_a, float val_b, double eps);
+extern template bool approxEquality<std::complex<float>>(std::complex<float> val_a,
+                                                         std::complex<float> val_b,
+                                                         double eps);
+extern template bool approxEquality<double>(double val_a, double val_b, double eps);
+extern template bool approxEquality<std::complex<double>>(std::complex<double> val_a,
+                                                          std::complex<double> val_b,
+                                                          double eps);
 } // namespace qmcplusplus
 #endif

--- a/src/Utilities/for_testing/checkMatrix.hpp
+++ b/src/Utilities/for_testing/checkMatrix.hpp
@@ -17,21 +17,27 @@
 #include <string>
 #include <complex>
 #include <type_traits>
-#include <limits>
+#include <optional>
 #include "type_traits/complex_help.hpp"
 namespace qmcplusplus
 {
 
 template<typename T, IsComplex<T> = true>
-bool approxEquality(T val_a, T val_b, double eps)
+bool approxEquality(T val_a, T val_b, std::optional<double> eps)
 {
-  return val_a == ComplexApprox(val_b).epsilon(eps);
+  if (eps)
+    return val_a == ComplexApprox(val_b).epsilon(eps.value());
+  else
+    return val_a == ComplexApprox(val_b);
 }
 
 template<typename T, IsReal<T> = true>
-bool approxEquality(T val_a, T val_b, double eps)
+bool approxEquality(T val_a, T val_b, std::optional<double> eps)
 {
-  return val_a == Approx(val_b).epsilon(eps);
+  if (eps)
+    return val_a == Approx(val_b).epsilon(eps.value());
+  else
+    return val_a == Approx(val_b);
 }
 
 struct CheckMatrixResult
@@ -56,8 +62,8 @@ struct CheckMatrixResult
 template<class M1, class M2>
 CheckMatrixResult checkMatrix(M1& a_mat,
                               M2& b_mat,
-                              const bool check_all              = false,
-                              const double eps = std::numeric_limits<float>::epsilon() * 100)
+                              const bool check_all            = false,
+                              std::optional<const double> eps = std::nullopt)
 {
   // This allows use to check a padded b matrix with a nonpadded a
   if (a_mat.rows() > b_mat.rows() || a_mat.cols() > b_mat.cols())
@@ -83,13 +89,13 @@ CheckMatrixResult checkMatrix(M1& a_mat,
   return {all_elements_match, error_msg.str()};
 }
 
-extern template bool approxEquality<float>(float val_a, float val_b, double eps);
+extern template bool approxEquality<float>(float val_a, float val_b, std::optional<double> eps);
 extern template bool approxEquality<std::complex<float>>(std::complex<float> val_a,
                                                          std::complex<float> val_b,
-                                                         double eps);
-extern template bool approxEquality<double>(double val_a, double val_b, double eps);
+                                                         std::optional<double> eps);
+extern template bool approxEquality<double>(double val_a, double val_b, std::optional<double> eps);
 extern template bool approxEquality<std::complex<double>>(std::complex<double> val_a,
                                                           std::complex<double> val_b,
-                                                          double eps);
+                                                          std::optional<double> eps);
 } // namespace qmcplusplus
 #endif

--- a/src/Utilities/tests/for_testing/test_checkMatrix.cpp
+++ b/src/Utilities/tests/for_testing/test_checkMatrix.cpp
@@ -54,6 +54,13 @@ TEST_CASE("checkMatrix_OhmmsMatrix_real", "[utilities][for_testing]")
   // This would be how you would fail and print the information about what element failed.
   CHECKED_ELSE(check_matrix_result.result) { FAIL(check_matrix_result.result_message); }
 
+  //check with epsilon
+  b_mat(0,2) = 2.6005;
+  check_matrix_result = checkMatrix(a_mat, b_mat, false, 1e-4);
+  REQUIRE(check_matrix_result.result == false);
+  check_matrix_result = checkMatrix(a_mat, b_mat, false, 1e-3);
+  REQUIRE(check_matrix_result.result == true);
+
   b_mat.resize(4, 4);
   b_mat(0, 0) = 2.3;
   b_mat(0, 1) = 4.5;


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

While trying to get a new feature tested that I'm working on, I noticed that a few unit tests have incorrect usage of the "checkMatrix". Those tests were just calling checkMatrix(matA, matB) and not getting the result and checking to see if the matrices agree or not. 

This means that some of those features could actually be failing and we have been missing it since the checks weren't correct. I think I caught all instances here.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
macOS

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed _(Kind of, it is fixing existing tests)_
- No. Documentation has been added (if appropriate)
