### PR TITLE
Fix T-move in batched DMC driver.

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.h
+++ b/src/QMCDrivers/DMC/DMCBatched.h
@@ -120,7 +120,7 @@ public:
 
   QMCRunType getRunType() override { return QMCRunType::DMC_BATCH; }
 
-  void setNonLocalMoveHandler(QMCHamiltonian& golden_hamiltonian);
+  void setNonLocalMoveHandler(QMCHamiltonian& hamiltonian);
 
 private:
   const DMCDriverInput dmcdriver_input_;

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -49,8 +49,7 @@ QMCDriverNew::QMCDriverNew(const ProjectData& project_data,
                            MCPopulation&& population,
                            const std::string timer_prefix,
                            Communicate* comm,
-                           const std::string& QMC_driver_type,
-                           SetNonLocalMoveHandler snlm_handler)
+                           const std::string& QMC_driver_type)
     : MPIObjectBase(comm),
       qmcdriver_input_(std::move(input)),
       QMCType(QMC_driver_type),
@@ -61,8 +60,7 @@ QMCDriverNew::QMCDriverNew(const ProjectData& project_data,
       driver_scope_timer_(createGlobalTimer(QMC_driver_type, timer_level_coarse)),
       driver_scope_profiler_(qmcdriver_input_.get_scoped_profiling()),
       project_data_(project_data),
-      walker_configs_ref_(wc),
-      setNonLocalMoveHandler_(snlm_handler)
+      walker_configs_ref_(wc)
 {
   // This is done so that the application level input structures reflect the actual input to the code.
   // While the actual simulation objects still take singular input structures at construction.
@@ -193,8 +191,8 @@ void QMCDriverNew::initializeQMC(const AdjustedWalkerCounts& awc)
  */
 void QMCDriverNew::setStatus(const std::string& aname, const std::string& h5name, bool append)
 {
-  app_log() << "\n========================================================="
-            << "\n  Start " << QMCType << "\n  File Root " << get_root_name();
+  app_log() << "\n=========================================================" << "\n  Start " << QMCType
+            << "\n  File Root " << get_root_name();
   app_log() << "\n=========================================================" << std::endl;
 
   if (h5name.size())
@@ -281,14 +279,6 @@ void QMCDriverNew::makeLocalWalkers(IndexType nwalkers, RealType reserve)
     for (int i = 0; i < num_walkers_to_kill; ++i)
       population_.killLastWalker();
   }
-
-  // \todo: this could be what is breaking spawned walkers
-  for (UPtr<QMCHamiltonian>& ham : population_.get_hamiltonians())
-    setNonLocalMoveHandler_(*ham);
-
-  // For the dead ones too. Since this should be on construction but...
-  for (UPtr<QMCHamiltonian>& ham : population_.get_dead_hamiltonians())
-    setNonLocalMoveHandler_(*ham);
 }
 
 /** Creates Random Number generators for crowds and step contexts
@@ -394,8 +384,6 @@ std::ostream& operator<<(std::ostream& o_stream, const QMCDriverNew& qmcd)
 
   return o_stream;
 }
-
-void QMCDriverNew::defaultSetNonLocalMoveHandler(QMCHamiltonian& ham) {}
 
 QMCDriverNew::AdjustedWalkerCounts QMCDriverNew::adjustGlobalWalkerCount(Communicate& comm,
                                                                          const IndexType current_configs,

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -133,8 +133,7 @@ public:
                MCPopulation&& population,
                const std::string timer_prefix,
                Communicate* comm,
-               const std::string& QMC_driver_type,
-               SetNonLocalMoveHandler = &QMCDriverNew::defaultSetNonLocalMoveHandler);
+               const std::string& QMC_driver_type);
 
   ///Move Constructor
   QMCDriverNew(QMCDriverNew&&) = default;
@@ -186,7 +185,7 @@ public:
    */
   void setStatus(const std::string& aname, const std::string& h5name, bool append) override;
 
-  void add_H_and_Psi(QMCHamiltonian* h, TrialWaveFunction* psi) override{};
+  void add_H_and_Psi(QMCHamiltonian* h, TrialWaveFunction* psi) override {};
 
   void createRngsStepContexts(int num_crowds);
 
@@ -231,9 +230,7 @@ public:
    */
   void process(xmlNodePtr cur) override = 0;
 
-  static void initialLogEvaluation(int crowd_id,
-                                   UPtrVector<Crowd>& crowds,
-                                   UPtrVector<ContextForSteps>& step_context);
+  static void initialLogEvaluation(int crowd_id, UPtrVector<Crowd>& crowds, UPtrVector<ContextForSteps>& step_context);
 
 
   /** should be set in input don't see a reason to set individually
@@ -465,10 +462,6 @@ protected:
 
 private:
   friend std::ostream& operator<<(std::ostream& o_stream, const QMCDriverNew& qmcd);
-
-  SetNonLocalMoveHandler setNonLocalMoveHandler_;
-
-  static void defaultSetNonLocalMoveHandler(QMCHamiltonian& gold_ham);
 
   friend class qmcplusplus::testing::VMCBatchedTest;
   friend class qmcplusplus::testing::DMCBatchedTest;


### PR DESCRIPTION
## Proposed changes

T-move info was only set to all the existing walkers (both live and dead) at the beginning of the DMC driver. If branching creates new walkers, these walkers will be running as locality approximation. The fix is to set the handler before each DMC step. A better solution will be moving such meta data out of each walker and keeping them to the driver. This will be done once I get around tho restructure T-move related codes.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted