### PR TITLE
Raise CMake minimum to 3.21

### DIFF
--- a/CMake/inspectCompiler.cmake
+++ b/CMake/inspectCompiler.cmake
@@ -4,20 +4,6 @@
 # Note: vendor compilers can be just rebranded customized Clang compiler.
 # It requires more recent CMake to handle it properly. We need to handle such cases for older CMake.
 
-execute_process(
-  COMMAND ${CMAKE_CXX_COMPILER} --version
-  RESULT_VARIABLE VERSION_QUERY_RETURN
-  OUTPUT_VARIABLE VERSION_QUERY_OUTPUT)
-
-if(VERSION_QUERY_RETURN EQUAL 0)
-  if(CMAKE_VERSION VERSION_LESS 3.20
-     AND VERSION_QUERY_OUTPUT MATCHES "Intel"
-     AND VERSION_QUERY_OUTPUT MATCHES "oneAPI")
-    # require 3.20 to recognize IntelLLVM compiler ID and check accurate version numbers.
-    message(FATAL_ERROR "Using Intel OneAPI compilers requires CMake 3.20.0 or later.")
-  endif()
-endif()
-
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   set(COMPILER GNU)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "XL")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ######################################################################
 # CMake version and policies
 ######################################################################
-cmake_minimum_required(VERSION 3.17.0)
+cmake_minimum_required(VERSION 3.21.0)
 # Note that cmake_minimum_required affects policy defaults.
 # All policies known to the running version of CMake and introduced in
 # cmake_minimum_required version or earlier will be set to use NEW behavior
@@ -82,14 +82,8 @@ endif(ENABLE_CUDA AND ENABLE_SYCL)
 if(ENABLE_CUDA)
   if(QMC_CUDA2HIP)
     message(STATUS "ENABLE_CUDA enabled, QMC_CUDA2HIP enabled")
-    if(CMAKE_VERSION VERSION_LESS 3.21.0)
-      message(FATAL_ERROR "ENABLE_ROCM or QMC_CUDA2HIP require CMake 3.21.0 or later")
-    endif()
   else(QMC_CUDA2HIP)
     message(STATUS "ENABLE_CUDA enabled, QMC_CUDA2HIP disabled")
-    if(CMAKE_VERSION VERSION_LESS 3.18.0)
-      message(FATAL_ERROR "ENABLE_CUDA require CMake 3.18.0 or later")
-    endif()
   endif()
 else(ENABLE_CUDA)
   if(QMC_CUDA2HIP)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ P. Kent _et al._ J. Chem. Phys. **152** 174105 (2020), https://doi.org/10.1063/5
 # Installation Prerequisites
 
  * C++ 17 and C99 capable compilers. 
- * CMake v3.17.0 or later, build utility, http://www.cmake.org
+ * CMake v3.21.0 or later, build utility, http://www.cmake.org
  * BLAS/LAPACK, numerical library. Use vendor and platform-optimized libraries.
  * LibXml2, XML parser, http://xmlsoft.org/
  * HDF5 v1.10.0 or later, portable I/O library, http://www.hdfgroup.org/HDF5/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -186,7 +186,7 @@ Building with CMake
 The build system for QMCPACK is based on CMake. It will autoconfigure
 based on the detected compilers and libraries. The most recent version
 of CMake has the best detection for the greatest variety of systems. The
-minimum required version of CMake is 3.17.0. Most
+minimum required version of CMake is 3.21.0. Most
 computer installations have a sufficiently recent CMake, though it might
 not be the default.
 


### PR DESCRIPTION
## Proposed changes
3.21 (July 2021) is over 2 years old.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
