### PR TITLE
extend h5 data proxy for std::vector<bool> needed for EDE

### DIFF
--- a/src/io/hdf/tests/test_hdf_archive.cpp
+++ b/src/io/hdf/tests/test_hdf_archive.cpp
@@ -2,9 +2,10 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2024 QMCPACK developers.
 //
 // File developed by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//                    Peter W. Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -451,4 +452,39 @@ TEST_CASE("hdf_archive_dataset_type_checking", "[hdf]")
   is_correct_type = hd2.is_dataset_of_type<int64_t>(ds_tag);
   REQUIRE(is_correct_type == false);
   REQUIRE_THROWS_AS(hd2.is_dataset_of_type<uint64_t>("tag_doesnt_exist"), std::runtime_error);
+}
+
+TEST_CASE("hdf_std_vec_bool", "[hdf]")
+{
+  hdf_archive hd;
+  hd.create("test_vec_bool.hdf");
+
+  std::vector<bool> v(3, false);
+  v[0] = true;
+
+  bool okay = hd.writeEntry(v, "vector_bool");
+  REQUIRE(okay);
+
+  const std::vector<bool> v_const(v);
+  okay = hd.writeEntry(v_const, "vector_bool_const");
+  REQUIRE(okay);
+
+  hd.close();
+
+  hdf_archive hd2;
+  okay = hd2.open("test_vec_bool.hdf");
+  REQUIRE(okay);
+
+  std::vector<bool> v2;
+  okay = hd2.readEntry(v2, "vector_bool");
+  REQUIRE(v2.size() == 3);
+  for (int i = 0; i < v.size(); i++)
+    CHECK(v[i] == v2[i]);
+
+  std::vector<bool> v2_for_const;
+  okay = hd2.readEntry(v2_for_const, "vector_bool_const");
+  REQUIRE(v2_for_const.size() == 3);
+  for (int i = 0; i < v_const.size(); i++)
+    CHECK(v_const[i] == v2_for_const[i]);
+
 }


### PR DESCRIPTION
## Proposed changes

std::vector<bool> is an exception case so it needs it own h5dataproxy.  There isn't a matching h5 data type so I convert it to/from char type. This is used by the energy density estimator to avoid adhoc kludging there.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

osx laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
