### PR TITLE
Disable target tasks in DTs.

### DIFF
--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -326,7 +326,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     {
       ScopedTimer offload(offload_timer_);
       PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(nw * num_teams) \
-                        nowait depend(out: r_dr_ptr[:mw_new_old_dist_displ.size()])")
+                          depend(out: r_dr_ptr[:mw_new_old_dist_displ.size()])")
       for (int iw = 0; iw < nw; ++iw)
         for (int team_id = 0; team_id < num_teams; team_id++)
         {

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -301,8 +301,8 @@ public:
     {
       ScopedTimer offload(dt_leader.offload_timer_);
       PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(total_targets*num_teams) \
-                        map(always, to: input_ptr[:offload_input.size()]) \
-                        depend(out:r_dr_ptr[:mw_r_dr.size()]) nowait")
+                          map(always, to: input_ptr[:offload_input.size()]) \
+                          depend(out:r_dr_ptr[:mw_r_dr.size()])")
       for (int iat = 0; iat < total_targets; ++iat)
         for (int team_id = 0; team_id < num_teams; team_id++)
         {


### PR DESCRIPTION
## Proposed changes
Using async target tasks causes unintended congestion. A task launched by crowd A (thread A) may run on thread B and slows down the execution of crowd B and amplify thread imbalance. Before we have a better understanding of target tasks, disable them and rely on multi-threaded offload for performance.

## What type(s) of changes does this code introduce?
- Other (please describe): Performance tuning.

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Polaris

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'