### PR TITLE
Adjust sulfur CI for throughput and debuggability

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -17,7 +17,7 @@ jobs:
       GH_JOBNAME: ${{matrix.jobname}}
       GH_OS: Linux
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         jobname: [
             GCC11-NoMPI-MKL-Real-Mixed, # mixed precision
@@ -112,7 +112,7 @@ jobs:
       GH_JOBNAME: ${{matrix.jobname}}
       GH_OS: Linux
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         jobname: [
             V100-Clang16-MPI-CUDA-AFQMC-Offload-Real-Mixed, # auxiliary field, offload

--- a/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-1.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-1.sh
@@ -15,14 +15,14 @@ case "$1" in
 
     QMC_DATA_DIR=/scratch/ci/QMC_DATA_FULL
 
-    if [ -d ${GITHUB_WORKSPACE}/../qmcpack-build ]
+    if [ -d ${GITHUB_WORKSPACE}/../qmcpack-build-1 ]
     then
-      echo "Found existing out-of-source build directory ${GITHUB_WORKSPACE}/../qmcpack-build, removing"
-      rm -fr ${GITHUB_WORKSPACE}/../qmcpack-build
+      echo "Found existing out-of-source build directory ${GITHUB_WORKSPACE}/../qmcpack-build-1, removing"
+      rm -fr ${GITHUB_WORKSPACE}/../qmcpack-build-1
     fi
 
-    echo "Creating new out-of-source build directory ${GITHUB_WORKSPACE}/../qmcpack-build"
-    cd ${GITHUB_WORKSPACE}/.. && mkdir qmcpack-build && cd qmcpack-build
+    echo "Creating new out-of-source build directory ${GITHUB_WORKSPACE}/../qmcpack-build-1"
+    cd ${GITHUB_WORKSPACE}/.. && mkdir qmcpack-build-1 && cd qmcpack-build-1
     
     # Build variants
     # Real or Complex configuration
@@ -68,14 +68,14 @@ case "$1" in
     ;;  
 
   build)
-    cd ${GITHUB_WORKSPACE}/../qmcpack-build
+    cd ${GITHUB_WORKSPACE}/../qmcpack-build-1
     ninja
     ;;
    
   test)
     source /opt/intel/oneapi/setvars.sh
     echo "Running deterministic tests"
-    cd ${GITHUB_WORKSPACE}/../qmcpack-build
+    cd ${GITHUB_WORKSPACE}/../qmcpack-build-1
     ctest --output-on-failure -L deterministic -j 32
     ;;
     

--- a/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
@@ -19,14 +19,14 @@ case "$1" in
     # caused by LLVM + GCC libstdc++ mismatch
     BOOST_DIR=$HOME/opt/spack/linux-rhel9-cascadelake/gcc-9.4.0/boost-1.74.0-gdhlc5uynyw5un6mniss7nfjdyqqjd7p
     
-    if [ -d ${GITHUB_WORKSPACE}/../qmcpack-build ]
+    if [ -d ${GITHUB_WORKSPACE}/../qmcpack-build-2 ]
     then
-      echo "Found existing out-of-source build directory ${GITHUB_WORKSPACE}/../qmcpack-build, removing"
-      rm -fr ${GITHUB_WORKSPACE}/../qmcpack-build
+      echo "Found existing out-of-source build directory ${GITHUB_WORKSPACE}/../qmcpack-build-2, removing"
+      rm -fr ${GITHUB_WORKSPACE}/../qmcpack-build-2
     fi
 
-    echo "Creating new out-of-source build directory ${GITHUB_WORKSPACE}/../qmcpack-build"
-    cd ${GITHUB_WORKSPACE}/.. && mkdir qmcpack-build && cd qmcpack-build
+    echo "Creating new out-of-source build directory ${GITHUB_WORKSPACE}/../qmcpack-build-2"
+    cd ${GITHUB_WORKSPACE}/.. && mkdir qmcpack-build-2 && cd qmcpack-build-2
     
     # Build variants
     # Real or Complex configuration
@@ -120,7 +120,7 @@ case "$1" in
   build)
     # Verify nvcc 
     which nvcc
-    cd ${GITHUB_WORKSPACE}/../qmcpack-build
+    cd ${GITHUB_WORKSPACE}/../qmcpack-build-2
     ninja
     ;;
    
@@ -136,7 +136,7 @@ case "$1" in
     export LIBOMP_USE_HIDDEN_HELPER_TASK=0
 
     echo "Running deterministic tests"
-    cd ${GITHUB_WORKSPACE}/../qmcpack-build
+    cd ${GITHUB_WORKSPACE}/../qmcpack-build-2
     ctest --output-on-failure -E ppconvert -L deterministic -j 32
     ;;
     


### PR DESCRIPTION
## Proposed changes

Use distinct build directories for the 2 classes of sulfur job. Fail fast so failing logs can be retrieved.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None

