### PR TITLE
Fix builds without OpenMP

### DIFF
--- a/src/Platforms/OMPTarget/OMPDeviceManager.cpp
+++ b/src/Platforms/OMPTarget/OMPDeviceManager.cpp
@@ -13,13 +13,15 @@
 
 #include "OMPDeviceManager.h"
 #include <stdexcept>
+#if defined(QMC_OMP)
 #include <omp.h>
+#endif
 #include "OutputManager.h"
 #include "determineDefaultDeviceNum.h"
 
 namespace qmcplusplus
 {
-
+#if defined(QMC_OMP)
 OMPDeviceManager::OMPDeviceManager(int& default_device_num, int& num_devices, int local_rank, int local_size)
     : omp_default_device_num(-1), omp_device_count(omp_get_num_devices())
 {
@@ -41,4 +43,11 @@ OMPDeviceManager::OMPDeviceManager(int& default_device_num, int& num_devices, in
     omp_set_default_device(omp_default_device_num);
   }
 }
+#else
+OMPDeviceManager::OMPDeviceManager(int& default_device_num, int& num_devices, int local_rank, int local_size)
+    : omp_default_device_num(-1), omp_device_count(0)
+{
+  num_devices = 0;
+}
+#endif
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes

Needed to get builds with AppleClang working. There was an unprotected omp include and calls.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Apple m1 laptop

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
