### PR TITLE
Additional zero protection in MSD.

### DIFF
--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -515,9 +515,8 @@ void MultiDiracDeterminant::evaluateDetsForPtclMove(const ParticleSet& P, int ia
     psiMinv_temp = psiMinv;
     for (size_t i = 0; i < NumPtcls; i++)
       psiV_temp[i] = psiV[*(it++)];
-    auto ratio_old_ref_det = DetRatioByColumn(psiMinv_temp, psiV_temp, WorkingIndex);
-    curRatio               = ratio_old_ref_det;
-    InverseUpdateByColumn(psiMinv_temp, psiV_temp, workV1, workV2, WorkingIndex, ratio_old_ref_det);
+    curRatio = DetRatioByColumn(psiMinv_temp, psiV_temp, WorkingIndex);
+    InverseUpdateByColumn(psiMinv_temp, psiV_temp, workV1, workV2, WorkingIndex, curRatio);
     for (size_t i = 0; i < NumOrbitals; i++)
       TpsiM(i, WorkingIndex) = psiV[i];
   }

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -413,6 +413,8 @@ void MultiDiracDeterminant::acceptMove(ParticleSet& P, int iat, bool safe_to_del
   const int WorkingIndex = iat - FirstIndex;
   assert(WorkingIndex >= 0 && WorkingIndex < LastIndex - FirstIndex);
   assert(P.isSpinor() == is_spinor_);
+  if (curRatio == ValueType(0))
+    throw std::runtime_error("MultiDiracDeterminant::acceptMove curRatio is zero! Report a bug.\n");
   log_value_ref_det_ += convertValueToLog(curRatio);
   curRatio = ValueType(1);
   switch (UpdateMode)


### PR DESCRIPTION
## Proposed changes
preventing NaN by indirectly protecting zero.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'