### PR TITLE
Fix AFQMC compilation with CUDA 12.x

### DIFF
--- a/src/AFQMC/Numerics/detail/CUDA/Kernels/strided_2Drange.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/Kernels/strided_2Drange.hpp
@@ -15,15 +15,15 @@
 #ifndef AFQMC_STRIDED_2DRANGE_KERNELS_HPP
 #define AFQMC_STRIDED_2DRANGE_KERNELS_HPP
 
-namespace kernels
-{
-/* Note: Taken from thrust examples.
- */
-
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/permutation_iterator.h>
 #include <thrust/functional.h>
+
+namespace kernels
+{
+/* Note: Taken from thrust examples.
+ */
 
 template<typename Iterator>
 class strided_2Drange

--- a/src/AFQMC/Numerics/detail/CUDA/Kernels/strided_range.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/Kernels/strided_range.hpp
@@ -15,15 +15,15 @@
 #ifndef AFQMC_STRIDED_RANGE_KERNELS_HPP
 #define AFQMC_STRIDED_RANGE_KERNELS_HPP
 
-namespace kernels
-{
-/* Note: Taken from thrust examples.
- */
-
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/permutation_iterator.h>
 #include <thrust/functional.h>
+
+namespace kernels
+{
+/* Note: Taken from thrust examples.
+ */
 
 template<typename Iterator>
 class strided_range


### PR DESCRIPTION
## Proposed changes
Fix compilation error for CUDA 12.x. 11.x was fine.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'