### PR TITLE
Introduce OMPTargetAllocator device-only allocator

### DIFF
--- a/src/Platforms/CUDA/CUDAallocator.hpp
+++ b/src/Platforms/CUDA/CUDAallocator.hpp
@@ -181,8 +181,8 @@ bool operator!=(const CUDAAllocator<T1>&, const CUDAAllocator<T2>&)
 {
   return false;
 }
-template<typename T>
 
+template<typename T>
 struct qmc_allocator_traits<qmcplusplus::CUDAAllocator<T>>
 {
   static const bool is_host_accessible = false;

--- a/src/Platforms/DualAllocatorAliases.hpp
+++ b/src/Platforms/DualAllocatorAliases.hpp
@@ -31,6 +31,8 @@ namespace qmcplusplus
   using UnpinnedDualAllocator = DualAllocator<T, CUDAAllocator<T>, aligned_allocator<T>>;
   template<typename T>
   using PinnedDualAllocator = DualAllocator<T, CUDAAllocator<T>, PinnedAlignedAllocator<T>>;
+  template<typename T>
+  using DeviceAllocator = CUDAAllocator<T>;
 }
 #elif defined(ENABLE_SYCL)
 namespace qmcplusplus
@@ -39,6 +41,8 @@ namespace qmcplusplus
   using UnpinnedDualAllocator = DualAllocator<T, SYCLAllocator<T>, aligned_allocator<T>>;
   template<typename T>
   using PinnedDualAllocator = DualAllocator<T, SYCLAllocator<T>, PinnedAlignedAllocator<T>>;
+  template<typename T>
+  using DeviceAllocator = SYCLAllocator<T>;
 }
 #else
 #error unhandled platform
@@ -52,6 +56,10 @@ namespace qmcplusplus
   using UnpinnedDualAllocator = OffloadAllocator<T>;
   template<typename T>
   using PinnedDualAllocator = OffloadPinnedAllocator<T>;
+#if defined(ENABLE_OFFLOAD)
+  template<typename T>
+  using DeviceAllocator = OMPTargetAllocator<T>;
+#endif
 }
 #endif
 

--- a/src/Platforms/OMPTarget/OMPallocator.hpp
+++ b/src/Platforms/OMPTarget/OMPallocator.hpp
@@ -204,7 +204,7 @@ public:
   T* allocate(std::size_t n)
   {
     void* pt = omp_target_alloc(n * sizeof(T), omp_get_default_device());
-    if(!pt)
+    if (!pt)
       throw std::runtime_error("Allocation failed in OMPTargetAllocator!");
     OMPallocator_device_mem_allocated += n * sizeof(T);
     return static_cast<T*>(pt);
@@ -246,19 +246,21 @@ public:
 
   void copyToDevice(T* device_ptr, T* host_ptr, size_t n)
   {
-    if(omp_target_memcpy(device_ptr, host_ptr, n, 0, 0, omp_get_default_device(), omp_get_initial_device()))
+    const auto host_id = omp_get_initial_device();
+    if (omp_target_memcpy(device_ptr, host_ptr, n, 0, 0, omp_get_default_device(), host_id))
       throw std::runtime_error("omp_target_memcpy failed in copyToDevice");
   }
 
   void copyFromDevice(T* host_ptr, T* device_ptr, size_t n)
   {
-    if(omp_target_memcpy(host_ptr, device_ptr, n, 0, 0, omp_get_initial_device(), omp_get_default_device()))
+    const auto host_id = omp_get_initial_device();
+    if (omp_target_memcpy(host_ptr, device_ptr, n, 0, 0, host_id, omp_get_default_device()))
       throw std::runtime_error("omp_target_memcpy failed in copyToDevice");
   }
 
   void copyDeviceToDevice(T* to_ptr, size_t n, T* from_ptr)
   {
-    if(omp_target_memcpy(to_ptr, from_ptr, n, 0, 0, omp_get_default_device(), omp_get_default_device()))
+    if (omp_target_memcpy(to_ptr, from_ptr, n, 0, 0, omp_get_default_device(), omp_get_default_device()))
       throw std::runtime_error("omp_target_memcpy failed in copyToDevice");
   }
 };
@@ -279,7 +281,7 @@ struct qmc_allocator_traits<qmcplusplus::OMPTargetAllocator<T>>
 {
   static const bool is_host_accessible = false;
   static const bool is_dual_space      = false;
-  static void fill_n(T* ptr, size_t n, const T& value) { }
+  static void fill_n(T* ptr, size_t n, const T& value) {}
 };
 #endif
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -454,6 +454,7 @@ void DiracDeterminantBatched<DET_ENGINE>::acceptMove(ParticleSet& P, int iat, bo
   log_value_ += convertValueToLog(curRatio);
   {
     ScopedTimer local_timer(UpdateTimer);
+    psiV.updateTo();
     det_engine_.updateRow(WorkingIndex, psiV, curRatio);
     if (UpdateMode == ORB_PBYP_PARTIAL)
     {

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -507,7 +507,6 @@ public:
 
   /** Update the "local" psiMinv_ on the device.
    *  Side Effect Transfers:
-   *  * phiV is left on host side in the single methods so it must be transferred to device
    *  * psiMinv_ is transferred back to host since single calls from QMCHamitonian and others
    *  * expect it to be.
    *
@@ -533,8 +532,7 @@ public:
     Value* rcopy_ptr      = rcopy.data();
     // This must be Ainv must be tofrom due to NonlocalEcpComponent and possibly
     // other modules assumptions about the state of psiMinv.
-    PRAGMA_OFFLOAD("omp target data map(always, to: phiV_ptr[:norb]) \
-                    map(always, tofrom: Ainv_ptr[:Ainv.size()]) \
+    PRAGMA_OFFLOAD("omp target data map(always, tofrom: Ainv_ptr[:Ainv.size()]) \
                     use_device_ptr(phiV_ptr, Ainv_ptr, temp_ptr, rcopy_ptr)")
     {
       int success = ompBLAS::gemv(dummy_handle, 'T', norb, norb, cone, Ainv_ptr, lda, phiV_ptr, 1, czero, temp_ptr, 1);

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -129,9 +129,9 @@ private:
   UnpinnedDualVector<Value> rcopy;
 
   template<typename DT>
-  using DeviceMatrix = Matrix<DT, CUDAAllocator<DT>>;
+  using DeviceMatrix = Matrix<DT, DeviceAllocator<DT>>;
   template<typename DT>
-  using DeviceVector = Vector<DT, CUDAAllocator<DT>>;
+  using DeviceVector = Vector<DT, DeviceAllocator<DT>>;
   /// orbital values of delayed electrons
   DeviceMatrix<Value> U_gpu;
   /// rows of Ainv corresponding to delayed electrons
@@ -143,7 +143,7 @@ private:
   /// new column of B
   DeviceVector<Value> p_gpu;
   /// list of delayed electrons
-  Vector<int, CUDAAllocator<int>> delay_list_gpu;
+  DeviceVector<int> delay_list_gpu;
   /// current number of delays, increase one for each acceptance, reset to 0 after updating Ainv
   int delay_count;
 

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -302,8 +302,7 @@ public:
     Value* Ainv_ptr       = Ainv.data();
     Value* temp_ptr       = temp.data();
     Value* rcopy_ptr      = rcopy.data();
-    PRAGMA_OFFLOAD("omp target data map(always, to: phiV_ptr[:norb]) \
-                    map(always, from: Ainv_ptr[:Ainv.size()]) \
+    PRAGMA_OFFLOAD("omp target data map(always, from: Ainv_ptr[:Ainv.size()]) \
                     use_device_ptr(phiV_ptr, Ainv_ptr, temp_ptr, rcopy_ptr)")
     {
       success = ompBLAS::gemv(dummy_handle, 'T', norb, norb, cone, Ainv_ptr, lda, phiV_ptr, 1, czero, temp_ptr, 1);


### PR DESCRIPTION
## Proposed changes
Introduce OMPTargetAllocator. Having OpenMP offload consistently manages all the device memory.


## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
