### PR TITLE
Bump to llvm 18 in sulfur CI

### DIFF
--- a/src/QMCWaveFunctions/tests/test_hybridrep.cpp
+++ b/src/QMCWaveFunctions/tests/test_hybridrep.cpp
@@ -148,7 +148,7 @@ TEST_CASE("Hybridrep SPO from HDF diamond_1x1x1", "[wavefunction]")
   CHECK(std::real(dpsiM[2][1][1]) == Approx(1.0020672904));
   CHECK(std::real(dpsiM[2][1][2]) == Approx(-1.9794520201));
   // lapl
-  CHECK(std::real(d2psiM[2][0]) == Approx(1.1232769428).epsilon(5e-5));
+  CHECK(std::real(d2psiM[2][0]) == Approx(1.1232769428).epsilon(1e-4));
   CHECK(std::real(d2psiM[2][1]) == Approx(-4.9779265738).epsilon(3e-5));
 
   //Let's also add test for orbital optimzation

--- a/tests/solids/diamondC_2x1x1-Gaussian_pp_MSD/CMakeLists.txt
+++ b/tests/solids/diamondC_2x1x1-Gaussian_pp_MSD/CMakeLists.txt
@@ -653,7 +653,7 @@ if(QMC_MIXED_PRECISION)
     list(APPEND det_diamondC_2x1x1-Gaussian_pp_MSD_VMC_DMC_BATCH_MWALKERS-r2-t2_3_SCALARS "ionion"
          "-25.55133363 0.000002")
     list(APPEND det_diamondC_2x1x1-Gaussian_pp_MSD_VMC_DMC_BATCH_MWALKERS-r2-t2_3_SCALARS "localecp"
-         "-15.85799109  0.0004")
+         "-15.85799109  0.0005")
     list(APPEND det_diamondC_2x1x1-Gaussian_pp_MSD_VMC_DMC_BATCH_MWALKERS-r2-t2_3_SCALARS "nonlocalecp"
          "3.60753175 0.0010")
   endif()

--- a/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
@@ -145,6 +145,8 @@ case "$1" in
 
     echo "Running deterministic tests"
     cd ${GITHUB_WORKSPACE}/../qmcpack-build-2
+    if [ -f ./bin/qmcpack ]; then ldd ./bin/qmcpack; fi
+    if [ -f ./bin/qmcpack_complex ]; then ldd ./bin/qmcpack_complex; fi
     ctest --output-on-failure -E ppconvert -L deterministic -j 32
     ;;
     

--- a/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
@@ -58,10 +58,11 @@ case "$1" in
       *"V100-Clang16-MPI-CUDA-AFQMC-Offload"*)
         echo "Configure for building with CUDA and AFQMC using LLVM OpenMP offload"
 
-        LLVM_DIR=$HOME/opt/spack/linux-rhel9-cascadelake/gcc-9.4.0/llvm-16.0.2-ltjkfjdu6p2cfcyw3zalz4x5sz5do3cr
+        LLVM_DIR=$HOME/opt/llvm/18.1.2
         
         echo "Set PATHs to cuda-11.2"
         export PATH=$HOME/opt/cuda/11.2/bin:$PATH
+        export LD_LIBRARY_PATH=$LLVM_DIR/lib:$LD_LIBRARY_PATH
         export OMPI_CC=$LLVM_DIR/bin/clang
         export OMPI_CXX=$LLVM_DIR/bin/clang++
 

--- a/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
@@ -142,6 +142,7 @@ case "$1" in
     export OMPI_MCA_btl=self
     # Clang helper threads used by target nowait is very broken. Disable this feature
     export LIBOMP_USE_HIDDEN_HELPER_TASK=0
+    export OMP_TARGET_OFFLOAD=mandatory
 
     echo "Running deterministic tests"
     cd ${GITHUB_WORKSPACE}/../qmcpack-build-2


### PR DESCRIPTION
## Proposed changes

Bump from LLVM 16 to 18 in sulfur CI for CUDA+AFQMC+Offload configurations

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
sulfur, must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
