### PR TITLE
[AFQMC] undeprecate memory block class

### DIFF
--- a/src/AFQMC/Memory/multi_memory/block.hpp
+++ b/src/AFQMC/Memory/multi_memory/block.hpp
@@ -59,7 +59,7 @@ struct basic_block {
 }  // namespace detail
 
 template<typename Ptr, typename Diff>
-struct [[deprecated("to be removed")]] block : detail::basic_block<Ptr, Diff> {
+struct block : detail::basic_block<Ptr, Diff> {
 	using detail::basic_block<Ptr, Diff>::basic_block;
 };
 


### PR DESCRIPTION
## Proposed changes

Undeprecate memory block class that can be used with the last release of Multi.

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 23.10

## Checklist

- Yes This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
