### PR TITLE
Add missing consistency test between per particle and per QMCHamiltonian energies

### DIFF
--- a/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
@@ -269,6 +269,19 @@ TEST_CASE("integrateListeners", "[hamiltonian]")
     auto sum_kinetic    = std::accumulate(kinetic.begin(), kinetic.end(), 0.0);
     auto sum_local_nrg  = std::accumulate(local_nrg.begin(), local_nrg.end(), 0.0);
     CHECK(sum_local_nrg == Approx(sum_local_pots + sum_kinetic));
+
+    // Here we test consistency between the per particle energies and the per hamiltonian energies
+    typename decltype(energies)::value_type hamiltonian_local_nrg_sum = 0.0;
+    typename decltype(energies)::value_type energies_sum = 0.0;
+    for (int iw = 0; iw < num_walkers; ++iw) {
+      hamiltonian_local_nrg_sum += ham_list[iw].getLocalEnergy();
+      energies_sum += energies[iw];
+    }
+
+    // the QMCHamiltonian.getLocalEnergy() contains the ion_potential as well.
+    sum_local_nrg += std::accumulate(ion_pots.begin(), ion_pots.end(), 0.0);
+    CHECK(sum_local_nrg == Approx(hamiltonian_local_nrg_sum));
+    CHECK(sum_local_nrg == Approx(energies_sum));
   }
 }
 


### PR DESCRIPTION
## Proposed changes

Adds additional unit level testing to QMCHamiltonian with per particle listeners in the multiwalker case.
Fufills #4769

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
OSX Laptoip

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
