### PR TITLE
Remove driver scope time and use function scope

### DIFF
--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -639,7 +639,8 @@ bool QMCMain::runQMC(xmlNodePtr cur, bool reuse)
       infoLog.flush();
 
       qmc_driver->run();
-      app_log() << "  " << qmc_driver->getEngineName() << " Execution time = " << std::setprecision(4) << process_and_run.elapsed() << " secs" << std::endl;
+      app_log() << "  " << qmc_driver->getEngineName() << " Execution time = " << std::setprecision(4)
+                << process_and_run.elapsed() << " secs" << std::endl;
     }
     // transfer the states of a driver before its destruction
     last_branch_engine_legacy_driver_ = qmc_driver->getBranchEngine();

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -631,12 +631,16 @@ bool QMCMain::runQMC(xmlNodePtr cur, bool reuse)
 #if !defined(REMOVE_TRACEMANAGER)
     qmc_driver->putTraces(traces_xml_);
 #endif
-    qmc_driver->process(cur);
-    infoSummary.flush();
-    infoLog.flush();
-    Timer qmcTimer;
-    qmc_driver->run();
-    app_log() << "  QMC Execution time = " << std::setprecision(4) << qmcTimer.elapsed() << " secs" << std::endl;
+    {
+      ScopedTimer qmc_run_timer(createGlobalTimer(qmc_driver->getEngineName(), timer_level_coarse));
+      Timer process_and_run;
+      qmc_driver->process(cur);
+      infoSummary.flush();
+      infoLog.flush();
+
+      qmc_driver->run();
+      app_log() << "  " << qmc_driver->getEngineName() << " Execution time = " << std::setprecision(4) << process_and_run.elapsed() << " secs" << std::endl;
+    }
     // transfer the states of a driver before its destruction
     last_branch_engine_legacy_driver_ = qmc_driver->getBranchEngine();
     // save the driver in a driver loop

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -55,7 +55,6 @@ QMCDriver::QMCDriver(const ProjectData& project_data,
       Psi(psi),
       H(h),
       checkpoint_timer_(createGlobalTimer("checkpoint::recordBlock", timer_level_medium)),
-      driver_scope_timer_(createGlobalTimer(QMC_driver_type, timer_level_coarse)),
       driver_scope_profiler_(enable_profiling)
 {
   ResetRandom  = false;

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -366,8 +366,6 @@ protected:
 
 private:
   NewTimer& checkpoint_timer_;
-  ///time the driver lifetime
-  ScopedTimer driver_scope_timer_;
   ///profile the driver lifetime
   ScopedProfiler driver_scope_profiler_;
 };

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -57,7 +57,6 @@ QMCDriverNew::QMCDriverNew(const ProjectData& project_data,
       dispatchers_(!qmcdriver_input_.areWalkersSerialized()),
       estimator_manager_(nullptr),
       timers_(timer_prefix),
-      driver_scope_timer_(createGlobalTimer(QMC_driver_type, timer_level_coarse)),
       driver_scope_profiler_(qmcdriver_input_.get_scoped_profiling()),
       project_data_(project_data),
       walker_configs_ref_(wc)

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -460,8 +460,6 @@ protected:
 
   DriverTimers timers_;
 
-  ///time the driver lifetime
-  ScopedTimer driver_scope_timer_;
   ///profile the driver lifetime
   ScopedProfiler driver_scope_profiler_;
 


### PR DESCRIPTION
## Proposed changes
driver class scope time didn't work well when a VMC driver is nested inside a WFOpt driver.
A lesson learned is that scoped timer should only be used in a function scope and cannot be in a class scope.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'