### PR TITLE
Fix GCC14-flagged uninitialized use warnings

### DIFF
--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -390,8 +390,7 @@ inline void OneBodyDensityMatrices::generateDensitySamplesWithSpin(bool save,
 
     //now do spin variables
     Real spinp;                         // trial spin
-    Real dspinp;                        // trial spindrifty
-    Real spin_ds;                       // spin drift sum
+    Real dspinp = 0;                    // trial spindrifty
     Real sdiff = diffuseSpin(sqt, rng); //spin diffusion
     if (input_.get_use_drift())
     {
@@ -400,7 +399,7 @@ inline void OneBodyDensityMatrices::generateDensitySamplesWithSpin(bool save,
       calcDensityDriftWithSpin(rp, spinp, rhop, dp, dspinp, pset_target); //get trial drift and density
       ratio   = rhop / rho;                                               //density ratio
       ds      = dp + d;                                                   //drift sum
-      spin_ds = dspinp + dspcur_;                                         //spin drift sum
+      auto spin_ds = dspinp + dspcur_;                                    //spin drift sum
       Pacc    = ratio * std::exp(-ot * (dot(diff, ds) + .5 * dot(ds, ds))) *
           std::exp(-ot * (sdiff * spin_ds) + 0.5 * spin_ds * spin_ds); //acceptance probability
     }

--- a/src/io/OhmmsData/Libxml2Doc.cpp
+++ b/src/io/OhmmsData/Libxml2Doc.cpp
@@ -80,7 +80,7 @@ void OhmmsXPathObject::put(const char* expression, xmlXPathContextPtr context)
 
 Libxml2Document::Libxml2Document() : m_doc(NULL), m_root(NULL), m_context(NULL) {}
 
-Libxml2Document::Libxml2Document(const std::string& xmlfile) { parse(xmlfile); }
+Libxml2Document::Libxml2Document(const std::string& xmlfile) : m_doc(NULL), m_root(NULL), m_context(NULL) { parse(xmlfile); }
 
 Libxml2Document::~Libxml2Document()
 {


### PR DESCRIPTION
## Proposed changes

With our default compilation options GCC14 usefully flags a couple of new routes to uninitialized variable use. Fixed.

There is still a large but not-new warning coming from ppconvert IO handling that I did not fix.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

nitrogen2, nightly config with trial installation of gcc 14.1

## Checklist

- Yes This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
