### PR TITLE
Nexus: Fix the qdens-radial test

### DIFF
--- a/nexus/bin/qdens-radial
+++ b/nexus/bin/qdens-radial
@@ -499,9 +499,9 @@ class QMCDensityRadialProcessor(QDRBase):
                     r = opt.radii[0]
                 #end if
                 if not show_error:
-                    self.log('{} Value of {} Species at Cutoff {} is: {}\n'.format(cstr,at,r,rdens.tot[at].density[-1]))
+                    self.log('{} Value of {} Species at Cutoff {} is: {:.8f}\n'.format(cstr,at,r,rdens.tot[at].density[-1]))
                 else:
-                    self.log('{} Value of {} Species at Cutoff {} is: {}+/-{}\n'.format(cstr,at,r,rdens.tot[at].density[-1],std_dict[at]))
+                    self.log('{} Value of {} Species at Cutoff {} is: {:.8f} +/- {:.8f}\n'.format(cstr,at,r,rdens.tot[at].density[-1],std_dict[at]))
                 #end if
             #end for
         else:
@@ -514,9 +514,9 @@ class QMCDensityRadialProcessor(QDRBase):
                     r = opt.radii[0]
                 #end if
                 if not show_error:
-                    self.log('{} Value of {} Species at Cutoff {} is: {}\n'.format(cstr,at,r,rdens.tot[at].density[-1]))
+                    self.log('{} Value of {} Species at Cutoff {} is: {:.8f}\n'.format(cstr,at,r,rdens.tot[at].density[-1]))
                 else:
-                    self.log('{} Value of {} Species at Cutoff {} is: {}+/-{}\n'.format(cstr,at,r,rdens.tot[at].density[-1],std_dict[at]))
+                    self.log('{} Value of {} Species at Cutoff {} is: {:.8f} +/- {:.8f}\n'.format(cstr,at,r,rdens.tot[at].density[-1],std_dict[at]))
                 #end if
             #end for
         #end if

--- a/nexus/tests/unit/test_qdens_radial.py
+++ b/nexus/tests/unit/test_qdens_radial.py
@@ -152,6 +152,6 @@ Norm:   tot             = 7.999999969999998
  
 Cumulative Value of C Species at Cutoff 0.6 is: 1.10782675 +/- 0.00160665
 '''
-        assert(text_eq(out,out_ref))
+        assert(text_eq(out,out_ref,atol=1e-8))
     #end def test_radial_density
 #end if

--- a/nexus/tests/unit/test_qdens_radial.py
+++ b/nexus/tests/unit/test_qdens_radial.py
@@ -78,8 +78,8 @@ if versions.spglib_available:
         # Assert that output is consistent with reference
         out_ref = '''
 Norm:   tot             = 8.00000003
-
-Non-Cumulative Value of C Species at Cutoff 0.6 is: 4.773264912162242
+ 
+Non-Cumulative Value of C Species at Cutoff 0.6 is: 4.77326491
 '''
         assert(text_eq(out,out_ref))
 
@@ -93,8 +93,8 @@ Non-Cumulative Value of C Species at Cutoff 0.6 is: 4.773264912162242
         # Assert that output is consistent with reference
         out_ref = '''
 Norm:   tot             = 8.00000003
-
-Cumulative Value of C Species at Cutoff 0.6 is: 1.0684248641866259
+ 
+Cumulative Value of C Species at Cutoff 0.6 is: 1.06842486
 '''
 
         # DMC extrapolated non-cumulative
@@ -109,8 +109,8 @@ Cumulative Value of C Species at Cutoff 0.6 is: 1.0684248641866259
 Extrapolating from VMC and DMC densities...
 
 Norm:   tot             = 7.999999969999998
-
-Non-Cumulative Value of C Species at Cutoff 0.6 is: 4.910093964664309
+ 
+Non-Cumulative Value of C Species at Cutoff 0.6 is: 4.91009396
 '''
         assert(text_eq(out,out_ref))
 
@@ -126,8 +126,8 @@ Non-Cumulative Value of C Species at Cutoff 0.6 is: 4.910093964664309
 Extrapolating from VMC and DMC densities...
 
 Norm:   tot             = 7.999999969999998
-
-Cumulative Value of C Species at Cutoff 0.6 is: 1.1078267486386275
+ 
+Cumulative Value of C Species at Cutoff 0.6 is: 1.10782675
 '''
         assert(text_eq(out,out_ref))
 
@@ -149,8 +149,8 @@ sample: 1
 sample: 2
 
 Norm:   tot             = 7.999999969999998
-
-Cumulative Value of C Species at Cutoff 0.6 is: 1.1078267486386275+/-0.0016066467833404942
+ 
+Cumulative Value of C Species at Cutoff 0.6 is: 1.10782675 +/- 0.00160665
 '''
         assert(text_eq(out,out_ref))
     #end def test_radial_density


### PR DESCRIPTION
## Proposed changes

The Nexus `qdens-radial` test is passing for me when running on a NERSC machine, but it's failing on my Linux laptop. Upon inspection, the test is failing due to float comparison with many significant digits, which is a problematic thing to do:

Laptop:
```
Cumulative Value of C Species at Cutoff 0.6 is: 1.1078267486386277+/-0.0016066467832022906
```

NERSC:
```
Cumulative Value of C Species at Cutoff 0.6 is: 1.1078267486386275+/-0.0016066467833404942
```

In practice, we don't need 16 digits after decimal for charge densities. So I changed the `qdens-radial` output to have 8 digits after decimal and updated the reference data for the tests. After this change, all tests are passing for me locally and on NERSC.


## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

NERSC, Laptop

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
