### PR TITLE
Nexus: Print warning for the Nexus user before pwscf rsync

### DIFF
--- a/nexus/lib/pwscf.py
+++ b/nexus/lib/pwscf.py
@@ -227,6 +227,7 @@ class Pwscf(Simulation):
                 outdir = os.path.join(self.locdir,c.outdir)
                 command = 'rsync -av {0}/* {1}/'.format(result.outdir,outdir)
                 if not os.path.exists(outdir):
+                    print('Running rsync for the {} directory. This might take a while.'.format(outdir))
                     os.makedirs(outdir)
                 #end if
                 sync_record = os.path.join(outdir,'nexus_sync_record')
@@ -283,6 +284,7 @@ class Pwscf(Simulation):
                 outdir = os.path.join(self.locdir,c.outdir)
                 command = 'rsync -av {0}/* {1}/'.format(result.outdir,outdir)
                 if not os.path.exists(outdir):
+                    print('Running rsync for the {} directory. This might take a while.'.format(outdir))
                     os.makedirs(outdir)
                 #end if
                 sync_record = os.path.join(outdir,'nexus_sync_record')

--- a/nexus/lib/pwscf.py
+++ b/nexus/lib/pwscf.py
@@ -227,12 +227,13 @@ class Pwscf(Simulation):
                 outdir = os.path.join(self.locdir,c.outdir)
                 command = 'rsync -av {0}/* {1}/'.format(result.outdir,outdir)
                 if not os.path.exists(outdir):
-                    print('Running rsync for the {} directory. This might take a while.'.format(outdir))
                     os.makedirs(outdir)
                 #end if
                 sync_record = os.path.join(outdir,'nexus_sync_record')
                 if not os.path.exists(sync_record):
+                    print('    Running rsync for the {} directory. This might take a while.'.format(outdir))
                     execute(command)
+                    print('    Completed rsync for the {} directory.'.format(outdir))
                     f = open(sync_record,'w')
                     f.write('\n')
                     f.close()
@@ -284,12 +285,13 @@ class Pwscf(Simulation):
                 outdir = os.path.join(self.locdir,c.outdir)
                 command = 'rsync -av {0}/* {1}/'.format(result.outdir,outdir)
                 if not os.path.exists(outdir):
-                    print('Running rsync for the {} directory. This might take a while.'.format(outdir))
                     os.makedirs(outdir)
                 #end if
                 sync_record = os.path.join(outdir,'nexus_sync_record')
                 if not os.path.exists(sync_record):
+                    print('    Running rsync for the {} directory. This might take a while.'.format(outdir))
                     execute(command)
+                    print('    Completed rsync for the {} directory.'.format(outdir))
                     f = open(sync_record,'w')
                     f.write('\n')
                     f.close()


### PR DESCRIPTION
## Proposed changes

When a new NSCF is located on a different path than SCF, Nexus will rsync the SCF results into the new path. This is a great feature for submitting multiple NSCF calculations with various k-points. However, this can take quite a while and can give the false sense that Nexus is hanging when, in fact, it is silently rsync'ing the results. This has confused me a few times.

I simply put two print statements warning the user that this is happening. It only executes the first time when the directory does not exist. There is probably a better way to output this - let me know if there is and I will be happy to update.

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
All Nexus tests pass on my laptop (Linux Mint 21.3), except for 61/69 qdens_radial. 

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
