### PR TITLE
Change macOS CI to use the classic linker

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -282,10 +282,11 @@ case "$1" in
               ${GITHUB_WORKSPACE}
       ;;
       *"macOS-GCC12-NoMPI-Real"*)
-        echo 'Configure for building on macOS using gcc11'
+        echo 'Configure for building on macOS using gcc12'
         cmake -GNinja \
               -DCMAKE_C_COMPILER=gcc-12 \
               -DCMAKE_CXX_COMPILER=g++-12 \
+              -DCMAKE_EXE_LINKER_FLAGS="-Wl,-ld_classic" \
               -DQMC_MPI=0 \
               -DQMC_COMPLEX=$IS_COMPLEX \
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \


### PR DESCRIPTION
## Proposed changes
Closes https://github.com/QMCPACK/qmcpack/issues/4924
Xcode 15 introduced a new linker which was not robust and caused sporadic crash.
Switch to the classic linker.

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
None
## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
