### PR TITLE
Disable DiracDeterminantBatched<MatrixUpdateOMPTarget> when ENABLE_CUDA=ON

### DIFF
--- a/src/QMCHamiltonians/tests/CMakeLists.txt
+++ b/src/QMCHamiltonians/tests/CMakeLists.txt
@@ -33,7 +33,9 @@ set(HAM_SRCS
 if(NOT QMC_COMPLEX)
   set(HAM_SRCS ${HAM_SRCS} test_RotatedSPOs_NLPP.cpp)
 else()
-  set(HAM_SRCS ${HAM_SRCS} test_SOECPotential.cpp)
+  if(NOT ENABLE_CUDA)
+    set(HAM_SRCS ${HAM_SRCS} test_SOECPotential.cpp)
+  endif()
 endif()
 
 set(FORCE_SRCS ${FORCE_SRCS} test_ion_derivs.cpp)

--- a/src/QMCHamiltonians/tests/test_SOECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_SOECPotential.cpp
@@ -65,7 +65,7 @@ public:
   {
     copyGridUnrotatedForTest(so_ecp);
     for (auto& uptr_comp : so_ecp.ppset_)
-        uptr_comp.get()->initVirtualParticle(elec);
+      uptr_comp.get()->initVirtualParticle(elec);
     so_ecp.evaluateImpl(elec, true);
     value = so_ecp.getValue();
   }
@@ -158,7 +158,8 @@ void doSOECPotentialTest(bool use_VPs)
   QMCTraits::IndexType norb = spinor_set->getOrbitalSetSize();
   REQUIRE(norb == 2);
 
-  auto dd = std::make_unique<DiracDeterminantBatched<MatrixUpdateOMPTarget<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>>(std::move(spinor_set), 0, nelec);
+  auto dd = std::make_unique<DiracDeterminantBatched<
+      MatrixUpdateOMPTarget<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>>(std::move(spinor_set), 0, nelec);
   std::vector<std::unique_ptr<DiracDeterminantBase>> dirac_dets;
   dirac_dets.push_back(std::move(dd));
   auto sd = std::make_unique<SlaterDet>(elec, std::move(dirac_dets));

--- a/src/QMCHamiltonians/tests/test_SOECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_SOECPotential.cpp
@@ -158,7 +158,7 @@ void doSOECPotentialTest(bool use_VPs)
   QMCTraits::IndexType norb = spinor_set->getOrbitalSetSize();
   REQUIRE(norb == 2);
 
-  auto dd = std::make_unique<DiracDeterminantBatched<>>(std::move(spinor_set), 0, nelec);
+  auto dd = std::make_unique<DiracDeterminantBatched<MatrixUpdateOMPTarget<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>>(std::move(spinor_set), 0, nelec);
   std::vector<std::unique_ptr<DiracDeterminantBase>> dirac_dets;
   dirac_dets.push_back(std::move(dd));
   auto sd = std::make_unique<SlaterDet>(elec, std::move(dirac_dets));

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -1242,9 +1242,12 @@ void DiracDeterminantBatched<DET_ENGINE>::releaseResource(
   collection.takebackResource(wfc_leader.accel_inverter_);
 }
 
-template class DiracDeterminantBatched<>;
-#if defined(ENABLE_CUDA) && defined(ENABLE_OFFLOAD)
+#if defined(ENABLE_CUDA)
+#if defined(ENABLE_OFFLOAD)
 template class DiracDeterminantBatched<MatrixDelayedUpdateCUDA<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>;
+#endif
+#else
+template class DiracDeterminantBatched<MatrixUpdateOMPTarget<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>;
 #endif
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -818,7 +818,10 @@ void DiracDeterminantBatched<DET_ENGINE>::evaluateRatios(const VirtualParticleSe
 }
 
 template<typename DET_ENGINE>
-void DiracDeterminantBatched<DET_ENGINE>::evaluateSpinorRatios(const VirtualParticleSet& VP, const std::pair<ValueVector, ValueVector>& spinor_multipler, std::vector<Value>& ratios)
+void DiracDeterminantBatched<DET_ENGINE>::evaluateSpinorRatios(
+    const VirtualParticleSet& VP,
+    const std::pair<ValueVector, ValueVector>& spinor_multipler,
+    std::vector<Value>& ratios)
 {
   {
     ScopedTimer local_timer(RatioTimer);

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -105,7 +105,9 @@ public:
    */
   void evaluateRatios(const VirtualParticleSet& VP, std::vector<Value>& ratios) override;
 
-  void evaluateSpinorRatios(const VirtualParticleSet& VP, const std::pair<ValueVector, ValueVector>& spinor_multiplier, std::vector<Value>& ratios) override;
+  void evaluateSpinorRatios(const VirtualParticleSet& VP,
+                            const std::pair<ValueVector, ValueVector>& spinor_multiplier,
+                            std::vector<Value>& ratios) override;
 
   void mw_evaluateRatios(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                          const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
@@ -341,7 +343,8 @@ extern template class DiracDeterminantBatched<
     MatrixDelayedUpdateCUDA<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>;
 #endif
 #else
-extern template class DiracDeterminantBatched<MatrixUpdateOMPTarget<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>;
+extern template class DiracDeterminantBatched<
+    MatrixUpdateOMPTarget<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>;
 #endif
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -32,7 +32,7 @@ namespace qmcplusplus
 //forward declaration
 class TWFFastDerivWrapper;
 
-template<typename DET_ENGINE = MatrixUpdateOMPTarget<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>
+template<typename DET_ENGINE>
 class DiracDeterminantBatched : public DiracDeterminantBase
 {
 public:
@@ -335,10 +335,13 @@ private:
   NewTimer &D2HTimer, &H2DTimer;
 };
 
-extern template class DiracDeterminantBatched<>;
-#if defined(ENABLE_CUDA) && defined(ENABLE_OFFLOAD)
+#if defined(ENABLE_CUDA)
+#if defined(ENABLE_OFFLOAD)
 extern template class DiracDeterminantBatched<
     MatrixDelayedUpdateCUDA<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>;
+#endif
+#else
+extern template class DiracDeterminantBatched<MatrixUpdateOMPTarget<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>;
 #endif
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -399,18 +399,21 @@ std::unique_ptr<DiracDeterminantBase> SlaterDetBuilder::putDeterminant(
       }
       else
 #endif
-        throw std::runtime_error("Neither pure CPU nor pure OpenMP offload implementation of walker-batched Slater determinant.");
+        throw std::runtime_error(
+            "Neither pure CPU nor pure OpenMP offload implementation of walker-batched Slater determinant.");
 #else
 #if defined(ENABLE_OFFLOAD)
-        if (CPUOMPTargetVendorSelector::selectPlatform(useGPU) == PlatformKind::CPU)
-          throw std::runtime_error("No pure CPU implementation of walker-batched Slater determinant.");
-        app_summary() << "      Running OpenMP offload code path on GPU. "
+      if (CPUOMPTargetVendorSelector::selectPlatform(useGPU) == PlatformKind::CPU)
+        throw std::runtime_error("No pure CPU implementation of walker-batched Slater determinant.");
+      app_summary() << "      Running OpenMP offload code path on GPU. "
 #else
-        app_summary() << "      Running OpenMP offload code path on CPU. "
+      app_summary() << "      Running OpenMP offload code path on CPU. "
 #endif
-                      << "Only SM1 update is supported. delay_rank is ignored." << std::endl;
-        adet = std::make_unique<DiracDeterminantBatched<MatrixUpdateOMPTarget<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>>(std::move(psi_clone), firstIndex, lastIndex, delay_rank,
-                                                           matrix_inverter_kind);
+                    << "Only SM1 update is supported. delay_rank is ignored." << std::endl;
+      adet = std::make_unique<DiracDeterminantBatched<
+          MatrixUpdateOMPTarget<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>>(std::move(psi_clone), firstIndex,
+                                                                                      lastIndex, delay_rank,
+                                                                                      matrix_inverter_kind);
 #endif
     }
     else

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -129,10 +129,13 @@ void test_DiracDeterminantBatched_first()
 
 TEST_CASE("DiracDeterminantBatched_first", "[wavefunction][fermion]")
 {
-#if defined(ENABLE_OFFLOAD) && defined(ENABLE_CUDA)
+#if defined(ENABLE_CUDA)
+#if defined(ENABLE_OFFLOAD)
   test_DiracDeterminantBatched_first<MatrixDelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>();
 #endif
+#else
   test_DiracDeterminantBatched_first<MatrixUpdateOMPTarget<ValueType, QMCTraits::QTFull::ValueType>>();
+#endif
 }
 
 //#define DUMP_INFO
@@ -267,10 +270,13 @@ void test_DiracDeterminantBatched_second()
 
 TEST_CASE("DiracDeterminantBatched_second", "[wavefunction][fermion]")
 {
-#if defined(ENABLE_OFFLOAD) && defined(ENABLE_CUDA)
+#if defined(ENABLE_CUDA)
+#if defined(ENABLE_OFFLOAD)
   test_DiracDeterminantBatched_second<MatrixDelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>();
 #endif
+#else
   test_DiracDeterminantBatched_second<MatrixUpdateOMPTarget<ValueType, QMCTraits::QTFull::ValueType>>();
+#endif
 }
 
 template<class DET_ENGINE>
@@ -483,16 +489,19 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
 TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")
 {
   // maximum delay 2
-#if defined(ENABLE_OFFLOAD) && defined(ENABLE_CUDA)
+#if defined(ENABLE_CUDA)
+#if defined(ENABLE_OFFLOAD)
   test_DiracDeterminantBatched_delayed_update<
       MatrixDelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>(2, DetMatInvertor::ACCEL);
   test_DiracDeterminantBatched_delayed_update<
       MatrixDelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>(2, DetMatInvertor::HOST);
 #endif
+#else
   test_DiracDeterminantBatched_delayed_update<
       MatrixUpdateOMPTarget<ValueType, QMCTraits::QTFull::ValueType>>(2, DetMatInvertor::ACCEL);
   test_DiracDeterminantBatched_delayed_update<
       MatrixUpdateOMPTarget<ValueType, QMCTraits::QTFull::ValueType>>(2, DetMatInvertor::HOST);
+#endif
 }
 
 
@@ -829,10 +838,12 @@ TEST_CASE("DiracDeterminantBatched_spinor_update", "[wavefunction][fermion]")
       MatrixDelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>(1, DetMatInvertor::HOST);
 #endif
 */
+#if !defined(ENABLE_CUDA)
   test_DiracDeterminantBatched_spinor_update<
       MatrixUpdateOMPTarget<ValueType, QMCTraits::QTFull::ValueType>>(1, DetMatInvertor::ACCEL);
   test_DiracDeterminantBatched_spinor_update<
       MatrixUpdateOMPTarget<ValueType, QMCTraits::QTFull::ValueType>>(1, DetMatInvertor::HOST);
+#endif
 }
 #endif
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -566,7 +566,8 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
   using VT   = QMCTraits::ValueType;
   using FPVT = QMCTraits::QTFull::ValueType;
 
-#if defined(ENABLE_CUDA) && defined(ENABLE_OFFLOAD)
+#if defined(ENABLE_CUDA)
+#if defined(ENABLE_OFFLOAD)
   SECTION("DiracDeterminantBatched<MatrixDelayedUpdateCUDA>")
   {
     using Det = DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>;
@@ -600,6 +601,7 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
     testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{true, true});
   }
 #endif
+#else
 
   // DiracDeterminantBatched<MatrixUpdateOMPTarget>
   SECTION("DiracDeterminantBatched<MatrixUpdateOMPTarget>")
@@ -634,6 +636,7 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
     testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(1, OffloadSwitches{true, true});
     testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{true, true});
   }
+#endif
 
   // DiracDeterminant<DelayedUpdate>
   SECTION("DiracDeterminant<DelayedUpdate>")

--- a/tests/solids/diamondC_2x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_2x1x1_pp/CMakeLists.txt
@@ -59,6 +59,7 @@ qmc_run_and_check(
   DIAMOND2_SCALARS # VMC
 )
 
+if(ENABLE_CUDA AND ENABLE_OFFLOAD OR NOT ENABLE_CUDA)
 qmc_run_and_check(
   short-diamondC_2x1x1_pp-vmcbatch-4b_sdbatch_jas
   "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
@@ -70,6 +71,7 @@ qmc_run_and_check(
   0
   DIAMOND2_SCALARS # VMC
 )
+endif()
 
 qmc_run_and_check(
   short-diamondC_2x1x1_pp-delayed_update-vmc_sdj
@@ -136,6 +138,7 @@ qmc_run_and_check(
   DIAMOND2_DMC_SCALARS # DMC
 )
 
+if(ENABLE_CUDA AND ENABLE_OFFLOAD OR NOT ENABLE_CUDA)
 #4 batches of 16 walkers in one rank, batched slater det
 qmc_run_and_check(
   short-diamondC_2x1x1_pp-vmcbatch_dmcbatch-4b_sdbatch_jas
@@ -148,6 +151,7 @@ qmc_run_and_check(
   1
   DIAMOND2_DMC_SCALARS # DMC
 )
+endif()
 
 # 4 batches of 16 walkers over 4 ranks
 qmc_run_and_check(
@@ -723,6 +727,7 @@ qmc_run_and_check(
   DET_DIAMOND2_VMC_BATCH_MWALKERS2_SCALARS # VMC cycle 2
 )
 
+if(ENABLE_CUDA AND ENABLE_OFFLOAD OR NOT ENABLE_CUDA)
 qmc_run_and_check(
   deterministic-diamondC_2x1x1_pp-vmcbatch-mwalkers_sdbatch_jas
   "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
@@ -736,6 +741,7 @@ qmc_run_and_check(
   1
   DET_DIAMOND2_VMC_BATCH_MWALKERS2_SCALARS # VMC cycle 2
 )
+endif()
 
 if(QMC_MIXED_PRECISION)
   if(QMC_COMPLEX)
@@ -895,6 +901,7 @@ qmc_run_and_check(
   DET_DIAMOND2_VMC_DMC_BATCH_MWALKERS-r1-t4_3_SCALARS # DMC
 )
 
+if(ENABLE_CUDA AND ENABLE_OFFLOAD OR NOT ENABLE_CUDA)
 qmc_run_and_check(
   deterministic-diamondC_2x1x1_pp-vmcbatch-dmcbatch-mwalkers_sdbatch_sdj
   "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
@@ -926,6 +933,7 @@ qmc_run_and_check(
   2
   DET_DIAMOND2_VMC_DMC_BATCH_MWALKERS-r1-t4_3_SCALARS # DMC
 )
+endif()
 
 if(QMC_MIXED_PRECISION)
   if(QMC_COMPLEX)
@@ -1069,6 +1077,7 @@ qmc_run_and_check(
   DET_DIAMOND2_VMC_DMC_BATCH_MWALKERS-r1-t16_3_SCALARS # DMC
 )
 
+if(ENABLE_CUDA AND ENABLE_OFFLOAD OR NOT ENABLE_CUDA)
 qmc_run_and_check(
   deterministic-diamondC_2x1x1_pp-vmcbatch-dmcbatch-mwalkers_sdbatch_sdj
   "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
@@ -1084,6 +1093,7 @@ qmc_run_and_check(
   2
   DET_DIAMOND2_VMC_DMC_BATCH_MWALKERS-r1-t16_3_SCALARS # DMC
 )
+endif()
 
 if(QMC_MIXED_PRECISION)
   if(QMC_COMPLEX)
@@ -1227,6 +1237,7 @@ qmc_run_and_check(
   DET_DIAMOND2_VMC_DMC_BATCH_MWALKERS-r2-t2_3_SCALARS # DMC
 )
 
+if(ENABLE_CUDA AND ENABLE_OFFLOAD OR NOT ENABLE_CUDA)
 qmc_run_and_check(
   deterministic-diamondC_2x1x1_pp-vmcbatch-dmcbatch-mwalkers_sdbatch_sdj
   "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
@@ -1242,6 +1253,7 @@ qmc_run_and_check(
   2
   DET_DIAMOND2_VMC_DMC_BATCH_MWALKERS-r2-t2_3_SCALARS # DMC
 )
+endif()
 
 if(QMC_MIXED_PRECISION)
   if(QMC_COMPLEX)
@@ -1401,6 +1413,7 @@ qmc_run_and_check(
   DET_DIAMOND2_VMC_DMC_BATCH_MWALKERS-r2-t3_3_SCALARS # DMC
 )
 
+if(ENABLE_CUDA AND ENABLE_OFFLOAD OR NOT ENABLE_CUDA)
 qmc_run_and_check(
   deterministic-diamondC_2x1x1_pp-vmcbatch-dmcbatch-mwalkers_sdbatch_sdj
   "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
@@ -1432,6 +1445,7 @@ qmc_run_and_check(
   2
   DET_DIAMOND2_VMC_DMC_BATCH_MWALKERS-r2-t3_3_SCALARS # DMC
 )
+endif()
 
 if(QMC_MIXED_PRECISION)
   if(QMC_COMPLEX)


### PR DESCRIPTION
## Proposed changes
Keep both
`DiracDeterminantBatched<MatrixUpdateOMPTarget>`
and
`DiracDeterminantBatched<MatrixDelayedUpdateCUDA>`
in a single build is largely unnecessary. Since users usually pick the most performant CUDA option.
As I'm going to retire MatrixUpdateOMPTarget and turn MatrixDelayedUpdateCUDA into supporting OMPTarget/CUDA/SYCL, it is a lot easier to disable MatrixUpdateOMPTarget when ENABLE_CUDA=ON and its functionality will be superseded by a more generic implementation.


## What type(s) of changes does this code introduce?
- Other (please describe): Disable less used code path to facilitate porting.

### Does this introduce a breaking change?
- Yes: ENABLE_CUDA=ON excludes single det pure OMPTarget implementation.

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
