### PR TITLE
Update 2 to 4 cores used in tests on GitHub Actions runners

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -376,20 +376,8 @@ case "$1" in
     fi
 
     # Add ctest concurrent parallel jobs 
-    # Default for Linux GitHub Action runners
-    CTEST_JOBS="2"
-    # Default for macOS GitHub Action runners
-    if [[ "${GH_OS}" =~ (macOS) ]]
-    then
-      CTEST_JOBS="3"
-    fi
-
-    if [[ "$HOST_NAME" =~ (sulfur) || "$HOST_NAME" =~ (nitrogen) ]]
-    then
-      CTEST_JOBS="32"
-    fi
-    
-    ctest --output-on-failure $TEST_LABEL -j $CTEST_JOBS
+    # 4 for Linux and macOS GitHub Actions free runners
+    ctest --output-on-failure $TEST_LABEL -j 4
     ;;
   
   # Generate coverage reports


### PR DESCRIPTION

## Proposed changes

GitHub Actions now provides 4 cores in free runners on [Linux and macOS 13](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
This PR adds more test concurrency from 2 to 4

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
N/A, must pass CI

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
