### PR TITLE
Move psiMinv out of delayed update engines to DiracDeterminantBatched

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -1096,7 +1096,6 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_recompute(const RefVectorWithLeader
                                                        const std::vector<bool>& recompute) const
 {
   auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminantBatched<DET_ENGINE>>();
-  auto& mw_res     = wfc_leader.mw_res_handle_.getResource();
   const auto nw    = wfc_list.size();
 
   RefVectorWithLeader<WaveFunctionComponent> wfc_filtered_list(wfc_list.getLeader());
@@ -1107,6 +1106,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_recompute(const RefVectorWithLeader
   RefVector<Matrix<Value>> psiM_host_list;
   RefVector<Matrix<Grad>> dpsiM_list;
   RefVector<Matrix<Value>> d2psiM_list;
+  RefVector<DualMatrix<Value>> psiMinv_list;
 
   wfc_filtered_list.reserve(nw);
   p_filtered_list.reserve(nw);
@@ -1115,6 +1115,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_recompute(const RefVectorWithLeader
   psiM_temp_list.reserve(nw);
   dpsiM_list.reserve(nw);
   d2psiM_list.reserve(nw);
+  psiMinv_list.reserve(nw);
 
   for (int iw = 0; iw < nw; iw++)
     if (recompute[iw])
@@ -1128,6 +1129,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_recompute(const RefVectorWithLeader
       psiM_host_list.push_back(det.psiM_host);
       dpsiM_list.push_back(det.dpsiM);
       d2psiM_list.push_back(det.d2psiM);
+      psiMinv_list.push_back(det.psiMinv_);
     }
 
   if (!wfc_filtered_list.size())
@@ -1142,7 +1144,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_recompute(const RefVectorWithLeader
                                             psiM_host_list, dpsiM_list, d2psiM_list);
   }
 
-  mw_invertPsiM(wfc_filtered_list, psiM_temp_list, mw_res.psiMinv_refs);
+  mw_invertPsiM(wfc_filtered_list, psiM_temp_list, psiMinv_list);
 
   { // transfer dpsiM, d2psiM, psiMinv to device
     ScopedTimer d2h(H2DTimer);

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -243,6 +243,7 @@ public:
 
   const auto& get_psiMinv() const { return psiMinv_; }
 
+private:
   /** @defgroup LegacySingleData
    *  @brief    Single Walker Data Members of Legacy OO design
    *            High and flexible throughput of walkers requires would ideally separate
@@ -296,7 +297,6 @@ public:
   struct DiracDeterminantBatchedMultiWalkerResource;
   ResourceHandle<DiracDeterminantBatchedMultiWalkerResource> mw_res_handle_;
 
-private:
   ///reset the size: with the number of particles and number of orbtials
   void resize(int nel, int morb);
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -105,7 +105,9 @@ public:
    */
   void evaluateRatios(const VirtualParticleSet& VP, std::vector<Value>& ratios) override;
 
-  void evaluateSpinorRatios(const VirtualParticleSet& VP, const std::pair<ValueVector, ValueVector>& spinor_multiplier, std::vector<Value>& ratios) override;
+  void evaluateSpinorRatios(const VirtualParticleSet& VP,
+                            const std::pair<ValueVector, ValueVector>& spinor_multiplier,
+                            std::vector<Value>& ratios) override;
 
   void mw_evaluateRatios(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                          const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
@@ -239,7 +241,7 @@ public:
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<Value>& ratios) override;
 
-  DET_ENGINE& get_det_engine() { return det_engine_; }
+  const auto& get_psiMinv() const { return psiMinv_; }
 
   /** @defgroup LegacySingleData
    *  @brief    Single Walker Data Members of Legacy OO design
@@ -250,6 +252,12 @@ public:
    *  @ingroup LegacySingleData
    *  @{
    */
+  /* inverse transpose of psiM(j,i) \f$= \psi_j({\bf r}_i)\f$
+   * Only NumOrbitals x NumOrbitals subblock has meaningful data
+   * The number of rows is equal to NumOrbitals
+   * The number of columns in each row is padded to a multiple of QMC_SIMD_ALIGNMENT
+   */
+  DualMatrix<Value> psiMinv_;
   /// fused memory for psiM, dpsiM and d2psiM. [5][norb*norb]
   DualVGLVector psiM_vgl;
   /** psiM(j,i) \f$= \psi_j({\bf r}_i)\f$. partial memory view of psiM_vgl

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -108,8 +108,6 @@ public:
   DualMatrix<Value>& get_ref_psiMinv() { return psiMinv_; }
 
 private:
-  /// legacy single walker matrix inversion engine
-  DiracMatrix<FullPrecValue> detEng;
   /* inverse transpose of psiM(j,i) \f$= \psi_j({\bf r}_i)\f$
    * Only NumOrbitals x NumOrbitals subblock has meaningful data
    * The number of rows is equal to NumOrbitals

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -167,18 +167,15 @@ private:
       // cone
       mw_mem.cone_vec.resize(nw);
       std::fill_n(mw_mem.cone_vec.data(), nw, Value(1));
-      Value* cone_ptr = mw_mem.cone_vec.data();
-      PRAGMA_OFFLOAD("omp target update to(cone_ptr[:nw])")
+      mw_mem.cone_vec.updateTo();
       // cminusone
       mw_mem.cminusone_vec.resize(nw);
       std::fill_n(mw_mem_handle_.getResource().cminusone_vec.data(), nw, Value(-1));
-      Value* cminusone_ptr = mw_mem.cminusone_vec.data();
-      PRAGMA_OFFLOAD("omp target update to(cminusone_ptr[:nw])")
+      mw_mem.cminusone_vec.updateTo();
       // czero
       mw_mem.czero_vec.resize(nw);
       std::fill_n(mw_mem.czero_vec.data(), nw, Value(0));
-      Value* czero_ptr = mw_mem.czero_vec.data();
-      PRAGMA_OFFLOAD("omp target update to(czero_ptr[:nw])")
+      mw_mem.czero_vec.updateTo();
     }
   }
 
@@ -802,16 +799,14 @@ public:
         for (DualMatrix<Value>& psiMinv : psiMinv_refs)
         {
           const size_t ncols = psiMinv.cols();
-          auto* ptr          = psiMinv.data();
-          PRAGMA_OFFLOAD("omp target update from(ptr[row_id * ncols : ncols])")
-          row_ptr_list.push_back(ptr + row_id * ncols);
+          psiMinv.updateFrom(ncols, row_id * ncols);
+          row_ptr_list.push_back(psiMinv.data() + row_id * ncols);
         }
       else
         for (This_t& engine : engines)
         {
-          auto* ptr = engine.invRow.data();
-          PRAGMA_OFFLOAD("omp target update from(ptr[:engine.invRow.size()])")
-          row_ptr_list.push_back(ptr);
+          engine.invRow.updateFrom();
+          row_ptr_list.push_back(engine.invRow.data());
         }
     }
     else

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -66,7 +66,7 @@ void test_DiracDeterminantBatched_first()
   b(2, 1) = -0.04586322768;
   b(2, 2) = 0.3927890292;
 
-  auto check = checkMatrix(b, ddb.get_det_engine().get_ref_psiMinv());
+  auto check = checkMatrix(b, ddb.get_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   ParticleSet::GradType grad;
@@ -86,7 +86,7 @@ void test_DiracDeterminantBatched_first()
   b(2, 1) = 0.7119205298;
   b(2, 2) = 0.9105960265;
 
-  check = checkMatrix(b, ddb.get_det_engine().get_ref_psiMinv());
+  check = checkMatrix(b, ddb.get_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // set virtutal particle position
@@ -261,7 +261,7 @@ void test_DiracDeterminantBatched_second()
   app_log() << ddb.getPsiMinv() << std::endl;
 #endif
 
-  auto check = checkMatrix(orig_a, ddb.get_det_engine().get_ref_psiMinv());
+  auto check = checkMatrix(orig_a, ddb.get_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 }
 
@@ -359,7 +359,7 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   // force update Ainv in ddc using SM-1 code path
   ddc.completeUpdates();
 
-  auto check = checkMatrix(a_update1, ddc.get_det_engine().get_ref_psiMinv());
+  auto check = checkMatrix(a_update1, ddc.get_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   grad = ddc.evalGrad(elec, 1);
@@ -415,7 +415,7 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
 #endif
 
   // compare all the elements of get_ref_psiMinv() in ddc and orig_a
-  check = checkMatrix(orig_a, ddc.get_det_engine().get_ref_psiMinv());
+  check = checkMatrix(orig_a, ddc.get_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // testing batched interfaces
@@ -451,10 +451,10 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   ddc.mw_accept_rejectMove(ddc_ref_list, p_ref_list, 0, isAccepted, true);
   ddc.mw_completeUpdates(ddc_ref_list);
 
-  check = checkMatrix(a_update1, ddc.get_det_engine().get_ref_psiMinv());
+  check = checkMatrix(a_update1, ddc.get_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
-  check = checkMatrix(a_update1, ddc_clone_ref.get_det_engine().get_ref_psiMinv());
+  check = checkMatrix(a_update1, ddc_clone_ref.get_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   ddc.mw_evalGrad(ddc_ref_list, p_ref_list, 1, grad_new);
@@ -473,10 +473,10 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   ddc.mw_accept_rejectMove(ddc_ref_list, p_ref_list, 2, isAccepted, true);
   ddc.mw_completeUpdates(ddc_ref_list);
 
-  check = checkMatrix(orig_a, ddc.get_det_engine().get_ref_psiMinv());
+  check = checkMatrix(orig_a, ddc.get_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
-  check = checkMatrix(orig_a, ddc_clone_ref.get_det_engine().get_ref_psiMinv());
+  check = checkMatrix(orig_a, ddc_clone_ref.get_psiMinv());
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 }
 

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -43,10 +43,6 @@ void test_DiracDeterminantBatched_first()
   DetType ddb(std::move(spo_init), 0, norb);
   auto spo = dynamic_cast<FakeSPO*>(ddb.getPhi());
 
-  // occurs in call to registerData
-  ddb.dpsiV.resize(norb);
-  ddb.d2psiV.resize(norb);
-
   const SimulationCell simulation_cell;
   ParticleSet elec(simulation_cell);
 
@@ -146,10 +142,6 @@ void test_DiracDeterminantBatched_second()
   spo_init->setOrbitalSetSize(norb);
   DetType ddb(std::move(spo_init), 0, norb);
   auto spo = dynamic_cast<FakeSPO*>(ddb.getPhi());
-
-  // occurs in call to registerData
-  ddb.dpsiV.resize(norb);
-  ddb.d2psiV.resize(norb);
 
   const SimulationCell simulation_cell;
   ParticleSet elec(simulation_cell);
@@ -282,10 +274,6 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   spo_init->setOrbitalSetSize(norb);
   DetType ddc(std::move(spo_init), 0, norb, delay_rank, matrix_inverter_kind);
   auto spo = dynamic_cast<FakeSPO*>(ddc.getPhi());
-
-  // occurs in call to registerData
-  ddc.dpsiV.resize(norb);
-  ddc.d2psiV.resize(norb);
 
   const SimulationCell simulation_cell;
   ParticleSet elec(simulation_cell);


### PR DESCRIPTION
## Proposed changes
Make delayed update engines holding less data.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'