### PR TITLE
add guard to prevent incorrect usage of 1rdm for spinor

### DIFF
--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -85,6 +85,11 @@ OneBodyDensityMatrices::OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obd
   if (is_spinor_)
     ssamples_.resize(samples_);
 
+  if (is_spinor_ && sampling_ != Sampling::METROPOLIS)
+    throw UniformCommunicateError("OneBodyDensityMatrices::OneBodyDensityMatrices only density sampling implemented "
+                                  "for calculations using spinors");
+
+
   // get the sposets that form the basis
   auto& sposets = input_.get_basis_sets();
 
@@ -391,29 +396,29 @@ inline void OneBodyDensityMatrices::generateDensitySamplesWithSpin(bool save,
     if (input_.get_use_drift())
     {
       rp    = r + diff + d;                                               //update trial position
-      spinp = spcur_ + sdiff + dspcur_;                                       //update trial spin
+      spinp = spcur_ + sdiff + dspcur_;                                   //update trial spin
       calcDensityDriftWithSpin(rp, spinp, rhop, dp, dspinp, pset_target); //get trial drift and density
       ratio   = rhop / rho;                                               //density ratio
       ds      = dp + d;                                                   //drift sum
-      spin_ds = dspinp + dspcur_;                                           //spin drift sum
+      spin_ds = dspinp + dspcur_;                                         //spin drift sum
       Pacc    = ratio * std::exp(-ot * (dot(diff, ds) + .5 * dot(ds, ds))) *
           std::exp(-ot * (sdiff * spin_ds) + 0.5 * spin_ds * spin_ds); //acceptance probability
     }
     else
     {
       rp    = r + diff;                                  //update trial position
-      spinp = spcur_ + sdiff;                              //update trial spin
+      spinp = spcur_ + sdiff;                            //update trial spin
       calcDensityWithSpin(rp, spinp, rhop, pset_target); //get trial density
       ratio = rhop / rho;                                //density ratio
       Pacc  = ratio;                                     //acceptance probability
     }
     if (rng() < Pacc)
     { //accept move
-      r     = rp;
-      d     = dp;
+      r       = rp;
+      d       = dp;
       spcur_  = spinp;
       dspcur_ = dspinp;
-      rho   = rhop;
+      rho     = rhop;
       naccepted_++;
     }
     if (save)


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
The OneBodyDensityMatrix only has been implemented for spinors if you're using the density integrator. This PR adds a guard to prevent other integrators being used. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
m1 mac

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
