### PR TITLE
Resolve noinline definition conflict between CUDA headerfiles and GCC 12 libraries

### DIFF
--- a/src/Platforms/CUDA/CUDADeviceManager.cpp
+++ b/src/Platforms/CUDA/CUDADeviceManager.cpp
@@ -14,7 +14,7 @@
 #include "CUDADeviceManager.h"
 #include <stdexcept>
 #include "OutputManager.h"
-#include "CUDAruntime.hpp"
+#include "CUDAruntime.hpp" // Positioned here to avoid conflict between CUDA and GCC >= 12 headers. https://github.com/QMCPACK/qmcpack/pull/4814 
 #include "determineDefaultDeviceNum.h"
 
 namespace qmcplusplus

--- a/src/Platforms/CUDA/CUDADeviceManager.cpp
+++ b/src/Platforms/CUDA/CUDADeviceManager.cpp
@@ -13,8 +13,8 @@
 
 #include "CUDADeviceManager.h"
 #include <stdexcept>
-#include "CUDAruntime.hpp"
 #include "OutputManager.h"
+#include "CUDAruntime.hpp"
 #include "determineDefaultDeviceNum.h"
 
 namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes
Fix the include conflict described in #4761

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'