### PR TITLE
Fix bug in TrialWaveFunction mw_evalGrad for spinor wave functions

### DIFF
--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -564,9 +564,9 @@ void TrialWaveFunction::mw_evalGrad(const RefVectorWithLeader<TrialWaveFunction>
   const int num_wfc             = wf_leader.Z.size();
   auto& wavefunction_components = wf_leader.Z;
 
+  TWFGrads<CT> grads_z(num_wf);
   for (int i = 0; i < num_wfc; i++)
   {
-    TWFGrads<CT> grads_z(num_wf);
     ScopedTimer localtimer(wf_leader.WFC_timers_[VGL_TIMER + TIMER_SKIP * i]);
     const auto wfc_list(extractWFCRefList(wf_list, i));
     wavefunction_components[i]->mw_evalGrad(wfc_list, p_list, iat, grads_z);

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -564,9 +564,9 @@ void TrialWaveFunction::mw_evalGrad(const RefVectorWithLeader<TrialWaveFunction>
   const int num_wfc             = wf_leader.Z.size();
   auto& wavefunction_components = wf_leader.Z;
 
-  TWFGrads<CT> grads_z(num_wf);
   for (int i = 0; i < num_wfc; i++)
   {
+    TWFGrads<CT> grads_z(num_wf);
     ScopedTimer localtimer(wf_leader.WFC_timers_[VGL_TIMER + TIMER_SKIP * i]);
     const auto wfc_list(extractWFCRefList(wf_list, i));
     wavefunction_components[i]->mw_evalGrad(wfc_list, p_list, iat, grads_z);

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -95,7 +95,10 @@ void WaveFunctionComponent::mw_evalGradWithSpin(const RefVectorWithLeader<WaveFu
 {
   assert(this == &wfc_list.getLeader());
   for (int iw = 0; iw < wfc_list.size(); iw++)
-    grad_now[iw] = wfc_list[iw].evalGradWithSpin(p_list[iw], iat, spingrad_now[iw]);
+  {
+    spingrad_now[iw] = 0;
+    grad_now[iw]     = wfc_list[iw].evalGradWithSpin(p_list[iw], iat, spingrad_now[iw]);
+  }
 }
 
 void WaveFunctionComponent::mw_calcRatio(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,

--- a/src/QMCWaveFunctions/tests/MinimalWaveFunctionPool.h
+++ b/src/QMCWaveFunctions/tests/MinimalWaveFunctionPool.h
@@ -53,6 +53,36 @@ class MinimalWaveFunctionPool
 </wavefunction>
   )";
 
+  static constexpr const char* const wf_input_spinor_J12 = R"(
+<wavefunction name="psi0" target="e">
+   <sposet_collection name="A" type="einspline" href="o2_45deg_spins.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" size="12"> 
+      <sposet name="spo_ud" size="12"/> 
+      <sposet name="spo_dm" size="8" index_min="12" index_max="20"/> 
+   </sposet_collection> 
+   <determinantset>
+      <slaterdeterminant>
+         <determinant sposet="spo_ud"/>
+      </slaterdeterminant>
+   </determinantset>
+   <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+      <correlation elementType="O" size="9" rcut="2.336894584512495" cusp="0.0">
+         <coefficients id="eO" type="Array">                  
+-0.51632 -0.1591167977 -0.172367432 -0.1238310413 -0.09792672786 
+-0.91785 -0.05476753103 -0.03482448615 -0.01864350288
+         </coefficients>
+      </correlation>
+   </jastrow>
+   <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+      <correlation speciesA="u" speciesB="u" size="9" rcut="2.336894584512495" cusp="-0.5">
+         <coefficients id="uu" type="Array">                  
+0.7554 0.5342428628 0.3861610501 0.2724177345 0.186010153 0.1213795099 
+0.04796 0.04068638111 0.01968948012
+         </coefficients>
+      </correlation>
+   </jastrow>
+</wavefunction>
+  )";
+
 public:
   static WaveFunctionPool make_diamondC_1x1x1(const RuntimeOptions& runtime_options,
                                               Communicate* comm,
@@ -79,6 +109,23 @@ public:
 
     Libxml2Document doc;
     bool okay = doc.parseFromString(wf_input_spinor);
+    REQUIRE(okay);
+
+    xmlNodePtr root = doc.getRoot();
+
+    wp.put(root);
+
+    return wp;
+  }
+
+  static WaveFunctionPool make_O2_spinor_J12(const RuntimeOptions& runtime_options,
+                                             Communicate* comm,
+                                             ParticleSetPool& particle_pool)
+  {
+    WaveFunctionPool wp(runtime_options, particle_pool, comm);
+
+    Libxml2Document doc;
+    bool okay = doc.parseFromString(wf_input_spinor_J12);
     REQUIRE(okay);
 
     xmlNodePtr root = doc.getRoot();

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -24,6 +24,9 @@
 #include "TWFGrads.hpp"
 #include "Utilities/RuntimeOptions.h"
 #include <ResourceCollection.h>
+#include "Particle/tests/MinimalParticlePool.h"
+#include "QMCWaveFunctions/tests/MinimalWaveFunctionPool.h"
+#include "Utilities/ProjectData.h"
 
 namespace qmcplusplus
 {
@@ -368,5 +371,62 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 #endif
 }
 
+#ifdef QMC_COMPLEX
+/** This test is intended to catch a bug that was found in the batched code 
+  * when using spinors and jastrows. The issue came about because WFCs that don't 
+  * contribute to the spin gradient end up going back to the normal mw_evalGrad
+  * In the TWF::mw_evalGrad, it uses TWFGrads to accumulate the spin gradient and normal gradients
+  * using a returned variable grads. The individual components are stored in grads_z and the update over the 
+  * component loop is grads += grads_z. Internally to the WFCs, the position gradients get zeroed and computed. 
+  * However, for the spins, if they weren't being touched then the spin part is left untouched. But that means that if 
+  * grads += grads_z didn't account for zeroing out the spin part for that component, then it acctually accumulates the previous ones. 
+  * This test fails with the buggy code, and now makes sure TWF has the right behavior. 
+  }
+  */
+TEST_CASE("TrialWaveFunction::mw_evalGrad for spinors", "[wavefunction]")
+{
+  ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
+  Communicate* comm = OHMMS::Controller;
+
+  auto particle_pool = MinimalParticlePool::make_O2_spinor(comm);
+  auto wavefunction_pool =
+      MinimalWaveFunctionPool::make_O2_spinor(test_project.getRuntimeOptions(), comm, particle_pool);
+
+  auto& elec    = *(particle_pool).getParticleSet("e");
+  auto& psi_noJ = *(wavefunction_pool).getWaveFunction("wavefunction");
+
+  elec.update();
+  auto logpsi = psi_noJ.evaluateLog(elec);
+  WaveFunctionComponent::ComplexType spingrad_ref(0);
+  WaveFunctionComponent::GradType grad = psi_noJ.evalGradWithSpin(elec, 0, spingrad_ref);
+
+  // Now tack on a jastrow to make sure it is still the same since jastrows don't contribute
+  auto wavefunction_pool2 =
+      MinimalWaveFunctionPool::make_O2_spinor_J12(test_project.getRuntimeOptions(), comm, particle_pool);
+  auto& psi = *(wavefunction_pool2).getWaveFunction("wavefunction");
+
+  // make clones
+  ParticleSet elec_clone(elec);
+  std::unique_ptr<TrialWaveFunction> psi_clone(psi.makeClone(elec_clone));
+
+  ResourceCollection elec_res("test_elec_res");
+  ResourceCollection psi_res("test_psi_res");
+  elec.createResource(elec_res);
+  psi.createResource(psi_res);
+
+  RefVectorWithLeader<ParticleSet> elec_ref_list(elec, {elec, elec_clone});
+  RefVectorWithLeader<TrialWaveFunction> psi_ref_list(psi, {psi, *psi_clone});
+
+  ResourceCollectionTeamLock<ParticleSet> mw_elec_lock(elec_res, elec_ref_list);
+  ResourceCollectionTeamLock<TrialWaveFunction> mw_psi_lock(psi_res, psi_ref_list);
+
+  ParticleSet::mw_update(elec_ref_list);
+  TrialWaveFunction::mw_evaluateLog(psi_ref_list, elec_ref_list);
+  TWFGrads<CoordsType::POS_SPIN> grads(2);
+  TrialWaveFunction::mw_evalGrad(psi_ref_list, elec_ref_list, 0, grads);
+  for (size_t iw = 0; iw < 2; iw++)
+    CHECK(grads.grads_spins[iw] == ComplexApprox(spingrad_ref));
+}
+#endif
 
 } // namespace qmcplusplus


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
This PR fixes a bug I found when doing some testing of the spinor code using the batched drivers. Essentially, I saw errors in the energy and kinetic energy relative to legacy only if there is a jastrow present and only if drift was on. Ended up tracking it down to the fact that WaveFunctionComponents that do not use the spins do not touch the spin gradient component, which they shouldn't. However,  the problem was that in the TWF::mw_evalGrad function, it was passing in the previous wave function components TWFGrad type. Since the Jastrow mw_evalGrad wasn't setting the spin component to zero, then the grads += grads_z ends up accumulating the first slater determinants value over and over again. So for 3 WF components, the spin gradient was 3x too large. 

~~Fixed by simply moving the TWFGrad initialization into the loop.~~
set zero before calling the single walker fallback.

Closes #4910 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
M1 mac

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
