### PR TITLE
Rewrite planewave orbital set builder

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
@@ -124,7 +124,6 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
       "no"); // use old spline library for high-order derivatives, e.g. needed for backflow optimization
   std::string useGPU;
   std::string GPUsharing = "no";
-  std::string spo_object_name;
 
   ScopedTimer spo_timer_scope(createGlobalTimer("einspline::CreateSPOSetFromXML", timer_level_medium));
 
@@ -177,8 +176,6 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   {
     OhmmsAttributeSet oAttrib;
     oAttrib.add(spinSet, "spindataset");
-    oAttrib.add(spo_object_name, "name");
-    oAttrib.add(spo_object_name, "id");
     oAttrib.put(cur);
   }
 

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -103,7 +103,7 @@ if(OHMMS_DIM MATCHES 3)
   endif(HAVE_EINSPLINE)
 
   # plane wave SPO
-  set(FERMION_SRCS ${FERMION_SRCS} PlaneWave/PWBasis.cpp PlaneWave/PWParameterSet.cpp PlaneWave/PWOrbitalBuilder.cpp)
+  set(FERMION_SRCS ${FERMION_SRCS} PlaneWave/PWBasis.cpp PlaneWave/PWParameterSet.cpp PlaneWave/PWOrbitalSetBuilder.cpp)
   if(QMC_COMPLEX)
     set(FERMION_SRCS ${FERMION_SRCS} PlaneWave/PWOrbitalSet.cpp)
   else()

--- a/src/QMCWaveFunctions/PlaneWave/PWBasis.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWBasis.cpp
@@ -34,10 +34,8 @@ int PWBasis::readbasis(hdf_archive& h5basisgroup,
   h5basisgroup.read(gvecs, "/electrons/kpoint_0/gvectors");
   NumPlaneWaves = std::max(gvecs.size(), kplusgvecs_cart.size());
   if (NumPlaneWaves == 0)
-  {
-    app_error() << "  PWBasis::readbasis Basis is missing. Abort " << std::endl;
-    abort(); //FIX_ABORT
-  }
+    throw std::runtime_error("  PWBasis::readbasis Basis is missing.");
+
   if (kplusgvecs_cart.empty())
   {
     kplusgvecs_cart.resize(NumPlaneWaves);

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.cpp
@@ -25,7 +25,12 @@
 namespace qmcplusplus
 {
 PWOrbitalSetBuilder::PWOrbitalSetBuilder(const ParticleSet& p, Communicate* comm, xmlNodePtr cur)
-    : SPOSetBuilder("Planewave", comm), targetPtcl(p), rootNode(cur), myParam{std::make_unique<PWParameterSet>(comm)}, hfile{comm} {
+    : SPOSetBuilder("Planewave", comm),
+      targetPtcl(p),
+      rootNode(cur),
+      myParam{std::make_unique<PWParameterSet>(comm)},
+      hfile{comm}
+{
   //
   //Get wavefunction data and parameters from XML and HDF5
   //
@@ -60,7 +65,6 @@ PWOrbitalSetBuilder::~PWOrbitalSetBuilder() = default;
 
 std::unique_ptr<SPOSet> PWOrbitalSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
 {
-
   int spin_group = 0;
   std::string spo_object_name;
   OhmmsAttributeSet aAttrib;
@@ -250,7 +254,7 @@ void PWOrbitalSetBuilder::transform2GridData(PWBasis::GIndex_t& nG, int spinInde
 {
   std::ostringstream splineTag;
   splineTag << "eigenstates_" << nG[0] << "_" << nG[1] << "_" << nG[2];
-  herr_t status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+  herr_t status            = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
   std::string splineTagStr = splineTag.str();
   app_log() << " splineTag " << splineTagStr << std::endl;
   if (!hfile.is_group(splineTagStr))
@@ -284,7 +288,6 @@ void PWOrbitalSetBuilder::transform2GridData(PWBasis::GIndex_t& nG, int spinInde
     {
       bname = myParam->getSpinName(spinIndex);
       hfile.push(bname, true);
-      }
     }
     for (int ig = 0; ig < nG[0]; ig++)
     {

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.cpp
@@ -2,12 +2,13 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2023 QMCPACK developers.
 //
 // File developed by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
 //                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
 //                    Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.h
@@ -65,7 +65,7 @@ public:
 
 private:
   bool getH5(xmlNodePtr cur, const char* aname);
-  bool createPWBasis(xmlNodePtr cur);
+  bool createPWBasis();
   std::unique_ptr<SPOSet> createPW(xmlNodePtr cur, const std::string& objname, int spinIndex);
 #if defined(QMC_COMPLEX)
   void transform2GridData(PWBasis::GIndex_t& nG, int spinIndex, PWOrbitalSet& pwFunc);

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.h
@@ -2,9 +2,10 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2023 QMCPACK developers.
 //
-// File developed by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
@@ -15,15 +16,17 @@
  * @brief Declaration of a builder class for PWOrbitalSet
  *
  */
-#ifndef QMCPLUSPLUS_PLANEWAVE_ORBITALBUILD_V0_H
-#define QMCPLUSPLUS_PLANEWAVE_ORBITALBUILD_V0_H
-#include "QMCWaveFunctions/WaveFunctionComponentBuilder.h"
+#ifndef QMCPLUSPLUS_PWORBITAL_BUILDER_H
+#define QMCPLUSPLUS_PWORBITAL_BUILDER_H
+
+#include "SPOSetBuilder.h"
 #include "hdf/hdf_archive.h"
 #if defined(QMC_COMPLEX)
 #include "QMCWaveFunctions/PlaneWave/PWOrbitalSet.h"
 #else
 #include "QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h"
 #endif
+
 namespace qmcplusplus
 {
 struct PWParameterSet;
@@ -31,7 +34,7 @@ class SlaterDet;
 
 /** OrbitalBuilder for Slater determinants in PW basis
 */
-class PWOrbitalBuilder : public WaveFunctionComponentBuilder
+class PWOrbitalSetBuilder : public SPOSetBuilder
 {
 private:
 #if defined(QMC_COMPLEX)
@@ -40,8 +43,8 @@ private:
   using SPOSetType = PWRealOrbitalSet;
 #endif
 
-  std::map<std::string, SPOSetPtr> spomap;
-  const PSetMap& ptclPool;
+  /// target particle set
+  const ParticleSet& targetPtcl;
   ///xml node for determinantset
   xmlNodePtr rootNode{nullptr};
   ///input twist angle
@@ -54,17 +57,16 @@ private:
   hdf_archive hfile;
 public:
   ///constructor
-  PWOrbitalBuilder(Communicate* comm, ParticleSet& els, const PSetMap& psets);
-  ~PWOrbitalBuilder() override;
+  PWOrbitalSetBuilder(const ParticleSet& p, Communicate* comm, xmlNodePtr cur);
+  ~PWOrbitalSetBuilder() override;
 
-  ///implement vritual function
-  std::unique_ptr<WaveFunctionComponent> buildComponent(xmlNodePtr cur) override;
+  /// create an sposet from xml and save the resulting SPOSet
+  std::unique_ptr<SPOSet> createSPOSetFromXML(xmlNodePtr cur) override;
 
 private:
   bool getH5(xmlNodePtr cur, const char* aname);
-  std::unique_ptr<WaveFunctionComponent> putSlaterDet(xmlNodePtr cur);
   bool createPWBasis(xmlNodePtr cur);
-  SPOSet* createPW(xmlNodePtr cur, int spinIndex);
+  std::unique_ptr<SPOSet> createPW(xmlNodePtr cur, const std::string& objname, int spinIndex);
 #if defined(QMC_COMPLEX)
   void transform2GridData(PWBasis::GIndex_t& nG, int spinIndex, PWOrbitalSet& pwFunc);
 #endif

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.h
@@ -55,6 +55,7 @@ private:
   std::unique_ptr<PWBasis> myBasisSet;
   ///hdf5 handler to clean up
   hdf_archive hfile;
+
 public:
   ///constructor
   PWOrbitalSetBuilder(const ParticleSet& p, Communicate* comm, xmlNodePtr cur);

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -17,23 +17,24 @@
 
 
 #include "SPOSetBuilderFactory.h"
-#include "QMCWaveFunctions/SPOSetScanner.h"
-#include "QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h"
+#include "SPOSetScanner.h"
+#include "HarmonicOscillator/SHOSetBuilder.h"
+#include "PlaneWave/PWOrbitalSetBuilder.h"
 #include "ModernStringUtils.hpp"
-#include "QMCWaveFunctions/ElectronGas/FreeOrbitalBuilder.h"
+#include "ElectronGas/FreeOrbitalBuilder.h"
 #if OHMMS_DIM == 3
-#include "QMCWaveFunctions/LCAO/LCAOrbitalBuilder.h"
+#include "LCAO/LCAOrbitalBuilder.h"
 
 #if defined(QMC_COMPLEX)
 #include "BsplineFactory/EinsplineSpinorSetBuilder.h"
-#include "QMCWaveFunctions/LCAO/LCAOSpinorBuilder.h"
+#include "LCAO/LCAOSpinorBuilder.h"
 #endif
 
 #if defined(HAVE_EINSPLINE)
 #include "BsplineFactory/EinsplineSetBuilder.h"
 #endif
 #endif
-#include "QMCWaveFunctions/CompositeSPOSet.h"
+#include "CompositeSPOSet.h"
 #include "Utilities/ProgressReportEngine.h"
 #include "Utilities/IteratorUtility.h"
 #include "OhmmsData/AttributeSet.h"
@@ -104,6 +105,11 @@ std::unique_ptr<SPOSetBuilder> SPOSetBuilderFactory::createSPOSetBuilder(xmlNode
   {
     app_log() << "Harmonic Oscillator SPO set" << std::endl;
     bb = std::make_unique<SHOSetBuilder>(targetPtcl, myComm);
+  }
+  else if (type == "PWBasis" || type == "PW" || type == "pw")
+  {
+    app_log() << "Planewave basis SPO set" << std::endl;
+    bb = std::make_unique<PWOrbitalSetBuilder>(targetPtcl, myComm, rootNode);
   }
 #if OHMMS_DIM == 3
   else if (type.find("spline") < type.size())

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -24,7 +24,6 @@
 #include "QMCWaveFunctions/Fermion/SlaterDetBuilder.h"
 #include "QMCWaveFunctions/LatticeGaussianProductBuilder.h"
 #include "QMCWaveFunctions/ExampleHeBuilder.h"
-#include "QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.h"
 #if OHMMS_DIM == 3 && !defined(QMC_COMPLEX)
 #include "QMCWaveFunctions/AGPDeterminantBuilder.h"
 #endif
@@ -186,10 +185,6 @@ bool WaveFunctionFactory::addFermionTerm(TrialWaveFunction& psi, SPOSetBuilderFa
     msg << "electron-gas in determinantset is deprecated";
     msg << " please use \"free\" orbitals in sposet_builder" << std::endl;
     throw std::runtime_error(msg.str());
-  }
-  else if (orbtype == "PWBasis" || orbtype == "PW" || orbtype == "pw")
-  {
-    detbuilder = std::make_unique<PWOrbitalBuilder>(myComm, targetPtcl, ptclPool);
   }
   else
     detbuilder = std::make_unique<SlaterDetBuilder>(myComm, spo_factory, targetPtcl, psi, ptclPool);

--- a/src/QMCWaveFunctions/tests/test_pw.cpp
+++ b/src/QMCWaveFunctions/tests/test_pw.cpp
@@ -16,9 +16,7 @@
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/ParticleSetPool.h"
-#include "QMCWaveFunctions/WaveFunctionComponent.h"
-#include "QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.h"
-#include "QMCWaveFunctions/Fermion/SlaterDet.h"
+#include "PlaneWave/PWOrbitalSetBuilder.h"
 
 
 #include <stdio.h>
@@ -70,18 +68,12 @@ TEST_CASE("PlaneWave SPO from HDF for BCC H", "[wavefunction]")
   elec.update();
 
   //BCC H
-  const char* particles = R"(<tmp>
-<determinantset type="PW" href="bccH.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion">
-   <slaterdeterminant>
-     <determinant id="updet" size="1">
-      <occupation mode="ground" spindataset="0"/>
-     </determinant>
-     <determinant id="downdet" size="1">
-        <occupation mode="ground" spindataset="0"/>
-     </determinant>
-  </slaterdeterminant>
-</determinantset>
-</tmp>
+  const char* particles = R"(
+<sposet_collection type="PW" href="bccH.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion">
+  <sposet name="updet" size="1" spindataset="0">
+    <occupation mode="ground"/>
+  </sposet>
+</sposet_collection>
 )";
 
   Libxml2Document doc;
@@ -89,21 +81,14 @@ TEST_CASE("PlaneWave SPO from HDF for BCC H", "[wavefunction]")
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-
   xmlNodePtr pw1 = xmlFirstElementChild(root);
 
 
-  PWOrbitalBuilder pw_builder(c, elec, ptcl.getPool());
-  auto orb      = pw_builder.buildComponent(pw1);
-  SlaterDet* sd = dynamic_cast<SlaterDet*>(orb.get());
-  REQUIRE(sd != nullptr);
-  REQUIRE(sd->Dets.size() == 2);
-  SPOSetPtr spo = sd->getPhi(0);
-  REQUIRE(spo != nullptr);
-  //SPOSet *spo = einSet.createSPOSetFromXML(ein1);
-  //REQUIRE(spo != nullptr);
+  PWOrbitalSetBuilder pw_builder(elec, c, root);
+  auto spo      = pw_builder.createSPOSet(pw1);
+  REQUIRE(spo);
 
-  int orbSize = spo->getOrbitalSetSize();
+  const int orbSize = spo->getOrbitalSetSize();
   elec.update();
   SPOSet::ValueVector orbs(orbSize);
   spo->evaluateValue(elec, 0, orbs);
@@ -189,18 +174,12 @@ TEST_CASE("PlaneWave SPO from HDF for LiH arb", "[wavefunction]")
   elec.update();
 
   //diamondC_1x1x1
-  const char* particles = R"(<tmp>
-<determinantset type="PW" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion">
-   <slaterdeterminant>
-     <determinant id="updet" size="2">
-      <occupation mode="ground" spindataset="0"/>
-     </determinant>
-     <determinant id="downdet" size="2">
-        <occupation mode="ground" spindataset="0"/>
-     </determinant>
-  </slaterdeterminant>
-</determinantset>
-</tmp>
+  const char* particles = R"(
+<sposet_collection type="PW" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion">
+  <sposet name="updet" size="2" spindataset="0">
+    <occupation mode="ground"/>
+  </sposet>
+</sposet_collection>
 )";
 
   Libxml2Document doc;
@@ -208,21 +187,14 @@ TEST_CASE("PlaneWave SPO from HDF for LiH arb", "[wavefunction]")
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-
   xmlNodePtr pw1 = xmlFirstElementChild(root);
 
 
-  PWOrbitalBuilder pw_builder(c, elec, ptcl.getPool());
-  auto orb      = pw_builder.buildComponent(pw1);
-  SlaterDet* sd = dynamic_cast<SlaterDet*>(orb.get());
-  REQUIRE(sd != nullptr);
-  REQUIRE(sd->Dets.size() == 2);
-  SPOSetPtr spo = sd->getPhi(0);
-  REQUIRE(spo != nullptr);
-  //SPOSet *spo = einSet.createSPOSetFromXML(ein1);
-  //REQUIRE(spo != nullptr);
+  PWOrbitalSetBuilder pw_builder(elec, c, root);
+  auto spo      = pw_builder.createSPOSet(pw1);
+  REQUIRE(spo);
 
-  int orbSize = spo->getOrbitalSetSize();
+  const int orbSize = spo->getOrbitalSetSize();
   elec.update();
   SPOSet::ValueVector orbs(orbSize);
   spo->evaluateValue(elec, 0, orbs);

--- a/src/QMCWaveFunctions/tests/test_pw.cpp
+++ b/src/QMCWaveFunctions/tests/test_pw.cpp
@@ -81,11 +81,11 @@ TEST_CASE("PlaneWave SPO from HDF for BCC H", "[wavefunction]")
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-  xmlNodePtr pw1 = xmlFirstElementChild(root);
+  xmlNodePtr pw1  = xmlFirstElementChild(root);
 
 
   PWOrbitalSetBuilder pw_builder(elec, c, root);
-  auto spo      = pw_builder.createSPOSet(pw1);
+  auto spo = pw_builder.createSPOSet(pw1);
   REQUIRE(spo);
 
   const int orbSize = spo->getOrbitalSetSize();
@@ -187,11 +187,11 @@ TEST_CASE("PlaneWave SPO from HDF for LiH arb", "[wavefunction]")
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-  xmlNodePtr pw1 = xmlFirstElementChild(root);
+  xmlNodePtr pw1  = xmlFirstElementChild(root);
 
 
   PWOrbitalSetBuilder pw_builder(elec, c, root);
-  auto spo      = pw_builder.createSPOSet(pw1);
+  auto spo = pw_builder.createSPOSet(pw1);
   REQUIRE(spo);
 
   const int orbSize = spo->getOrbitalSetSize();


### PR DESCRIPTION
## Proposed changes
PWorbitalBuilder was based on WaveFunctionComponentBuilder
reworked PWorbitalSetBuilder is based on SPOSetBuilder and connected to the rest like other SPOSet builders.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
