### PR TITLE
Update macos CI to latest version

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -141,7 +141,7 @@ jobs:
           fail_ci_if_error: true # optional (default = false)
 
   macos:
-    runs-on: macos-11
+    runs-on: macos-13
     env:
       GH_JOBNAME: ${{ matrix.jobname }}
       GH_OS: macOS
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jobname: [macOS-GCC11-NoMPI-Real]
+        jobname: [macOS-GCC12-NoMPI-Real]
 
     steps:
       - name: Checkout Action

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -281,11 +281,11 @@ case "$1" in
               -DQMC_DATA=$QMC_DATA_DIR \
               ${GITHUB_WORKSPACE}
       ;;
-      *"macOS-GCC11-NoMPI-Real"*)
+      *"macOS-GCC12-NoMPI-Real"*)
         echo 'Configure for building on macOS using gcc11'
         cmake -GNinja \
-              -DCMAKE_C_COMPILER=gcc-11 \
-              -DCMAKE_CXX_COMPILER=g++-11 \
+              -DCMAKE_C_COMPILER=gcc-12 \
+              -DCMAKE_CXX_COMPILER=g++-12 \
               -DQMC_MPI=0 \
               -DQMC_COMPLEX=$IS_COMPLEX \
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \


### PR DESCRIPTION
## Proposed changes

Move to supported macos-13 and gcc-12 on macos CI
Attempt to Address current failure in HDF 1.14 in current CI e.g. #4905 
Fixes #4907 

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
N/A. Must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
