### PR TITLE
Change 'memoryType' to 'type' for ROCM >= 6

### DIFF
--- a/src/Platforms/ROCm/cuda2hip.h
+++ b/src/Platforms/ROCm/cuda2hip.h
@@ -102,6 +102,7 @@
 #define cudaPointerAttributes           hipPointerAttribute_t
 #define cudaMemoryTypeHost              hipMemoryTypeHost
 #define cudaMemoryTypeDevice            hipMemoryTypeDevice
+#define cudaMemoryTypeManaged           hipMemoryTypeManaged
 #define cudaIpcGetMemHandle             hipIpcGetMemHandle
 #define cudaIpcMemHandle_t              hipIpcMemHandle_t
 #define cudaIpcMemLazyEnablePeerAccess  hipIpcMemLazyEnablePeerAccess

--- a/src/Platforms/tests/CUDA/test_CUDAallocator.cpp
+++ b/src/Platforms/tests/CUDA/test_CUDAallocator.cpp
@@ -26,7 +26,7 @@ TEST_CASE("CUDA_allocators", "[CUDA]")
     Vector<double, CUDAManagedAllocator<double>> vec(1024);
     cudaPointerAttributes attr;
     cudaErrorCheck(cudaPointerGetAttributes(&attr, vec.data()), "cudaPointerGetAttributes failed!");
-#if (CUDART_VERSION >= 10000)
+#if (CUDART_VERSION >= 10000 || HIP_VERSION_MAJOR >= 6)
     REQUIRE(attr.type == cudaMemoryTypeManaged);
 #endif
   }
@@ -34,20 +34,20 @@ TEST_CASE("CUDA_allocators", "[CUDA]")
     Vector<double, CUDAAllocator<double>> vec(1024);
     cudaPointerAttributes attr;
     cudaErrorCheck(cudaPointerGetAttributes(&attr, vec.data()), "cudaPointerGetAttributes failed!");
-#if (CUDART_VERSION < 10000)
-    REQUIRE(attr.memoryType == cudaMemoryTypeDevice);
-#else
+#if (CUDART_VERSION >= 10000 || HIP_VERSION_MAJOR >= 6)
     REQUIRE(attr.type == cudaMemoryTypeDevice);
+#else
+    REQUIRE(attr.memoryType == cudaMemoryTypeDevice);
 #endif
   }
   { // CUDAHostAllocator
     Vector<double, CUDAHostAllocator<double>> vec(1024);
     cudaPointerAttributes attr;
     cudaErrorCheck(cudaPointerGetAttributes(&attr, vec.data()), "cudaPointerGetAttributes failed!");
-#if (CUDART_VERSION < 10000)
-    REQUIRE(attr.memoryType == cudaMemoryTypeHost);
-#else
+#if (CUDART_VERSION >= 10000 || HIP_VERSION_MAJOR >= 6)
     REQUIRE(attr.type == cudaMemoryTypeHost);
+#else
+    REQUIRE(attr.memoryType == cudaMemoryTypeHost);
 #endif
   }
 #if !defined(QMC_DISABLE_HIP_HOST_REGISTER)
@@ -55,10 +55,10 @@ TEST_CASE("CUDA_allocators", "[CUDA]")
     Vector<double, CUDALockedPageAllocator<double>> vec(1024);
     cudaPointerAttributes attr;
     cudaErrorCheck(cudaPointerGetAttributes(&attr, vec.data()), "cudaPointerGetAttributes failed!");
-#if (CUDART_VERSION < 10000)
-    REQUIRE(attr.memoryType == cudaMemoryTypeHost);
-#else
+#if (CUDART_VERSION >= 10000 || HIP_VERSION_MAJOR >= 6)
     REQUIRE(attr.type == cudaMemoryTypeHost);
+#else
+    REQUIRE(attr.memoryType == cudaMemoryTypeHost);
 #endif
     Vector<double, CUDALockedPageAllocator<double>> vecb(vec);
   }


### PR DESCRIPTION
`cudaPointerAttributes.memoryType` was renamed to `cudaPointerAttributes.type` in CUDA 10.
The same change is introduced in ROCm 6.
Adding a check of `HIP_VERSION_MAJOR` to use the correct name.
