### PR TITLE
Add TrialWaveFunction::findMSD() query function

### DIFF
--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -54,11 +54,7 @@ set(PARTICLE_OMPTARGET_SRCS
     createDistanceTableAAOMPTarget.cpp
     createDistanceTableABOMPTarget.cpp)
 
-if(USE_OBJECT_TARGET)
-  add_library(qmcparticle_omptarget OBJECT ${PARTICLE_OMPTARGET_SRCS})
-else(USE_OBJECT_TARGET)
-  add_library(qmcparticle_omptarget ${PARTICLE_OMPTARGET_SRCS})
-endif(USE_OBJECT_TARGET)
+add_library(qmcparticle_omptarget OBJECT ${PARTICLE_OMPTARGET_SRCS})
 
 target_include_directories(qmcparticle_omptarget PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcparticle_omptarget PUBLIC qmcutil containers)

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -148,11 +148,7 @@ target_include_directories(qmcwfs PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcwfs PUBLIC qmcutil qmcparticle platform_runtime platform_LA)
 target_link_libraries(qmcwfs PRIVATE einspline Math::FFTW3)
 
-if(USE_OBJECT_TARGET)
-  add_library(qmcwfs_omptarget OBJECT ${JASTROW_OMPTARGET_SRCS} ${FERMION_OMPTARGET_SRCS})
-else(USE_OBJECT_TARGET)
-  add_library(qmcwfs_omptarget ${JASTROW_OMPTARGET_SRCS} ${FERMION_OMPTARGET_SRCS})
-endif(USE_OBJECT_TARGET)
+add_library(qmcwfs_omptarget OBJECT ${JASTROW_OMPTARGET_SRCS} ${FERMION_OMPTARGET_SRCS})
 
 target_include_directories(qmcwfs_omptarget PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcwfs_omptarget PUBLIC qmcutil qmcparticle containers platform_LA)

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -24,6 +24,7 @@
 #include "Concurrency/Info.hpp"
 #include "type_traits/ConvertToReal.h"
 #include "NaNguard.h"
+#include "Fermion/MultiSlaterDetTableMethod.h"
 
 namespace qmcplusplus
 {
@@ -104,6 +105,14 @@ const SPOSet& TrialWaveFunction::getSPOSet(const std::string& name) const
   if (spoit == spomap_->end())
     throw std::runtime_error("SPOSet " + name + " cannot be found!");
   return *spoit->second;
+}
+
+std::optional<std::reference_wrapper<MultiSlaterDetTableMethod>> TrialWaveFunction::findMSD() const
+{
+  for (auto& component : Z)
+    if (auto* comp_ptr = dynamic_cast<MultiSlaterDetTableMethod*>(component.get()); comp_ptr)
+      return *comp_ptr;
+  return std::nullopt;
 }
 
 /** return log(|psi|)
@@ -709,7 +718,8 @@ void TrialWaveFunction::mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunc
     wf_list[iw].PhaseDiff = std::arg(ratios[iw]);
     NaNguard::checkOneParticleRatio(ratios[iw], "TWF::mw_calcRatioGrad at particle " + std::to_string(iat));
     if (ratios[iw] != PsiValue(0))
-      NaNguard::checkOneParticleGradients(grad_new.grads_positions[iw], "TWF::mw_calcRatioGrad at particle " + std::to_string(iat));
+      NaNguard::checkOneParticleGradients(grad_new.grads_positions[iw],
+                                          "TWF::mw_calcRatioGrad at particle " + std::to_string(iat));
   }
 }
 

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -38,6 +38,8 @@
 
 namespace qmcplusplus
 {
+class MultiSlaterDetTableMethod;
+
 /** @ingroup MBWfs
  * @brief Class to represent a many-body trial wave function
  *
@@ -501,6 +503,11 @@ public:
 
   /// spomap_ reference accessor
   const SPOMap& getSPOMap() const { return *spomap_; }
+
+  /** find the first MSD WFC if exists
+   * @return the first found MSD WFC
+   */
+  std::optional<std::reference_wrapper<MultiSlaterDetTableMethod>> findMSD() const;
 
 private:
   static void debugOnlyCheckBuffer(WFBufferType& buffer);

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -134,6 +134,9 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   RadialJastrowBuilder jb(c, elec_);
   psi.addComponent(jb.buildComponent(jas1));
 
+  // should not find MSD
+  CHECK(!psi.findMSD());
+
   // initialize distance tables.
   elec_.update();
   double logpsi = psi.evaluateLog(elec_);

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -96,6 +96,7 @@ void test_LiH_msd(const std::string& spo_xml_string,
   elec_.update();
 
   auto& twf(*twf_ptr);
+  CHECK(twf.findMSD());
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
 


### PR DESCRIPTION
## Proposed changes
The query function is introduced for refactoring better #4789.

When working on this, I noticed a linking headache caused by libqmcwfs and libqmcwfs_omptarget as two separate libraries with cyclic dependency. The solution is fairly simple. Just make qmcwfs_omptarget an object target and libqmcwfs contains all the object files of qmcwfs_omptarget. This restored the old library organization, there is only `libqmcwfs.a` at linking.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
