### PR TITLE
Relax NaN check in TWF::calcRatioGrad

### DIFF
--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -633,12 +633,11 @@ int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P)
     //make a non-local move
     if (oneTMove)
     {
-      int iat = oneTMove->PID;
+      const int iat = oneTMove->PID;
       Psi.prepareGroup(P, P.getGroupID(iat));
-      if (P.makeMoveAndCheck(iat, oneTMove->Delta))
+      GradType grad_iat;
+      if (P.makeMoveAndCheck(iat, oneTMove->Delta) && Psi.calcRatioGrad(P, iat, grad_iat) != ValueType(0))
       {
-        GradType grad_iat;
-        Psi.calcRatioGrad(P, iat, grad_iat);
         Psi.acceptMove(P, iat, true);
         P.acceptMove(iat);
         NonLocalMoveAccepted++;
@@ -658,9 +657,8 @@ int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P)
         const NonLocalData* oneTMove = nonLocalOps.selectMove(RandomGen(), tmove_xy_);
         if (oneTMove)
         {
-          if (P.makeMoveAndCheck(iat, oneTMove->Delta))
+          if (P.makeMoveAndCheck(iat, oneTMove->Delta) && Psi.calcRatioGrad(P, iat, grad_iat) != ValueType(0))
           {
-            Psi.calcRatioGrad(P, iat, grad_iat);
             Psi.acceptMove(P, iat, true);
             P.acceptMove(iat);
             NonLocalMoveAccepted++;
@@ -691,9 +689,8 @@ int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P)
           oneTMove = nonLocalOps.selectMove(RandomGen(), iat);
         if (oneTMove)
         {
-          if (P.makeMoveAndCheck(iat, oneTMove->Delta))
+          if (P.makeMoveAndCheck(iat, oneTMove->Delta) && Psi.calcRatioGrad(P, iat, grad_iat) != ValueType(0))
           {
-            Psi.calcRatioGrad(P, iat, grad_iat);
             Psi.acceptMove(P, iat, true);
             // mark all affected electrons
             markAffectedElecs(P.getDistTableAB(myTableIndex), iat);

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -618,7 +618,8 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatioGrad(ParticleSet& P, in
       r *= Z[i]->ratioGrad(P, iat, grad_iat);
     }
 
-  checkOneParticleGradientsNaN(iat, grad_iat, "TWF::calcRatioGrad");
+  if(r != PsiValueType(0)) // grad_iat is meaningful only when r is strictly non-zero
+    checkOneParticleGradientsNaN(iat, grad_iat, "TWF::calcRatioGrad");
   LogValueType logratio = convertValueToLog(r);
   PhaseDiff             = std::imag(logratio);
   return static_cast<ValueType>(r);
@@ -694,10 +695,11 @@ void TrialWaveFunction::mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunc
     }
   }
   for (int iw = 0; iw < wf_list.size(); iw++)
+  {
     wf_list[iw].PhaseDiff = std::imag(std::arg(ratios[iw]));
-
-  for (const GradType& grads : grad_new.grads_positions)
-    checkOneParticleGradientsNaN(iat, grads, "TWF::mw_calcRatioGrad");
+    if (ratios[iw] != PsiValueType(0))
+      checkOneParticleGradientsNaN(iat, grad_new.grads_positions[iw], "TWF::mw_calcRatioGrad");
+  }
 }
 
 void TrialWaveFunction::printGL(ParticleSet::ParticleGradient& G, ParticleSet::ParticleLaplacian& L, std::string tag)

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -328,8 +328,8 @@ public:
    * It returns a complex value if the wavefunction is complex.
    * @param P the active ParticleSet
    * @param iat the index of a particle moved to the new position.
-   * @param grad_iat gradients
-   * @return ratio value
+   * @param grad_iat gradients. The consumer must verify if ratio is non-zero.
+   * @return ratio value. The caller must reject zero ratio moves.
    */
   ValueType calcRatioGrad(ParticleSet& P, int iat, GradType& grad_iat);
 
@@ -337,9 +337,9 @@ public:
    * It returns a complex value if the wavefunction is complex.
    * @param P the active ParticleSet
    * @param iat the index of a particle moved to the new position.
-   * @param grad_iat real space gradient for iat
-   * @param spingrad_iat spin gradient for iat
-   * @return ratio value
+   * @param grad_iat real space gradient for iat. The consumer must verify if ratio is non-zero.
+   * @param spingrad_iat spin gradient for iat. The consumer must verify if ratio is non-zero.
+   * @return ratio value. The caller must reject zero ratio moves.
    */
   ValueType calcRatioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ComplexType& spingrad_iat);
 


### PR DESCRIPTION
## Proposed changes
When the ratio of calcRatioGrad returns 0, gradients can be NaN. The accept/reject algorithm naturally rejects such moves and thus the NaN check should be skipped. I updated the comment of calcRatioGrad to remind its caller checking the ratio value before accepting a move and fixed its use cases in NLPP T-move related routines.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Summit

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
