### PR TITLE
Fix test input file for LiH energy density estimator voronoi variant

### DIFF
--- a/tests/molecules/LiH_ae_gms/vmc_noj_edens_vor_long.in.xml
+++ b/tests/molecules/LiH_ae_gms/vmc_noj_edens_vor_long.in.xml
@@ -12028,7 +12028,7 @@ PROPERTY VALUES FOR THE ROHF  SELF-CONSISTENT FIELD WAVEFUNCTION
          <determinantset>
             <slaterdeterminant>
 	      <determinant sposet="spo-up"/>
-	      <detetminant sposet="spo-dn"/>
+	      <determinant sposet="spo-dn"/>
             </slaterdeterminant>
          </determinantset>
       </wavefunction>

--- a/tests/molecules/LiH_ae_gms/vmc_noj_edens_vor_short.in.xml
+++ b/tests/molecules/LiH_ae_gms/vmc_noj_edens_vor_short.in.xml
@@ -12028,7 +12028,7 @@ PROPERTY VALUES FOR THE ROHF  SELF-CONSISTENT FIELD WAVEFUNCTION
          <determinantset>
             <slaterdeterminant>
 	      <determinant sposet="spo-up"/>
-	      <detetminant sposet="spo-dn"/>
+	      <determinant sposet="spo-dn"/>
             </slaterdeterminant>
          </determinantset>
       </wavefunction>


### PR DESCRIPTION
## Proposed changes
Fixes https://cdash.qmcpack.org/CDash/testDetails.php?test=28509968&build=446427

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
