### PR TITLE
Remove unused template parameter

### DIFF
--- a/src/Containers/OhmmsSoA/PosTransformer.h
+++ b/src/Containers/OhmmsSoA/PosTransformer.h
@@ -102,12 +102,12 @@ namespace qmcplusplus
    *
    * Modeled after blas/lapack for lda/ldb
    */
-template<typename T1, typename T2>
-void PosAoS2SoA(int nrows, int ncols, const T1* restrict iptr, int lda, T2* restrict out, int ldb)
+template<typename T>
+void PosAoS2SoA(int nrows, int ncols, const T* restrict iptr, int lda, T* restrict out, int ldb)
 {
-  T2* restrict x = out;
-  T2* restrict y = out + ldb;
-  T2* restrict z = out + 2 * ldb;
+  T* restrict x = out;
+  T* restrict y = out + ldb;
+  T* restrict z = out + 2 * ldb;
 #if !defined(__ibmxl__)
 #pragma omp simd aligned(x, y, z: QMC_SIMD_ALIGNMENT)
 #endif

--- a/src/Containers/OhmmsSoA/VectorSoaContainer.h
+++ b/src/Containers/OhmmsSoA/VectorSoaContainer.h
@@ -217,10 +217,9 @@ struct VectorSoaContainer
        *
        * The same sizes are assumed.
        */
-  template<typename T1>
-  void copyOut(Vector<TinyVector<T1, D>>& out) const
+  void copyOut(Vector<TinyVector<T, D>>& out) const
   {
-    PosSoA2AoS(nLocal, D, myData, nGhosts, reinterpret_cast<T1*>(out.first_address()), D);
+    PosSoA2AoS(nLocal, D, myData, nGhosts, reinterpret_cast<T*>(out.first_address()), D);
   }
 
   /** return TinyVector<T,D>


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

The member function `VectorSoaContainer::copyOut` has a template parameter `T1` that in the current codebase is always equal to `T`. I see more risks than benefits to the additional functionality.

This is a followup to #4786 and found while working on https://github.com/QMCPACK/qmcpack/pull/4684.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
