### PR TITLE
Update sunspot recipe and suppress CMake warning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ cmake_minimum_required(VERSION 3.21.0)
 if(POLICY CMP0127)
   cmake_policy(SET CMP0127 NEW) # Condition evaluation v3.22+ https://cmake.org/cmake/help/latest/policy/CMP0127.html
 endif()
+if(POLICY CMP0144)
+  cmake_policy(SET CMP0144 NEW) # v3.27+ find_package() uses upper-case <PACKAGENAME>_ROOT variables.
+endif()
 
 ######################################################################
 # QMCPACK project

--- a/config/build_alcf_sunspot_icpx.sh
+++ b/config/build_alcf_sunspot_icpx.sh
@@ -1,20 +1,16 @@
 #!/bin/bash
 # This recipe is intended for ALCF Sunspot https://www.alcf.anl.gov/support-center/aurora-sunspot
-# last revision: Jan 8th 2023
+# last revision: Mar 29th 2024
 #
 # How to invoke this script?
 # build_alcf_sunspot_icpx.sh # build all the variants assuming the current directory is the source directory.
 # build_alcf_sunspot_icpx.sh <source_dir> # build all the variants with a given source directory <source_dir>
 # build_alcf_sunspot_icpx.sh <source_dir> <install_dir> # build all the variants with a given source directory <source_dir> and install to <install_dir>
 
-module load spack libxml2 cmake
-module load cray-hdf5
-module load oneapi/eng-compiler/2023.05.15.007
+module load cmake hdf5/1.14.3 boost/1.83.0
+module load oneapi/eng-compiler/2023.12.15.002
 
 module list >& module_list.txt
-
-# edit this line for your own boost header files.
-export BOOST_ROOT=/home/yeluo/opt/boost_1_80_0
 
 echo "**********************************"
 echo '$ icpx -v'
@@ -23,7 +19,7 @@ echo "**********************************"
 
 TYPE=Release
 Machine=sunspot
-Compiler=icpx20230613
+Compiler=icpx20231130
 
 if [[ $# -eq 0 ]]; then
   source_folder=`pwd`


### PR DESCRIPTION
## Proposed changes
The explicit setting of CMP0144 only suppresses warning. We always have the new behavior.

## What type(s) of changes does this code introduce?
- Documentation or build script changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
sunspot

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
