### PR TITLE
Make InputSection full precision only.

### DIFF
--- a/src/Estimators/InputSection.cpp
+++ b/src/Estimators/InputSection.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2022 QMCPACK developers.
+// Copyright (c) 2023 QMCPACK developers.
 //
 // File developed by: Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
 //                    Peter W. Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
@@ -49,7 +49,6 @@ void InputSection::readAttributes(xmlNodePtr cur,
       setFromStreamCustom(element_name, qualified_name, stream);
     else
       setFromStream(qualified_name, stream);
-
     att = att->next;
   }
 }
@@ -65,6 +64,7 @@ void InputSection::handleDelegate(const std::string& ename, const xmlNodePtr ele
 
 void InputSection::readXML(xmlNodePtr cur)
 {
+  assert(cur != nullptr);
   // For historical reasons that actual "type" of the element/input section is expressed in a very inconsistent way.
   // It could be coded via the element name i.e. the tag, or at minimum a method, type, or name attribute.
   std::string section_ename{lowerCase(castXMLCharToChar(cur->name))};
@@ -200,7 +200,7 @@ void InputSection::setFromStream(const std::string& name, std::istringstream& sv
   else if (isMultiReal(name))
   {
     std::vector<Real> real_values;
-    for (FullPrecReal value; svalue >> value;)
+    for (Real value; svalue >> value;)
       real_values.push_back(static_cast<Real>(value));
     assignValue(name, real_values);
   }
@@ -219,7 +219,7 @@ void InputSection::setFromStream(const std::string& name, std::istringstream& sv
   }
   else if (isReal(name))
   {
-    FullPrecReal value;
+    Real value;
     svalue >> value;
     assignValue(name, Real(value));
   }
@@ -249,7 +249,7 @@ void InputSection::assignValue(const std::string& name, const T& value)
   else
   {
     if (has(name))
-      std::any_cast<std::vector<T>>(values_[name]).push_back(value);
+      std::any_cast<std::vector<T>&>(values_[name]).push_back(value);
     else
       values_[name] = std::vector<T>{value};
   }
@@ -316,6 +316,12 @@ void InputSection::report(std::ostream& out) const
       out << std::any_cast<Real>(value);
   }
   out << "\n\n";
+}
+
+void InputSection::report() const
+{
+  auto& out = app_log();
+  report(out);
 }
 
 std::any InputSection::lookupAnyEnum(const std::string& enum_name,

--- a/src/Estimators/InputSection.h
+++ b/src/Estimators/InputSection.h
@@ -28,16 +28,22 @@
 namespace qmcplusplus
 {
 
+  /** Input section provides basic parsing and a uniform method of access to the raw parsed input.
+   *  It is still expected to be a composed part of the actual input class for a simulation class.
+   *  It does not operate at reduced precision, i.e. numerical input is always parsed and retrieved
+   *  at full precision. Gettting values from input section is strongly typed so you will get errors
+   *  if you try to get numeric types at reduced precision.
+   */
 class InputSection
 {
 public:
-  using FullPrecReal = QMCTraits::FullPrecRealType;
-  using Real         = QMCTraits::RealType;
-  using Position     = QMCTraits::PosType;
+  using Real         = QMCTraits::FullPrecRealType;
+  using Position     = typename QMCTypes<Real,OHMMS_DIM>::PosType;
 
   InputSection()                          = default;
   InputSection(const InputSection& other) = default;
-
+  InputSection& operator=(const InputSection& other) = default;
+  
 protected:
   // Internal data below comprise the input specification.
   //   Most apply attributes to input variables.
@@ -233,11 +239,11 @@ protected:
   static std::any lookupAnyEnum(const std::string& enum_name,
                                 const std::string& enum_value,
                                 const std::unordered_map<std::string, std::any>& enum_map);
-
 protected:
   // Simple dump of contents. Useful for developing and as
   // debugging function useful when input sections local error reports
   // may be insufficient.
+  void report() const;
   void report(std::ostream& out) const;
 
 private:

--- a/src/Estimators/MagnetizationDensityInput.cpp
+++ b/src/Estimators/MagnetizationDensityInput.cpp
@@ -17,6 +17,10 @@
 #include "EstimatorInput.h"
 namespace qmcplusplus
 {
+template bool InputSection::setIfInInput<qmcplusplus::MagnetizationDensityInput::Integrator>(
+    qmcplusplus::MagnetizationDensityInput::Integrator& var,
+    const std::string& tag);
+
 MagnetizationDensityInput::MagnetizationDensityInput(xmlNodePtr cur)
 {
   input_section_.readXML(cur);

--- a/src/Estimators/MagnetizationDensityInput.h
+++ b/src/Estimators/MagnetizationDensityInput.h
@@ -35,10 +35,10 @@ public:
       lookup_input_enum_value{{"integrator-simpsons", Integrator::SIMPSONS},
                               {"integrator-montecarlo", Integrator::MONTECARLO}};
   // clang-format on
-  using Real               = QMCTraits::RealType;
+  using Real               = QMCTraits::FullPrecRealType;
   using POLT               = PtclOnLatticeTraits;
   using Lattice            = POLT::ParticleLayout;
-  using PosType            = QMCTraits::PosType;
+  using PosType            = TinyVector<Real, OHMMS_DIM>;
   using Consumer           = MagnetizationDensity;
   static constexpr int DIM = QMCTraits::DIM;
 

--- a/src/Estimators/MomentumDistribution.cpp
+++ b/src/Estimators/MomentumDistribution.cpp
@@ -43,7 +43,8 @@ MomentumDistribution::MomentumDistribution(MomentumDistributionInput&& mdi,
   for (int i = 0; i < OHMMS_DIM; i++)
     vec_length[i] = 2.0 * M_PI * std::sqrt(dot(Lattice.Gv[i], Lattice.Gv[i]));
   RealType kmax      = input_.get_kmax();
-  PosType kmaxs      = {input_.get_kmax0(), input_.get_kmax1(), input_.get_kmax2()};
+  auto realCast      = [](auto& real) { return static_cast<RealType>(real); };
+  PosType kmaxs      = {realCast(input_.get_kmax0()), realCast(input_.get_kmax1()), realCast(input_.get_kmax2())};
   RealType sum_kmaxs = kmaxs[0] + kmaxs[1] + kmaxs[2];
   RealType sphere_kmax;
   bool sphere      = input_.get_kmax() > 0.0 ? true : false;

--- a/src/Estimators/MomentumDistributionInput.h
+++ b/src/Estimators/MomentumDistributionInput.h
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2021 QMCPACK developers.
+// Copyright (c) 2023 QMCPACK developers.
 //
 // File developed by: Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
 //
@@ -24,7 +24,7 @@ class MomentumDistributionInput
 {
 public:
   using Consumer = MomentumDistribution;
-  using Real = QMCTraits::RealType;
+  using Real = QMCTraits::FullPrecRealType;
 
   class MomentumDistributionInputSection : public InputSection
   {

--- a/src/Estimators/OneBodyDensityMatricesInput.cpp
+++ b/src/Estimators/OneBodyDensityMatricesInput.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2021 QMCPACK developers.
+// Copyright (c) 2023 QMCPACK developers.
 //
 // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
@@ -16,6 +16,9 @@
 namespace qmcplusplus
 {
 
+template bool InputSection::setIfInInput<qmcplusplus::OneBodyDensityMatricesInput::Integrator>(qmcplusplus::OneBodyDensityMatricesInput::Integrator& var, const std::string& tag);
+
+  
 OneBodyDensityMatricesInput::OneBodyDensityMatricesInput(xmlNodePtr cur)
 {
   // This results in checkParticularValidity being called on OneBodyDensityMatrixInputSection

--- a/src/Estimators/OneBodyDensityMatricesInput.h
+++ b/src/Estimators/OneBodyDensityMatricesInput.h
@@ -94,8 +94,8 @@ public:
     std::any assignAnyEnum(const std::string& name) const override;
   };
 
-  using Position = QMCTraits::PosType;
-  using Real     = QMCTraits::RealType;
+  using Real     = QMCTraits::FullPrecRealType;
+  using Position = TinyVector<Real, OHMMS_DIM>;
 
   /** default copy constructor
    *  This is required due to OBDMI being part of a variant used as a vector element.

--- a/src/Estimators/ReferencePointsInput.cpp
+++ b/src/Estimators/ReferencePointsInput.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2022 QMCPACK developers.
+// Copyright (c) 2023 QMCPACK developers.
 //
 // File developed by: Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
 //                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
@@ -20,6 +20,8 @@
 
 namespace qmcplusplus
 {
+template bool InputSection::setIfInInput<ReferencePointsInput::Coord>(ReferencePointsInput::Coord& var,
+                                                                      const std::string& tag);
 
 ReferencePointsInput::ReferencePointsInput(xmlNodePtr cur)
 {

--- a/src/Estimators/tests/test_InputSection.cpp
+++ b/src/Estimators/tests/test_InputSection.cpp
@@ -25,7 +25,8 @@
 
 namespace qmcplusplus
 {
-using Real = QMCTraits::RealType;
+// Take note that all input is done at full precision.
+using Real = QMCTraits::FullPrecRealType;
 
 enum class TestEnum1
 {
@@ -51,11 +52,11 @@ public:
   TestInputSection()
   {
     section_name   = "Test";
-    attributes     = {"name", "samples", "kmax", "full","width::type"};
+    attributes     = {"name", "samples", "kmax", "full", "width::type"};
     parameters     = {"label",     "count",   "width",  "rational", "testenum1",
                       "testenum2", "sposets", "center", "density",  "target"};
     required       = {"count", "full"};
-    strings        = {"name", "label","width::type"};
+    strings        = {"name", "label", "width::type"};
     multi_strings  = {"sposets"};
     multi_reals    = {"density"};
     multiple       = {"target"};
@@ -227,28 +228,27 @@ TEST_CASE("InputSection::readXML", "[estimators]")
     //     required attribute/parameter is missing
     //     unrecognized attribute/parameter encountered
 
-    std::unordered_map<std::string, const char*> invalid_inputs = {
-        {"missing_attribute", R"(
+    std::unordered_map<std::string, const char*> invalid_inputs =
+        {{"missing_attribute", R"(
 <test>
   <parameter name="count"> 15 </parameter>
 </test>
 )"},
-        {"missing_parameter", R"(
+         {"missing_parameter", R"(
 <test full="no"/>
 )"},
-        {"foreign_attribute", R"(
+         {"foreign_attribute", R"(
 <test full="no" area="51">
   <parameter name="count"> 15 </parameter>
 </test>
 )"},
-        {"foreign_parameter", R"(
+         {"foreign_parameter", R"(
 <test full="no">
   <parameter name="count"> 15 </parameter>
   <parameter name="area" > 51 </parameter>
 </test>
 )"},
-	{"invalid_section_name", R"(<not_test><parameter name="nothing"></parameter></not_test>)"}
-    };
+         {"invalid_section_name", R"(<not_test><parameter name="nothing"></parameter></not_test>)"}};
 
     for (auto& [label, xml] : invalid_inputs)
     {
@@ -430,9 +430,6 @@ public:
     {
       std::string cus_at;
       std::getline(svalue, cus_at);
-      // if (ename != section_name)
-      // 	values_[ename + " " + name] = cus_at;
-      // else
       values_[name] = cus_at;
     }
     else
@@ -490,7 +487,6 @@ TEST_CASE("InputSection::custom", "[estimators]")
   CHECK(ws.numbers == exp_numbers);
 
   cti.report(std::cout);
-
   std::string custom_attribute = cti.get<std::string>("with_custom::custom_attribute");
   CHECK(custom_attribute == "This is a custom attribute.");
   custom_attribute = cti.get<std::string>("custom_attribute");
@@ -520,10 +516,10 @@ public:
   public:
     AnotherInputSection()
     {
-      section_name = "AnotherInput";
+      section_name            = "AnotherInput";
       section_name_alternates = {"ainput"};
-      attributes   = {"name", "optional"};
-      strings      = {"name", "optional"};
+      attributes              = {"name", "optional"};
+      strings                 = {"name", "optional"};
     }
   };
 


### PR DESCRIPTION
## Proposed changes

Input section should always read input at full precision and if a particular object wants to operate at lower precision that object needs to handle the narrowing cast.

In general we should avoid reduced precision unless analysis proves that there will be a significant gain in scientific capability from maintaining mixed precision code.

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
x86 V100 cloud instance.

## Checklist

- Yes  This PR is up to date with current the current state of 'develop'
- Yes  Code added or changed in the PR has been clang-formatted
- Yes  This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes  Documentation has been added (if appropriate)
