### PR TITLE
Fix spinors for orb opt

### DIFF
--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -288,7 +288,12 @@ public:
     Phi_->evaluateVGL(P, iat, psi, dpsi, d2psi);
   }
 
-  void evaluateVGL_spin(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi, ValueVector& dspin_psi) override
+  void evaluateVGL_spin(const ParticleSet& P,
+                        int iat,
+                        ValueVector& psi,
+                        GradVector& dpsi,
+                        ValueVector& d2psi,
+                        ValueVector& dspin_psi) override
   {
     assert(psi.size() <= OrbitalSetSize);
     Phi_->evaluateVGL_spin(P, iat, psi, dpsi, d2psi, dspin_psi);
@@ -343,10 +348,7 @@ public:
     Phi_->evaluate_notranspose(P, first, last, logdet, dlogdet, d2logdet);
   }
 
-  void evaluate_spin(const ParticleSet& P, 
-                     int iat, 
-                     ValueVector& psi, 
-                     ValueVector& dspin_psi) override
+  void evaluate_spin(const ParticleSet& P, int iat, ValueVector& psi, ValueVector& dspin_psi) override
   {
     Phi_->evaluate_spin(P, iat, psi, dspin_psi);
   }

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -337,6 +337,14 @@ public:
     Phi_->evaluate_notranspose(P, first, last, logdet, dlogdet, d2logdet);
   }
 
+  void evaluate_spin(const ParticleSet& P, 
+                     int iat, 
+                     ValueVector& psi, 
+                     ValueVector& dspin_psi) override
+  {
+    Phi_->evaluate_spin(P, iat, psi, dspin_psi);
+  }
+
   void evaluate_notranspose(const ParticleSet& P,
                             int first,
                             int last,

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -288,6 +288,12 @@ public:
     Phi_->evaluateVGL(P, iat, psi, dpsi, d2psi);
   }
 
+  void evaluateVGL_spin(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi, ValueVector& dspin_psi) override
+  {
+    assert(psi.size() <= OrbitalSetSize);
+    Phi_->evaluateVGL_spin(P, iat, psi, dpsi, d2psi, dspin_psi);
+  }
+
   void evaluateDetRatios(const VirtualParticleSet& VP,
                          ValueVector& psi,
                          const ValueVector& psiinv,

--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -56,14 +56,6 @@ void SpinorSet::set_spos(std::unique_ptr<SPOSet>&& up, std::unique_ptr<SPOSet>&&
   spo_up = std::move(up);
   spo_dn = std::move(dn);
 
-  psi_work_up.resize(OrbitalSetSize);
-  psi_work_down.resize(OrbitalSetSize);
-
-  dpsi_work_up.resize(OrbitalSetSize);
-  dpsi_work_down.resize(OrbitalSetSize);
-
-  d2psi_work_up.resize(OrbitalSetSize);
-  d2psi_work_down.resize(OrbitalSetSize);
 }
 
 void SpinorSet::setOrbitalSetSize(int norbs) { OrbitalSetSize = norbs; };
@@ -71,6 +63,9 @@ void SpinorSet::setOrbitalSetSize(int norbs) { OrbitalSetSize = norbs; };
 
 void SpinorSet::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
 {
+  const size_t norb_requested = psi.size();
+  psi_work_up.resize(norb_requested);
+  psi_work_down.resize(norb_requested);
   psi_work_up   = 0.0;
   psi_work_down = 0.0;
 
@@ -93,6 +88,13 @@ void SpinorSet::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
 
 void SpinorSet::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)
 {
+  const size_t norb_requested = psi.size();
+  psi_work_up.resize(norb_requested);
+  psi_work_down.resize(norb_requested);
+  dpsi_work_up.resize(norb_requested);
+  dpsi_work_down.resize(norb_requested);
+  d2psi_work_up.resize(norb_requested);
+  d2psi_work_down.resize(norb_requested);
   psi_work_up     = 0.0;
   psi_work_down   = 0.0;
   dpsi_work_up    = 0.0;
@@ -125,6 +127,13 @@ void SpinorSet::evaluateVGL_spin(const ParticleSet& P,
                                  ValueVector& d2psi,
                                  ValueVector& dspin)
 {
+  const size_t norb_requested = psi.size();
+  psi_work_up.resize(norb_requested);
+  psi_work_down.resize(norb_requested);
+  dpsi_work_up.resize(norb_requested);
+  dpsi_work_down.resize(norb_requested);
+  d2psi_work_up.resize(norb_requested);
+  d2psi_work_down.resize(norb_requested);
   psi_work_up     = 0.0;
   psi_work_down   = 0.0;
   dpsi_work_up    = 0.0;
@@ -175,6 +184,16 @@ void SpinorSet::mw_evaluateVGLWithSpin(const RefVectorWithLeader<SPOSet>& spo_li
   for (int iw = 0; iw < nw; iw++)
   {
     auto& spo = spo_list.getCastedElement<SpinorSet>(iw);
+    auto& psi = psi_v_list[iw].get();
+    const size_t norb_requested = psi.size();
+
+    spo.psi_work_up.resize(norb_requested);
+    spo.psi_work_down.resize(norb_requested);
+    spo.dpsi_work_up.resize(norb_requested);
+    spo.dpsi_work_down.resize(norb_requested);
+    spo.d2psi_work_up.resize(norb_requested);
+    spo.d2psi_work_down.resize(norb_requested);
+
     up_psi_v_list.push_back(spo.psi_work_up);
     dn_psi_v_list.push_back(spo.psi_work_down);
     up_dpsi_v_list.push_back(spo.dpsi_work_up);
@@ -199,7 +218,7 @@ void SpinorSet::mw_evaluateVGLWithSpin(const RefVectorWithLeader<SPOSet>& spo_li
     psi_v_list[iw].get()   = eis * up_psi_v_list[iw].get() + emis * dn_psi_v_list[iw].get();
     dpsi_v_list[iw].get()  = eis * up_dpsi_v_list[iw].get() + emis * dn_dpsi_v_list[iw].get();
     d2psi_v_list[iw].get() = eis * up_d2psi_v_list[iw].get() + emis * dn_d2psi_v_list[iw].get();
-    for (int iorb = 0; iorb < OrbitalSetSize; iorb++)
+    for (int iorb = 0; iorb < mw_dspin.cols(); iorb++)
       mw_dspin(iw, iorb) = eye * (eis * (up_psi_v_list[iw].get())[iorb] - emis * (dn_psi_v_list[iw].get())[iorb]);
   }
   //Data above is all on host, but since mw_dspin is DualMatrix we need to sync the host and device
@@ -294,20 +313,22 @@ void SpinorSet::evaluate_notranspose(const ParticleSet& P,
 {
   IndexType nelec = P.getTotalNum();
 
-  logpsi_work_up.resize(nelec, OrbitalSetSize);
-  logpsi_work_down.resize(nelec, OrbitalSetSize);
+  const size_t norb_requested = logdet.cols();
 
-  dlogpsi_work_up.resize(nelec, OrbitalSetSize);
-  dlogpsi_work_down.resize(nelec, OrbitalSetSize);
+  logpsi_work_up.resize(nelec, norb_requested);
+  logpsi_work_down.resize(nelec, norb_requested);
 
-  d2logpsi_work_up.resize(nelec, OrbitalSetSize);
-  d2logpsi_work_down.resize(nelec, OrbitalSetSize);
+  dlogpsi_work_up.resize(nelec, norb_requested);
+  dlogpsi_work_down.resize(nelec, norb_requested);
+
+  d2logpsi_work_up.resize(nelec, norb_requested);
+  d2logpsi_work_down.resize(nelec, norb_requested);
 
   spo_up->evaluate_notranspose(P, first, last, logpsi_work_up, dlogpsi_work_up, d2logpsi_work_up);
   spo_dn->evaluate_notranspose(P, first, last, logpsi_work_down, dlogpsi_work_down, d2logpsi_work_down);
 
 
-  for (int iat = 0; iat < nelec; iat++)
+  for (int iat = first; iat < last; iat++)
   {
     ParticleSet::Scalar_t s = P.activeSpin(iat);
 
@@ -319,7 +340,7 @@ void SpinorSet::evaluate_notranspose(const ParticleSet& P,
     ValueType eis(coss, sins);
     ValueType emis(coss, -sins);
 
-    for (int no = 0; no < OrbitalSetSize; no++)
+    for (int no = 0; no < norb_requested; no++)
     {
       logdet(iat, no)   = eis * logpsi_work_up(iat, no) + emis * logpsi_work_down(iat, no);
       dlogdet(iat, no)  = eis * dlogpsi_work_up(iat, no) + emis * dlogpsi_work_down(iat, no);
@@ -367,8 +388,9 @@ void SpinorSet::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_l
   up_d2logdet_list.reserve(nw);
   dn_d2logdet_list.reserve(nw);
 
-  ValueMatrix tmp_val_mat(nelec, OrbitalSetSize);
-  GradMatrix tmp_grad_mat(nelec, OrbitalSetSize);
+  const size_t norb_requested = logdet_list.front().get().cols();
+  ValueMatrix tmp_val_mat(nelec, norb_requested);
+  GradMatrix tmp_grad_mat(nelec, norb_requested);
   for (int iw = 0; iw < nw; iw++)
   {
     mw_up_logdet.emplace_back(tmp_val_mat);
@@ -393,7 +415,7 @@ void SpinorSet::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_l
                                         dn_d2logdet_list);
 
   for (int iw = 0; iw < nw; iw++)
-    for (int iat = 0; iat < nelec; iat++)
+    for (int iat = first; iat < last; iat++)
     {
       ParticleSet::Scalar_t s = P_list[iw].activeSpin(iat);
       RealType coss           = std::cos(s);
@@ -401,7 +423,7 @@ void SpinorSet::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_l
       ValueType eis(coss, sins);
       ValueType emis(coss, -sins);
 
-      for (int no = 0; no < OrbitalSetSize; no++)
+      for (int no = 0; no < norb_requested; no++)
       {
         logdet_list[iw].get()(iat, no) =
             eis * up_logdet_list[iw].get()(iat, no) + emis * dn_logdet_list[iw].get()(iat, no);
@@ -423,14 +445,15 @@ void SpinorSet::evaluate_notranspose_spin(const ParticleSet& P,
 {
   IndexType nelec = P.getTotalNum();
 
-  logpsi_work_up.resize(nelec, OrbitalSetSize);
-  logpsi_work_down.resize(nelec, OrbitalSetSize);
+  const size_t norb_requested = logdet.cols();
+  logpsi_work_up.resize(nelec, norb_requested);
+  logpsi_work_down.resize(nelec, norb_requested);
 
-  dlogpsi_work_up.resize(nelec, OrbitalSetSize);
-  dlogpsi_work_down.resize(nelec, OrbitalSetSize);
+  dlogpsi_work_up.resize(nelec, norb_requested);
+  dlogpsi_work_down.resize(nelec, norb_requested);
 
-  d2logpsi_work_up.resize(nelec, OrbitalSetSize);
-  d2logpsi_work_down.resize(nelec, OrbitalSetSize);
+  d2logpsi_work_up.resize(nelec, norb_requested);
+  d2logpsi_work_down.resize(nelec, norb_requested);
 
   spo_up->evaluate_notranspose(P, first, last, logpsi_work_up, dlogpsi_work_up, d2logpsi_work_up);
   spo_dn->evaluate_notranspose(P, first, last, logpsi_work_down, dlogpsi_work_down, d2logpsi_work_down);
@@ -449,7 +472,7 @@ void SpinorSet::evaluate_notranspose_spin(const ParticleSet& P,
     ValueType emis(coss, -sins);
     ValueType eye(0, 1.0);
 
-    for (int no = 0; no < OrbitalSetSize; no++)
+    for (int no = 0; no < norb_requested; no++)
     {
       logdet(iat, no)      = eis * logpsi_work_up(iat, no) + emis * logpsi_work_down(iat, no);
       dlogdet(iat, no)     = eis * dlogpsi_work_up(iat, no) + emis * dlogpsi_work_down(iat, no);
@@ -462,6 +485,9 @@ void SpinorSet::evaluate_notranspose_spin(const ParticleSet& P,
 
 void SpinorSet::evaluate_spin(const ParticleSet& P, int iat, ValueVector& psi, ValueVector& dpsi)
 {
+  const size_t norb_requested = psi.size();
+  psi_work_up.resize(norb_requested);
+  psi_work_down.resize(norb_requested);
   psi_work_up   = 0.0;
   psi_work_down = 0.0;
 
@@ -492,19 +518,20 @@ void SpinorSet::evaluateGradSource(const ParticleSet& P,
 {
   IndexType nelec = P.getTotalNum();
 
-  GradMatrix gradphi_up(nelec, OrbitalSetSize);
-  GradMatrix gradphi_dn(nelec, OrbitalSetSize);
+  const size_t norb_requested = gradphi.size();
+  GradMatrix gradphi_up(nelec, norb_requested);
+  GradMatrix gradphi_dn(nelec, norb_requested);
   spo_up->evaluateGradSource(P, first, last, source, iat_src, gradphi_up);
   spo_dn->evaluateGradSource(P, first, last, source, iat_src, gradphi_dn);
 
-  for (int iat = 0; iat < nelec; iat++)
+  for (int iat = first; iat < last; iat++)
   {
     ParticleSet::Scalar_t s = P.activeSpin(iat);
     RealType coss           = std::cos(s);
     RealType sins           = std::sin(s);
     ValueType eis(coss, sins);
     ValueType emis(coss, -sins);
-    for (int imo = 0; imo < OrbitalSetSize; imo++)
+    for (int imo = 0; imo < norb_requested; imo++)
       gradphi(iat, imo) = gradphi_up(iat, imo) * eis + gradphi_dn(iat, imo) * emis;
   }
 }

--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -55,7 +55,6 @@ void SpinorSet::set_spos(std::unique_ptr<SPOSet>&& up, std::unique_ptr<SPOSet>&&
 
   spo_up = std::move(up);
   spo_dn = std::move(dn);
-
 }
 
 void SpinorSet::setOrbitalSetSize(int norbs) { OrbitalSetSize = norbs; };
@@ -183,8 +182,8 @@ void SpinorSet::mw_evaluateVGLWithSpin(const RefVectorWithLeader<SPOSet>& spo_li
   RefVector<ValueVector> up_d2psi_v_list, dn_d2psi_v_list;
   for (int iw = 0; iw < nw; iw++)
   {
-    auto& spo = spo_list.getCastedElement<SpinorSet>(iw);
-    auto& psi = psi_v_list[iw].get();
+    auto& spo                   = spo_list.getCastedElement<SpinorSet>(iw);
+    auto& psi                   = psi_v_list[iw].get();
     const size_t norb_requested = psi.size();
 
     spo.psi_work_up.resize(norb_requested);

--- a/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
@@ -67,7 +67,7 @@ void test_lcao_spinor()
   const char* particles = R"XML(<tmp> 
    <sposet_builder name="spinorbuilder" type="molecularorbital" href="lcao_spinor.h5" source="ion" precision="float"> 
      <basisset transform="yes"/> 
-     <sposet name="myspo" size="1"/> 
+     <sposet name="myspo" size="2"/> 
    </sposet_builder> 
    </tmp>)XML";
 
@@ -90,10 +90,14 @@ void test_lcao_spinor()
   });
   REQUIRE(spo);
 
-  SPOSet::ValueMatrix psiM(elec_.R.size(), spo->getOrbitalSetSize());
-  SPOSet::GradMatrix dpsiM(elec_.R.size(), spo->getOrbitalSetSize());
-  SPOSet::ValueMatrix dspsiM(elec_.R.size(), spo->getOrbitalSetSize()); //spin gradient
-  SPOSet::ValueMatrix d2psiM(elec_.R.size(), spo->getOrbitalSetSize());
+  //For this test, we are making the number of total orbitals in the SPOSet larger
+  //than what is requested for all SPOSet calls. 
+  //That will allow us to check the behavior of SpinorSet doing the right thing if 
+  //OrbitalSetSize > norbs_requested. This is necessary for things like orb opt with single determinants
+  SPOSet::ValueMatrix psiM(elec_.R.size(), elec_.R.size());
+  SPOSet::GradMatrix dpsiM(elec_.R.size(), elec_.R.size());
+  SPOSet::ValueMatrix dspsiM(elec_.R.size(), elec_.R.size()); //spin gradient
+  SPOSet::ValueMatrix d2psiM(elec_.R.size(), elec_.R.size());
 
   spo->evaluate_notranspose(elec_, 0, elec_.R.size(), psiM, dpsiM, d2psiM);
 
@@ -119,7 +123,7 @@ void test_lcao_spinor()
    * In this case, the ion derivative is actually just the negative of 
    * the electron gradient. 
    */
-  SPOSet::GradMatrix gradIon(elec_.R.size(), spo->getOrbitalSetSize());
+  SPOSet::GradMatrix gradIon(elec_.R.size(), elec_.R.size());
   spo->evaluateGradSource(elec_, 0, elec_.R.size(), ions_, 0, gradIon);
   for (int iat = 0; iat < 1; iat++)
   {
@@ -128,7 +132,6 @@ void test_lcao_spinor()
     CHECK(gradIon[iat][0][2] == ComplexApprox(-vdz).epsilon(eps));
   }
 
-  int OrbitalSetSize = spo->getOrbitalSetSize();
   //temporary arrays for holding the values of the up and down channels respectively.
   SPOSet::ValueVector psi_work;
 
@@ -141,10 +144,10 @@ void test_lcao_spinor()
   //temporary arrays for holding spin gradient
   SPOSet::ValueVector dspsi_work;
 
-  psi_work.resize(OrbitalSetSize);
-  dpsi_work.resize(OrbitalSetSize);
-  d2psi_work.resize(OrbitalSetSize);
-  dspsi_work.resize(OrbitalSetSize);
+  psi_work.resize(elec_.R.size());
+  dpsi_work.resize(elec_.R.size());
+  d2psi_work.resize(elec_.R.size());
+  dspsi_work.resize(elec_.R.size());
 
   //We worked hard to generate nice reference data above.  Let's generate a test for evaluateV
   //and evaluateVGL by perturbing the electronic configuration by dR, and then make
@@ -257,9 +260,9 @@ void test_lcao_spinor()
   ResourceCollectionTeamLock<SPOSet> mw_spo_lock(spo_res, spo_list);
   REQUIRE(spinor.isResourceOwned());
 
-  SPOSet::ValueMatrix psiM_2(elec_.R.size(), spo->getOrbitalSetSize());
-  SPOSet::GradMatrix dpsiM_2(elec_.R.size(), spo->getOrbitalSetSize());
-  SPOSet::ValueMatrix d2psiM_2(elec_.R.size(), spo->getOrbitalSetSize());
+  SPOSet::ValueMatrix psiM_2(elec_.R.size(), elec_.R.size());
+  SPOSet::GradMatrix dpsiM_2(elec_.R.size(), elec_.R.size());
+  SPOSet::ValueMatrix d2psiM_2(elec_.R.size(), elec_.R.size());
 
   RefVector<SPOSet::ValueMatrix> logdet_list;
   RefVector<SPOSet::GradMatrix> dlogdet_list;
@@ -301,15 +304,15 @@ void test_lcao_spinor()
   }
   elec_.mw_update(p_list);
 
-  SPOSet::ValueVector psi_work_2(OrbitalSetSize);
-  SPOSet::GradVector dpsi_work_2(OrbitalSetSize);
-  SPOSet::ValueVector d2psi_work_2(OrbitalSetSize);
+  SPOSet::ValueVector psi_work_2(elec_.R.size());
+  SPOSet::GradVector dpsi_work_2(elec_.R.size());
+  SPOSet::ValueVector d2psi_work_2(elec_.R.size());
 
   RefVector<SPOSet::ValueVector> psi_v_list   = {psi_work, psi_work_2};
   RefVector<SPOSet::GradVector> dpsi_v_list   = {dpsi_work, dpsi_work_2};
   RefVector<SPOSet::ValueVector> d2psi_v_list = {d2psi_work, d2psi_work_2};
   SPOSet::OffloadMatrix<SPOSet::ComplexType> mw_dspin;
-  mw_dspin.resize(2, OrbitalSetSize);
+  mw_dspin.resize(2, elec_.R.size());
   //check mw_evaluateVGLWithSpin
   for (int iat = 0; iat < 1; iat++)
   {

--- a/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
@@ -91,8 +91,8 @@ void test_lcao_spinor()
   REQUIRE(spo);
 
   //For this test, we are making the number of total orbitals in the SPOSet larger
-  //than what is requested for all SPOSet calls. 
-  //That will allow us to check the behavior of SpinorSet doing the right thing if 
+  //than what is requested for all SPOSet calls.
+  //That will allow us to check the behavior of SpinorSet doing the right thing if
   //OrbitalSetSize > norbs_requested. This is necessary for things like orb opt with single determinants
   SPOSet::ValueMatrix psiM(elec_.R.size(), elec_.R.size());
   SPOSet::GradMatrix dpsiM(elec_.R.size(), elec_.R.size());


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
Orbital optimization with spinors had a few issues. First, RotatedSPOs were missing a few spin APIs. Second, once the appropriate APIs were added, there were some sizing issues when spinors were used with DiracDeterminants. This is because DD always passes in data structues sized nelec x nelec, whereas in the case of orb opt the spinorset has OrbitalSetSize > nelec. This is now fixed, and orb opt with spinors should be working

Unit tests were modified or added to in order to check both the missing spin APIs in RotatedSPOs as well as the sizing issues in SpinorSet. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
M1 mac

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
