### PR TITLE
Do not error out with non-empty stderr in converter test scripts.

### DIFF
--- a/tests/converter/converter_test.py
+++ b/tests/converter/converter_test.py
@@ -88,12 +88,8 @@ def run_test(test_name, c4q_exe, h5diff_exe, conv_inp, gold_file, expect_fail, e
             okay = False
 
         if len(stderr.strip()) != 0:
-            # some MPI output on stderr is okay
-            # TODO - more general way of checking acceptable stderr strings
-            if not stderr.startswith('Rank'):
-                print("Stderr not empty")
-                print(stderr)
-                okay = False
+            print("Stderr not empty:")
+            print(stderr)
 
         if not os.path.exists(gold_file):
             print("Gold file missing")

--- a/tests/converter/gpaw/gpaw4qmcpack_test.py
+++ b/tests/converter/gpaw/gpaw4qmcpack_test.py
@@ -37,12 +37,8 @@ def run_gpaw4qmcpack_test(test_name, g4q_exe, h5diff_exe):
         okay = False
 
     if len(stderr.strip()) != 0:
-        # some MPI output on stderr is okay
-        # TODO - more general way of checking acceptable stderr strings
-        if not stderr.startswith('Rank'):
-            print("Stderr not empty")
-            print(stderr)
-            okay = False
+        print("Stderr not empty:")
+        print(stderr)
 
     ret = os.system(h5diff_exe + ' -d 0.000001 gold.orbs.h5 test.orbs.h5')
     # if it's okay up to this point

--- a/tests/converter/pwconverter_test.py
+++ b/tests/converter/pwconverter_test.py
@@ -25,15 +25,8 @@ def run_test(cpw4q_exe, h5diff_exe, gold_file, conv_inp):
         okay = False
     
     if len(stderr.strip()) != 0:
-        print ("Stderr not empty ")
+        print ("Stderr not empty:")
         print (stderr)
-        san = stderr.decode("utf-8").find("Sanitizer")
-        sup = stderr.decode("utf-8").find("Suppressions")
-        if sup >= 0 or san >= 0 :
-            print("Ignoring sanitizer suppressions")
-            okay = True
-        else:
-            okay = False
         
     if not os.path.exists(gold_file):
         print ("Gold file missing")


### PR DESCRIPTION
## Proposed changes
Robust against miscellaneous warning printout.
The return code checks before stderr checks are supposed to do the actual work.

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
