### PR TITLE
Expansion of ModernStringUtils with modern string2Int

### DIFF
--- a/src/Utilities/for_testing/NativeInitializerPrint.hpp
+++ b/src/Utilities/for_testing/NativeInitializerPrint.hpp
@@ -20,7 +20,10 @@
 #ifndef QMCPLUSPLUS_NATIVE_INTITIALIZER_PRINT_HPP
 #define QMCPLUSPLUS_NATIVE_INTITIALIZER_PRINT_HPP
 
+#include <string>
 #include <iostream>
+#include "OhmmsPETE/TinyVector.h"
+#include "OhmmsPETE/OhmmsVector.h"
 
 namespace qmcplusplus
 {

--- a/src/Utilities/tests/test_ModernStringUtils.cpp
+++ b/src/Utilities/tests/test_ModernStringUtils.cpp
@@ -11,6 +11,7 @@
 
 #include "catch.hpp"
 #include "ModernStringUtils.hpp"
+#include <limits>
 
 /** \file
  */
@@ -86,6 +87,24 @@ TEST_CASE("ModernStringUtils_string2Real", "[utilities]")
   CHECK(value == Approx(101.52326626));
 } // namespace qmcplusplus
 
+TEST_CASE("ModernStringUtils_string2Int", "[utilities]")
+{
+  std::string_view svalue{"1003"};
+  auto value = string2Int<int>(svalue);
+  CHECK(value == 1003);
+  long too_large_for_int = std::numeric_limits<int>::max();
+  too_large_for_int += 2;
+  std::ostringstream input;
+  input << too_large_for_int;
+//Safety pre stdlibcxx 10 doesn't seem worth the effort
+#if _GLIBCXX_RELEASE > 10
+  CHECK_THROWS_AS(string2Int<int>(input.str()),std::range_error);
+#endif
+  long big_enough = string2Int<decltype(big_enough)>(input.str());
+  CHECK(big_enough == too_large_for_int);
+} // namespace qmcplusplus
+
+  
 TEST_CASE("ModernStringUtils_strip", "[utilities]")
 {
   using modernstrutil::strip;


### PR DESCRIPTION
## Proposed changes

string2Int implementation used to parse int grid input in future PR for energy density estimator.
for stringview and using std::from_chars with modern stdlibc++
libc++ and older stdlibc++ revert to atoi.

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- Yes
- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
