### PR TITLE
Convert VariableSet to RealType only

### DIFF
--- a/src/Optimize/OptimizeBase.h
+++ b/src/Optimize/OptimizeBase.h
@@ -42,7 +42,7 @@ public:
 
   virtual int getNumParams() const = 0;
 
-  virtual Return_t& Params(int i) = 0;
+  virtual Return_rt& Params(int i) = 0;
 
   virtual Return_t Params(int i) const = 0;
 

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -271,7 +271,7 @@ void QMCCostFunctionBase::reportParametersH5()
     if (ci_size > 0)
     {
       CI_Opt = true;
-      newh5 = RootName + ".opt.h5";
+      newh5  = RootName + ".opt.h5";
       *msg_stream << "  <Ci Coeffs saved in opt_coeffs=\"" << newh5 << "\">" << std::endl;
       hdf_archive hout;
       hout.create(newh5, H5F_ACC_TRUNC);

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -251,7 +251,7 @@ void QMCCostFunctionBase::reportParametersH5()
   if (!myComm->rank())
   {
     int ci_size = 0;
-    std::vector<opt_variables_type::value_type> CIcoeff;
+    std::vector<opt_variables_type::real_type> CIcoeff;
     for (int i = 0; i < OptVariables.size(); i++)
     {
       std::array<char, 128> Coeff;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -85,7 +85,7 @@ public:
   ///Path and name of the HDF5 prefix where CI coeffs are saved
   std::string newh5;
   ///assign optimization parameter i
-  Return_t& Params(int i) override { return OptVariables[i]; }
+  Return_rt& Params(int i) override { return OptVariables[i]; }
   ///return optimization parameter i
   Return_t Params(int i) const override { return OptVariables[i]; }
   int getType(int i) const { return OptVariables.getType(i); }

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -68,7 +68,7 @@ public:
     SUM_INDEX_SIZE
   };
 
-  using EffectiveWeight = QMCTraits::QTFull::RealType;
+  using EffectiveWeight  = QMCTraits::QTFull::RealType;
   using FullPrecRealType = QMCTraits::FullPrecRealType;
   ///Constructor.
   QMCCostFunctionBase(ParticleSet& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm);

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -1054,7 +1054,7 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
             << std::endl;
 
   // for each set of shifts, solve the linear method equations for the parameter update direction
-  std::vector<std::vector<ValueType>> parameterDirections;
+  std::vector<std::vector<RealType>> parameterDirections;
 #ifdef HAVE_LMY_ENGINE
   // call the engine to perform update
   EngineObj->wfn_update_compute();
@@ -1070,7 +1070,7 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
     if (true)
     {
       for (int j = 0; j < N; j++)
-        parameterDirections.at(i).at(j) = EngineObj->wfn_update().at(i * N + j);
+        parameterDirections.at(i).at(j) = std::real(EngineObj->wfn_update().at(i * N + j));
     }
     else
       parameterDirections.at(i).at(0) = 1.0;
@@ -1080,7 +1080,7 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
   optTarget->setneedGrads(false);
 
   // prepare vectors to hold the initial and current parameters
-  std::vector<ValueType> currParams(numParams, 0.0);
+  std::vector<RealType> currParams(numParams, 0.0);
 
   // initialize the initial and current parameter vectors
   for (int i = 0; i < numParams; i++)
@@ -1168,7 +1168,7 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
   }
 
   // find the best shift and the corresponding update direction
-  const std::vector<ValueType>* bestDirection = 0;
+  const std::vector<RealType>* bestDirection = 0;
   int best_shift                              = -1;
   for (int k = 0; k < costValues.size() && std::abs((initCost - initCost) / initCost) < max_relative_cost_change; k++)
     if (is_best_cost(k, costValues, shifts_i, initCost) && good_update.at(k))
@@ -1440,7 +1440,7 @@ bool QMCFixedSampleLinearOptimize::descent_run()
 
   for (int i = 0; i < results.size(); i++)
   {
-    optTarget->Params(i) = results[i];
+    optTarget->Params(i) = std::real(results[i]);
   }
 
   //If descent is being run as part of a hybrid optimization, need to check if a vector of
@@ -1488,7 +1488,7 @@ bool QMCFixedSampleLinearOptimize::hybrid_run()
     app_log() << "Update descent engine parameter values after Blocked LM step" << std::endl;
     for (int i = 0; i < optTarget->getNumParams(); i++)
     {
-      ValueType val = optTarget->Params(i);
+      RealType val = optTarget->Params(i);
       descentEngineObj->setParamVal(i, val);
     }
   }

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -1169,7 +1169,7 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
 
   // find the best shift and the corresponding update direction
   const std::vector<RealType>* bestDirection = 0;
-  int best_shift                              = -1;
+  int best_shift                             = -1;
   for (int k = 0; k < costValues.size() && std::abs((initCost - initCost) / initCost) < max_relative_cost_change; k++)
     if (is_best_cost(k, costValues, shifts_i, initCost) && good_update.at(k))
     {

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -1344,7 +1344,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
             << std::endl;
 
   // for each set of shifts, solve the linear method equations for the parameter update direction
-  std::vector<std::vector<ValueType>> parameterDirections;
+  std::vector<std::vector<RealType>> parameterDirections;
 #ifdef HAVE_LMY_ENGINE
   // call the engine to perform update
   EngineObj->wfn_update_compute();
@@ -1360,7 +1360,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
     if (true)
     {
       for (int j = 0; j < N; j++)
-        parameterDirections.at(i).at(j) = EngineObj->wfn_update().at(i * N + j);
+        parameterDirections.at(i).at(j) = std::real(EngineObj->wfn_update().at(i * N + j));
     }
     else
       parameterDirections.at(i).at(0) = 1.0;
@@ -1370,7 +1370,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
   //There will be updates of 0 for parameters that were filtered out before derivative ratios were used by the engine.
   if (options_LMY_.filter_param)
   {
-    std::vector<std::vector<ValueType>> tmpParameterDirections;
+    std::vector<std::vector<RealType>> tmpParameterDirections;
     tmpParameterDirections.resize(shifts_i.size());
 
     for (int i = 0; i < shifts_i.size(); i++)
@@ -1400,7 +1400,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
   optTarget->setneedGrads(false);
 
   // prepare vectors to hold the initial and current parameters
-  std::vector<ValueType> currParams(numParams, 0.0);
+  std::vector<RealType> currParams(numParams, 0.0);
 
   // initialize the initial and current parameter vectors
   for (int i = 0; i < numParams; i++)
@@ -1493,7 +1493,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
   }
 
   // find the best shift and the corresponding update direction
-  const std::vector<ValueType>* bestDirection = 0;
+  const std::vector<RealType>* bestDirection = 0;
   int best_shift                              = -1;
   for (int k = 0;
        k < costValues.size() && std::abs((initCost - initCost) / initCost) < options_LMY_.max_relative_cost_change; k++)
@@ -1778,7 +1778,7 @@ bool QMCFixedSampleLinearOptimizeBatched::descent_run()
 
   for (int i = 0; i < results.size(); i++)
   {
-    optTarget->Params(i) = results[i];
+    optTarget->Params(i) = std::real(results[i]);
   }
 
   //If descent is being run as part of a hybrid optimization, need to check if a vector of

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -1494,7 +1494,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
 
   // find the best shift and the corresponding update direction
   const std::vector<RealType>* bestDirection = 0;
-  int best_shift                              = -1;
+  int best_shift                             = -1;
   for (int k = 0;
        k < costValues.size() && std::abs((initCost - initCost) / initCost) < options_LMY_.max_relative_cost_change; k++)
     if (is_best_cost(k, costValues, shifts_i, initCost) && good_update.at(k))

--- a/src/QMCDrivers/tests/test_DescentEngine.cpp
+++ b/src/QMCDrivers/tests/test_DescentEngine.cpp
@@ -44,8 +44,8 @@ TEST_CASE("DescentEngine RMSprop update", "[drivers][descent]")
   optimize::VariableSet myVars;
 
   //Two fake parameters are specified
-  optimize::VariableSet::value_type first_param(1.0);
-  optimize::VariableSet::value_type second_param(-2.0);
+  optimize::VariableSet::real_type first_param(1.0);
+  optimize::VariableSet::real_type second_param(-2.0);
 
   myVars.insert("first", first_param);
   myVars.insert("second", second_param);

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -561,10 +561,10 @@ std::unique_ptr<MultiSlaterDetTableMethod> SlaterDetBuilder::createMSDFast(
     Optimizable = CI_Optimizable = true;
     if (csf_data_ptr)
       for (int i = 1; i < csf_data_ptr->coeffs.size(); i++)
-        myVars.insert(CItags[i], csf_data_ptr->coeffs[i], true, optimize::LINEAR_P);
+        myVars.insert(CItags[i], std::real(csf_data_ptr->coeffs[i]), true, optimize::LINEAR_P);
     else
       for (int i = 1; i < C.size(); i++)
-        myVars.insert(CItags[i], C[i], true, optimize::LINEAR_P);
+        myVars.insert(CItags[i], std::real(C[i]), true, optimize::LINEAR_P);
   }
   else
   {

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -32,7 +32,7 @@ RotatedSPOs::RotatedSPOs(const std::string& my_name, std::unique_ptr<SPOSet>&& s
 
 RotatedSPOs::~RotatedSPOs() {}
 
-
+  
 void RotatedSPOs::setRotationParameters(const std::vector<RealType>& param_list)
 {
   params          = param_list;

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -32,7 +32,7 @@ RotatedSPOs::RotatedSPOs(const std::string& my_name, std::unique_ptr<SPOSet>&& s
 
 RotatedSPOs::~RotatedSPOs() {}
 
-  
+
 void RotatedSPOs::setRotationParameters(const std::vector<RealType>& param_list)
 {
   params          = param_list;

--- a/src/QMCWaveFunctions/VariableSet.cpp
+++ b/src/QMCWaveFunctions/VariableSet.cpp
@@ -54,7 +54,7 @@ void VariableSet::insertFrom(const VariableSet& input)
 
 void VariableSet::insertFromSum(const VariableSet& input_1, const VariableSet& input_2)
 {
-  value_type sum_val;
+  real_type sum_val;
   std::string vname;
 
   // Check that objects to be summed together have the same number of active
@@ -94,7 +94,7 @@ void VariableSet::insertFromSum(const VariableSet& input_1, const VariableSet& i
 
 void VariableSet::insertFromDiff(const VariableSet& input_1, const VariableSet& input_2)
 {
-  value_type diff_val;
+  real_type diff_val;
   std::string vname;
 
   // Check that objects to be subtracted have the same number of active
@@ -259,7 +259,7 @@ void VariableSet::writeToHDF(const std::string& filename, qmcplusplus::hdf_archi
 
   hout.push("name_value_lists");
 
-  std::vector<qmcplusplus::QMCTraits::ValueType> param_values;
+  std::vector<qmcplusplus::QMCTraits::RealType> param_values;
   std::vector<std::string> param_names;
   for (auto& pair_it : NameAndValue)
   {
@@ -292,7 +292,7 @@ void VariableSet::readFromHDF(const std::string& filename, qmcplusplus::hdf_arch
     throw std::runtime_error(err_msg.str());
   }
 
-  std::vector<qmcplusplus::QMCTraits::ValueType> param_values;
+  std::vector<qmcplusplus::QMCTraits::RealType> param_values;
   hin.read(param_values, "parameter_values");
 
   std::vector<std::string> param_names;

--- a/src/QMCWaveFunctions/VariableSet.h
+++ b/src/QMCWaveFunctions/VariableSet.h
@@ -48,7 +48,7 @@ enum
  */
 struct VariableSet
 {
-  using real_type  = qmcplusplus::QMCTraits::RealType;
+  using real_type = qmcplusplus::QMCTraits::RealType;
 
   using pair_type       = std::pair<std::string, real_type>;
   using index_pair_type = std::pair<std::string, int>;

--- a/src/QMCWaveFunctions/VariableSet.h
+++ b/src/QMCWaveFunctions/VariableSet.h
@@ -48,10 +48,9 @@ enum
  */
 struct VariableSet
 {
-  using value_type = qmcplusplus::QMCTraits::ValueType;
   using real_type  = qmcplusplus::QMCTraits::RealType;
 
-  using pair_type       = std::pair<std::string, value_type>;
+  using pair_type       = std::pair<std::string, real_type>;
   using index_pair_type = std::pair<std::string, int>;
   using iterator        = std::vector<pair_type>::iterator;
   using const_iterator  = std::vector<pair_type>::const_iterator;
@@ -131,7 +130,7 @@ struct VariableSet
     return -1;
   }
 
-  inline void insert(const std::string& vname, value_type v, bool enable = true, int type = OTHER_P)
+  inline void insert(const std::string& vname, real_type v, bool enable = true, int type = OTHER_P)
   {
     iterator loc = find(vname);
     int ind_loc  = loc - NameAndValue.begin();
@@ -169,7 +168,7 @@ struct VariableSet
 
   /** equivalent to std::map<std::string,T>[string] operator
    */
-  inline value_type& operator[](const std::string& vname)
+  inline real_type& operator[](const std::string& vname)
   {
     iterator loc = find(vname);
     if (loc == NameAndValue.end())
@@ -192,12 +191,12 @@ struct VariableSet
   /** return the i-th value
    * @param i index
    */
-  inline value_type operator[](int i) const { return NameAndValue[i].second; }
+  inline real_type operator[](int i) const { return NameAndValue[i].second; }
 
   /** assign the i-th value
    * @param i index
    */
-  inline value_type& operator[](int i) { return NameAndValue[i].second; }
+  inline real_type& operator[](int i) { return NameAndValue[i].second; }
 
   /** get the i-th parameter's type
   * @param i index

--- a/src/QMCWaveFunctions/tests/test_variable_set.cpp
+++ b/src/QMCWaveFunctions/tests/test_variable_set.cpp
@@ -11,7 +11,6 @@
 
 
 #include "catch.hpp"
-#include "complex_approx.hpp"
 
 #include "VariableSet.h"
 #include "io/hdf/hdf_archive.h"
@@ -20,7 +19,6 @@
 #include <string>
 
 using std::string;
-using qmcplusplus::ValueApprox;
 
 namespace optimize
 {
@@ -37,7 +35,7 @@ TEST_CASE("VariableSet empty", "[optimize]")
 TEST_CASE("VariableSet one", "[optimize]")
 {
   VariableSet vs;
-  VariableSet::value_type first_val(1.123456789);
+  VariableSet::real_type first_val(1.123456789);
   vs.insert("first", first_val);
   std::vector<std::string> names{"first"};
   vs.activate(names.begin(), names.end(), true);
@@ -52,39 +50,26 @@ TEST_CASE("VariableSet one", "[optimize]")
   std::ostringstream o;
   vs.print(o, 0, false);
   //std::cout << o.str() << std::endl;
-  #ifdef QMC_COMPLEX
-  REQUIRE(o.str() == "first  (1.123457e+00,0.000000e+00) 0 1  ON 0\n");
-  #else
   REQUIRE(o.str() == "first                 1.123457e+00 0 1  ON 0\n");
-  #endif
 
   std::ostringstream o2;
   vs.print(o2, 1, true);
   //std::cout << o2.str() << std::endl;
 
-  #ifdef QMC_COMPLEX
-  char formatted_output[] = "  Name                        Value Type Recompute Use Index\n"
-                            " ----- ---------------------------- ---- --------- --- -----\n"
-                            " first  (1.123457e+00,0.000000e+00)    0         1  ON     0\n";
-
-
-  REQUIRE(o2.str() == formatted_output);
-  #else
   char formatted_output[] = "  Name                        Value Type Recompute Use Index\n"
                             " ----- ---------------------------- ---- --------- --- -----\n"
                             " first                 1.123457e+00    0         1  ON     0\n";
 
 
   REQUIRE(o2.str() == formatted_output);
-  #endif
 }
 
 TEST_CASE("VariableSet output", "[optimize]")
 {
   VariableSet vs;
-  VariableSet::value_type first_val(11234.56789);
-  VariableSet::value_type second_val(0.000256789);
-  VariableSet::value_type third_val(-1.2);
+  VariableSet::real_type first_val(11234.56789);
+  VariableSet::real_type second_val(0.000256789);
+  VariableSet::real_type third_val(-1.2);
   vs.insert("s", first_val);
   vs.insert("second", second_val);
   vs.insert("really_long_name", third_val);
@@ -95,19 +80,11 @@ TEST_CASE("VariableSet output", "[optimize]")
   vs.print(o, 0, true);
   //std::cout << o.str() << std::endl;
 
-  #ifdef QMC_COMPLEX
-  char formatted_output[] = "            Name                        Value Type Recompute Use Index\n"
-                            "---------------- ---------------------------- ---- --------- --- -----\n"
-                            "               s  (1.123457e+04,0.000000e+00)    0         1  ON     0\n"
-                            "          second  (2.567890e-04,0.000000e+00)    0         1  ON     1\n"
-                            "really_long_name (-1.200000e+00,0.000000e+00)    0         1  ON     2\n";
-  #else
   char formatted_output[] = "            Name                        Value Type Recompute Use Index\n"
                             "---------------- ---------------------------- ---- --------- --- -----\n"
                             "               s                 1.123457e+04    0         1  ON     0\n"
                             "          second                 2.567890e-04    0         1  ON     1\n"
                             "really_long_name                -1.200000e+00    0         1  ON     2\n";
-  #endif
 
   REQUIRE(o.str() == formatted_output);
 }
@@ -115,9 +92,9 @@ TEST_CASE("VariableSet output", "[optimize]")
 TEST_CASE("VariableSet HDF output and input", "[optimize]")
 {
   VariableSet vs;
-  VariableSet::value_type first_val(11234.56789);
-  VariableSet::value_type second_val(0.000256789);
-  VariableSet::value_type third_val(-1.2);
+  VariableSet::real_type first_val(11234.56789);
+  VariableSet::real_type second_val(0.000256789);
+  VariableSet::real_type third_val(-1.2);
   vs.insert("s", first_val);
   vs.insert("second", second_val);
   vs.insert("really_really_really_long_name", third_val);
@@ -129,8 +106,8 @@ TEST_CASE("VariableSet HDF output and input", "[optimize]")
   vs2.insert("second", 0.0);
   qmcplusplus::hdf_archive hin;
   vs2.readFromHDF("vp.h5", hin);
-  CHECK(vs2.find("s")->second == ValueApprox(first_val));
-  CHECK(vs2.find("second")->second == ValueApprox(second_val));
+  CHECK(vs2.find("s")->second == Approx(first_val));
+  CHECK(vs2.find("second")->second == Approx(second_val));
   // This value as in the file, but not in the VariableSet that loaded the file,
   // so the value does not get added.
   CHECK(vs2.find("really_really_really_long_name") == vs2.end());

--- a/src/QMCWaveFunctions/tests/test_variable_set.cpp
+++ b/src/QMCWaveFunctions/tests/test_variable_set.cpp
@@ -45,7 +45,7 @@ TEST_CASE("VariableSet one", "[optimize]")
   REQUIRE(vs.getIndex("first") == 0);
   REQUIRE(vs.name(0) == "first");
   double first_val_real = 1.123456789;
-  CHECK(std::real(vs[0] ) == Approx(first_val_real));
+  CHECK(vs[0] == Approx(first_val_real));
 
   std::ostringstream o;
   vs.print(o, 0, false);


### PR DESCRIPTION
## Proposed changes

While working to enable complex orbital rotations, @rcclay, @jptowns and I realized there were some inconsistencies in how we deal with optimizable parameters and their types. 

The optimizer is hard coded deal with only real parameters since it takes the real part of the parameters stored in VariableSet.  Generally, to minimize a **complex analytic** function you only need to consider d/dz, but general functions that aren't complex analytic need to be formulated with d/dz and d/dz*.  For those types of functions, it is completely equivalent to work with just d/d(re(z)) and d/d(im(z)) though. The local energy and cost function that we minimize are not complex analytic, so we need to work with both d/d(re(z)) and d/d(im(z)). So, to make the optimizer properly deal with complex parameters, can keep the optimizer as is if we just treat the real and imaginary part of complex numbers as two independent real parameters. So the optimizer wouldn't need to be touched.

The interface between the optimizer and optimizable wave function components is VariableSet, and it currently stored everything as ValueType. Since the optimizer only ever needs to deal with reals (treating the real/imaguinary components as 2 reals), the VariableSet should only store reals. Currently, no existing wave function component actually supports optimizing a complex parameter, so changing VariableSet to be RealType only is not a breaking change. 

If any future wave function component wants to support optimizing a complex parameter, it needs to simply register the complex parameter as two reals into VariableSet, and then the optimizer will work as it is currently written. We are going to submit a future PR enabling this functionality for RotatedSPOs. 

This PR simply makes the change in VariableSet to remove ValueType, and change the various places in the code where it was used. The existing unit test for VariableSet is modified to remove the checks on ValueType, so these changes are already being tested with existing code. If there are any additional tests that should be added, let me know. 


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No. Note that complex MSD CI coefficients optimization is broken as it is.

## What systems has this change been tested on?
macOS

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
