### PR TITLE
[WIP] ReferencePoints report -0.0 is equivalent to 0.0 output either as 0.

### DIFF
--- a/src/Containers/OhmmsPETE/TinyVector.h
+++ b/src/Containers/OhmmsPETE/TinyVector.h
@@ -41,6 +41,7 @@
 #include <cmath>
 #include "PETE/PETE.h"
 #include "OhmmsPETE/OhmmsTinyMeta.h"
+#include "type_traits/complex_help.hpp"
 
 namespace qmcplusplus
 {
@@ -221,6 +222,8 @@ struct printTinyVector
 
 /** template functor for Vector<TinyVector<T,D> streamn output
  *  0 equivalent values are output as 0.
+ *  In the case of complex or integer type T's this can be added if needed.
+ *  But now you don't pay for this if unless T is actually real.
  */
 template<class T, unsigned D>
 struct printTinyVector<TinyVector<T, D>>
@@ -228,10 +231,15 @@ struct printTinyVector<TinyVector<T, D>>
   inline static void print(std::ostream& os, const TinyVector<T, D>& r)
   {
     for (int d = 0; d < D; d++)
-      if (FP_ZERO == std::fpclassify(r[d]))
-        os << std::setw(18) << std::setprecision(10) << 0;
+      if constexpr(IsComplex_t<T>::value)
+	os << std::setw(18) << std::setprecision(10) << r[d];
+      else if constexpr(IsReal_t<T>::value)
+	if (FP_ZERO == std::fpclassify(r[d]))
+	  os << std::setw(18) << std::setprecision(10) << 0;
+	else
+	  os << std::setw(18) << std::setprecision(10) << r[d];
       else
-        os << std::setw(18) << std::setprecision(10) << r[d];
+	os << r[d];
   }
 };
 

--- a/src/Containers/OhmmsPETE/TinyVector.h
+++ b/src/Containers/OhmmsPETE/TinyVector.h
@@ -219,7 +219,9 @@ template<class T>
 struct printTinyVector
 {};
 
-// specialized for Vector<TinyVector<T,D> >
+/** template functor for Vector<TinyVector<T,D> streamn output
+ *  0 equivalent values are output as 0.
+ */
 template<class T, unsigned D>
 struct printTinyVector<TinyVector<T, D>>
 {

--- a/src/Containers/OhmmsPETE/TinyVector.h
+++ b/src/Containers/OhmmsPETE/TinyVector.h
@@ -38,6 +38,7 @@
 
 // include files
 #include <iomanip>
+#include <cmath>
 #include "PETE/PETE.h"
 #include "OhmmsPETE/OhmmsTinyMeta.h"
 
@@ -225,7 +226,10 @@ struct printTinyVector<TinyVector<T, D>>
   inline static void print(std::ostream& os, const TinyVector<T, D>& r)
   {
     for (int d = 0; d < D; d++)
-      os << std::setw(18) << std::setprecision(10) << r[d];
+      if (FP_ZERO == std::fpclassify(r[d]))
+	os << std::setw(18) << std::setprecision(10) << 0;
+      else
+	os << std::setw(18) << std::setprecision(10) << r[d];
   }
 };
 

--- a/src/Containers/OhmmsPETE/TinyVector.h
+++ b/src/Containers/OhmmsPETE/TinyVector.h
@@ -114,7 +114,7 @@ struct TinyVector
   inline int size() const { return D; }
 
   inline TinyVector& operator=(const TinyVector& rhs) = default;
-  inline TinyVector& operator=(TinyVector&& rhs)      = default;
+  inline TinyVector& operator=(TinyVector&& rhs) = default;
 
   template<class T1>
   inline TinyVector<T, D>& operator=(const TinyVector<T1, D>& rhs)
@@ -229,9 +229,9 @@ struct printTinyVector<TinyVector<T, D>>
   {
     for (int d = 0; d < D; d++)
       if (FP_ZERO == std::fpclassify(r[d]))
-	os << std::setw(18) << std::setprecision(10) << 0;
+        os << std::setw(18) << std::setprecision(10) << 0;
       else
-	os << std::setw(18) << std::setprecision(10) << r[d];
+        os << std::setw(18) << std::setprecision(10) << r[d];
   }
 };
 

--- a/src/Containers/OhmmsPETE/tests/test_TinyVector.cpp
+++ b/src/Containers/OhmmsPETE/tests/test_TinyVector.cpp
@@ -16,6 +16,7 @@
 
 #include <stdio.h>
 #include <string>
+#include <iostream>
 
 using std::string;
 
@@ -82,4 +83,10 @@ TEST_CASE("tiny vector", "[OhmmsPETE]")
   test_tiny_vector_size_two<4>();
 }
 
+TEST_CASE("tiny vector operator out", "[OhmmsPETE]")
+{
+  TinyVector<double,3> point{0.0,-0.0,1.0};
+  std::cout << point;
+}
+  
 } // namespace qmcplusplus

--- a/src/Containers/OhmmsPETE/tests/test_TinyVector.cpp
+++ b/src/Containers/OhmmsPETE/tests/test_TinyVector.cpp
@@ -85,11 +85,11 @@ TEST_CASE("tiny vector", "[OhmmsPETE]")
 
 TEST_CASE("tiny vector operator out", "[OhmmsPETE]")
 {
-  TinyVector<double,3> point{0.0,-0.0,1.0};
+  TinyVector<double, 3> point{0.0, -0.0, 1.0};
   std::ostringstream ostr;
   ostr << point;
   std::string expected{"                 0                 0                 1"};
   CHECK(expected == ostr.str());
 }
-  
+
 } // namespace qmcplusplus

--- a/src/Containers/OhmmsPETE/tests/test_TinyVector.cpp
+++ b/src/Containers/OhmmsPETE/tests/test_TinyVector.cpp
@@ -86,7 +86,10 @@ TEST_CASE("tiny vector", "[OhmmsPETE]")
 TEST_CASE("tiny vector operator out", "[OhmmsPETE]")
 {
   TinyVector<double,3> point{0.0,-0.0,1.0};
-  std::cout << point;
+  std::ostringstream ostr;
+  ostr << point;
+  std::string expected{"                 0                 0                 1"};
+  CHECK(expected == ostr.str());
 }
   
 } // namespace qmcplusplus

--- a/src/type_traits/complex_help.hpp
+++ b/src/type_traits/complex_help.hpp
@@ -26,6 +26,11 @@ struct IsComplex_t<std::complex<T>> : public std::true_type
 
 template<typename T>
 using IsComplex = std::enable_if_t<IsComplex_t<T>::value, bool>;
+
+// for symmetry with IsComplex_t
+template<typename T>
+using IsReal_t = std::is_floating_point<T>;
+
 template<typename T>
 using IsReal = std::enable_if_t<std::is_floating_point<T>::value, bool>;
 


### PR DESCRIPTION
## Proposed changes

This changes the string output of `TinyVector` so that all values that std::fpclassify recognizes as FP_ZERO are output as 0.  Importantly for #4857 -0.0 is output as 0.0. This should remove another potential divergence for comparing the output of NEReferencePoints description output.

## What type(s) of changes does this code introduce?

- Bugfix
- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
x86 v100 cloud instance

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
