### PR TITLE
Shorten timeout on AMD CI runs.

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
@@ -74,7 +74,7 @@ case "$1" in
   test)
     echo "Running deterministic tests"
     cd ${GITHUB_WORKSPACE}/../qmcpack-build
-    ctest --output-on-failure -L deterministic -j 32
+    ctest --output-on-failure -L deterministic -j 32 --timeout 120 --repeat after-timeout:2
     ;;
     
 esac


### PR DESCRIPTION
## Proposed changes
CI tests may hang on AMD GPU runs. Add a 180sec timeout and allow repeat at most twice. Better than current 1h limit.

## What type(s) of changes does this code introduce?
- Other (please describe): CI settings

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
None

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'