### PR TITLE
Workaround for offload compilation using clang with glibc 12 include files

### DIFF
--- a/src/Platforms/CUDA/CUDAruntime.hpp
+++ b/src/Platforms/CUDA/CUDAruntime.hpp
@@ -25,6 +25,17 @@
 #include "Platforms/ROCm/cuda2hip.h"
 #endif
 
+// Work around for clang using gcc/glibc 12 include files in CUDA mode.
+// Clang was fixed to recognize __noinline__ as an attribute,
+// but the CUDA include files still have a define for __noinline__.
+// The attribute started to be used in gcc 12 include files, which expands
+// to __attribute__((__attribute__((noinline)))), which the compiler rejects.
+// See https://github.com/NVIDIA/thrust/issues/1703 and
+//     https://github.com/llvm/llvm-project/issues/57544
+#if defined(__clang__) && (_GLIBCXX_RELEASE >= 12)
+#undef __noinline__
+#endif
+
 #include "CUDAerror.h"
 
 size_t getCUDAdeviceFreeMem();


### PR DESCRIPTION
Shows up when doing offload compilation with Clang on a system with gcc/glibc 12 (or newer) include files.

Clang was fixed to recognize `__noinline__` as an attribute, but the CUDA include files still have a define for `__noinline__`. The attribute started to be used in glibc 12 include files, which expands to `__attribute__((__attribute__((noinline))))`, which the compiler rejects.  Clang includes a workaround, but it applies to CUDA code.  This is C++ code using the CUDA include files.
See https://github.com/llvm/llvm-project/issues/57544 (and https://github.com/NVIDIA/thrust/issues/1703 ).


The `__clang__` and `_GLIBCXX_RELEASE` guards were added because I'm not sure of the effects on other compilers.
The `_GLIBCXX_RELEASE` macro is documented here (item 8): https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html

The error message that indicates the problem:
```
In file included from /home/mdewing/nvme/physics/qmcpack/main/qmcpack/src/Platforms/CUDA/CUDADeviceManager.cpp:26:
In file included from /home/mdewing/nvme/physics/qmcpack/main/qmcpack/src/Platforms/Host/OutputManager.h:19:
In file included from /home/mdewing/nvme/physics/qmcpack/main/qmcpack/src/Platforms/Host/InfoStream.h:21:
In file included from /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/memory:76:
In file included from /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/shared_ptr.h:53:
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/shared_ptr_base.h:196:22: error: use of undeclared identifier 'noinline'; did you mean 'inline'?
  196 |       __attribute__((__noinline__))
      |                      ^
/usr/local/cuda-12.2/include/crt/host_defines.h:83:24: note: expanded from macro '__noinline__'
   83 |         __attribute__((noinline))
      |                        ^
```

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Local server

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
