### PR TITLE
Move the role of LCAO::setOrbitalSetSize to constructors

### DIFF
--- a/src/QMCWaveFunctions/LCAO/CuspCorrectionConstruction.cpp
+++ b/src/QMCWaveFunctions/LCAO/CuspCorrectionConstruction.cpp
@@ -580,11 +580,11 @@ void applyCuspCorrection(const Matrix<CuspCorrectionParameters>& info,
 
   ScopedTimer cuspApplyTimerWrapper(cuspApplyTimer);
 
-  LCAOrbitalSet phi("phi", std::unique_ptr<LCAOrbitalSet::basis_type>(lcao.myBasisSet->makeClone()));
-  phi.setOrbitalSetSize(lcao.getOrbitalSetSize());
+  LCAOrbitalSet phi("phi", std::unique_ptr<LCAOrbitalSet::basis_type>(lcao.myBasisSet->makeClone()),
+                    lcao.getOrbitalSetSize(), lcao.isIdentity());
 
-  LCAOrbitalSet eta("eta", std::unique_ptr<LCAOrbitalSet::basis_type>(lcao.myBasisSet->makeClone()));
-  eta.setOrbitalSetSize(lcao.getOrbitalSetSize());
+  LCAOrbitalSet eta("eta", std::unique_ptr<LCAOrbitalSet::basis_type>(lcao.myBasisSet->makeClone()),
+                    lcao.getOrbitalSetSize(), lcao.isIdentity());
 
   std::vector<bool> corrCenter(num_centers, "true");
 
@@ -675,12 +675,11 @@ void generateCuspInfo(Matrix<CuspCorrectionParameters>& info,
 
   ScopedTimer createCuspTimerWrapper(cuspCreateTimer);
 
-  LCAOrbitalSet phi("phi", std::unique_ptr<LCAOrbitalSet::basis_type>(lcao.myBasisSet->makeClone()));
-  phi.setOrbitalSetSize(lcao.getOrbitalSetSize());
+  LCAOrbitalSet phi("phi", std::unique_ptr<LCAOrbitalSet::basis_type>(lcao.myBasisSet->makeClone()),
+                    lcao.getOrbitalSetSize(), lcao.isIdentity());
 
-  LCAOrbitalSet eta("eta", std::unique_ptr<LCAOrbitalSet::basis_type>(lcao.myBasisSet->makeClone()));
-  eta.setOrbitalSetSize(lcao.getOrbitalSetSize());
-
+  LCAOrbitalSet eta("eta", std::unique_ptr<LCAOrbitalSet::basis_type>(lcao.myBasisSet->makeClone()),
+                    lcao.getOrbitalSetSize(), lcao.isIdentity());
 
   std::vector<bool> corrCenter(num_centers, "true");
 
@@ -705,11 +704,11 @@ void generateCuspInfo(Matrix<CuspCorrectionParameters>& info,
       ParticleSet localTargetPtcl(targetPtcl);
       ParticleSet localSourcePtcl(sourcePtcl);
 
-      LCAOrbitalSet local_phi("local_phi", std::unique_ptr<LCAOrbitalSet::basis_type>(phi.myBasisSet->makeClone()));
-      local_phi.setOrbitalSetSize(phi.getOrbitalSetSize());
+      LCAOrbitalSet local_phi("local_phi", std::unique_ptr<LCAOrbitalSet::basis_type>(phi.myBasisSet->makeClone()),
+                              phi.getOrbitalSetSize(), phi.isIdentity());
 
-      LCAOrbitalSet local_eta("local_eta", std::unique_ptr<LCAOrbitalSet::basis_type>(eta.myBasisSet->makeClone()));
-      local_eta.setOrbitalSetSize(eta.getOrbitalSetSize());
+      LCAOrbitalSet local_eta("local_eta", std::unique_ptr<LCAOrbitalSet::basis_type>(eta.myBasisSet->makeClone()),
+                              eta.getOrbitalSetSize(), eta.isIdentity());
 
 #pragma omp critical
       app_log() << "   Working on MO: " << mo_idx << " Center: " << center_idx << std::endl;

--- a/src/QMCWaveFunctions/LCAO/LCAOSpinorBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOSpinorBuilder.cpp
@@ -32,10 +32,12 @@ std::unique_ptr<SPOSet> LCAOSpinorBuilder::createSPOSetFromXML(xmlNodePtr cur)
   ReportEngine PRE(ClassName, "createSPO(xmlNodePtr)");
   std::string spo_name(""), optimize("no");
   std::string basisset_name("LCAOBSet");
+  size_t norbs(0);
   OhmmsAttributeSet spoAttrib;
   spoAttrib.add(spo_name, "name");
   spoAttrib.add(optimize, "optimize");
   spoAttrib.add(basisset_name, "basisset");
+  spoAttrib.add(norbs, "size");
   spoAttrib.put(cur);
 
   BasisSet_t* myBasisSet = nullptr;
@@ -48,10 +50,11 @@ std::unique_ptr<SPOSet> LCAOSpinorBuilder::createSPOSetFromXML(xmlNodePtr cur)
     app_log() << "  SPOSet " << spo_name << " is optimizable\n";
 
   std::unique_ptr<LCAOrbitalSet> upspo =
-      std::make_unique<LCAOrbitalSet>(spo_name + "_up", std::unique_ptr<BasisSet_t>(myBasisSet->makeClone()));
+      std::make_unique<LCAOrbitalSet>(spo_name + "_up", std::unique_ptr<BasisSet_t>(myBasisSet->makeClone()), norbs,
+                                      false);
   std::unique_ptr<LCAOrbitalSet> dnspo =
-      std::make_unique<LCAOrbitalSet>(spo_name + "_dn", std::unique_ptr<BasisSet_t>(myBasisSet->makeClone()));
-
+      std::make_unique<LCAOrbitalSet>(spo_name + "_dn", std::unique_ptr<BasisSet_t>(myBasisSet->makeClone()), norbs,
+                                      false);
   loadMO(*upspo, *dnspo, cur);
 
   //create spinor and register up/dn
@@ -63,15 +66,10 @@ std::unique_ptr<SPOSet> LCAOSpinorBuilder::createSPOSetFromXML(xmlNodePtr cur)
 bool LCAOSpinorBuilder::loadMO(LCAOrbitalSet& up, LCAOrbitalSet& dn, xmlNodePtr cur)
 {
   bool PBC = false;
-  int norb = up.getBasisSetSize();
   std::string debugc("no");
   OhmmsAttributeSet aAttrib;
-  aAttrib.add(norb, "size");
   aAttrib.add(debugc, "debug");
   aAttrib.put(cur);
-
-  up.setOrbitalSetSize(norb);
-  dn.setOrbitalSetSize(norb);
 
   xmlNodePtr occ_ptr = nullptr;
   cur                = cur->xmlChildrenNode;

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
@@ -566,7 +566,7 @@ bool LCAOrbitalBuilder::loadMO(LCAOrbitalSet& spo, xmlNodePtr cur)
   double orbital_mix_magnitude = 0.0;
   bool PBC                     = false;
   OhmmsAttributeSet aAttrib;
-  aAttrib.add(norb, "orbitals");
+  aAttrib.add(norb, "orbitals", {}, TagStatus::DELETED);
   aAttrib.add(norb, "size");
   aAttrib.add(debugc, "debug");
   aAttrib.add(orbital_mix_magnitude, "orbital_mix_magnitude");
@@ -645,7 +645,7 @@ bool LCAOrbitalBuilder::putFromXML(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
   int norbs = 0;
   OhmmsAttributeSet aAttrib;
   aAttrib.add(norbs, "size");
-  aAttrib.add(norbs, "orbitals");
+  aAttrib.add(norbs, "orbitals", {}, TagStatus::DELETED);
   aAttrib.put(coeff_ptr);
   if (norbs < spo.getOrbitalSetSize())
   {
@@ -685,7 +685,7 @@ bool LCAOrbitalBuilder::putFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
   OhmmsAttributeSet aAttrib;
   aAttrib.add(setVal, "spindataset");
   aAttrib.add(neigs, "size");
-  aAttrib.add(neigs, "orbitals");
+  aAttrib.add(neigs, "orbitals", {}, TagStatus::DELETED);
   aAttrib.put(coeff_ptr);
   hdf_archive hin(myComm);
   if (myComm->rank() == 0)
@@ -757,12 +757,14 @@ bool LCAOrbitalBuilder::putPBCFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
   int setVal     = -1;
   bool IsComplex = false;
   bool MultiDet  = false;
+  std::string use_sorted;
   PosType SuperTwist(0.0);
   PosType SuperTwistH5(0.0);
   OhmmsAttributeSet aAttrib;
   aAttrib.add(setVal, "spindataset");
   aAttrib.add(neigs, "size");
-  aAttrib.add(neigs, "orbitals");
+  aAttrib.add(neigs, "orbitals", {}, TagStatus::DELETED);
+  aAttrib.add(use_sorted, "sorted");
   aAttrib.put(coeff_ptr);
   hdf_archive hin(myComm);
 

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
@@ -41,9 +41,12 @@ public:
   std::shared_ptr<ValueMatrix> C;
 
   /** constructor
+     * @param my_name name of the SPOSet object
      * @param bs pointer to the BasisSet
+     * @param norb number of orbitals
+     * @param identity if true, the MO coefficients matrix is identity
      */
-  LCAOrbitalSet(const std::string& my_name, std::unique_ptr<basis_type>&& bs);
+  LCAOrbitalSet(const std::string& my_name, std::unique_ptr<basis_type>&& bs, size_t norbs, bool identity = false);
 
   LCAOrbitalSet(const LCAOrbitalSet& in);
 
@@ -222,7 +225,7 @@ protected:
   std::shared_ptr<ValueMatrix> C_copy;
 
   ///true if C is an identity matrix
-  bool Identity;
+  const bool Identity;
   ///Temp(BasisSetSize) : Row index=V,Gx,Gy,Gz,L
   vgl_type Temp;
   ///Tempv(OrbitalSetSize) Tempv=C*Temp

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.cpp
@@ -15,17 +15,19 @@
 namespace qmcplusplus
 {
 LCAOrbitalSetWithCorrection::LCAOrbitalSetWithCorrection(const std::string& my_name,
+                                                         std::unique_ptr<basis_type>&& bs,
+                                                         size_t norbs,
+                                                         bool identity,
                                                          ParticleSet& ions,
-                                                         ParticleSet& els,
-                                                         std::unique_ptr<basis_type>&& bs)
-    : SPOSet(my_name), lcao(my_name + "_modified", std::move(bs)), cusp(ions, els)
-{}
+                                                         ParticleSet& els)
+    : SPOSet(my_name), lcao(my_name + "_modified", std::move(bs), norbs, identity), cusp(ions, els, norbs)
+{
+  OrbitalSetSize = norbs;
+}
 
 void LCAOrbitalSetWithCorrection::setOrbitalSetSize(int norbs)
 {
-  assert(lcao.getOrbitalSetSize() == norbs && "norbs doesn't agree with lcao!");
-  OrbitalSetSize = norbs;
-  cusp.setOrbitalSetSize(norbs);
+  throw std::runtime_error("LCAOrbitalSetWithCorrection::setOrbitalSetSize should not be called");
 }
 
 

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.h
@@ -29,15 +29,20 @@ class LCAOrbitalSetWithCorrection : public SPOSet
 public:
   using basis_type = LCAOrbitalSet::basis_type;
   /** constructor
+     * @param my_name name of the SPOSet object
+     * @param bs pointer to the BasisSet
+     * @param norb number of orbitals
+     * @param identity if true, the MO coefficients matrix is identity
      * @param ions
      * @param els
-     * @param bs pointer to the BasisSet
      * @param rl report level
      */
   LCAOrbitalSetWithCorrection(const std::string& my_name,
+                              std::unique_ptr<basis_type>&& bs,
+                              size_t norbs,
+                              bool identity,
                               ParticleSet& ions,
-                              ParticleSet& els,
-                              std::unique_ptr<basis_type>&& bs);
+                              ParticleSet& els);
 
   LCAOrbitalSetWithCorrection(const LCAOrbitalSetWithCorrection& in) = default;
 

--- a/src/QMCWaveFunctions/LCAO/SoaCuspCorrection.cpp
+++ b/src/QMCWaveFunctions/LCAO/SoaCuspCorrection.cpp
@@ -17,20 +17,16 @@
 
 namespace qmcplusplus
 {
-SoaCuspCorrection::SoaCuspCorrection(ParticleSet& ions, ParticleSet& els) : myTableIndex(els.addTable(ions))
+SoaCuspCorrection::SoaCuspCorrection(ParticleSet& ions, ParticleSet& els, size_t norbs)
+    : myTableIndex(els.addTable(ions)), MaxOrbSize(norbs)
 {
   NumCenters = ions.getTotalNum();
   NumTargets = els.getTotalNum();
   LOBasisSet.resize(NumCenters);
+  myVGL.resize(5, MaxOrbSize);
 }
 
 SoaCuspCorrection::SoaCuspCorrection(const SoaCuspCorrection& a) = default;
-
-void SoaCuspCorrection::setOrbitalSetSize(int norbs)
-{
-  MaxOrbSize = norbs;
-  myVGL.resize(5, MaxOrbSize);
-}
 
 inline void SoaCuspCorrection::evaluateVGL(const ParticleSet& P, int iat, VGLVector& vgl)
 {

--- a/src/QMCWaveFunctions/LCAO/SoaCuspCorrection.h
+++ b/src/QMCWaveFunctions/LCAO/SoaCuspCorrection.h
@@ -50,7 +50,7 @@ class SoaCuspCorrection
   /** Maximal number of supported MOs
    * this is not the AO basis because cusp correction is applied on the MO directly.
    */
-  int MaxOrbSize = 0;
+  const size_t MaxOrbSize;
 
   ///COMPLEX WON'T WORK
   using COT = CuspCorrectionAtomicBasis<RealType>;
@@ -68,15 +68,12 @@ public:
   /** constructor
    * @param ions ionic system
    * @param els electronic system
+   * @param norbs the number of orbitals this cusp correction may serve
    */
-  SoaCuspCorrection(ParticleSet& ions, ParticleSet& els);
+  SoaCuspCorrection(ParticleSet& ions, ParticleSet& els, size_t norbs);
 
   /** copy constructor */
   SoaCuspCorrection(const SoaCuspCorrection& a);
-
-  /** set the number of orbitals this cusp correction may serve. call this before adding any correction centers.
-   */
-  void setOrbitalSetSize(int norbs);
 
   /** compute VGL
    * @param P quantum particleset

--- a/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
+++ b/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
@@ -120,11 +120,11 @@ TEST_CASE("applyCuspInfo", "[wavefunction]")
 
   LCAOrbitalSet& lcob = dynamic_cast<LCAOrbitalSet&>(*sposet);
 
-  LCAOrbitalSet phi("phi", std::unique_ptr<LCAOrbitalSet::basis_type>(lcob.myBasisSet->makeClone()));
-  phi.setOrbitalSetSize(lcob.getOrbitalSetSize());
+  LCAOrbitalSet phi("phi", std::unique_ptr<LCAOrbitalSet::basis_type>(lcob.myBasisSet->makeClone()),
+                    lcob.getOrbitalSetSize(), lcob.isIdentity());
 
-  LCAOrbitalSet eta("eta", std::unique_ptr<LCAOrbitalSet::basis_type>(lcob.myBasisSet->makeClone()));
-  eta.setOrbitalSetSize(lcob.getOrbitalSetSize());
+  LCAOrbitalSet eta("eta", std::unique_ptr<LCAOrbitalSet::basis_type>(lcob.myBasisSet->makeClone()),
+                    lcob.getOrbitalSetSize(), lcob.isIdentity());
 
   *(eta.C) = *(lcob.C);
   *(phi.C) = *(lcob.C);


### PR DESCRIPTION
## Proposed changes
On the path to eventually remove SPOSet::setOrbitalSetSize. The size should be recorded in the constructor and not be allowed to change at a later point. Simplify the initialization logic.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'