### PR TITLE
Refine WFOpt batched driver timer reporting

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -92,7 +92,7 @@ QMCFixedSampleLinearOptimize::QMCFixedSampleLinearOptimize(const ProjectData& pr
       Max_iterations(1),
       wfNode(NULL),
       param_tol(1e-4),
-      generate_samples_timer_(createGlobalTimer("QMCLinearOptimize::GenerateSamples", timer_level_medium)),
+      generate_samples_timer_(createGlobalTimer("QMCLinearOptimize::generateSamples", timer_level_medium)),
       initialize_timer_(createGlobalTimer("QMCLinearOptimize::Initialize", timer_level_medium)),
       eigenvalue_timer_(createGlobalTimer("QMCLinearOptimize::EigenvalueSolve", timer_level_medium)),
       involvmat_timer_(createGlobalTimer("QMCLinearOptimize::invertOverlapMat", timer_level_medium)),

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -86,10 +86,11 @@ QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(
       do_output_matrices_hdf_(false),
       output_matrices_initialized_(false),
       freeze_parameters_(false),
-      generate_samples_timer_(createGlobalTimer("QMCLinearOptimizeBatched::GenerateSamples", timer_level_medium)),
       initialize_timer_(createGlobalTimer("QMCLinearOptimizeBatched::Initialize", timer_level_medium)),
+      generate_samples_timer_(createGlobalTimer("QMCLinearOptimizeBatched::generateSamples", timer_level_medium)),
+      build_olv_ham_timer_(createGlobalTimer("QMCLinearOptimizedBatched::build_ovl_ham_matrix", timer_level_medium)),
+      invert_olvmat_timer_(createGlobalTimer("QMCLinearOptimizedBatched::invert_ovlMat", timer_level_medium)),
       eigenvalue_timer_(createGlobalTimer("QMCLinearOptimizeBatched::Eigenvalue", timer_level_medium)),
-      involvmat_timer_(createGlobalTimer("QMCLinearOptimizedBatched::invert_matrix", timer_level_medium)),
       line_min_timer_(createGlobalTimer("QMCLinearOptimizeBatched::Line_Minimization", timer_level_medium)),
       cost_function_timer_(createGlobalTimer("QMCLinearOptimizeBatched::CostFunction", timer_level_medium)),
       wfNode(NULL),
@@ -1587,13 +1588,6 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
   // compute the initial cost
   const RealType initCost = optTarget->computedCost();
 
-  // say what we are doing
-  app_log() << std::endl
-            << "*****************************************" << std::endl
-            << "Building overlap and Hamiltonian matrices" << std::endl
-            << "*****************************************" << std::endl;
-
-  Timer t_build_matrices;
   // allocate the matrices we will need
   Matrix<RealType> ovlMat(N, N);
   ovlMat = 0.0;
@@ -1604,79 +1598,92 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
   Matrix<RealType> prdMat(N, N);
   prdMat = 0.0;
 
-  // build the overlap and hamiltonian matrices
-  optTarget->fillOverlapHamiltonianMatrices(hamMat, ovlMat);
-
-  if (do_output_matrices_csv_)
-  {
-    output_overlap_.output(ovlMat);
-    output_hamiltonian_.output(hamMat);
-  }
-
+  // for outputing matrices and eigenvalue/vectors to disk
   hdf_archive hout;
-  if (do_output_matrices_hdf_)
+
   {
-    std::string newh5 = get_root_name() + ".linear_matrices.h5";
-    hout.create(newh5, H5F_ACC_TRUNC);
-    hout.write(ovlMat, "overlap");
-    hout.write(hamMat, "Hamiltonian");
-    hout.write(bestShift_i, "bestShift_i");
-    hout.write(bestShift_s, "bestShift_s");
+    ScopedTimer local(build_olv_ham_timer_);
+    Timer t_build_matrices;
+    // say what we are doing
+    app_log() << std::endl
+              << "*****************************************" << std::endl
+              << "Building overlap and Hamiltonian matrices" << std::endl
+              << "*****************************************" << std::endl;
+
+    // build the overlap and hamiltonian matrices
+    optTarget->fillOverlapHamiltonianMatrices(hamMat, ovlMat);
+
+    if (do_output_matrices_csv_)
+    {
+      output_overlap_.output(ovlMat);
+      output_hamiltonian_.output(hamMat);
+    }
+
+    if (do_output_matrices_hdf_)
+    {
+      std::string newh5 = get_root_name() + ".linear_matrices.h5";
+      hout.create(newh5, H5F_ACC_TRUNC);
+      hout.write(ovlMat, "overlap");
+      hout.write(hamMat, "Hamiltonian");
+      hout.write(bestShift_i, "bestShift_i");
+      hout.write(bestShift_s, "bestShift_s");
+    }
+    app_log() << "  Execution time (building matrices) = " << std::setprecision(4) << t_build_matrices.elapsed()
+              << std::endl;
   }
-  app_log() << "  Execution time (building matrices) = " << std::setprecision(4) << t_build_matrices.elapsed() << std::endl;
 
-  app_log() << std::endl
-            << "**************************" << std::endl
-            << "Solving eigenvalue problem" << std::endl
-            << "**************************" << std::endl;
-
-  Timer t_eigen;
-  invMat.copy(ovlMat);
-  // apply the identity shift
-  for (int i = 1; i < N; i++)
-  {
-    hamMat(i, i) += bestShift_i;
-    if (invMat(i, i) == 0)
-      invMat(i, i) = bestShift_i * bestShift_s;
-  }
-
-  // compute the inverse of the overlap matrix
-  {
-    ScopedTimer local(involvmat_timer_);
-    invert_matrix(invMat, false);
-  }
-
-  // apply the overlap shift
-  for (int i = 1; i < N; i++)
-    for (int j = 1; j < N; j++)
-      hamMat(i, j) += bestShift_s * ovlMat(i, j);
-
-  // multiply the shifted hamiltonian matrix by the inverse of the overlap matrix
-  qmcplusplus::MatrixOperators::product(invMat, hamMat, prdMat);
-
-  // transpose the result (why?)
-  for (int i = 0; i < N; i++)
-    for (int j = i + 1; j < N; j++)
-      std::swap(prdMat(i, j), prdMat(j, i));
-
-  // compute the lowest eigenvalue of the product matrix and the corresponding eigenvector
-  RealType lowestEV = 0.;
   {
     ScopedTimer local(eigenvalue_timer_);
-    lowestEV = getLowestEigenvector(prdMat, parameterDirections);
-  }
+    Timer t_eigen;
+    app_log() << std::endl
+              << "**************************" << std::endl
+              << "Solving eigenvalue problem" << std::endl
+              << "**************************" << std::endl;
 
-  // compute the scaling constant to apply to the update
-  objFuncWrapper_.Lambda = getNonLinearRescale(parameterDirections, ovlMat, *optTarget);
+    invMat.copy(ovlMat);
+    // apply the identity shift
+    for (int i = 1; i < N; i++)
+    {
+      hamMat(i, i) += bestShift_i;
+      if (invMat(i, i) == 0)
+        invMat(i, i) = bestShift_i * bestShift_s;
+    }
 
-  if (do_output_matrices_hdf_)
-  {
-    hout.write(lowestEV, "lowest_eigenvalue");
-    hout.write(parameterDirections, "scaled_eigenvector");
-    hout.write(objFuncWrapper_.Lambda, "non_linear_rescale");
-    hout.close();
+    // compute the inverse of the overlap matrix
+    {
+      ScopedTimer local(invert_olvmat_timer_);
+      invert_matrix(invMat, false);
+    }
+
+    // apply the overlap shift
+    for (int i = 1; i < N; i++)
+      for (int j = 1; j < N; j++)
+        hamMat(i, j) += bestShift_s * ovlMat(i, j);
+
+    // multiply the shifted hamiltonian matrix by the inverse of the overlap matrix
+    qmcplusplus::MatrixOperators::product(invMat, hamMat, prdMat);
+
+    // transpose the result (why?)
+    for (int i = 0; i < N; i++)
+      for (int j = i + 1; j < N; j++)
+        std::swap(prdMat(i, j), prdMat(j, i));
+
+    // compute the lowest eigenvalue of the product matrix and the corresponding eigenvector
+    RealType lowestEV = 0.;
+    lowestEV          = getLowestEigenvector(prdMat, parameterDirections);
+
+    // compute the scaling constant to apply to the update
+    objFuncWrapper_.Lambda = getNonLinearRescale(parameterDirections, ovlMat, *optTarget);
+
+    if (do_output_matrices_hdf_)
+    {
+      hout.write(lowestEV, "lowest_eigenvalue");
+      hout.write(parameterDirections, "scaled_eigenvector");
+      hout.write(objFuncWrapper_.Lambda, "non_linear_rescale");
+      hout.close();
+    }
+    app_log() << "  Execution time (eigenvalue) = " << std::setprecision(4) << t_eigen.elapsed() << std::endl;
   }
-  app_log() << "  Execution time (eigenvalue) = " << std::setprecision(4) << t_eigen.elapsed() << std::endl;
 
   // scale the update by the scaling constant
   for (int i = 0; i < numParams; i++)

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -274,10 +274,11 @@ private:
   // Freeze variational parameters.  Do not update them during each step.
   bool freeze_parameters_;
 
-  NewTimer& generate_samples_timer_;
   NewTimer& initialize_timer_;
+  NewTimer& generate_samples_timer_;
+  NewTimer& build_olv_ham_timer_;
+  NewTimer& invert_olvmat_timer_;
   NewTimer& eigenvalue_timer_;
-  NewTimer& involvmat_timer_;
   NewTimer& line_min_timer_;
   NewTimer& cost_function_timer_;
 


### PR DESCRIPTION
## Proposed changes

Review after #4961
Updated timer reporting at medium level
```
  QMCLinearOptimizeBatched                                       0.0131     0.0055              2       0.006525866
    QMCCostFunctionBatched::correlatedSampling                   0.0007     0.0007              2       0.000333037
      Hamiltonian:h_free::evaluate                               0.0000     0.0000              2       0.000001550
      ParticleSet:none::update                                   0.0000     0.0000              2       0.000001915
      WaveFunction:psi0::recompute                               0.0000     0.0000              2       0.000002405
    QMCLinearOptimizeBatched::Eigenvalue                         0.0005     0.0004              2       0.000225491
      QMCLinearOptimizedBatched::invert_ovlMat                   0.0000     0.0000              2       0.000004340
    QMCLinearOptimizeBatched::Initialize                         0.0012     0.0002              2       0.000622479
      QMCCostFunctionBatched::checkConfigurations                0.0010     0.0010              2       0.000519918
        ParticleSet:none::update                                 0.0000     0.0000              2       0.000002040
        WaveFunction:psi0::recompute                             0.0000     0.0000              2       0.000010435
    QMCLinearOptimizeBatched::generateSamples                    0.0037     0.0009              2       0.001860310
      VMCBatched::InitWalkers                                    0.0006     0.0005              2       0.000299027
        Hamiltonian:h0::evaluate                                 0.0000     0.0000              2       0.000003700
        ParticleSet:none::donePbyP                               0.0000     0.0000              2       0.000000255
        ParticleSet:none::loadWalker                             0.0000     0.0000              2       0.000002900
        WaveFunction:psi0::recompute                             0.0001     0.0001              2       0.000046121
      VMCBatched::Production                                     0.0022     0.0016              2       0.001106656
        VMCBatched::BlockEndDataAggregation                      0.0002     0.0002             10       0.000018158
        VMCBatched::RunSteps                                     0.0004     0.0001             12       0.000035711
          VMCBatched::Buffer                                     0.0000     0.0000             12       0.000001798
            WaveFunction:psi0::buffer                            0.0000     0.0000             12       0.000001639
          VMCBatched::Collectables                               0.0000     0.0000             12       0.000000089
          VMCBatched::Estimators                                 0.0000     0.0000             10       0.000000205
          VMCBatched::Hamiltonian                                0.0000     0.0000             12       0.000003984
            Hamiltonian:h0::evaluate                             0.0000     0.0000             12       0.000003221
          VMCBatched::MovePbyP                                   0.0002     0.0001             12       0.000018225
            ParticleSet:none::acceptMove                         0.0000     0.0000             48       0.000000316
            ParticleSet:none::computeNewPosDT                    0.0000     0.0000             48       0.000000550
              ParticleSet:none::dt_move                          0.0000     0.0000             48       0.000000284
              ParticleSet:none::mw_copy                          0.0000     0.0000             48       0.000000103
            ParticleSet:none::donePbyP                           0.0000     0.0000             12       0.000000147
            WaveFunction:psi0::V                                 0.0001     0.0001             48       0.000001238
            WaveFunction:psi0::accept                            0.0000     0.0000             72       0.000000627
            WaveFunction:psi0::preparegroup                      0.0000     0.0000             48       0.000000176
          VMCBatched::Resources                                  0.0000     0.0000             12       0.000001317
    QMCLinearOptimizedBatched::build_ovl_ham_matrix              0.0005     0.0003              2       0.000229742
      QMCCostFunctionBatched::fillOverlapHamiltonianMatrices     0.0002     0.0002              2       0.000077820
    VMCBatched::Startup                                          0.0010     0.0008              2       0.000487848
      VMCBatched::CreateWalkers                                  0.0002     0.0002              2       0.000105321
```

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Polaris

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted