### PR TITLE
Use 32bit integer for loop indices in offload region.

### DIFF
--- a/src/Platforms/OMPTarget/ompBLAS.cpp
+++ b/src/Platforms/OMPTarget/ompBLAS.cpp
@@ -42,11 +42,11 @@ ompBLAS_status gemv_impl(ompBLAS_handle& handle,
       throw std::runtime_error("incx !=1 or incy != 1 are not implemented in ompBLAS::gemv_impl!");
 
     PRAGMA_OFFLOAD("omp target teams distribute num_teams(n) is_device_ptr(A, x, y)")
-    for(size_t i = 0; i < n; i++)
+    for (uint32_t i = 0; i < n; i++)
     {
       T dot_sum(0);
       PRAGMA_OFFLOAD("omp parallel for simd reduction(+: dot_sum)")
-      for(size_t j = 0; j < m; j++)
+      for (uint32_t j = 0; j < m; j++)
         dot_sum += x[j] * A[i * lda + j];
       if (beta == T(0))
         y[i] = alpha * dot_sum; // protecting NaN from y
@@ -61,11 +61,11 @@ ompBLAS_status gemv_impl(ompBLAS_handle& handle,
       throw std::runtime_error("incx !=1 or incy != 1 are not implemented in ompBLAS::gemv_impl!");
 
     PRAGMA_OFFLOAD("omp target teams distribute num_teams(n) is_device_ptr(A, x, y)")
-    for (size_t i = 0; i < m; i++)
+    for (uint32_t i = 0; i < m; i++)
     {
       T dot_sum(0);
       PRAGMA_OFFLOAD("omp parallel for simd reduction(+: dot_sum)")
-      for (size_t j = 0; j < n; j++)
+      for (uint32_t j = 0; j < n; j++)
         dot_sum += x[j] * A[j * lda + i];
       if (beta == T(0))
         y[i] = alpha * dot_sum; // protecting NaN from y
@@ -166,12 +166,12 @@ ompBLAS_status gemv_batched_impl(ompBLAS_handle& handle,
       throw std::runtime_error("incx !=1 or incy != 1 are not implemented in ompBLAS::gemv_batched_impl!");
 
     PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(batch_count * n) is_device_ptr(A, x, y, alpha, beta)")
-    for (size_t ib = 0; ib < batch_count; ib++)
-      for (size_t i = 0; i < n; i++)
+    for (uint32_t ib = 0; ib < batch_count; ib++)
+      for (uint32_t i = 0; i < n; i++)
       {
         T dot_sum(0);
         PRAGMA_OFFLOAD("omp parallel for simd reduction(+: dot_sum)")
-        for (size_t j = 0; j < m; j++)
+        for (uint32_t j = 0; j < m; j++)
           dot_sum += x[ib][j] * A[ib][i * lda + j];
         if (beta[ib] == T(0))
           y[ib][i] = alpha[ib] * dot_sum; // protecting NaN from y
@@ -186,12 +186,12 @@ ompBLAS_status gemv_batched_impl(ompBLAS_handle& handle,
       throw std::runtime_error("incx !=1 or incy != 1 are not implemented in ompBLAS::gemv_batched_impl!");
 
     PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(batch_count * n) is_device_ptr(A, x, y, alpha, beta)")
-    for (size_t ib = 0; ib < batch_count; ib++)
-      for (size_t i = 0; i < m; i++)
+    for (uint32_t ib = 0; ib < batch_count; ib++)
+      for (uint32_t i = 0; i < m; i++)
       {
         T dot_sum(0);
         PRAGMA_OFFLOAD("omp parallel for simd reduction(+: dot_sum)")
-        for (size_t j = 0; j < n; j++)
+        for (uint32_t j = 0; j < n; j++)
           dot_sum += x[ib][j] * A[ib][j * lda + i];
         if (beta[ib] == T(0))
           y[ib][i] = alpha[ib] * dot_sum; // protecting NaN from y
@@ -290,8 +290,8 @@ ompBLAS_status ger_impl(ompBLAS_handle& handle,
 
   //BLAS::ger(m, n, alpha, x, incx, y, incy, A, lda);
   PRAGMA_OFFLOAD("omp target teams distribute parallel for collapse(2) is_device_ptr(A, x, y)")
-  for(size_t i = 0; i < n; i++)
-    for(size_t j = 0; j < m; j++)
+  for (uint32_t i = 0; i < n; i++)
+    for (uint32_t j = 0; j < m; j++)
       A[i * lda + j] += alpha * x[j] * y[i];
   return 0;
 }
@@ -374,9 +374,9 @@ ompBLAS_status ger_batched_impl(ompBLAS_handle& handle,
     throw std::runtime_error("incx !=1 or incy != 1 are not implemented in ompBLAS::ger_batched_impl!");
 
   PRAGMA_OFFLOAD("omp target teams distribute parallel for collapse(3) is_device_ptr(A, x, y, alpha)")
-  for(size_t ib = 0; ib < batch_count; ib++)
-    for(size_t i = 0; i < n; i++)
-      for(size_t j = 0; j < m; j++)
+  for (uint32_t ib = 0; ib < batch_count; ib++)
+    for (uint32_t i = 0; i < n; i++)
+      for (uint32_t j = 0; j < m; j++)
         A[ib][i * lda + j] += alpha[ib] * x[ib][j] * y[ib][i];
   return 0;
 }
@@ -456,8 +456,8 @@ ompBLAS_status copy_batched_impl(ompBLAS_handle& handle,
   if (batch_count == 0) return 0;
 
   PRAGMA_OFFLOAD("omp target teams distribute parallel for collapse(2) is_device_ptr(x, y)")
-  for (size_t ib = 0; ib < batch_count; ib++)
-    for (size_t i = 0; i < n; i++)
+  for (uint32_t ib = 0; ib < batch_count; ib++)
+    for (uint32_t i = 0; i < n; i++)
       y[ib][i * incy] = x[ib][i * incx];
   return 0;
 }
@@ -522,8 +522,8 @@ ompBLAS_status copy_batched_offset_impl(ompBLAS_handle& handle,
   if (batch_count == 0) return 0;
 
   PRAGMA_OFFLOAD("omp target teams distribute parallel for collapse(2) is_device_ptr(x, y)")
-  for (size_t ib = 0; ib < batch_count; ib++)
-    for (size_t i = 0; i < n; i++)
+  for (uint32_t ib = 0; ib < batch_count; ib++)
+    for (uint32_t i = 0; i < n; i++)
       y[ib][y_offset + i * incy] = x[ib][x_offset + i * incx];
   return 0;
 }

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -704,12 +704,12 @@ std::vector<CoulombPBCAA::Return_t> CoulombPBCAA::mw_evalSR_offload(const RefVec
       ScopedTimer offload_scope(caa_leader.offload_timer_);
 
       PRAGMA_OFFLOAD("omp target teams distribute num_teams(nw)")
-      for (size_t iw = 0; iw < nw; iw++)
+      for (uint32_t iw = 0; iw < nw; iw++)
       {
         mRealType SR = 0.0;
         PRAGMA_OFFLOAD("omp parallel for reduction(+ : SR)")
-        for (size_t jcol = 0; jcol < total_num; jcol++)
-          for (size_t irow = first; irow < last; irow++)
+        for (uint32_t jcol = 0; jcol < total_num; jcol++)
+          for (uint32_t irow = first; irow < last; irow++)
           {
             const RealType dist = mw_dist[num_padded * (irow - first + iw * this_chunk_size) + jcol];
             if (irow == jcol || (irow * 2 + 1 == total_num && jcol > irow))

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -566,7 +566,7 @@ void SplineC2COMPTarget<ST>::mw_evaluateVGL(const RefVectorWithLeader<SPOSet>& s
                                             const RefVector<ValueVector>& d2psi_v_list) const
 {
   assert(this == &sa_list.getLeader());
-  auto& phi_leader = sa_list.getCastedLeader<SplineC2COMPTarget<ST>>();
+  auto& phi_leader         = sa_list.getCastedLeader<SplineC2COMPTarget<ST>>();
   auto& mw_mem             = phi_leader.mw_mem_handle_.getResource();
   auto& mw_pos_copy        = mw_mem.mw_pos_copy;
   auto& mw_offload_scratch = mw_mem.mw_offload_scratch;
@@ -720,7 +720,7 @@ void SplineC2COMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
 
         ValueType ratio(0), grad_x(0), grad_y(0), grad_z(0);
         PRAGMA_OFFLOAD("omp parallel for reduction(+: ratio, grad_x, grad_y, grad_z)")
-        for (size_t j = first_cplx; j < last_cplx; j++)
+        for (int j = first_cplx; j < last_cplx; j++)
         {
           const size_t psiIndex = first_spo_local + j;
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -197,7 +197,7 @@ public:
     PRAGMA_OFFLOAD("omp target update to(mKK_ptr[0:mKK->size()])")
     auto* myKcart_ptr = myKcart->data();
     PRAGMA_OFFLOAD("omp target update to(myKcart_ptr[0:myKcart->capacity()*3])")
-    for (size_t i = 0; i < 9; i++)
+    for (uint32_t i = 0; i < 9; i++)
     {
       (*GGt_offload)[i]           = GGt[i];
       (*PrimLattice_G_offload)[i] = PrimLattice.G[i];

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
@@ -707,7 +707,7 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGL(const RefVectorWithLeader<SPOSet>& s
                                             const RefVector<ValueVector>& d2psi_v_list) const
 {
   assert(this == &sa_list.getLeader());
-  auto& phi_leader = sa_list.getCastedLeader<SplineC2ROMPTarget<ST>>();
+  auto& phi_leader         = sa_list.getCastedLeader<SplineC2ROMPTarget<ST>>();
   auto& mw_mem             = phi_leader.mw_mem_handle_.getResource();
   auto& mw_pos_copy        = mw_mem.mw_pos_copy;
   auto& mw_offload_scratch = mw_mem.mw_offload_scratch;
@@ -866,7 +866,7 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
             omptarget::min(last_cplx + omptarget::min(nComplexBands_local, last_cplx), requested_orb_size);
         ValueType ratio(0), grad_x(0), grad_y(0), grad_z(0);
         PRAGMA_OFFLOAD("omp parallel for reduction(+: ratio, grad_x, grad_y, grad_z)")
-        for (size_t j = first_real; j < last_real; j++)
+        for (int j = first_real; j < last_real; j++)
         {
           out_phi[j]    = psi[j];
           out_dphi_x[j] = dpsi_x[j];

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -202,7 +202,7 @@ public:
     PRAGMA_OFFLOAD("omp target update to(mKK_ptr[0:mKK->size()])")
     auto* myKcart_ptr = myKcart->data();
     PRAGMA_OFFLOAD("omp target update to(myKcart_ptr[0:myKcart->capacity()*3])")
-    for (size_t i = 0; i < 9; i++)
+    for (uint32_t i = 0; i < 9; i++)
     {
       (*GGt_offload)[i]           = GGt[i];
       (*PrimLattice_G_offload)[i] = PrimLattice.G[i];

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -786,9 +786,9 @@ public:
       auto* temp_ptr = engine.get_psiMinv().data();
       PRAGMA_OFFLOAD("omp target update from(temp_ptr[:psiMinv_.size()])")
       std::cout << "debug Ainv devi";
-      for (size_t row = 0; row < psiMinv_.rows(); row++)
+      for (int row = 0; row < psiMinv_.rows(); row++)
       {
-        for (size_t col = 0; col < psiMinv_.cols(); col++)
+        for (int col = 0; col < psiMinv_.cols(); col++)
           std::cout << " " << row << " " << col << " " << engine.get_psiMinv()[row][col];
         std::cout << std::endl;
       }

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -127,14 +127,14 @@ void MultiDiracDeterminant::mw_buildTableMatrix_calculateRatios_impl(
           map(always, to: psiinv_list_ptr[:nw], psi_list_ptr[:nw]) \
           map(always, to: ratios_list_ptr[:nw], table_matrix_list_ptr[:nw]) \
 	  map(to:first[:npairs], second[:npairs])")
-      for (size_t iw = 0; iw < nw; iw++)
-        for (size_t i = 0; i < npairs; ++i)
+      for (uint32_t iw = 0; iw < nw; iw++)
+        for (uint32_t i = 0; i < npairs; ++i)
         {
           const int I = first[i];
           const int J = second[i];
 
           ValueType table_matrix_local = 0.0;
-          for (size_t ind = 0; ind < num; ind++)
+          for (uint32_t ind = 0; ind < num; ind++)
             table_matrix_local +=
                 psiinv_list_ptr[iw][I * nb_cols_psiinv + ind] * psi_list_ptr[iw][J * nb_cols_psi + ind];
           table_matrix_list_ptr[iw][I * nb_cols_table_matrix + J] = table_matrix_local;
@@ -295,8 +295,8 @@ void MultiDiracDeterminant::mw_buildTableMatrix_calculateGradRatios(
 
   PRAGMA_OFFLOAD("omp target teams distribute parallel for collapse(2)  map(from:mw_grads_ptr[:mw_grads.size()]) \
 		                                                        map(always, to:WorkSpace_list_ptr[:nw])")
-  for (size_t iw = 0; iw < nw; iw++)
-    for (size_t count = 0; count < getNumDets; ++count)
+  for (uint32_t iw = 0; iw < nw; iw++)
+    for (uint32_t count = 0; count < getNumDets; ++count)
       mw_grads_ptr[(3 * iw + dx) * Grads_cols + count] = WorkSpace_list_ptr[iw][count];
 }
 
@@ -447,7 +447,7 @@ void MultiDiracDeterminant::mw_evaluateDetsForPtclMove(const RefVectorWithLeader
     {
       ValueType c_ratio = 0.0;
       PRAGMA_OFFLOAD("omp parallel for reduction(+ : c_ratio)")
-      for (size_t jc = 0; jc < NumPtcls; jc++)
+      for (uint32_t jc = 0; jc < NumPtcls; jc++)
       {
         const size_t J             = confgListOccup_ptr[jc];
         psiV_temp_list_ptr[iw][jc] = psiV_list_devptr[iw][J];
@@ -477,8 +477,8 @@ void MultiDiracDeterminant::mw_evaluateDetsForPtclMove(const RefVectorWithLeader
     // restore the modified column of TpsiM.
     PRAGMA_OFFLOAD("omp target teams distribute parallel for collapse(2) is_device_ptr(TpsiM_list_devptr) \
 		                                    map(always, to:psiM_list_ptr[:nw])")
-    for (size_t iw = 0; iw < nw; iw++)
-      for (size_t i = 0; i < NumOrbitals; i++)
+    for (uint32_t iw = 0; iw < nw; iw++)
+      for (uint32_t i = 0; i < NumOrbitals; i++)
         TpsiM_list_devptr[iw][i * TpsiM_cols + WorkingIndex] = psiM_list_ptr[iw][i + psiM_cols * WorkingIndex];
   }
 
@@ -787,7 +787,7 @@ void MultiDiracDeterminant::mw_evaluateDetsAndGradsForPtclMove(
     {
       GradType ratioGradRef_local(0);
       PRAGMA_OFFLOAD("omp parallel for reduction(+ : ratioGradRef_local)")
-      for (size_t i = 0; i < NumPtcls; i++)
+      for (uint32_t i = 0; i < NumPtcls; i++)
       {
         const size_t J            = confgListOccup_ptr[i];
         psiV_temp_list_ptr[iw][i] = psiV_list_devptr[iw][J];
@@ -797,7 +797,7 @@ void MultiDiracDeterminant::mw_evaluateDetsAndGradsForPtclMove(
 
       ValueType c_ratio = 0.0;
       PRAGMA_OFFLOAD("omp parallel for reduction(+ : c_ratio)")
-      for (size_t jc = 0; jc < psiMinv_cols; jc += 1)
+      for (uint32_t jc = 0; jc < psiMinv_cols; jc += 1)
       {
         const size_t ic = jc * psiMinv_cols;
         c_ratio += (psiMinv_temp_list_devptr[iw] + WorkingIndex)[ic] * psiV_temp_list_ptr[iw][jc];
@@ -837,11 +837,11 @@ void MultiDiracDeterminant::mw_evaluateDetsAndGradsForPtclMove(
         throw std::runtime_error("In MultiDiracDeterminant ompBLAS::copy_batched_offset failed.");
 
       PRAGMA_OFFLOAD("omp target teams distribute map(to: ratioGradRef_list_ptr[:nw])")
-      for (size_t iw = 0; iw < nw; iw++)
+      for (uint32_t iw = 0; iw < nw; iw++)
       {
         inv_curRatio_list_ptr[iw] = ValueType(1) / ratioGradRef_list_ptr[iw][idim];
 
-        for (size_t i = 0; i < NumPtcls; i++)
+        for (uint32_t i = 0; i < NumPtcls; i++)
         {
           const size_t J            = confgListOccup_ptr[i];
           psiV_temp_list_ptr[iw][i] = dpsiV_list_ptr[iw][J][idim];
@@ -855,10 +855,10 @@ void MultiDiracDeterminant::mw_evaluateDetsAndGradsForPtclMove(
       PRAGMA_OFFLOAD("omp target teams distribute map(to:dpsiV_list_ptr[:nw], curRatio_list_ptr[:nw]) \
 		                       map(always,from:det0_grad_list_ptr[:nw]) \
 		                       is_device_ptr(TpsiM_list_devptr)")
-      for (size_t iw = 0; iw < nw; iw++)
+      for (uint32_t iw = 0; iw < nw; iw++)
       {
         det0_grad_list_ptr[iw] = ratioGradRef_list_ptr[iw][idim] / curRatio_list_ptr[iw];
-        for (size_t i = 0; i < NumOrbitals; i++)
+        for (uint32_t i = 0; i < NumOrbitals; i++)
           TpsiM_list_devptr[iw][i * TpsiM_num_cols + WorkingIndex] = dpsiV_list_ptr[iw][i][idim];
       }
 
@@ -872,10 +872,11 @@ void MultiDiracDeterminant::mw_evaluateDetsAndGradsForPtclMove(
     // restore the modified column of TpsiM.
     PRAGMA_OFFLOAD("omp target teams distribute parallel for collapse(2) is_device_ptr(TpsiM_list_devptr) \
 		                                    map(always, to:psiM_list_ptr[:nw])")
-    for (size_t iw = 0; iw < nw; iw++)
-      for (size_t i = 0; i < NumOrbitals; i++)
+    for (uint32_t iw = 0; iw < nw; iw++)
+      for (uint32_t i = 0; i < NumOrbitals; i++)
         TpsiM_list_devptr[iw][i * TpsiM_num_cols + WorkingIndex] = psiM_list_ptr[iw][i + psiM_num_cols * WorkingIndex];
   }
+
   for (size_t iw = 0; iw < nw; iw++)
   {
     MultiDiracDeterminant& det = (det_list[iw]);
@@ -1040,8 +1041,8 @@ void MultiDiracDeterminant::mw_evaluateGrads(const RefVectorWithLeader<MultiDira
 
       PRAGMA_OFFLOAD("omp target teams distribute  map(always, to: psiV_temp_list_ptr[:nw]) \
 		                                  map(always, to: dpsiM_list_ptr[:nw])")
-      for (size_t iw = 0; iw < nw; iw++)
-        for (size_t i = 0; i < NumPtcls; i++)
+      for (uint32_t iw = 0; iw < nw; iw++)
+        for (uint32_t i = 0; i < NumPtcls; i++)
         {
           size_t J                  = confgListOccup_ptr[i];
           psiV_temp_list_ptr[iw][i] = dpsiM_list_ptr[iw][WorkingIndex * dpsiM_cols + J][idim];
@@ -1053,7 +1054,7 @@ void MultiDiracDeterminant::mw_evaluateGrads(const RefVectorWithLeader<MultiDira
       {
         ValueType ratioG_local(0);
         PRAGMA_OFFLOAD("omp parallel for reduction(+ : ratioG_local)")
-        for (size_t i = 0; i < NumPtcls; i++)
+        for (uint32_t i = 0; i < NumPtcls; i++)
         {
           size_t J = confgListOccup_ptr[i];
           ratioG_local += psiMinv_list_devptr[iw][i * psiMinv_cols + WorkingIndex] *
@@ -1069,8 +1070,8 @@ void MultiDiracDeterminant::mw_evaluateGrads(const RefVectorWithLeader<MultiDira
 
       PRAGMA_OFFLOAD("omp target teams distribute parallel for collapse(2) map(to:dpsiM_list_ptr[:nw]) \
 		                                              map(always, to: TpsiM_list_devptr[:nw])")
-      for (size_t iw = 0; iw < nw; iw++)
-        for (size_t i = 0; i < NumOrbitals; i++)
+      for (uint32_t iw = 0; iw < nw; iw++)
+        for (uint32_t i = 0; i < NumOrbitals; i++)
           TpsiM_list_devptr[iw][i * TpsiM_cols + WorkingIndex] =
               dpsiM_list_ptr[iw][dpsiM_cols * WorkingIndex + i][idim];
 
@@ -1085,8 +1086,8 @@ void MultiDiracDeterminant::mw_evaluateGrads(const RefVectorWithLeader<MultiDira
     // restore the modified column of TpsiM.
     PRAGMA_OFFLOAD("omp target teams distribute parallel for map(from:TpsiM_list_devptr[:nw]) \
                                                        map(always,to:psiM_list_ptr[:nw])")
-    for (size_t iw = 0; iw < nw; iw++)
-      for (size_t i = 0; i < NumOrbitals; i++)
+    for (uint32_t iw = 0; iw < nw; iw++)
+      for (uint32_t i = 0; i < NumOrbitals; i++)
         TpsiM_list_devptr[iw][i * TpsiM_cols + WorkingIndex] = psiM_list_ptr[iw][i + psiM_cols * WorkingIndex];
   }
 }
@@ -1121,7 +1122,7 @@ void MultiDiracDeterminant::mw_updateRatios_det0(const OffloadVector<ValueType>&
   const auto* det0_list_ptr = det0_list.data();
 
   PRAGMA_OFFLOAD("omp target teams distribute parallel for map(always, to: det0_list_ptr[:nw])")
-  for (size_t iw = 0; iw < nw; iw++)
+  for (uint32_t iw = 0; iw < nw; iw++)
     ratios_list_ptr[iw][0] = det0_list_ptr[iw];
 }
 
@@ -1146,8 +1147,8 @@ void MultiDiracDeterminant::mw_updateRatios(const size_t det_offset,
   const auto* table_matrix_list_ptr = table_matrix_deviceptr_list.data();
 
   PRAGMA_OFFLOAD("omp target teams distribute parallel for collapse(2)")
-  for (size_t iw = 0; iw < nw; iw++)
-    for (size_t count = 0; count < ndet_ext; ++count)
+  for (uint32_t iw = 0; iw < nw; iw++)
+    for (uint32_t count = 0; count < ndet_ext; ++count)
     {
       size_t det_id               = det_offset + count;
       ratios_list_ptr[iw][det_id] = sign_ptr[det_id] * ratios_list_ptr[iw][0] *
@@ -1189,7 +1190,7 @@ void MultiDiracDeterminant::mw_InverseUpdateByColumn(MultiDiracDetMultiWalkerRes
     throw std::runtime_error("In MultiDiracDeterminant ompBLAS::gemv_batched failed.");
 
   PRAGMA_OFFLOAD("omp target teams distribute parallel for is_device_ptr(workV1_list_ptr, inv_curRatio_list_devptr)")
-  for (size_t iw = 0; iw < nw; iw++)
+  for (uint32_t iw = 0; iw < nw; iw++)
     workV1_list_ptr[iw][working_index] = cone - inv_curRatio_list_devptr[iw];
   if (success != 0)
     throw std::runtime_error("In MultiDiracDeterminant ompBLAS::copy_batched_offset failed.");

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
@@ -289,7 +289,7 @@ void MultiSlaterDetTableMethod::mw_evalGrad_impl(const RefVectorWithLeader<WaveF
       PsiValue grad_local_y(0);
       PsiValue grad_local_z(0);
       PRAGMA_OFFLOAD("omp parallel for reduction(+:psi_local, grad_local_x, grad_local_y, grad_local_z)")
-      for (size_t i = 0; i < ndets; i++)
+      for (uint32_t i = 0; i < ndets; i++)
       {
         psi_local += det_value_ptr_list_ptr[iw][i] * C_otherDs_ptr_list_ptr[iw][i];
         grad_local_x += C_otherDs_ptr_list_ptr[iw][i] * mw_grads_ptr[(3 * iw + 0) * ndets + i];
@@ -613,7 +613,7 @@ void MultiSlaterDetTableMethod::mw_calcRatio(const RefVectorWithLeader<WaveFunct
     {
       PsiValue psi_local(0);
       PRAGMA_OFFLOAD("omp parallel for reduction(+ : psi_local)")
-      for (size_t i = 0; i < ndets; i++)
+      for (uint32_t i = 0; i < ndets; i++)
         psi_local += det_value_ptr_list_ptr[iw][i] * C_otherDs_ptr_list_ptr[iw][i];
       psi_list_ptr[iw] = psi_local;
     }


### PR DESCRIPTION
## Proposed changes
Close https://github.com/QMCPACK/qmcpack/issues/4774
Use int or uint32_t in offload loop indices.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'