### PR TITLE
[BUG] Fix wrong PhaseDiff and protect NaN for DMCBatched

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -33,6 +33,7 @@ namespace qmcplusplus
 {
 using std::placeholders::_1;
 using WP = WalkerProperties::Indexes;
+using PsiValueType = TrialWaveFunction::PsiValueType;
 
 /** Constructor maintains proper ownership of input parameters
  *
@@ -118,7 +119,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
   //This generates an entire steps worth of deltas.
   makeGaussRandomWithEngine(walker_deltas, step_context.get_random_gen());
 
-  std::vector<TrialWaveFunction::PsiValueType> ratios(num_walkers, TrialWaveFunction::PsiValueType(0.0));
+  std::vector<PsiValueType> ratios(num_walkers, PsiValueType(0.0));
   std::vector<RealType> log_gf(num_walkers, 0.0);
   std::vector<RealType> log_gb(num_walkers, 0.0);
   std::vector<RealType> prob(num_walkers, 0.0);
@@ -194,8 +195,8 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
         computeLogGreensFunction(drifts_reverse, taus, log_gb);
 
-        auto checkPhaseChanged = [&sft](const TrialWaveFunction& twf, int& is_reject) {
-          if (sft.branch_engine.phaseChanged(twf.getPhaseDiff()))
+        auto checkPhaseChanged = [&sft](const PsiValueType& ratio, int& is_reject) {
+          if (ratio == PsiValueType(0) || sft.branch_engine.phaseChanged(std::arg(ratio)))
             is_reject = 1;
           else
             is_reject = 0;
@@ -205,7 +206,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
         std::vector<int> rejects(num_walkers); // instead of std::vector<bool>
         for (int iw = 0; iw < num_walkers; ++iw)
         {
-          checkPhaseChanged(walker_twfs[iw], rejects[iw]);
+          checkPhaseChanged(ratios[iw], rejects[iw]);
           //This is just convenient to do here
           rr_proposed[iw] += rr[iw];
         }

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -32,7 +32,7 @@
 namespace qmcplusplus
 {
 using std::placeholders::_1;
-using WP = WalkerProperties::Indexes;
+using WP           = WalkerProperties::Indexes;
 using PsiValueType = TrialWaveFunction::PsiValueType;
 
 /** Constructor maintains proper ownership of input parameters
@@ -217,7 +217,6 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
         isAccepted.clear();
 
         for (int iw = 0; iw < num_walkers; ++iw)
-        {
           if ((!rejects[iw]) && prob[iw] >= std::numeric_limits<RealType>::epsilon() &&
               step_context.get_random_gen()() < prob[iw])
           {
@@ -230,7 +229,6 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
             crowd.incReject();
             isAccepted.push_back(false);
           }
-        }
 
         twf_dispatcher.flex_accept_rejectMove(walker_twfs, walker_elecs, iat, isAccepted, true);
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -281,6 +281,8 @@ void DiracDeterminant<DU_TYPE>::mw_ratioGrad(const RefVectorWithLeader<WaveFunct
 template<typename DU_TYPE>
 void DiracDeterminant<DU_TYPE>::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
 {
+  if (curRatio == PsiValueType(0))
+    throw std::runtime_error("DiracDeterminant::acceptMove curRatio is zero! Report a bug.\n");
   ScopedTimer local_timer(UpdateTimer);
   const int WorkingIndex = iat - FirstIndex;
   assert(WorkingIndex >= 0);

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -444,6 +444,8 @@ typename DiracDeterminantBatched<DET_ENGINE>::PsiValue DiracDeterminantBatched<D
 template<typename DET_ENGINE>
 void DiracDeterminantBatched<DET_ENGINE>::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
 {
+  if (curRatio == PsiValueType(0))
+    throw std::runtime_error("DiracDeterminant::acceptMove curRatio is zero! Report a bug.\n");
   const int WorkingIndex = iat - FirstIndex;
   log_value_ += convertValueToLog(curRatio);
   {
@@ -496,6 +498,8 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_accept_rejectMove(
     {
       psiM_g_dev_ptr_list[count] = det.psiM_vgl.device_data() + psiM_vgl.capacity() + NumOrbitals * WorkingIndex * DIM;
       psiM_l_dev_ptr_list[count] = det.psiM_vgl.device_data() + psiM_vgl.capacity() * 4 + NumOrbitals * WorkingIndex;
+      if (det.curRatio == PsiValueType(0))
+        throw std::runtime_error("DiracDeterminant::mw_accept_rejectMove det.curRatio is zero! Report a bug.\n");
       det.log_value_ += convertValueToLog(det.curRatio);
       count++;
     }

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -479,7 +479,7 @@ void TrialWaveFunction::mw_calcRatio(const RefVectorWithLeader<TrialWaveFunction
     }
   }
   for (int iw = 0; iw < wf_list.size(); iw++)
-    wf_list[iw].PhaseDiff = std::imag(std::arg(ratios[iw]));
+    wf_list[iw].PhaseDiff = std::arg(ratios[iw]);
 }
 
 void TrialWaveFunction::prepareGroup(ParticleSet& P, int ig)
@@ -696,7 +696,7 @@ void TrialWaveFunction::mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunc
   }
   for (int iw = 0; iw < wf_list.size(); iw++)
   {
-    wf_list[iw].PhaseDiff = std::imag(std::arg(ratios[iw]));
+    wf_list[iw].PhaseDiff = std::arg(ratios[iw]);
     if (ratios[iw] != PsiValueType(0))
       checkOneParticleGradientsNaN(iat, grad_new.grads_positions[iw], "TWF::mw_calcRatioGrad");
   }


### PR DESCRIPTION
## Proposed changes
Found a severe bug in the batched DMC driver. It was introduced in 534fffc9d213935df04725305d89061a7aec1fd0
PhaseDiff is constantly 0 due to `std::imag(std::arg(ratios[iw]))`, the return of `std::arg` is always a real number. It doesn't affect complex build but breaks fixed node approximation in the real build. The insensitive `short-diamondC_2x1x1_pp-vmcbatch_dmcbatch` indicates lack of tests.

I would like to eventually remove TWF::PhaseDiff which is an unnecessary state to carry with. It can always be recomputed from ratio and the computation is cheap.

Also protect another source of NaN in DMCBatched.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server, frontier

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
