### PR TITLE
[WIP] dump walkers periodically for post-processing

### DIFF
--- a/src/Particle/HDFWalkerOutput.h
+++ b/src/Particle/HDFWalkerOutput.h
@@ -52,7 +52,7 @@ public:
   /** dump configurations
    * @param w walkers
    */
-  bool dump(const WalkerConfigurations& w, int block);
+  bool dump(const WalkerConfigurations& w, int block, const bool identify_block=false);
   //     bool dump(ForwardWalkingHistoryObject& FWO);
 
 private:
@@ -62,7 +62,7 @@ private:
   std::array<BufferType, 2> RemoteData;
   std::array<std::vector<QMCTraits::FullPrecRealType>, 2> RemoteDataW;
   int block;
-  void write_configuration(const WalkerConfigurations& W, hdf_archive& hout, int block);
+  void write_configuration(const WalkerConfigurations& W, hdf_archive& hout, int block, const bool identify_block);
 };
 
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes

Repurpose unused input "record_configs" to set frequency of dumping walkers for post-processing.

*work in progress*: I'm stuck at step 1 "reuse config.h5 instead of deleting and re-creating it at every checkpoint".
serial execution runs through, but an mpi execution would get stuck. Any suggestions?

Example input of a simple harmonic oscillator [tb38_msho.zip](https://github.com/QMCPACK/qmcpack/files/14594402/tb38_msho.zip)



## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Intel workstation

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes/No. This PR is up to date with current the current state of 'develop'
- Yes/No. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
