### PR TITLE
Nexus: Replace deprecated load_source

### DIFF
--- a/nexus/lib/machines.py
+++ b/nexus/lib/machines.py
@@ -54,10 +54,23 @@ from developer import DevBase,to_str
 from nexus_base import NexusCore,nexus_core
 from execute import execute
 from debug import *
-from imp import load_source
-
 
 import re,subprocess
+
+import importlib.util
+import importlib.machinery
+
+def our_load_source(modname, filename):
+    """" Replacement for the deprecated imp.load_source function"""
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
+
 def cpu_count():
     """ Number of virtual or physical CPUs on this system, i.e.
     user/real as output by time(1) when called with an optimally scaling
@@ -1932,13 +1945,12 @@ class Clustername(Supercomputer):
 Clustername(      4,   1,    16,   24,    4, 'mpirun',     'qsub',   'qstat',    'qdel')
 '''
 try:
-    load_source('*',os.path.expanduser('~/.nexus/local_machines.py'))
+    our_load_source('*',os.path.expanduser('~/.nexus/local_machines.py'))
 except IOError:
     pass
 except:
     raise
 #end try
-
 
 class Kraken(Supercomputer):
 


### PR DESCRIPTION
## Proposed changes

Replace the deprecated and recently removed load_source function using the recommended replacement https://github.com/python/cpython/blob/main/Doc/whatsnew/3.12.rst

The undocumented ability to use a ~/.nexus/local_machines.py would be useful e.g. for central installations of nexus where the user doesn't have write access to the machines.py file

CI needs to run to see if this closes #4949

## What type(s) of changes does this code introduce?

- Bugfix
- New feature
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

nitrogen2 with and without ~/.nexus/local_machines.py and python 3.11.7. (CI on mac has 3.12)

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
