### PR TITLE
Enable batched determinant with CUDA without OMPTarget

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -119,7 +119,11 @@ public:
   virtual std::string getClassName() const override { return "SplineC2COMPTarget"; }
   virtual std::string getKeyword() const override { return "SplineC2C"; }
   bool isComplex() const override { return true; };
+#if defined(ENABLE_OFFLOAD)
   virtual bool isOMPoffload() const override { return true; }
+#else
+  virtual bool isOMPoffload() const override { return false; }
+#endif
 
   void createResource(ResourceCollection& collection) const override
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -125,7 +125,11 @@ public:
   virtual std::string getClassName() const override { return "SplineC2ROMPTarget"; }
   virtual std::string getKeyword() const override { return "SplineC2R"; }
   bool isComplex() const override { return true; };
+#if defined(ENABLE_OFFLOAD)
   virtual bool isOMPoffload() const override { return true; }
+#else
+  virtual bool isOMPoffload() const override { return false; }
+#endif
 
   void createResource(ResourceCollection& collection) const override
   {

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -454,6 +454,7 @@ void DiracDeterminantBatched<DET_ENGINE>::acceptMove(ParticleSet& P, int iat, bo
   log_value_ += convertValueToLog(curRatio);
   {
     ScopedTimer local_timer(UpdateTimer);
+    psiV.updateTo();
     det_engine_.updateRow(WorkingIndex, psiV, curRatio);
     if (UpdateMode == ORB_PBYP_PARTIAL)
     {

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -1243,7 +1243,7 @@ void DiracDeterminantBatched<DET_ENGINE>::releaseResource(
 }
 
 template class DiracDeterminantBatched<>;
-#if defined(ENABLE_CUDA) && defined(ENABLE_OFFLOAD)
+#if defined(ENABLE_CUDA)
 template class DiracDeterminantBatched<MatrixDelayedUpdateCUDA<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>;
 #endif
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -19,7 +19,7 @@
 
 #include "QMCWaveFunctions/Fermion/DiracDeterminantBase.h"
 #include "QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h"
-#if defined(ENABLE_CUDA) && defined(ENABLE_OFFLOAD)
+#if defined(ENABLE_CUDA)
 #include "QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h"
 #endif
 #include "DualAllocatorAliases.hpp"
@@ -336,7 +336,7 @@ private:
 };
 
 extern template class DiracDeterminantBatched<>;
-#if defined(ENABLE_CUDA) && defined(ENABLE_OFFLOAD)
+#if defined(ENABLE_CUDA)
 extern template class DiracDeterminantBatched<
     MatrixDelayedUpdateCUDA<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>;
 #endif

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -504,7 +504,6 @@ public:
 
   /** Update the "local" psiMinv_ on the device.
    *  Side Effect Transfers:
-   *  * phiV is left on host side in the single methods so it must be transferred to device
    *  * psiMinv_ is transferred back to host since single calls from QMCHamitonian and others
    *  * expect it to be.
    *
@@ -530,8 +529,7 @@ public:
     Value* rcopy_ptr      = rcopy.data();
     // This must be Ainv must be tofrom due to NonlocalEcpComponent and possibly
     // other modules assumptions about the state of psiMinv.
-    PRAGMA_OFFLOAD("omp target data map(always, to: phiV_ptr[:norb]) \
-                    map(always, tofrom: Ainv_ptr[:Ainv.size()]) \
+    PRAGMA_OFFLOAD("omp target data map(always, tofrom: Ainv_ptr[:Ainv.size()]) \
                     use_device_ptr(phiV_ptr, Ainv_ptr, temp_ptr, rcopy_ptr)")
     {
       int success = ompBLAS::gemv(dummy_handle, 'T', norb, norb, cone, Ainv_ptr, lda, phiV_ptr, 1, czero, temp_ptr, 1);

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -182,18 +182,15 @@ private:
       // cone
       mw_mem.cone_vec.resize(nw);
       std::fill_n(mw_mem.cone_vec.data(), nw, Value(1));
-      Value* cone_ptr = mw_mem.cone_vec.data();
-      PRAGMA_OFFLOAD("omp target update to(cone_ptr[:nw])")
+      mw_mem.cone_vec.updateTo();
       // cminusone
       mw_mem.cminusone_vec.resize(nw);
       std::fill_n(mw_mem_handle_.getResource().cminusone_vec.data(), nw, Value(-1));
-      Value* cminusone_ptr = mw_mem.cminusone_vec.data();
-      PRAGMA_OFFLOAD("omp target update to(cminusone_ptr[:nw])")
+      mw_mem.cminusone_vec.updateTo();
       // czero
       mw_mem.czero_vec.resize(nw);
       std::fill_n(mw_mem.czero_vec.data(), nw, Value(0));
-      Value* czero_ptr = mw_mem.czero_vec.data();
-      PRAGMA_OFFLOAD("omp target update to(czero_ptr[:nw])")
+      mw_mem.czero_vec.updateTo();
     }
   }
 
@@ -824,13 +821,13 @@ public:
         if (engine_leader.isSM1())
         {
           auto* ptr = engine.get_ref_psiMinv().data();
-          PRAGMA_OFFLOAD("omp target update from(ptr[row_id * ncols : ncols])")
+          engine.get_ref_psiMinv().updateFrom(ncols, row_id * ncols);
           row_ptr_list.push_back(ptr + row_id * ncols);
         }
         else
         {
           auto* ptr = engine.invRow.data();
-          PRAGMA_OFFLOAD("omp target update from(ptr[:engine.invRow.size()])")
+          engine.invRow.updateFrom();
           row_ptr_list.push_back(ptr);
         }
     }

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -302,8 +302,7 @@ public:
     Value* Ainv_ptr       = Ainv.data();
     Value* temp_ptr       = temp.data();
     Value* rcopy_ptr      = rcopy.data();
-    PRAGMA_OFFLOAD("omp target data map(always, to: phiV_ptr[:norb]) \
-                    map(always, from: Ainv_ptr[:Ainv.size()]) \
+    PRAGMA_OFFLOAD("omp target data map(always, from: Ainv_ptr[:Ainv.size()]) \
                     use_device_ptr(phiV_ptr, Ainv_ptr, temp_ptr, rcopy_ptr)")
     {
       success = ompBLAS::gemv(dummy_handle, 'T', norb, norb, cone, Ainv_ptr, lda, phiV_ptr, 1, czero, temp_ptr, 1);

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -386,7 +386,7 @@ std::unique_ptr<DiracDeterminantBase> SlaterDetBuilder::putDeterminant(
     {
       app_summary() << "      Using walker batching." << std::endl;
 
-#if defined(ENABLE_CUDA) && defined(ENABLE_OFFLOAD)
+#if defined(ENABLE_CUDA)
       if (CPUOMPTargetVendorSelector::selectPlatform(useGPU) == PlatformKind::CUDA)
       {
         app_summary() << "      Running on an NVIDIA GPU via CUDA acceleration and OpenMP offload." << std::endl;

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -129,7 +129,7 @@ void test_DiracDeterminantBatched_first()
 
 TEST_CASE("DiracDeterminantBatched_first", "[wavefunction][fermion]")
 {
-#if defined(ENABLE_OFFLOAD) && defined(ENABLE_CUDA)
+#if defined(ENABLE_CUDA)
   test_DiracDeterminantBatched_first<MatrixDelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>();
 #endif
   test_DiracDeterminantBatched_first<MatrixUpdateOMPTarget<ValueType, QMCTraits::QTFull::ValueType>>();
@@ -267,7 +267,7 @@ void test_DiracDeterminantBatched_second()
 
 TEST_CASE("DiracDeterminantBatched_second", "[wavefunction][fermion]")
 {
-#if defined(ENABLE_OFFLOAD) && defined(ENABLE_CUDA)
+#if defined(ENABLE_CUDA)
   test_DiracDeterminantBatched_second<MatrixDelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>();
 #endif
   test_DiracDeterminantBatched_second<MatrixUpdateOMPTarget<ValueType, QMCTraits::QTFull::ValueType>>();
@@ -483,7 +483,7 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
 TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")
 {
   // maximum delay 2
-#if defined(ENABLE_OFFLOAD) && defined(ENABLE_CUDA)
+#if defined(ENABLE_CUDA)
   test_DiracDeterminantBatched_delayed_update<
       MatrixDelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>(2, DetMatInvertor::ACCEL);
   test_DiracDeterminantBatched_delayed_update<
@@ -822,7 +822,7 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
 TEST_CASE("DiracDeterminantBatched_spinor_update", "[wavefunction][fermion]")
 {
   /* Uncomment when MatrixDelayedUpdateCUDA::mw_evalGradWithSpin is implemented
-#if defined(ENABLE_OFFLOAD) && defined(ENABLE_CUDA)
+#if defined(ENABLE_CUDA)
   test_DiracDeterminantBatched_spinor_update<
       MatrixDelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>(1, DetMatInvertor::ACCEL);
   test_DiracDeterminantBatched_spinor_update<

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -566,7 +566,7 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
   using VT   = QMCTraits::ValueType;
   using FPVT = QMCTraits::QTFull::ValueType;
 
-#if defined(ENABLE_CUDA) && defined(ENABLE_OFFLOAD)
+#if defined(ENABLE_CUDA)
   SECTION("DiracDeterminantBatched<MatrixDelayedUpdateCUDA>")
   {
     using Det = DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>;

--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
@@ -76,6 +76,7 @@ case "$1" in
     cd ${GITHUB_WORKSPACE}/../qmcpack-build
     if [ -f ./bin/qmcpack ] ; then ldd ./bin/qmcpack ; fi
     if [ -f ./bin/qmcpack_complex ] ; then ldd ./bin/qmcpack_complex ; fi
+    export HSA_USE_SVM=0
     ctest --output-on-failure -L deterministic -j 32 --timeout 120 --repeat after-timeout:4
     ;;
     

--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
@@ -75,6 +75,8 @@ case "$1" in
     echo "Running deterministic tests"
     rocm-smi --showdriverversion
     cd ${GITHUB_WORKSPACE}/../qmcpack-build
+    if [ -f ./bin/qmcpack ] ; then ldd ./bin/qmcpack ; fi
+    if [ -f ./bin/qmcpack_complex ] ; then ldd ./bin/qmcpack_complex ; fi
     ctest --output-on-failure -L deterministic -j 32 --timeout 120 --repeat after-timeout:4
     ;;
     

--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
@@ -77,7 +77,7 @@ case "$1" in
     if [ -f ./bin/qmcpack ] ; then ldd ./bin/qmcpack ; fi
     if [ -f ./bin/qmcpack_complex ] ; then ldd ./bin/qmcpack_complex ; fi
     export HSA_USE_SVM=0
-    ctest --output-on-failure -L deterministic -j 32 --timeout 120 --repeat after-timeout:4
+    ctest --output-on-failure -L unit -j 32 --timeout 120 --repeat after-timeout:4
     ;;
     
 esac

--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
@@ -77,6 +77,7 @@ case "$1" in
     if [ -f ./bin/qmcpack ] ; then ldd ./bin/qmcpack ; fi
     if [ -f ./bin/qmcpack_complex ] ; then ldd ./bin/qmcpack_complex ; fi
     export HSA_USE_SVM=0
+    export HSA_ENABLE_SDMA=0
     ctest --output-on-failure -L unit -j 32 --timeout 120 --repeat after-timeout:4
     ;;
     

--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
@@ -60,7 +60,6 @@ case "$1" in
           -DQMC_GPU_ARCHS=gfx906 \
           -DQMC_COMPLEX=$IS_COMPLEX \
           -DQMC_MIXED_PRECISION=$IS_MIXED_PRECISION \
-          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DQMC_DATA=$QMC_DATA_DIR \
           ${GITHUB_WORKSPACE}
           


### PR DESCRIPTION
## Proposed changes
Review after https://github.com/QMCPACK/qmcpack/pull/4966

code path used to be under `defined(ENABLE_OFFLOAD) && defined(ENABLE_CUDA)`
are available to `defined(ENABLE_OFFLOAD)`

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
