### PR TITLE
Check compilers before handling MPI in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,20 @@ if(QMC_OMP)
   # A workaround is making the vendor native runtime responsible for memory allocations and OpenMP associate/disassocate them.
   cmake_dependent_option(QMC_OFFLOAD_MEM_ASSOCIATED "Manage OpenMP memory allocations via the vendor runtime"
     ${QMC_OFFLOAD_MEM_ASSOCIATED_DEFAULT} "ENABLE_OFFLOAD;ENABLE_CUDA" OFF)
+
+  #--------------------------------------------------------------
+  # Workaround for breakage of OMP Target kernels at -O0 by Clang
+  #--------------------------------------------------------------
+  # When the build type is Debug, default -O0 compilation is broken by
+  # Clang 15 as of 5d2ce7663b10c107328a4ae0c678165209e64619.
+  # Previous compilers are not suggested for clang offload builds.
+  #
+  # You can set this option to false on the command line to check
+  # if this problem has been fixed.
+  if((${COMPILER} MATCHES "Clang") AND ENABLE_OFFLOAD)
+    option(ENABLE_OFFLOAD_CLANG_DEBUG_O3 "build OMP target kernels with -O3 in the build type Debug" ON)
+  endif()
+  mark_as_advanced(ENABLE_OFFLOAD_CLANG_DEBUG_O3)
 endif()
 
 #-------------------------------------------------------------------------------------
@@ -410,8 +424,23 @@ if(QMC_EXP_THREADING)
   add_definitions(-DQMC_EXP_THREADING)
 endif(QMC_EXP_THREADING)
 
+#--------------------------------------------------------------
+# final test for compile options before searching for libraries
+#--------------------------------------------------------------
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles("int main(){}" TEST_CXX_COMPILE_MAIN)
+if(NOT TEST_CXX_COMPILE_MAIN)
+  unset(TEST_CXX_COMPILE_MAIN CACHE)
+  message(FATAL_ERROR "Failed in compiling a main() function likely due to incorrect compile options. "
+                      "Check error in \"${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/CMakeError.log\".")
+endif()
+
+######################################################################
+# Check external libraries.
+######################################################################
+
 #-------------------------------------------------------------------
-# Check MPI installation. MPI is treated as a part of compiler
+# Check MPI installation. MPI is treated as a library
 #-------------------------------------------------------------------
 if(QMC_MPI)
   # for backward compatibility with MPIEXEC
@@ -489,36 +518,6 @@ else(QMC_MPI)
   set(HAVE_MPI 0)
   message(STATUS "MPI is disabled")
 endif(QMC_MPI)
-
-#--------------------------------------------------------------
-# final test for compile options before searching for libraries
-#--------------------------------------------------------------
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles("int main(){}" TEST_CXX_COMPILE_MAIN)
-if(NOT TEST_CXX_COMPILE_MAIN)
-  unset(TEST_CXX_COMPILE_MAIN CACHE)
-  message(FATAL_ERROR "Failed in compiling a main() function likely due to incorrect compile options. "
-                      "Check error in \"${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/CMakeError.log\".")
-endif()
-
-#--------------------------------------------------------------
-# Workaround for breakage of OMP Target kernels at -O0 by Clang
-#--------------------------------------------------------------
-# When the build type is Debug, default -O0 compilation is broken by
-# Clang 15 as of 5d2ce7663b10c107328a4ae0c678165209e64619.
-# Previous compilers are not suggested for clang offload builds.
-#
-# You can set this option to false on the command line to check
-# if this problem has been fixed.
-
-if((${COMPILER} MATCHES "Clang") AND ENABLE_OFFLOAD)
-  option(ENABLE_OFFLOAD_CLANG_DEBUG_O3 "build OMP target kernels with -O3 in the build type Debug" ON)
-endif()
-mark_as_advanced(ENABLE_OFFLOAD_CLANG_DEBUG_O3)
-
-######################################################################
-# Check external libraries.
-######################################################################
 
 #-------------------------------------------------------------------
 # check OS related libraries

--- a/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
@@ -60,9 +60,8 @@ case "$1" in
 
         LLVM_DIR=$HOME/opt/spack/linux-rhel9-cascadelake/gcc-9.4.0/llvm-16.0.2-ltjkfjdu6p2cfcyw3zalz4x5sz5do3cr
         
-        echo "Set PATHs to cuda 11.2 due to a regression bug in 11.6"
-        export PATH=$HOME/opt/cuda/11.2/bin:$PATH
-        export LD_LIBRARY_PATH=$HOME/opt/cuda/11.2/lib64:$LD_LIBRARY_PATH
+        echo "Set PATHs to cuda-12.1"
+        export PATH=/usr/local/cuda-12.1/bin:$PATH
         export OMPI_CC=$LLVM_DIR/bin/clang
         export OMPI_CXX=$LLVM_DIR/bin/clang++
 
@@ -72,7 +71,7 @@ case "$1" in
         echo "OMPI_CC=$OMPI_CC" >> $GITHUB_ENV
         echo "OMPI_CXX=$OMPI_CXX" >> $GITHUB_ENV
 
-        # Confirm that cuda 11.2 gets picked up by the compiler
+        # Confirm that cuda 12.1 gets picked up by the compiler
         $OMPI_CXX -v
 
         cmake -GNinja \
@@ -97,7 +96,6 @@ case "$1" in
 
         echo "Set PATHs to cuda-12.1"
         export PATH=/usr/local/cuda-12.1/bin:$PATH
-        export LD_LIBRARY_PATH=/usr/local/cuda-12.1/bin:$LD_LIBRARY_PATH
 
         # Make current environment variables available to subsequent steps
         echo "PATH=$PATH" >> $GITHUB_ENV

--- a/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
@@ -60,8 +60,8 @@ case "$1" in
 
         LLVM_DIR=$HOME/opt/spack/linux-rhel9-cascadelake/gcc-9.4.0/llvm-16.0.2-ltjkfjdu6p2cfcyw3zalz4x5sz5do3cr
         
-        echo "Set PATHs to cuda-12.1"
-        export PATH=/usr/local/cuda-12.1/bin:$PATH
+        echo "Set PATHs to cuda-12.3"
+        export PATH=/usr/local/cuda-12.3/bin:$PATH
         export OMPI_CC=$LLVM_DIR/bin/clang
         export OMPI_CXX=$LLVM_DIR/bin/clang++
 
@@ -71,7 +71,7 @@ case "$1" in
         echo "OMPI_CC=$OMPI_CC" >> $GITHUB_ENV
         echo "OMPI_CXX=$OMPI_CXX" >> $GITHUB_ENV
 
-        # Confirm that cuda 12.1 gets picked up by the compiler
+        # Confirm that cuda 12.3 gets picked up by the compiler
         $OMPI_CXX -v
 
         cmake -GNinja \
@@ -91,11 +91,11 @@ case "$1" in
       ;;
 
       *"V100-GCC11-MPI-CUDA"*)
-        echo "Configure for building with CUDA 12.1 and" \
+        echo "Configure for building with CUDA 12.3 and" \
              "GCC11 system compiler" 
 
-        echo "Set PATHs to cuda-12.1"
-        export PATH=/usr/local/cuda-12.1/bin:$PATH
+        echo "Set PATHs to cuda-12.3"
+        export PATH=/usr/local/cuda-12.3/bin:$PATH
 
         # Make current environment variables available to subsequent steps
         echo "PATH=$PATH" >> $GITHUB_ENV

--- a/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
@@ -60,8 +60,8 @@ case "$1" in
 
         LLVM_DIR=$HOME/opt/spack/linux-rhel9-cascadelake/gcc-9.4.0/llvm-16.0.2-ltjkfjdu6p2cfcyw3zalz4x5sz5do3cr
         
-        echo "Set PATHs to cuda-12.3"
-        export PATH=/usr/local/cuda-12.3/bin:$PATH
+        echo "Set PATHs to cuda-12.1"
+        export PATH=/usr/local/cuda-12.1/bin:$PATH
         export OMPI_CC=$LLVM_DIR/bin/clang
         export OMPI_CXX=$LLVM_DIR/bin/clang++
 
@@ -71,7 +71,7 @@ case "$1" in
         echo "OMPI_CC=$OMPI_CC" >> $GITHUB_ENV
         echo "OMPI_CXX=$OMPI_CXX" >> $GITHUB_ENV
 
-        # Confirm that cuda 12.3 gets picked up by the compiler
+        # Confirm that cuda 12.1 gets picked up by the compiler
         $OMPI_CXX -v
 
         cmake -GNinja \
@@ -91,11 +91,11 @@ case "$1" in
       ;;
 
       *"V100-GCC11-MPI-CUDA"*)
-        echo "Configure for building with CUDA 12.3 and" \
+        echo "Configure for building with CUDA 12.1 and" \
              "GCC11 system compiler" 
 
-        echo "Set PATHs to cuda-12.3"
-        export PATH=/usr/local/cuda-12.3/bin:$PATH
+        echo "Set PATHs to cuda-12.1"
+        export PATH=/usr/local/cuda-12.1/bin:$PATH
 
         # Make current environment variables available to subsequent steps
         echo "PATH=$PATH" >> $GITHUB_ENV


### PR DESCRIPTION
## Proposed changes
Usually [findMPI failure](https://github.com/QMCPACK/qmcpack/actions/runs/6856906594/job/18647090392) is caused by compiler failure. Move the compilation ahead of findMPI.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'