### PR TITLE
Fix dangling else warning on clang

### DIFF
--- a/src/Utilities/ModernStringUtils.hpp
+++ b/src/Utilities/ModernStringUtils.hpp
@@ -37,20 +37,22 @@ namespace qmcplusplus
 std::string lowerCase(const std::string_view s);
 
 /** prevent clash with string_utils.h */
-namespace modernstrutil {
-  /** return string_view tokens */
-  std::vector<std::string_view> split(const std::string_view s, const std::string_view delimiters);
-  /** remove white space from each beginning and end of string_view */
-  std::string_view strip(const std::string_view s);
-}
+namespace modernstrutil
+{
+/** return string_view tokens */
+std::vector<std::string_view> split(const std::string_view s, const std::string_view delimiters);
+/** remove white space from each beginning and end of string_view */
+std::string_view strip(const std::string_view s);
+} // namespace modernstrutil
 
 /** alternate to string2real
  *  calls c++ string to real conversion based on T's precision template<typename T>
  */
 template<typename T>
-inline T string2Real(const std::string_view svalue) {
+inline T string2Real(const std::string_view svalue)
+{
   static_assert(std::is_floating_point_v<T>);
-      T result;
+  T result;
 // full support for floating point from char not present until stdlibc++ aligned with gcc11
 // there is still not from_char for floats as of libc++ 15
 #if _GLIBCXX_RELEASE > 10
@@ -69,29 +71,34 @@ inline T string2Real(const std::string_view svalue) {
  *  calls c++ string to real conversion based on T's precision template<typename T>
  */
 template<typename T>
-inline T string2Int(const std::string_view svalue) {
+inline T string2Int(const std::string_view svalue)
+{
   static_assert(std::is_integral_v<T>);
-// full support for floating point from char not present until stdlibc++ aligned with gcc11
-// there is still not from_char for floats as of libc++ 15
+  // full support for floating point from char not present until stdlibc++ aligned with gcc11
+  // there is still not from_char for floats as of libc++ 15
   T result{};
 #if _GLIBCXX_RELEASE > 10
   auto [prt, ec] = std::from_chars(svalue.data(), svalue.data() + svalue.size(), result);
+  // std::errc() represents success or a value of 0 with respect to errc's error enumeration.
   if (ec != std::errc())
+  {
     if (ec == std::errc::result_out_of_range)
       throw std::range_error("Value out of range for integral type parameter of string2Int");
-    else {
+    else
+    {
       std::ostringstream msg;
       msg << "Could not convert from string " << std::string(svalue) << " to int!";
       throw std::runtime_error(msg.str());
     }
+  }
 #else
   // atof must be given a null terminated string, string_view is not guaranteed to have a null terminator.
   std::string str_value(svalue);
   if constexpr (std::is_same_v<T, int>)
     result = atoi(str_value.c_str());
-  else if constexpr(std::is_same_v<T, long>)
+  else if constexpr (std::is_same_v<T, long>)
     result = atol(str_value.c_str());
-  else if constexpr(std::is_same_v<T, long long>)
+  else if constexpr (std::is_same_v<T, long long>)
     result = atol(str_value.c_str());
   else
     throw std::runtime_error("unsupported type for string to integral type conversion with pre v.10 stdlibc++!");

--- a/src/Utilities/tests/test_ModernStringUtils.cpp
+++ b/src/Utilities/tests/test_ModernStringUtils.cpp
@@ -50,7 +50,7 @@ TEST_CASE("ModernStringUtils_split", "[utilities]")
 
   tokens = split(white_space, " ");
   CHECK(tokens.empty());
-  
+
   std::string test_line{"hi there 101, random line"};
   tokens = split(test_line, " ");
   CHECK(tokens[0].size() == 2);
@@ -62,7 +62,7 @@ TEST_CASE("ModernStringUtils_split", "[utilities]")
 
   tokens = split(test_line, ";");
   CHECK(tokens.size() == 1);
-  
+
   std::string test_lines{R"(
 this is a multi
 line
@@ -98,13 +98,14 @@ TEST_CASE("ModernStringUtils_string2Int", "[utilities]")
   input << too_large_for_int;
 //Safety pre stdlibcxx 10 doesn't seem worth the effort
 #if _GLIBCXX_RELEASE > 10
-  CHECK_THROWS_AS(string2Int<int>(input.str()),std::range_error);
+  CHECK_THROWS_AS(string2Int<int>(input.str()), std::range_error);
+  CHECK_THROWS_AS(string2Int<int>("bad"), std::runtime_error);
 #endif
   long big_enough = string2Int<decltype(big_enough)>(input.str());
   CHECK(big_enough == too_large_for_int);
 } // namespace qmcplusplus
 
-  
+
 TEST_CASE("ModernStringUtils_strip", "[utilities]")
 {
   using modernstrutil::strip;
@@ -136,5 +137,5 @@ TEST_CASE("ModernStringUtils_strip", "[utilities]")
   std::string_view unneeded_stripped = strip(unneeded);
   CHECK(unneeded_stripped == unneeded);
 }
-  
-}
+
+} // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes

Fixes dangling else warning seen by clang.
Also extends unit test to the non number exception.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
osx clang 16
gcc 11.3.0 x86 v100

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes  Code added or changed in the PR has been clang-formatted
- Yes  This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes  Documentation has been added (if appropriate)
