### PR TITLE
Add Hamiltonian (lists) to Crowd Estimator accumulate() Calls.

### DIFF
--- a/src/Estimators/EstimatorManagerCrowd.cpp
+++ b/src/Estimators/EstimatorManagerCrowd.cpp
@@ -25,6 +25,7 @@ EstimatorManagerCrowd::EstimatorManagerCrowd(EstimatorManagerNew& em)
 void EstimatorManagerCrowd::accumulate(const RefVector<MCPWalker>& walkers,
                                        const RefVector<ParticleSet>& psets,
                                        const RefVector<TrialWaveFunction>& wfns,
+                                       const RefVector<QMCHamiltonian>& hams,
                                        RandomBase<FullPrecRealType>& rng)
 {
   block_num_samples_ += walkers.size();
@@ -35,7 +36,7 @@ void EstimatorManagerCrowd::accumulate(const RefVector<MCPWalker>& walkers,
   for (int i = 0; i < num_scalar_estimators; ++i)
     scalar_estimators_[i]->accumulate(walkers);
   for (int i = 0; i < operator_ests_.size(); ++i)
-    operator_ests_[i]->accumulate(walkers, psets, wfns, rng);
+    operator_ests_[i]->accumulate(walkers, psets, wfns, hams, rng);
 }
 
 void EstimatorManagerCrowd::registerListeners(const RefVectorWithLeader<QMCHamiltonian>& ham_list)

--- a/src/Estimators/EstimatorManagerCrowd.h
+++ b/src/Estimators/EstimatorManagerCrowd.h
@@ -64,6 +64,7 @@ public:
    *  \param[in]     walkers         walkers in crowd
    *  \param[in]     psets           walker particle sets
    *  \param[in]     wfns            walker wavefunctions
+   *  \param[in]     hams            walker Hamiltonians
    *  \param[inout]  rng             crowd scope RandomGenerator
    *
    *  walkers is especially questionable since its really just hiding the full sweep hamiltonian values from
@@ -78,6 +79,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
+                  const RefVector<QMCHamiltonian>& hams,
                   RandomBase<FullPrecRealType>& rng);
 
   ScalarEstimatorBase& get_main_estimator() { return *main_estimator_; }

--- a/src/Estimators/MagnetizationDensity.cpp
+++ b/src/Estimators/MagnetizationDensity.cpp
@@ -49,6 +49,7 @@ size_t MagnetizationDensity::getFullDataSize() { return npoints_ * DIM; }
 void MagnetizationDensity::accumulate(const RefVector<MCPWalker>& walkers,
                                       const RefVector<ParticleSet>& psets,
                                       const RefVector<TrialWaveFunction>& wfns,
+                                      const RefVector<QMCHamiltonian>& hams,
                                       RandomBase<FullPrecReal>& rng)
 {
   for (int iw = 0; iw < walkers.size(); ++iw)

--- a/src/Estimators/MagnetizationDensity.h
+++ b/src/Estimators/MagnetizationDensity.h
@@ -60,6 +60,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
+                  const RefVector<QMCHamiltonian>& hams,
                   RandomBase<FullPrecReal>& rng) override;
 
   void collect(const RefVector<OperatorEstBase>& operator_estimators) override;

--- a/src/Estimators/MomentumDistribution.cpp
+++ b/src/Estimators/MomentumDistribution.cpp
@@ -234,6 +234,7 @@ void MomentumDistribution::startBlock(int steps)
 void MomentumDistribution::accumulate(const RefVector<MCPWalker>& walkers,
                                       const RefVector<ParticleSet>& psets,
                                       const RefVector<TrialWaveFunction>& wfns,
+                                      const RefVector<QMCHamiltonian>& hams,
                                       RandomBase<FullPrecRealType>& rng)
 {
   for (int iw = 0; iw < walkers.size(); ++iw)

--- a/src/Estimators/MomentumDistribution.h
+++ b/src/Estimators/MomentumDistribution.h
@@ -98,6 +98,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
+                  const RefVector<QMCHamiltonian>& hams,
                   RandomBase<FullPrecRealType>& rng) override;
 
   /** this allows the EstimatorManagerNew to reduce without needing to know the details

--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -397,6 +397,7 @@ void OneBodyDensityMatrices::calcDensityDrift(const Position& r, Real& dens, Pos
 void OneBodyDensityMatrices::accumulate(const RefVector<MCPWalker>& walkers,
                                         const RefVector<ParticleSet>& psets,
                                         const RefVector<TrialWaveFunction>& wfns,
+                                        const RefVector<QMCHamiltonian>& hams,
                                         RandomBase<FullPrecReal>& rng)
 {
   implAccumulate(walkers, psets, wfns, rng);

--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -166,6 +166,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
+                  const RefVector<QMCHamiltonian>& hams,
                   RandomBase<FullPrecReal>& rng) override;
 
   void startBlock(int steps) override;

--- a/src/Estimators/OperatorEstBase.h
+++ b/src/Estimators/OperatorEstBase.h
@@ -74,6 +74,7 @@ public:
   virtual void accumulate(const RefVector<MCPWalker>& walkers,
                           const RefVector<ParticleSet>& psets,
                           const RefVector<TrialWaveFunction>& wfns,
+                          const RefVector<QMCHamiltonian>& hams,
                           RandomBase<FullPrecRealType>& rng) = 0;
 
   /** Reduce estimator result data from crowds to rank

--- a/src/Estimators/PerParticleHamiltonianLogger.cpp
+++ b/src/Estimators/PerParticleHamiltonianLogger.cpp
@@ -59,6 +59,7 @@ void PerParticleHamiltonianLogger::write(CrowdLogValues& cl_values, const std::v
 void PerParticleHamiltonianLogger::accumulate(const RefVector<MCPWalker>& walkers,
                                               const RefVector<ParticleSet>& psets,
                                               const RefVector<TrialWaveFunction>& wfns,
+                                              const RefVector<QMCHamiltonian>& hams,
                                               RandomBase<FullPrecRealType>& rng)
 
 {

--- a/src/Estimators/PerParticleHamiltonianLogger.h
+++ b/src/Estimators/PerParticleHamiltonianLogger.h
@@ -38,6 +38,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
+                  const RefVector<QMCHamiltonian>& hams,
                   RandomBase<FullPrecRealType>& rng) override;
 
   UPtr<OperatorEstBase> spawnCrowdClone() const override;

--- a/src/Estimators/SpinDensityNew.cpp
+++ b/src/Estimators/SpinDensityNew.cpp
@@ -117,6 +117,7 @@ void SpinDensityNew::startBlock(int steps)
 void SpinDensityNew::accumulate(const RefVector<MCPWalker>& walkers,
                                 const RefVector<ParticleSet>& psets,
                                 const RefVector<TrialWaveFunction>& wfns,
+                                const RefVector<QMCHamiltonian>& hams,
                                 RandomBase<FullPrecRealType>& rng)
 {
   auto& dp_ = derived_parameters_;

--- a/src/Estimators/SpinDensityNew.h
+++ b/src/Estimators/SpinDensityNew.h
@@ -85,6 +85,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
+                  const RefVector<QMCHamiltonian>& hams,
                   RandomBase<FullPrecRealType>& rng) override;
 
   /** this allows the EstimatorManagerNew to reduce without needing to know the details

--- a/src/Estimators/tests/FakeOperatorEstimator.h
+++ b/src/Estimators/tests/FakeOperatorEstimator.h
@@ -32,6 +32,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
+                  const RefVector<QMCHamiltonian>& hams,
                   RandomBase<FullPrecRealType>& rng) override
   {}
 

--- a/src/Estimators/tests/test_EstimatorManagerCrowd.cpp
+++ b/src/Estimators/tests/test_EstimatorManagerCrowd.cpp
@@ -159,7 +159,7 @@ TEST_CASE("EstimatorManagerCrowd PerParticleHamiltonianLogger integration", "[es
   for (int iw = 0; iw < num_walkers; ++iw)
     savePropertiesIntoWalker(*(hams[iw]), walkers[iw]);
 
-  emc.accumulate(walker_refs, p_refs, twf_refs, rng);
+  emc.accumulate(walker_refs, p_refs, twf_refs, ham_refs, rng);
 }
 
 

--- a/src/Estimators/tests/test_MagnetizationDensity.cpp
+++ b/src/Estimators/tests/test_MagnetizationDensity.cpp
@@ -423,12 +423,14 @@ TEST_CASE("MagnetizationDensity::IntegrationTest", "[estimators]")
   for (int iw = 0; iw < nwalkers; iw++)
     updateWalker(walkers[iw], psets[iw], *(twfcs[iw]));
 
+  std::vector<QMCHamiltonian> hams;
   auto ref_walkers(makeRefVector<MCPWalker>(walkers));
   auto ref_psets(makeRefVector<ParticleSet>(psets));
   auto ref_twfcs(convertUPtrToRefVector(twfcs));
+  auto ref_hams(makeRefVector<QMCHamiltonian>(hams));
 
   FakeRandom rng;
-  magdensity.accumulate(ref_walkers, ref_psets, ref_twfcs, rng);
+  magdensity.accumulate(ref_walkers, ref_psets, ref_twfcs, ref_hams, rng);
 
   //Now the reference data
   //

--- a/src/Estimators/tests/test_MomentumDistribution.cpp
+++ b/src/Estimators/tests/test_MomentumDistribution.cpp
@@ -173,15 +173,18 @@ TEST_CASE("MomentumDistribution::accumulate", "[estimators]")
   }
 
   //     Create ref vectors
+  std::vector<QMCHamiltonian> hams;
+
   auto ref_walkers = makeRefVector<MCPWalker>(walkers);
   auto ref_psets   = makeRefVector<ParticleSet>(psets);
   auto ref_wfns    = convertUPtrToRefVector(wfns);
+  auto ref_hams    = makeRefVector<QMCHamiltonian>(hams);
 
   //   Setup RNG
   FakeRandom<OHMMS_PRECISION_FULL> rng;
 
   //   Perform accumulate
-  md.accumulate(ref_walkers, ref_psets, ref_wfns, rng);
+  md.accumulate(ref_walkers, ref_psets, ref_wfns, ref_hams, rng);
 
   //   Check data
   std::vector<RealType>& data = md.get_data();

--- a/src/Estimators/tests/test_PerParticleHamiltonianLogger.cpp
+++ b/src/Estimators/tests/test_PerParticleHamiltonianLogger.cpp
@@ -95,10 +95,12 @@ TEST_CASE("PerParticleHamiltonianLogger_sum", "[estimators]")
     }
 
     std::vector<TrialWaveFunction> wfns;
+    std::vector<QMCHamiltonian> hams;
 
     auto ref_walkers = makeRefVector<OperatorEstBase::MCPWalker>(walkers);
     auto ref_psets   = makeRefVector<ParticleSet>(psets);
     auto ref_wfns    = makeRefVector<TrialWaveFunction>(wfns);
+    auto ref_hams    = makeRefVector<QMCHamiltonian>(hams);
 
     std::vector<MultiWalkerTalker> multi_walker_talkers{{"Talker1", nwalkers},
                                                         {"Talker2", nwalkers},
@@ -127,7 +129,7 @@ TEST_CASE("PerParticleHamiltonianLogger_sum", "[estimators]")
       using Walker = typename decltype(ref_walkers)::value_type::type;
       for(Walker& walker : ref_walkers)
 	walker.ID = walker_id++;
-      crowd_oeb->accumulate(ref_walkers, ref_psets, ref_wfns, rng);
+      crowd_oeb->accumulate(ref_walkers, ref_psets, ref_wfns, ref_hams, rng);
     }
 
     RefVector<OperatorEstBase> crowd_loggers_refs = convertUPtrToRefVector(crowd_loggers);

--- a/src/Estimators/tests/test_SpinDensityNew.cpp
+++ b/src/Estimators/tests/test_SpinDensityNew.cpp
@@ -73,14 +73,16 @@ void accumulateFromPsets(int ncrowds, SpinDensityNew& sdn, UPtrVector<OperatorEs
     }
 
     std::vector<TrialWaveFunction> wfns;
+    std::vector<QMCHamiltonian> hams;
 
     auto ref_walkers = makeRefVector<OperatorEstBase::MCPWalker>(walkers);
     auto ref_psets   = makeRefVector<ParticleSet>(psets);
     auto ref_wfns    = makeRefVector<TrialWaveFunction>(wfns);
+    auto ref_hams    = makeRefVector<QMCHamiltonian>(hams);
 
     FakeRandom<OHMMS_PRECISION_FULL> rng;
 
-    crowd_sdn.accumulate(ref_walkers, ref_psets, ref_wfns, rng);
+    crowd_sdn.accumulate(ref_walkers, ref_psets, ref_wfns, ref_hams, rng);
   }
 }
 
@@ -111,14 +113,15 @@ void randomUpdateAccumulate(testing::RandomForTest<QMCT::RealType>& rft, UPtrVec
     }
 
     std::vector<TrialWaveFunction> wfns;
-
+    std::vector<QMCHamiltonian> hams;
     auto ref_walkers = makeRefVector<OperatorEstBase::MCPWalker>(walkers);
     auto ref_psets   = makeRefVector<ParticleSet>(psets);
     auto ref_wfns    = makeRefVector<TrialWaveFunction>(wfns);
+    auto ref_hams    = makeRefVector<QMCHamiltonian>(hams);
 
     FakeRandom<OHMMS_PRECISION_FULL> rng;
 
-    crowd_sdn.accumulate(ref_walkers, ref_psets, ref_wfns, rng);
+    crowd_sdn.accumulate(ref_walkers, ref_psets, ref_wfns, ref_hams, rng);
   }
 }
 
@@ -215,14 +218,16 @@ TEST_CASE("SpinDensityNew::accumulate", "[estimators]")
   }
 
   std::vector<TrialWaveFunction> wfns;
+  std::vector<QMCHamiltonian> hams;
 
   auto ref_walkers = makeRefVector<MCPWalker>(walkers);
   auto ref_psets   = makeRefVector<ParticleSet>(psets);
   auto ref_wfns    = makeRefVector<TrialWaveFunction>(wfns);
+  auto ref_hams    = makeRefVector<QMCHamiltonian>(hams);
 
   FakeRandom<OHMMS_PRECISION_FULL> rng;
 
-  sdn.accumulate(ref_walkers, ref_psets, ref_wfns, rng);
+  sdn.accumulate(ref_walkers, ref_psets, ref_wfns, ref_hams, rng);
 
   std::vector<QMCT::RealType>& data_ref = sdn.get_data();
   // There should be a check that the discretization of particle locations expressed in lattice coords

--- a/src/QMCDrivers/Crowd.h
+++ b/src/QMCDrivers/Crowd.h
@@ -80,7 +80,7 @@ public:
   {
     if (this->size() == 0)
       return;
-    estimator_manager_crowd_.accumulate(mcp_walkers_, walker_elecs_, walker_twfs_, rng);
+    estimator_manager_crowd_.accumulate(mcp_walkers_, walker_elecs_, walker_twfs_, walker_hamiltonians_, rng);
   }
 
   void setRNGForHamiltonian(RandomBase<FullPrecRealType>& rng);


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

For zero variance, zero bias estimators, one needs access to the Hamiltonian, in addition to the trial wave function and particle set.  This change adds the crowd QMCHamiltonian lists to the accumulate() API's EstimatorManagerCrowd and OperatorEstBase.  This way the QMCHamiltonians will be in scope if needed, but otherwise can be ignored for observables that don't require access to it.  

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Intel xeon, RHEL 8
## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
