### PR TITLE
Nexus: set correct cusp in SOC jastrow

### DIFF
--- a/docs/spin_orbit.rst
+++ b/docs/spin_orbit.rst
@@ -75,7 +75,7 @@ where we now utilize determinants of spinors, as opposed to the usual product of
           </correlation>
        </jastrow> 
       <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
-        <correlation speciesA="u" speciesB="u" size="8">
+        <correlation speciesA="u" speciesB="u" size="8" cusp="-0.5">
           <coefficients id="uu" type="Array">                  
           </coefficients>
         </correlation> 
@@ -88,8 +88,9 @@ need a product of up and down determinants.
 In the Jastrow specification, we only need to provide 
 the jastrow terms for the same spin as there is no longer a
 distinction between the up and down spins. 
+The electon-electron cusp in this case should be -1/2, as discussed in :
 
-We also make a small modification in the particleset specification:
+We also make a small modification in the particleset specification :cite:`Melton2016-2`
 
 .. code-block::
   :caption: specification for the electron particle when performing spin-orbit calculations

--- a/docs/spin_orbit.rst
+++ b/docs/spin_orbit.rst
@@ -88,9 +88,9 @@ need a product of up and down determinants.
 In the Jastrow specification, we only need to provide 
 the jastrow terms for the same spin as there is no longer a
 distinction between the up and down spins. 
-The electon-electron cusp in this case should be -1/2, as discussed in :
+The electon-electron cusp in this case should be -1/2, as discussed in :cite:`Melton2016-2`.
 
-We also make a small modification in the particleset specification :cite:`Melton2016-2`
+We also make a small modification in the particleset specification 
 
 .. code-block::
   :caption: specification for the electron particle when performing spin-orbit calculations

--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -287,11 +287,14 @@ class Qmcpack(Simulation):
                 spinor = input.get('spinor')
                 if spinor is not None and spinor:
                     # remove u-d term from optmized jastrow
+                    # also set correct cusp condition
                     J2 = optwf.get('J2')
                     if J2 is not None:
                         corr = J2.get('correlation')
                         if 'ud' in corr:
                             del corr.ud
+                        if 'uu' in corr:
+                            corr.uu.cusp = -0.5
                         #end if
                     #end if
                 #end if

--- a/nexus/lib/qmcpack_input.py
+++ b/nexus/lib/qmcpack_input.py
@@ -7600,11 +7600,14 @@ def generate_basic_input(**kwargs):
 
     if kw.spinor is not None and kw.spinor:
       # remove u-d 
+      # also set correct cusp
       J2 = wfn.jastrows.get('J2')
       if J2 is not None:
         corr = J2.get('correlation')
         if 'ud' in corr:
           del corr.ud
+        if 'uu' in corr:
+          corr.uu.cusp = -0.5
 
     h_estimators = kw.estimators
     d_estimators = None


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Set correct cusp in two body jastrow when spinors are enabled so the user doesn't have to

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- New feature

### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
M1 mac

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
