### PR TITLE
Remove unused template parameter

### DIFF
--- a/src/Containers/OhmmsSoA/PosTransformer.h
+++ b/src/Containers/OhmmsSoA/PosTransformer.h
@@ -129,12 +129,12 @@ void PosAoS2SoA(int nrows, int ncols, const T1* restrict iptr, int lda, T2* rest
    *
    * Modeled after blas/lapack for lda/ldb
    */
-template<typename T1, typename T2>
-void PosSoA2AoS(int nrows, int ncols, const T1* restrict iptr, int lda, T2* restrict out, int ldb)
+template<typename T>
+void PosSoA2AoS(int nrows, int ncols, const T* restrict iptr, int lda, T* restrict out, int ldb)
 {
-  const T1* restrict x = iptr;
-  const T1* restrict y = iptr + lda;
-  const T1* restrict z = iptr + 2 * lda;
+  const T* restrict x = iptr;
+  const T* restrict y = iptr + lda;
+  const T* restrict z = iptr + 2 * lda;
 #if !defined(__ibmxl__)
 #pragma omp simd aligned(x, y, z: QMC_SIMD_ALIGNMENT)
 #endif

--- a/src/Containers/OhmmsSoA/VectorSoaContainer.h
+++ b/src/Containers/OhmmsSoA/VectorSoaContainer.h
@@ -208,11 +208,9 @@ struct VectorSoaContainer
        *
        * The same sizes are assumed.
        */
-  template<typename T1>
-  void copyIn(const Vector<TinyVector<T1, D>>& in)
+  void copyIn(const Vector<TinyVector<T, D>>& in)
   {
-    //if(nLocal!=in.size()) resize(in.size());
-    PosAoS2SoA(nLocal, D, reinterpret_cast<const T1*>(in.first_address()), D, myData, nGhosts);
+    PosAoS2SoA(nLocal, D, reinterpret_cast<const T*>(in.first_address()), D, myData, nGhosts);
   }
 
   /** SoA to AoS : copy to Vector<TinyVector<>>


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

The member function `VectorSoaContainer::copyIn` has a template parameter  `T1` that in the current codebase is always equal to `T`. I see more risks than benefits to the additional functionality.   

Found while working on #4684.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted

