### PR TITLE
Fix MP compilation with Clang.

### DIFF
--- a/src/QMCHamiltonians/tests/test_ewald2d.cpp
+++ b/src/QMCHamiltonians/tests/test_ewald2d.cpp
@@ -183,10 +183,11 @@ TEST_CASE("Coulomb PBC A-A Ewald2D honeycomb", "[hamiltonian]")
 
 TEST_CASE("Coulomb PBC A-A Ewald2D tri. in rect.", "[hamiltonian]")
 {
+  using RealType = QMCTraits::RealType;
   LRCoulombSingleton::CoulombHandler = 0; // !!!! crucial if not first test
   LRCoulombSingleton::this_lr_type = LRCoulombSingleton::STRICT2D;
   const double vmad_tri = -1.1061025865191676;
-  const double alat = std::sqrt(2.0*M_PI/std::sqrt(3));
+  const RealType alat = std::sqrt(2.0*M_PI/std::sqrt(3));
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
   lattice.BoxBConds = true; // periodic
@@ -204,7 +205,7 @@ TEST_CASE("Coulomb PBC A-A Ewald2D tri. in rect.", "[hamiltonian]")
   elec.setName("e");
   elec.create({2});
   elec.R[0] = {0.0, 0.0, 0.0};
-  elec.R[1] = {alat/2, std::sqrt(3.0)*alat/2, 0.0};
+  elec.R[1] = {alat/2, static_cast<RealType>(std::sqrt(3))*alat/2, 0.0};
 
   SpeciesSet& tspecies       = elec.getSpeciesSet();
   int upIdx                  = tspecies.addSpecies("u");


### PR DESCRIPTION
## Proposed changes
Issue reported by Intel but the cause was Clang tightening precision handling https://cdash.qmcpack.org/CDash/viewBuildError.php?buildid=457608


## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
