### PR TITLE
Run omptarget tests unconditionally as the omptarget runtime

### DIFF
--- a/src/Platforms/tests/CMakeLists.txt
+++ b/src/Platforms/tests/CMakeLists.txt
@@ -19,9 +19,7 @@ if(ENABLE_SYCL)
   add_subdirectory(SYCL)
 endif()
 
-if(ENABLE_OFFLOAD)
-  add_subdirectory(OMPTarget)
-endif(ENABLE_OFFLOAD)
+add_subdirectory(OMPTarget)
 
 set(UTEST_EXE test_platforms)
 set(UTEST_NAME deterministic-unit_${UTEST_EXE})


### PR DESCRIPTION
## Proposed changes
Should fix missing coverage in #4847.

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'