### PR TITLE
Refactor SplineSetReader and HybridRepSetReader

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/BsplineReaderBase.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineReaderBase.cpp
@@ -28,29 +28,12 @@
 namespace qmcplusplus
 {
 BsplineReaderBase::BsplineReaderBase(EinsplineSetBuilder* e)
-    : mybuilder(e), MeshSize(0), checkNorm(true), saveSplineCoefs(false), rotate(true)
+    : mybuilder(e), checkNorm(true), saveSplineCoefs(false), rotate(true)
 {
   myComm = mybuilder->getCommunicator();
 }
 
-void BsplineReaderBase::get_psi_g(int ti, int spin, int ib, Vector<std::complex<double>>& cG)
-{
-  int ncg = 0;
-  if (myComm->rank() == 0)
-  {
-    std::string path = psi_g_path(ti, spin, ib);
-    mybuilder->H5File.read(cG, path);
-    ncg = cG.size();
-  }
-  myComm->bcast(ncg);
-  if (ncg != mybuilder->MaxNumGvecs)
-  {
-    APP_ABORT("Failed : ncg != MaxNumGvecs");
-  }
-  myComm->bcast(cG);
-}
-
-BsplineReaderBase::~BsplineReaderBase() {}
+BsplineReaderBase::~BsplineReaderBase() = default;
 
 inline std::string make_bandinfo_filename(const std::string& root,
                                           int spin,
@@ -216,11 +199,11 @@ void BsplineReaderBase::initialize_spo2band(int spin,
     << std::endl;
   for (int i = 0; i < bigspace.size(); ++i)
   {
-    int ti    = bigspace[i].TwistIndex;
-    int bi    = bigspace[i].BandIndex;
-    double e  = bigspace[i].Energy;
-    int nd    = (bigspace[i].MakeTwoCopies) ? 2 : 1;
-    PosType k = mybuilder->PrimCell.k_cart(mybuilder->primcell_kpoints[ti]);
+    int ti     = bigspace[i].TwistIndex;
+    int bi     = bigspace[i].BandIndex;
+    double e   = bigspace[i].Energy;
+    int nd     = (bigspace[i].MakeTwoCopies) ? 2 : 1;
+    PosType k  = mybuilder->PrimCell.k_cart(mybuilder->primcell_kpoints[ti]);
     int s_size = std::snprintf(s.data(), s.size(), "%8d %8d %8d %8d %12.6f %7.4f %7.4f %7.4f %7.4f %7.4f %7.4f %6d\n",
                                i, ns, ti, bi, e, k[0], k[1], k[2], mybuilder->primcell_kpoints[ti][0],
                                mybuilder->primcell_kpoints[ti][1], mybuilder->primcell_kpoints[ti][2], nd);

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
@@ -242,7 +242,7 @@ public:
   }
 
   template<class BSPLINESPO>
-  friend struct SplineSetReader;
+  friend class SplineSetReader;
   friend struct BsplineReaderBase;
 };
 

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
@@ -283,7 +283,7 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   auto OrbitalSet = MixedSplineReader->create_spline_set(spinSet, spo_cur);
   if (!OrbitalSet)
     myComm->barrier_and_abort("Failed to create SPOSet*");
-  app_log() << "Time spent in creating B-spline SPOs " << mytimer.elapsed() << "sec" << std::endl;
+  app_log() << "Time spent in creating B-spline SPOs " << mytimer.elapsed() << " sec" << std::endl;
   OrbitalSet->finalizeConstruction();
   SPOSetMap[aset] = OrbitalSet.get();
   return OrbitalSet;

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
@@ -32,6 +32,7 @@ template<typename SPLINEBASE>
 class HybridRepCplx : public SPLINEBASE, private HybridRepCenterOrbitals<typename SPLINEBASE::DataType>
 {
 public:
+  using SplineBase       = SPLINEBASE;
   using HYBRIDBASE       = HybridRepCenterOrbitals<typename SPLINEBASE::DataType>;
   using ST               = typename SPLINEBASE::DataType;
   using PointType        = typename SPLINEBASE::PointType;
@@ -70,12 +71,6 @@ public:
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<HybridRepCplx>(*this); }
 
-  inline void resizeStorage(size_t n, size_t nvals)
-  {
-    SPLINEBASE::resizeStorage(n, nvals);
-    HYBRIDBASE::resizeStorage(myV.size());
-  }
-
   void bcast_tables(Communicate* comm)
   {
     SPLINEBASE::bcast_tables(comm);
@@ -91,12 +86,6 @@ public:
   bool read_splines(hdf_archive& h5f) { return HYBRIDBASE::read_splines(h5f) && SPLINEBASE::read_splines(h5f); }
 
   bool write_splines(hdf_archive& h5f) { return HYBRIDBASE::write_splines(h5f) && SPLINEBASE::write_splines(h5f); }
-
-  inline void flush_zero()
-  {
-    //SPLINEBASE::flush_zero();
-    HYBRIDBASE::flush_zero();
-  }
 
   void evaluateValue(const ParticleSet& P, const int iat, ValueVector& psi) override
   {

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
@@ -231,7 +231,7 @@ public:
   template<class BSPLINESPO>
   friend class HybridRepSetReader;
   template<class BSPLINESPO>
-  friend struct SplineSetReader;
+  friend class SplineSetReader;
   friend struct BsplineReaderBase;
 };
 

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
@@ -238,7 +238,7 @@ public:
   template<class BSPLINESPO>
   friend class HybridRepSetReader;
   template<class BSPLINESPO>
-  friend struct SplineSetReader;
+  friend class SplineSetReader;
   friend struct BsplineReaderBase;
 };
 

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
@@ -32,6 +32,7 @@ template<typename SPLINEBASE>
 class HybridRepReal : public SPLINEBASE, private HybridRepCenterOrbitals<typename SPLINEBASE::DataType>
 {
 public:
+  using SplineBase       = SPLINEBASE;
   using HYBRIDBASE       = HybridRepCenterOrbitals<typename SPLINEBASE::DataType>;
   using ST               = typename SPLINEBASE::DataType;
   using PointType        = typename SPLINEBASE::PointType;
@@ -72,12 +73,6 @@ public:
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<HybridRepReal>(*this); }
 
-  inline void resizeStorage(size_t n, size_t nvals)
-  {
-    SPLINEBASE::resizeStorage(n, nvals);
-    HYBRIDBASE::resizeStorage(myV.size());
-  }
-
   void bcast_tables(Communicate* comm)
   {
     SPLINEBASE::bcast_tables(comm);
@@ -88,12 +83,6 @@ public:
   {
     SPLINEBASE::gather_tables(comm);
     HYBRIDBASE::gather_atomic_tables(comm, SPLINEBASE::offset);
-  }
-
-  inline void flush_zero()
-  {
-    //SPLINEBASE::flush_zero();
-    HYBRIDBASE::flush_zero();
   }
 
   bool read_splines(hdf_archive& h5f) { return HYBRIDBASE::read_splines(h5f) && SPLINEBASE::read_splines(h5f); }

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.h
@@ -218,7 +218,7 @@ public:
                      GGGVector& grad_grad_grad_psi) override;
 
   template<class BSPLINESPO>
-  friend struct SplineSetReader;
+  friend class SplineSetReader;
   friend struct BsplineReaderBase;
 };
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -305,7 +305,7 @@ public:
                                     ValueMatrix& d2logdet) override;
 
   template<class BSPLINESPO>
-  friend struct SplineSetReader;
+  friend class SplineSetReader;
   friend struct BsplineReaderBase;
 };
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
@@ -206,7 +206,7 @@ public:
                      GGGVector& grad_grad_grad_psi) override;
 
   template<class BSPLINESPO>
-  friend struct SplineSetReader;
+  friend class SplineSetReader;
   friend struct BsplineReaderBase;
 };
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -311,7 +311,7 @@ public:
                                     ValueMatrix& d2logdet) override;
 
   template<class BSPLINESPO>
-  friend struct SplineSetReader;
+  friend class SplineSetReader;
   friend struct BsplineReaderBase;
 };
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
@@ -212,7 +212,7 @@ public:
                      GGGVector& grad_grad_grad_psi) override;
 
   template<class BSPLINESPO>
-  friend struct SplineSetReader;
+  friend class SplineSetReader;
   friend struct BsplineReaderBase;
 };
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.h
@@ -31,28 +31,50 @@
 
 namespace qmcplusplus
 {
-/** General SplineSetReader to handle any unitcell
- */
-template<typename SA>
-struct SplineSetReader : public BsplineReaderBase
+class OneSplineOrbData
 {
-  using splineset_t = SA;
-  using DataType    = typename splineset_t::DataType;
-  using SplineType  = typename splineset_t::SplineType;
-
   Array<std::complex<double>, 3> FFTbox;
   Array<double, 3> splineData_r, splineData_i;
   double rotate_phase_r, rotate_phase_i;
-  UBspline_3d_d* spline_r;
-  UBspline_3d_d* spline_i;
-  splineset_t* bspline;
-  fftw_plan FFTplan;
+  UBspline_3d_d* spline_r = nullptr;
+  UBspline_3d_d* spline_i = nullptr;
+  fftw_plan FFTplan       = nullptr;
 
-  SplineSetReader(EinsplineSetBuilder* e)
-      : BsplineReaderBase(e), spline_r(nullptr), spline_i(nullptr), bspline(nullptr), FFTplan(nullptr)
-  {}
+  const TinyVector<int, 3>& mesh_size_;
+  const bool isComplex_;
 
-  ~SplineSetReader() override { clear(); }
+  void create(const TinyVector<int, 3>& halfG)
+  {
+    const int nx = mesh_size_[0];
+    const int ny = mesh_size_[1];
+    const int nz = mesh_size_[2];
+    //perform FFT using FFTW
+    FFTbox.resize(nx, ny, nz);
+    FFTplan = fftw_plan_dft_3d(nx, ny, nz, reinterpret_cast<fftw_complex*>(FFTbox.data()),
+                               reinterpret_cast<fftw_complex*>(FFTbox.data()), +1, FFTW_ESTIMATE);
+    splineData_r.resize(nx, ny, nz);
+    if (isComplex_)
+      splineData_i.resize(nx, ny, nz);
+
+    TinyVector<double, 3> start(0.0);
+    TinyVector<double, 3> end(1.0);
+    spline_r = einspline::create(spline_r, start, end, mesh_size_, halfG);
+    if (isComplex_)
+      spline_i = einspline::create(spline_i, start, end, mesh_size_, halfG);
+  }
+
+public:
+  OneSplineOrbData(const TinyVector<int, 3>& mesh_size, const TinyVector<int, 3>& halfG, const bool isComplex)
+      : mesh_size_(mesh_size), isComplex_(isComplex)
+  {
+    create(halfG);
+  }
+
+  ~OneSplineOrbData() { clear(); }
+
+  auto getRotatePhase() const { return std::complex<double>(rotate_phase_r, rotate_phase_i); }
+  auto& get_spline_r() { return *spline_r; }
+  auto& get_spline_i() { return *spline_i; }
 
   void clear()
   {
@@ -63,131 +85,6 @@ struct SplineSetReader : public BsplineReaderBase
     FFTplan = nullptr;
   }
 
-  // set info for Hybrid
-  virtual void initialize_hybridrep_atomic_centers() {}
-  // transform cG to radial functions
-  virtual void create_atomic_centers_Gspace(Vector<std::complex<double>>& cG, Communicate& band_group_comm, int iorb) {}
-
-  std::unique_ptr<SPOSet> create_spline_set(const std::string& my_name,
-                                            int spin,
-                                            const BandInfoGroup& bandgroup) override
-  {
-    ReportEngine PRE("SplineSetReader", "create_spline_set(spin,SPE*)");
-    //Timer c_prep, c_unpack,c_fft, c_phase, c_spline, c_newphase, c_h5, c_init;
-    //double t_prep=0.0, t_unpack=0.0, t_fft=0.0, t_phase=0.0, t_spline=0.0, t_newphase=0.0, t_h5=0.0, t_init=0.0;
-    bspline = new splineset_t(my_name);
-    app_log() << "  ClassName = " << bspline->getClassName() << std::endl;
-    if (bspline->isComplex())
-      app_log() << "  Using complex einspline table" << std::endl;
-    else
-      app_log() << "  Using real einspline table" << std::endl;
-
-    // set info for Hybrid
-    this->initialize_hybridrep_atomic_centers();
-
-    //baseclass handles twists
-    check_twists(bspline, bandgroup);
-
-    Ugrid xyz_grid[3];
-
-    typename splineset_t::BCType xyz_bc[3];
-    bool havePsig = set_grid(bspline->HalfG, xyz_grid, xyz_bc);
-    if (!havePsig)
-      myComm->barrier_and_abort("SplineSetReader needs psi_g. Set precision=\"double\".");
-    bspline->create_spline(xyz_grid, xyz_bc);
-
-    std::ostringstream oo;
-    oo << bandgroup.myName << ".g" << MeshSize[0] << "x" << MeshSize[1] << "x" << MeshSize[2] << ".h5";
-
-    const std::string splinefile(oo.str());
-    bool root       = (myComm->rank() == 0);
-    int foundspline = 0;
-    Timer now;
-    if (root)
-    {
-      now.restart();
-      hdf_archive h5f(myComm);
-      foundspline = h5f.open(splinefile, H5F_ACC_RDONLY);
-      if (foundspline)
-      {
-        std::string aname("none");
-        foundspline = h5f.readEntry(aname, "class_name");
-        foundspline = (aname.find(bspline->getKeyword()) != std::string::npos);
-      }
-      if (foundspline)
-      {
-        int sizeD   = 0;
-        foundspline = h5f.readEntry(sizeD, "sizeof");
-        foundspline = (sizeD == sizeof(typename splineset_t::DataType));
-      }
-      if (foundspline)
-      {
-        foundspline = bspline->read_splines(h5f);
-        if (foundspline)
-          app_log() << "  Successfully restored coefficients from " << splinefile << ". The reading time is "
-                    << now.elapsed() << " sec." << std::endl;
-      }
-      h5f.close();
-    }
-    myComm->bcast(foundspline);
-    if (foundspline)
-    {
-      now.restart();
-      bspline->bcast_tables(myComm);
-      app_log() << "  SplineSetReader bcast the full table " << now.elapsed() << " sec." << std::endl;
-      app_log().flush();
-    }
-    else
-    {
-      bspline->flush_zero();
-
-      int nx = MeshSize[0];
-      int ny = MeshSize[1];
-      int nz = MeshSize[2];
-      if (havePsig) //perform FFT using FFTW
-      {
-        FFTbox.resize(nx, ny, nz);
-        FFTplan = fftw_plan_dft_3d(nx, ny, nz, reinterpret_cast<fftw_complex*>(FFTbox.data()),
-                                   reinterpret_cast<fftw_complex*>(FFTbox.data()), +1, FFTW_ESTIMATE);
-        splineData_r.resize(nx, ny, nz);
-        if (bspline->isComplex())
-          splineData_i.resize(nx, ny, nz);
-
-        TinyVector<double, 3> start(0.0);
-        TinyVector<double, 3> end(1.0);
-        spline_r = einspline::create(spline_r, start, end, MeshSize, bspline->HalfG);
-        if (bspline->isComplex())
-          spline_i = einspline::create(spline_i, start, end, MeshSize, bspline->HalfG);
-
-        now.restart();
-        initialize_spline_pio_gather(spin, bandgroup);
-        app_log() << "  SplineSetReader initialize_spline_pio " << now.elapsed() << " sec" << std::endl;
-
-        fftw_destroy_plan(FFTplan);
-        FFTplan = NULL;
-      }
-      else //why, don't know
-        initialize_spline_psi_r(spin, bandgroup);
-      if (saveSplineCoefs && root)
-      {
-        now.restart();
-        hdf_archive h5f;
-        h5f.create(splinefile);
-        std::string classname = bspline->getClassName();
-        h5f.write(classname, "class_name");
-        int sizeD = sizeof(typename splineset_t::DataType);
-        h5f.write(sizeD, "sizeof");
-        bspline->write_splines(h5f);
-        h5f.close();
-        app_log() << "  Stored spline coefficients in " << splinefile << " for potential reuse. The writing time is "
-                  << now.elapsed() << " sec." << std::endl;
-      }
-    }
-
-    clear();
-    return std::unique_ptr<SPOSet>{bspline};
-  }
-
   /** fft and spline cG
    * @param cG psi_g to be processed
    * @param ti twist index
@@ -195,15 +92,17 @@ struct SplineSetReader : public BsplineReaderBase
    *
    * Perform FFT and spline to spline_r and spline_i
    */
-  inline void fft_spline(Vector<std::complex<double>>& cG, int ti)
+  void fft_spline(const Vector<std::complex<double>>& cG,
+                  const std::vector<TinyVector<int, 3>>& gvecs,
+                  const TinyVector<double, 3>& primcell_kpoint,
+                  const bool rotate)
   {
-    unpack4fftw(cG, mybuilder->Gvecs[0], MeshSize, FFTbox);
+    unpack4fftw(cG, gvecs, mesh_size_, FFTbox);
     fftw_execute(FFTplan);
-    if (bspline->isComplex())
+    if (isComplex_)
     {
       if (rotate)
-        fix_phase_rotate_c2c(FFTbox, splineData_r, splineData_i, mybuilder->primcell_kpoints[ti], rotate_phase_r,
-                             rotate_phase_i);
+        fix_phase_rotate_c2c(FFTbox, splineData_r, splineData_i, primcell_kpoint, rotate_phase_r, rotate_phase_i);
       else
       {
         split_real_components_c2c(FFTbox, splineData_r, splineData_i);
@@ -215,15 +114,146 @@ struct SplineSetReader : public BsplineReaderBase
     }
     else
     {
-      fix_phase_rotate_c2r(FFTbox, splineData_r, mybuilder->primcell_kpoints[ti], rotate_phase_r, rotate_phase_i);
+      fix_phase_rotate_c2r(FFTbox, splineData_r, primcell_kpoint, rotate_phase_r, rotate_phase_i);
       einspline::set(spline_r, splineData_r.data());
     }
   }
+};
 
+/** General SplineSetReader to handle any unitcell
+ */
+template<typename SA>
+class SplineSetReader : public BsplineReaderBase
+{
+public:
+  using DataType   = typename SA::DataType;
+  using SplineType = typename SA::SplineType;
+
+  SplineSetReader(EinsplineSetBuilder* e) : BsplineReaderBase(e) {}
+
+  std::unique_ptr<SPOSet> create_spline_set(const std::string& my_name,
+                                            int spin,
+                                            const BandInfoGroup& bandgroup) override
+  {
+    auto bspline = std::make_unique<SA>(my_name);
+    app_log() << "  ClassName = " << bspline->getClassName() << std::endl;
+    bool foundspline = fill_spline_set(*bspline, spin, bandgroup);
+    if (foundspline)
+    {
+      Timer now;
+      hdf_archive h5f(myComm);
+      const auto splinefile = getSplineDumpFileName(bandgroup);
+      h5f.open(splinefile, H5F_ACC_RDONLY);
+      foundspline = bspline->read_splines(h5f);
+      if (foundspline)
+        app_log() << "  Successfully restored 3D B-spline coefficients from " << splinefile << ". The reading time is "
+                  << now.elapsed() << " sec." << std::endl;
+    }
+
+    if (!foundspline)
+    {
+      bspline->flush_zero();
+
+      Timer now;
+      initialize_spline_pio_gather(spin, bandgroup, *bspline);
+      app_log() << "  SplineSetReader initialize_spline_pio " << now.elapsed() << " sec" << std::endl;
+
+      if (saveSplineCoefs && myComm->rank() == 0)
+      {
+        Timer now;
+        const std::string splinefile(getSplineDumpFileName(bandgroup));
+        hdf_archive h5f;
+        h5f.create(splinefile);
+        std::string classname = bspline->getClassName();
+        h5f.write(classname, "class_name");
+        int sizeD = sizeof(DataType);
+        h5f.write(sizeD, "sizeof");
+        bspline->write_splines(h5f);
+        h5f.close();
+        app_log() << "  Stored spline coefficients in " << splinefile << " for potential reuse. The writing time is "
+                  << now.elapsed() << " sec." << std::endl;
+      }
+    }
+
+    {
+      Timer now;
+      bspline->bcast_tables(myComm);
+      app_log() << "  Time to bcast the table = " << now.elapsed() << std::endl;
+    }
+
+    return bspline;
+  }
+
+  bool fill_spline_set(SA& bspline, int spin, const BandInfoGroup& bandgroup) const
+  {
+    ReportEngine PRE("SplineSetReader", "create_spline_set(spin,SPE*)");
+    //Timer c_prep, c_unpack,c_fft, c_phase, c_spline, c_newphase, c_h5, c_init;
+    //double t_prep=0.0, t_unpack=0.0, t_fft=0.0, t_phase=0.0, t_spline=0.0, t_newphase=0.0, t_h5=0.0, t_init=0.0;
+    if (bspline.isComplex())
+      app_log() << "  Using complex einspline table" << std::endl;
+    else
+      app_log() << "  Using real einspline table" << std::endl;
+
+    //baseclass handles twists
+    check_twists(bspline, bandgroup);
+
+    Ugrid xyz_grid[3];
+
+    typename SA::BCType xyz_bc[3];
+    bool havePsig = set_grid(bspline.HalfG, xyz_grid, xyz_bc);
+    if (!havePsig)
+      myComm->barrier_and_abort("SplineSetReader needs psi_g. Set precision=\"double\".");
+    bspline.create_spline(xyz_grid, xyz_bc);
+
+    int foundspline = 0;
+    Timer now;
+    if (myComm->rank() == 0)
+    {
+      now.restart();
+      hdf_archive h5f(myComm);
+      foundspline = h5f.open(getSplineDumpFileName(bandgroup), H5F_ACC_RDONLY);
+      if (foundspline)
+      {
+        std::string aname("none");
+        foundspline = h5f.readEntry(aname, "class_name");
+        foundspline = (aname.find(bspline.getKeyword()) != std::string::npos);
+      }
+      if (foundspline)
+      {
+        int sizeD   = 0;
+        foundspline = h5f.readEntry(sizeD, "sizeof");
+        foundspline = (sizeD == sizeof(DataType));
+      }
+      h5f.close();
+    }
+    myComm->bcast(foundspline);
+    return foundspline;
+  }
+
+  void readOneOrbitalCoefs(const std::string& s, hdf_archive& h5f, Vector<std::complex<double>>& cG) const
+  {
+    if (!h5f.readEntry(cG, s))
+    {
+      std::ostringstream msg;
+      msg << "SplineSetReader Failed to read band(s) from h5 file. " << "Attempted dataset " << s << " with "
+          << cG.size() << " complex numbers." << std::endl;
+      throw std::runtime_error(msg.str());
+    }
+    double total_norm = compute_norm(cG);
+    if ((checkNorm) && (std::abs(total_norm - 1.0) > PW_COEFF_NORM_TOLERANCE))
+    {
+      std::ostringstream msg;
+      msg << "SplineSetReader The orbital dataset " << s << " has a wrong norm " << total_norm
+          << ", computed from plane wave coefficients!" << std::endl
+          << "This may indicate a problem with the HDF5 library versions used "
+          << "during wavefunction conversion or read." << std::endl;
+      throw std::runtime_error(msg.str());
+    }
+  }
 
   /** initialize the splines
    */
-  void initialize_spline_pio_gather(int spin, const BandInfoGroup& bandgroup)
+  void initialize_spline_pio_gather(const int spin, const BandInfoGroup& bandgroup, SA& bspline) const
   {
     //distribute bands over processor groups
     int Nbands            = bandgroup.getNumDistinctOrbitals();
@@ -236,58 +266,28 @@ struct SplineSetReader : public BsplineReaderBase
     int iorb_last  = band_groups[band_group_comm.getGroupID() + 1];
 
     app_log() << "Start transforming plane waves to 3D B-Splines." << std::endl;
+    OneSplineOrbData oneband(mybuilder->MeshSize, bspline.HalfG, bspline.isComplex());
     hdf_archive h5f(&band_group_comm, false);
     Vector<std::complex<double>> cG(mybuilder->Gvecs[0].size());
     const std::vector<BandInfo>& cur_bands = bandgroup.myBands;
     if (band_group_comm.isGroupLeader())
+    {
       h5f.open(mybuilder->H5FileName, H5F_ACC_RDONLY);
-    for (int iorb = iorb_first; iorb < iorb_last; iorb++)
-    {
-      if (band_group_comm.isGroupLeader())
+      for (int iorb = iorb_first; iorb < iorb_last; iorb++)
       {
-        int iorb_h5   = bspline->BandIndexMap[iorb];
-        int ti        = cur_bands[iorb_h5].TwistIndex;
-        std::string s = psi_g_path(ti, spin, cur_bands[iorb_h5].BandIndex);
-        if (!h5f.readEntry(cG, s))
-        {
-          std::ostringstream msg;
-          msg << "SplineSetReader Failed to read band(s) from h5 file. "
-              << "Attempted dataset " << s << " with " << cG.size() << " complex numbers." << std::endl;
-          throw std::runtime_error(msg.str());
-        }
-        double total_norm = compute_norm(cG);
-        if ((checkNorm) && (std::abs(total_norm - 1.0) > PW_COEFF_NORM_TOLERANCE))
-        {
-          std::ostringstream msg;
-          msg << "SplineSetReader The orbital " << iorb_h5 << " has a wrong norm " << total_norm
-              << ", computed from plane wave coefficients!" << std::endl
-              << "This may indicate a problem with the HDF5 library versions used "
-              << "during wavefunction conversion or read." << std::endl;
-          throw std::runtime_error(msg.str());
-        }
-        fft_spline(cG, ti);
-        bspline->set_spline(spline_r, spline_i, cur_bands[iorb_h5].TwistIndex, iorb, 0);
+        const auto& cur_band = cur_bands[bspline.BandIndexMap[iorb]];
+        const int ti         = cur_band.TwistIndex;
+        readOneOrbitalCoefs(psi_g_path(ti, spin, cur_band.BandIndex), h5f, cG);
+        oneband.fft_spline(cG, mybuilder->Gvecs[0], mybuilder->primcell_kpoints[ti], rotate);
+        bspline.set_spline(&oneband.get_spline_r(), &oneband.get_spline_i(), cur_band.TwistIndex, iorb, 0);
       }
-      this->create_atomic_centers_Gspace(cG, band_group_comm, iorb);
+      band_group_comm.getGroupLeaderComm()->barrier();
+      {
+        Timer now;
+        bspline.gather_tables(band_group_comm.getGroupLeaderComm());
+        app_log() << "  Time to gather the table = " << now.elapsed() << std::endl;
+      }
     }
-
-    myComm->barrier();
-    Timer now;
-    if (band_group_comm.isGroupLeader())
-    {
-      now.restart();
-      bspline->gather_tables(band_group_comm.getGroupLeaderComm());
-      app_log() << "  Time to gather the table = " << now.elapsed() << std::endl;
-    }
-    now.restart();
-    bspline->bcast_tables(myComm);
-    app_log() << "  Time to bcast the table = " << now.elapsed() << std::endl;
-  }
-
-  void initialize_spline_psi_r(int spin, const BandInfoGroup& bandgroup)
-  {
-    // old implementation buried in the history
-    myComm->barrier_and_abort("SplineSetReaderP initialize_spline_psi_r implementation not finished.");
   }
 };
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes
Avoid multi level inheritance.  SplineSetReader is no more a base of HybridRepSetReader.
Make most functions const and kill as much state machines as possible.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'