### PR TITLE
Improve EinsplineSpinorSetBuilder

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
@@ -75,6 +75,9 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
     a.add(spinSet, "spindataset");
     a.add(spinSet, "group");
     a.put(cur);
+
+    if (myName.empty())
+      myName = "einspline.spinor";
   }
 
   auto pit(ParticleSets.find(sourceName));
@@ -202,11 +205,13 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
   //Make the up spin set.
   bcastSortBands(spinSet, NumDistinctOrbitals, myComm->rank() == 0);
   auto bspline_zd_u = MixedSplineReader->create_spline_set(spinSet, spo_cur);
+  bspline_zd_u->finalizeConstruction();
 
   //Make the down spin set.
   OccupyBands(spinSet2, sortBands, numOrbs, skipChecks);
   bcastSortBands(spinSet2, NumDistinctOrbitals, myComm->rank() == 0);
   auto bspline_zd_d = MixedSplineReader->create_spline_set(spinSet2, spo_cur);
+  bspline_zd_d->finalizeConstruction();
 
   //register with spin set and we're off to the races.
   auto spinor_set = std::make_unique<SpinorSet>(spo_object_name);


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

This enables the writing of the einspline bandinfo files for spinors. It turns out these were actually being written as hidden files, because a string variable was empty in EinsplineSpinorSetBuilder. This now produces the expected behavior

Additionally, I noticed a difference between EinsplineSetBuilder and EinsplineSpinorSetBuilder in that a finalizeConstruction call was missing in the spinor code. This is needed when we have SplineX2XOMPTarget in order to map the coefficients onto the device. I added those calls as well. 

Closes #4770 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
macOS

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
