### PR TITLE
Refine EinsplineSetBuilder::ReadOrbitalInfo error handling.

### DIFF
--- a/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp
@@ -40,7 +40,8 @@ bool EinsplineSetBuilder::ReadOrbitalInfo(bool skipChecks)
   catch (const std::exception& e)
   {
     app_error() << e.what() << std::endl
-                << "EinsplineSetBuilder::ReadOrbitalInfo too old h5 file which is not in ESHDF format!" << std::endl;
+                << "EinsplineSetBuilder::ReadOrbitalInfo h5 file format is too old or it is not a bspline orbital file!"
+                << std::endl;
     return false;
   }
 

--- a/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp
@@ -15,17 +15,6 @@
 
 
 #include "QMCWaveFunctions/EinsplineSetBuilder.h"
-#include "QMCWaveFunctions/WaveFunctionComponentBuilder.h"
-#include "OhmmsData/AttributeSet.h"
-#include "Utilities/Timer.h"
-#include "Message/Communicate.h"
-#include "Message/CommOperators.h"
-#include <vector>
-#include "ParticleBase/RandomSeqGenerator.h"
-#include "CPU/math.hpp"
-
-#include <array>
-#include <string_view>
 
 namespace qmcplusplus
 {
@@ -37,20 +26,25 @@ bool EinsplineSetBuilder::ReadOrbitalInfo(bool skipChecks)
     return false;
   }
 
-  // Read format
-  std::string format;
-  H5File.read(format, "/format");
-  H5File.read(Version, "/version");
-  app_log() << "  HDF5 orbital file version " << Version[0] << "." << Version[1] << "." << Version[2] << "\n";
-  if (format.find("ES") < format.size())
+  try
   {
+    // Read format
+    std::string format;
+    H5File.read(format, "/format");
+    if (format.find("ES") == std::string::npos)
+      throw std::runtime_error("Format string input \"" + format + "\" doesn't contain \"ES\" keyword.");
     Format = ESHDF;
-    return ReadOrbitalInfo_ESHDF(skipChecks);
+    H5File.read(Version, "/version");
+    app_log() << "  HDF5 orbital file version " << Version[0] << "." << Version[1] << "." << Version[2] << std::endl;
+  }
+  catch (const std::exception& e)
+  {
+    app_error() << e.what() << std::endl
+                << "EinsplineSetBuilder::ReadOrbitalInfo too old h5 file which is not in ESHDF format!" << std::endl;
+    return false;
   }
 
-  app_error()
-      << "EinsplineSetBuilder::ReadOrbitalInfo too old h5 file which is not in ESHDF format! Regenerate the h5 file";
-  return false;
+  return ReadOrbitalInfo_ESHDF(skipChecks);
 }
 
 } // namespace qmcplusplus

--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -1994,6 +1994,15 @@ qmc_run_and_check(
   FALSE)
 
 qmc_run_and_check(
+  deterministic-input_check_bad_splineh5
+  "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+  det_qmc_input_check_bad_splineh5
+  det_qmc_input_check_bad_splineh5.in.xml
+  1
+  1
+  FALSE)
+
+qmc_run_and_check(
   deterministic-input_check_no_wf
   "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
   det_qmc_input_check_no_wf

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_input_check_bad_splineh5.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_input_check_bad_splineh5.in.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<!-- Spline input file is not a plane wave input -->
+<simulation>
+   <project id="det_qmc_input_check_no_splineh5" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+   </project>
+   <random seed="71"/>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <sposet_collection type="bspline" href="notapwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+            <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
+         </sposet_collection>
+         <determinantset>
+           <slaterdeterminant>
+               <determinant sposet="spo_ud"/>
+               <determinant sposet="spo_ud"/>
+           </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <pairpot name="MPC" type="MPC" source="e" target="e" ecut="60.0" physical="false"/>         
+         <estimator type="flux" name="Flux"/>
+      </hamiltonian>
+   </qmcsystem>
+   <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
+      <parameter name="walkers"             >    1               </parameter>
+      <parameter name="blocks"              >    3               </parameter>
+      <parameter name="steps"               >    3               </parameter>
+      <parameter name="subSteps"            >    2               </parameter>
+      <parameter name="timestep"            >    0.3             </parameter>
+      <parameter name="warmupSteps"         >    3               </parameter>
+   </qmc>
+</simulation>

--- a/tests/solids/diamondC_1x1x1_pp/notapwscf.h5
+++ b/tests/solids/diamondC_1x1x1_pp/notapwscf.h5
@@ -1,0 +1,1 @@
+../diamondC_1x1x1-Gaussian_pp/C_Diamond.h5


### PR DESCRIPTION
## Proposed changes
Addresses https://github.com/QMCPACK/qmcpack/issues/4744#issuecomment-1735955308
the refined error for #4744 reproducer is
```
ERROR HDF5 read failure in hdf_archive::read /format
EinsplineSetBuilder::ReadOrbitalInfo h5 file format is too old or it is not a bspline orbital file!
EinsplineSetBuilder::set_metadata Error reading orbital info from HDF5 file.
```

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'