### PR TITLE
Fix NaN check failure in offload build with clang

### DIFF
--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -781,7 +781,7 @@ void MultiDiracDeterminant::mw_evaluateDetsAndGradsForPtclMove(
 
 
     PRAGMA_OFFLOAD("omp target teams distribute is_device_ptr(psiV_list_devptr, psiMinv_temp_list_devptr) \
-		                    map(always, from:curRatio_list_ptr[:nw], ratioGradRef_list_ptr[:nw])")
+		                    map(always, from:curRatio_list_ptr[:nw])")
     for (size_t iw = 0; iw < nw; iw++)
     {
       GradType ratioGradRef_local(0);


### PR DESCRIPTION
Addresses https://github.com/QMCPACK/qmcpack/issues/4767 by assigning each component of the TinyVector individually.

Also adds `ratioGradRef_list_ptr` to the mapping list. (Code works without it, but it seems like it ought to be there along with `curRatio_list_ptr`)

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
local server, JLSE machine with A40.

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
