### PR TITLE
Fix QMC_OMP=OFF compilation.

### DIFF
--- a/src/Platforms/OMPTarget/CMakeLists.txt
+++ b/src/Platforms/OMPTarget/CMakeLists.txt
@@ -9,7 +9,10 @@
 #// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 #//////////////////////////////////////////////////////////////////////////////////////
 
-set(OMP_RT_SRCS OMPallocator.cpp OMPDeviceManager.cpp)
+set(OMP_RT_SRCS OMPallocator.cpp)
+if(ENABLE_OFFLOAD)
+  set(OMP_RT_SRCS ${OMP_RT_SRCS} OMPDeviceManager.cpp)
+endif(ENABLE_OFFLOAD)
 set(OMP_LA_SRCS ompBLAS.cpp)
 
 add_library(platform_omptarget_runtime ${OMP_RT_SRCS})


### PR DESCRIPTION
## Proposed changes
Fix the issue raised in #4815. The consumer has been protected already https://github.com/QMCPACK/qmcpack/blob/252da5363755e987b1214d8d81c9ed422da84807/src/Platforms/DeviceManager.h#L22

## What type(s) of changes does this code introduce?
- Bugfix
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
