### PR TITLE
[AFQMC] Implement uninit_copy for shm_ptr_with_raw_ptr_dispatch

### DIFF
--- a/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
+++ b/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
@@ -466,14 +466,14 @@ shm_ptr_with_raw_ptr_dispatch<T> copy(It1 first, It1 last, shm_ptr_with_raw_ptr_
   return d_first + distance(first, last);
 }
 
-template<class It1, class Size, typename T>
+template<class It1, typename Size, typename T>
 shm_ptr_with_raw_ptr_dispatch<T> uninitialized_copy_n(It1 f, Size n, shm_ptr_with_raw_ptr_dispatch<T> d)
 {
   if (n == 0)
     return d;
   d.wSP_->fence();
   using std::uninitialized_copy_n;
-  if (d.wSP_->get_group().root())
+  if (d.wSP_->get_group().root()) 
     uninitialized_copy_n(f, n, to_address(d));
   d.wSP_->fence();
   mpi3::communicator(d.wSP_->get_group(), 0).barrier();

--- a/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
+++ b/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
@@ -485,13 +485,12 @@ It2 uninitialized_copy_n(shm_ptr_with_raw_ptr_dispatch<T> f, Size n, It2 d)
 {
   if (n == 0)
     return d;
-  throw std::runtime_error("shm_ptr uninitialized_copy_n not implemented");
-  // d.wSP_->fence();
-  // using std::uninitialized_copy_n;
-  // if (d.wSP_->get_group().root())
-  //   uninitialized_copy_n(f, n, to_address(d));
-  // d.wSP_->fence();
-  // mpi3::communicator(d.wSP_->get_group(), 0).barrier();
+  f.wSP_->fence();
+  using std::uninitialized_copy_n;
+  if (f.wSP_->get_group().root())
+    uninitialized_copy_n(f, n, to_address(d));
+  f.wSP_->fence();
+  mpi3::communicator(f.wSP_->get_group(), 0).barrier();
   return d + n;
 }
 

--- a/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
+++ b/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
@@ -473,7 +473,7 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_copy_n(It1 f, Size n, shm_ptr_wit
     return d;
   d.wSP_->fence();
   using std::uninitialized_copy_n;
-  if (d.wSP_->get_group().root()) 
+  if (d.wSP_->get_group().root())
     uninitialized_copy_n(f, n, to_address(d));
   d.wSP_->fence();
   mpi3::communicator(d.wSP_->get_group(), 0).barrier();

--- a/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
+++ b/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
@@ -480,6 +480,22 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_copy_n(It1 f, Size n, shm_ptr_wit
   return d + n;
 }
 
+template<class T, class Size, typename It2>
+shm_ptr_with_raw_ptr_dispatch<T> uninitialized_copy_n(shm_ptr_with_raw_ptr_dispatch<T> f, Size n, It2 d)
+{
+  if (n == 0)
+    return d;
+  throw std::runtime_error("shm_ptr uninitialized_copy_n not implemented");
+  // d.wSP_->fence();
+  // using std::uninitialized_copy_n;
+  // if (d.wSP_->get_group().root())
+  //   uninitialized_copy_n(f, n, to_address(d));
+  // d.wSP_->fence();
+  // mpi3::communicator(d.wSP_->get_group(), 0).barrier();
+  return d + n;
+}
+
+
 template<class Alloc, class It1, class Size, typename T>
 shm_ptr_with_raw_ptr_dispatch<T> uninitialized_copy_n(Alloc& a, It1 f, Size n, shm_ptr_with_raw_ptr_dispatch<T> d)
 {

--- a/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
+++ b/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
@@ -481,7 +481,7 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_copy_n(It1 f, Size n, shm_ptr_wit
 }
 
 template<class T, class Size, typename It2>
-shm_ptr_with_raw_ptr_dispatch<T> uninitialized_copy_n(shm_ptr_with_raw_ptr_dispatch<T> f, Size n, It2 d)
+It2 uninitialized_copy_n(shm_ptr_with_raw_ptr_dispatch<T> f, Size n, It2 d)
 {
   if (n == 0)
     return d;

--- a/src/AFQMC/Memory/device_pointers.hpp
+++ b/src/AFQMC/Memory/device_pointers.hpp
@@ -797,8 +797,8 @@ device_pointer<T> uninitialized_copy(device_pointer<T> first, device_pointer<T> 
 }
 */
 // only trivial types for now, no placement new yet
-template<typename T, typename Size>
-device_pointer<T> uninitialized_copy_n(device_pointer<T> A, Size n, device_pointer<T> B)
+template<typename T1, typename Size, typename T2>
+device_pointer<T2> uninitialized_copy_n(device_pointer<T1> A, Size n, device_pointer<T2> B)
 {
   return copy_n(A, n, B);
 }


### PR DESCRIPTION
declare stub for uninitialized_copy_n of shm_ptr in AFQMC

## Proposed changes

Implement missing algorithm reflecting changes in Multi

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
