### PR TITLE
Rerun matrix inversion when failure happens (non-batched inversion case)

### DIFF
--- a/src/QMCWaveFunctions/Fermion/cuSolverInverter.hpp
+++ b/src/QMCWaveFunctions/Fermion/cuSolverInverter.hpp
@@ -187,6 +187,10 @@ public:
       err << "cusolver::getrs calculation failed with devInfo = " << ipiv[0] << std::endl;
       throw std::runtime_error(err.str());
     }
+
+    for(int i = 0; i < norb; i++)
+      if (qmcplusplus::isnan(Ainv[i][i]))
+        throw std::runtime_error("Ainv[i][i] is NaN. i = " + std::to_string(i));
   }
 };
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/cuSolverInverter.hpp
+++ b/src/QMCWaveFunctions/Fermion/cuSolverInverter.hpp
@@ -189,7 +189,7 @@ public:
     }
 
     for(int i = 0; i < norb; i++)
-      if (qmcplusplus::isnan(Ainv[i][i]))
+      if (qmcplusplus::isnan(std::norm(Ainv[i][i])))
         throw std::runtime_error("Ainv[i][i] is NaN. i = " + std::to_string(i));
   }
 };

--- a/src/QMCWaveFunctions/Fermion/cuSolverInverter.hpp
+++ b/src/QMCWaveFunctions/Fermion/cuSolverInverter.hpp
@@ -167,7 +167,6 @@ public:
     {
       std::ostringstream err;
       err << "cusolver::getrf calculation failed with devInfo = " << ipiv[0] << std::endl;
-      std::cerr << err.str();
       throw std::runtime_error(err.str());
     }
     make_identity_matrix_cuda(norb, Mat2_gpu.data(), norb, hstream_);
@@ -186,7 +185,6 @@ public:
     {
       std::ostringstream err;
       err << "cusolver::getrs calculation failed with devInfo = " << ipiv[0] << std::endl;
-      std::cerr << err.str();
       throw std::runtime_error(err.str());
     }
   }

--- a/src/QMCWaveFunctions/Fermion/rocSolverInverter.hpp
+++ b/src/QMCWaveFunctions/Fermion/rocSolverInverter.hpp
@@ -204,7 +204,7 @@ public:
     }
 
     for(int i = 0; i < norb; i++)
-      if (qmcplusplus::isnan(Ainv[i][i]))
+      if (qmcplusplus::isnan(std::norm(Ainv[i][i])))
         throw std::runtime_error("Ainv[i][i] is NaN. i = " + std::to_string(i));
   }
 };

--- a/src/QMCWaveFunctions/Fermion/rocSolverInverter.hpp
+++ b/src/QMCWaveFunctions/Fermion/rocSolverInverter.hpp
@@ -202,6 +202,10 @@ public:
       std::cerr << err.str();
       throw std::runtime_error(err.str());
     }
+
+    for(int i = 0; i < norb; i++)
+      if (qmcplusplus::isnan(Ainv[i][i]))
+        throw std::runtime_error("Ainv[i][i] is NaN. i = " + std::to_string(i));
   }
 };
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/syclSolverInverter.hpp
+++ b/src/QMCWaveFunctions/Fermion/syclSolverInverter.hpp
@@ -134,7 +134,7 @@ public:
     m_queue.memcpy(Ainv.data(), Ainv_gpu.data(), Ainv.size() * sizeof(TMAT)).wait();
 
     for(int i = 0; i < norb; i++)
-      if (qmcplusplus::isnan(Ainv[i][i]))
+      if (qmcplusplus::isnan(std::norm(Ainv[i][i])))
         throw std::runtime_error("Ainv[i][i] is NaN. i = " + std::to_string(i));
   }
 };

--- a/src/QMCWaveFunctions/Fermion/syclSolverInverter.hpp
+++ b/src/QMCWaveFunctions/Fermion/syclSolverInverter.hpp
@@ -132,6 +132,10 @@ public:
     syclBLAS::copy_n(m_queue, Mat1_gpu.data(), Mat1_gpu.size(), Ainv_gpu.data());
 
     m_queue.memcpy(Ainv.data(), Ainv_gpu.data(), Ainv.size() * sizeof(TMAT)).wait();
+
+    for(int i = 0; i < norb; i++)
+      if (qmcplusplus::isnan(Ainv[i][i]))
+        throw std::runtime_error("Ainv[i][i] is NaN. i = " + std::to_string(i));
   }
 };
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes
One failure mode of 512 atom running on Summit.
cuSolver was showing non-deterministic failure. Re-doing inversion seems to rescue the run.
Add additional scanning of NaN.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Summit.

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
