### PR TITLE
Fix assertion failure

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -657,6 +657,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evaluateGL(const RefVectorWithLeade
       auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE>>(iw);
 
 #ifndef NDEBUG
+      // at this point, host and device should have exactly the same G and L values.
       GradMatrix dpsiM_from_device     = det.dpsiM;
       Matrix<Value> d2psiM_from_device = det.d2psiM;
 
@@ -664,9 +665,6 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evaluateGL(const RefVectorWithLeade
       auto* psiM_vgl_ptr = my_psiM_vgl.data();
       // transfer device to host, total size 4, g(3) + l(1)
       PRAGMA_OFFLOAD("omp target update from(psiM_vgl_ptr[my_psiM_vgl.capacity():my_psiM_vgl.capacity()*4])")
-      Matrix<Value> psiM_temp_host(det.psiM_temp.data(), det.psiM_temp.rows(), det.psiM_temp.cols());
-      det.Phi->evaluate_notranspose(p_list[iw], FirstIndex, LastIndex, psiM_temp_host, det.dpsiM, det.d2psiM);
-
       assert(dpsiM_from_device == det.dpsiM);
       assert(d2psiM_from_device == det.d2psiM);
 #endif


### PR DESCRIPTION
## Proposed changes
Addresses #4666.
mw_evaluate_notranspose and evaluate_notranspose don't produce bitwise identical results. 
The problem started by https://github.com/QMCPACK/qmcpack/pull/4407 which introduce a batched evaluation and caused bitwise matrix value checking failure. I printed diff and found the value is at the epsilon of float or double. So no concern.

The intention of the assertion was to catch any missing D2H transfer earlier and there is no need of recomputing. So the solution is removing the re-computation.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'