### PR TITLE
Move resource out of delayed update engines into DiracDeterminantBatched

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -212,7 +212,8 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evalGrad(const RefVectorWithLeader<
     engine_list.push_back(det.det_engine_);
   }
 
-  DET_ENGINE::mw_evalGrad(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs, dpsiM_row_list, WorkingIndex, grad_now);
+  DET_ENGINE::mw_evalGrad(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs,
+                          dpsiM_row_list, WorkingIndex, grad_now);
 
 #ifndef NDEBUG
   for (int iw = 0; iw < nw; iw++)
@@ -287,8 +288,8 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evalGradWithSpin(
     engine_list.push_back(det.det_engine_);
   }
 
-  DET_ENGINE::mw_evalGradWithSpin(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs, dpsiM_row_list, mw_dspin, WorkingIndex, grad_now,
-                                  spingrad_now);
+  DET_ENGINE::mw_evalGradWithSpin(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs,
+                                  dpsiM_row_list, mw_dspin, WorkingIndex, grad_now, spingrad_now);
 
 #ifndef NDEBUG
   for (int iw = 0; iw < nw; iw++)
@@ -346,7 +347,8 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_ratioGrad(const RefVectorWithLeader
     }
 
     auto psiMinv_row_dev_ptr_list =
-        DET_ENGINE::mw_getInvRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs, WorkingIndex, !Phi->isOMPoffload());
+        DET_ENGINE::mw_getInvRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs,
+                                 WorkingIndex, !Phi->isOMPoffload());
 
     phi_vgl_v.resize(DIM_VGL, wfc_list.size(), NumOrbitals);
     ratios_local.resize(wfc_list.size());
@@ -397,7 +399,8 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_ratioGradWithSpin(
     }
 
     auto psiMinv_row_dev_ptr_list =
-        DET_ENGINE::mw_getInvRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs, WorkingIndex, !Phi->isOMPoffload());
+        DET_ENGINE::mw_getInvRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs,
+                                 WorkingIndex, !Phi->isOMPoffload());
 
     phi_vgl_v.resize(DIM_VGL, wfc_list.size(), NumOrbitals);
     ratios_local.resize(wfc_list.size());
@@ -524,8 +527,9 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_accept_rejectMove(
     det.curRatio = 1.0;
   }
 
-  DET_ENGINE::mw_accept_rejectRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs, WorkingIndex, psiM_g_dev_ptr_list,
-                                  psiM_l_dev_ptr_list, isAccepted, phi_vgl_v, ratios_local);
+  DET_ENGINE::mw_accept_rejectRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs,
+                                  WorkingIndex, psiM_g_dev_ptr_list, psiM_l_dev_ptr_list, isAccepted, phi_vgl_v,
+                                  ratios_local);
 
   if (!safe_to_delay)
     DET_ENGINE::mw_updateInvMat(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs);
@@ -577,7 +581,8 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_completeUpdates(
     ScopedTimer d2h(D2HTimer);
 
     // this call also completes all the device copying of dpsiM, d2psiM before the target update
-    DET_ENGINE::mw_transferAinv_D2H(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs);
+    DET_ENGINE::mw_transferAinv_D2H(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc,
+                                    mw_res.psiMinv_refs);
 
     if (UpdateMode == ORB_PBYP_PARTIAL)
     {
@@ -590,7 +595,8 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_completeUpdates(
       }
 
       // transfer device to host, total size 4, g(3) + l(1), skipping v
-      DET_ENGINE::mw_transferVGL_D2H(wfc_leader.det_engine_, wfc_leader.mw_res_handle_.getResource().engine_rsc, psiM_vgl_list, 1, 4);
+      DET_ENGINE::mw_transferVGL_D2H(wfc_leader.det_engine_, wfc_leader.mw_res_handle_.getResource().engine_rsc,
+                                     psiM_vgl_list, 1, 4);
     }
   }
 }
@@ -786,7 +792,8 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_calcRatio(const RefVectorWithLeader
     }
 
     auto psiMinv_row_dev_ptr_list =
-        DET_ENGINE::mw_getInvRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs, WorkingIndex, !Phi->isOMPoffload());
+        DET_ENGINE::mw_getInvRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs,
+                                 WorkingIndex, !Phi->isOMPoffload());
 
     phi_vgl_v.resize(DIM_VGL, wfc_list.size(), NumOrbitals);
     ratios_local.resize(wfc_list.size());
@@ -1161,7 +1168,8 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_recompute(const RefVectorWithLeader
     }
 
     // transfer host to device, total size 4, g(3) + l(1), skipping v
-    DET_ENGINE::mw_transferVGL_H2D(wfc_leader.det_engine_, wfc_leader.mw_res_handle_.getResource().engine_rsc, psiM_vgl_list, 1, 4);
+    DET_ENGINE::mw_transferVGL_H2D(wfc_leader.det_engine_, wfc_leader.mw_res_handle_.getResource().engine_rsc,
+                                   psiM_vgl_list, 1, 4);
   }
 }
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -50,6 +50,8 @@ struct DiracDeterminantBatched<DET_ENGINE>::DiracDeterminantBatchedMultiWalkerRe
   OffloadMatrix<ComplexType> mw_dspin;
   /// reference to per DDB psiMinvs in a crowd
   RefVector<DualMatrix<Value>> psiMinv_refs;
+  ///
+  typename DET_ENGINE::MultiWalkerResource engine_rsc;
 };
 
 /** constructor
@@ -116,7 +118,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_invertPsiM(const RefVectorWithLeade
       mw_res.log_values[iw] = {0.0, 0.0};
     }
 
-    wfc_leader.accel_inverter_.getResource().mw_invertTranspose(wfc_leader.det_engine_.getLAhandles(), logdetT_list,
+    wfc_leader.accel_inverter_.getResource().mw_invertTranspose(mw_res.engine_rsc.getLAhandles(), logdetT_list,
                                                                 a_inv_list, mw_res.log_values);
 
     for (int iw = 0; iw < nw; ++iw)
@@ -210,7 +212,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evalGrad(const RefVectorWithLeader<
     engine_list.push_back(det.det_engine_);
   }
 
-  DET_ENGINE::mw_evalGrad(engine_list, mw_res.psiMinv_refs, dpsiM_row_list, WorkingIndex, grad_now);
+  DET_ENGINE::mw_evalGrad(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs, dpsiM_row_list, WorkingIndex, grad_now);
 
 #ifndef NDEBUG
   for (int iw = 0; iw < nw; iw++)
@@ -285,7 +287,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evalGradWithSpin(
     engine_list.push_back(det.det_engine_);
   }
 
-  DET_ENGINE::mw_evalGradWithSpin(engine_list, mw_res.psiMinv_refs, dpsiM_row_list, mw_dspin, WorkingIndex, grad_now,
+  DET_ENGINE::mw_evalGradWithSpin(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs, dpsiM_row_list, mw_dspin, WorkingIndex, grad_now,
                                   spingrad_now);
 
 #ifndef NDEBUG
@@ -344,7 +346,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_ratioGrad(const RefVectorWithLeader
     }
 
     auto psiMinv_row_dev_ptr_list =
-        DET_ENGINE::mw_getInvRow(engine_list, mw_res.psiMinv_refs, WorkingIndex, !Phi->isOMPoffload());
+        DET_ENGINE::mw_getInvRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs, WorkingIndex, !Phi->isOMPoffload());
 
     phi_vgl_v.resize(DIM_VGL, wfc_list.size(), NumOrbitals);
     ratios_local.resize(wfc_list.size());
@@ -395,7 +397,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_ratioGradWithSpin(
     }
 
     auto psiMinv_row_dev_ptr_list =
-        DET_ENGINE::mw_getInvRow(engine_list, mw_res.psiMinv_refs, WorkingIndex, !Phi->isOMPoffload());
+        DET_ENGINE::mw_getInvRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs, WorkingIndex, !Phi->isOMPoffload());
 
     phi_vgl_v.resize(DIM_VGL, wfc_list.size(), NumOrbitals);
     ratios_local.resize(wfc_list.size());
@@ -522,11 +524,11 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_accept_rejectMove(
     det.curRatio = 1.0;
   }
 
-  DET_ENGINE::mw_accept_rejectRow(engine_list, mw_res.psiMinv_refs, WorkingIndex, psiM_g_dev_ptr_list,
+  DET_ENGINE::mw_accept_rejectRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs, WorkingIndex, psiM_g_dev_ptr_list,
                                   psiM_l_dev_ptr_list, isAccepted, phi_vgl_v, ratios_local);
 
   if (!safe_to_delay)
-    DET_ENGINE::mw_updateInvMat(engine_list, mw_res.psiMinv_refs);
+    DET_ENGINE::mw_updateInvMat(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs);
 }
 
 /** move was rejected. copy the real container to the temporary to move on
@@ -568,14 +570,14 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_completeUpdates(
 
   {
     ScopedTimer update(UpdateTimer);
-    DET_ENGINE::mw_updateInvMat(engine_list, mw_res.psiMinv_refs);
+    DET_ENGINE::mw_updateInvMat(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs);
   }
 
   { // transfer dpsiM, d2psiM, psiMinv to host
     ScopedTimer d2h(D2HTimer);
 
     // this call also completes all the device copying of dpsiM, d2psiM before the target update
-    DET_ENGINE::mw_transferAinv_D2H(engine_list, mw_res.psiMinv_refs);
+    DET_ENGINE::mw_transferAinv_D2H(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs);
 
     if (UpdateMode == ORB_PBYP_PARTIAL)
     {
@@ -588,7 +590,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_completeUpdates(
       }
 
       // transfer device to host, total size 4, g(3) + l(1), skipping v
-      DET_ENGINE::mw_transferVGL_D2H(wfc_leader.det_engine_, psiM_vgl_list, 1, 4);
+      DET_ENGINE::mw_transferVGL_D2H(wfc_leader.det_engine_, wfc_leader.mw_res_handle_.getResource().engine_rsc, psiM_vgl_list, 1, 4);
     }
   }
 }
@@ -784,7 +786,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_calcRatio(const RefVectorWithLeader
     }
 
     auto psiMinv_row_dev_ptr_list =
-        DET_ENGINE::mw_getInvRow(engine_list, mw_res.psiMinv_refs, WorkingIndex, !Phi->isOMPoffload());
+        DET_ENGINE::mw_getInvRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs, WorkingIndex, !Phi->isOMPoffload());
 
     phi_vgl_v.resize(DIM_VGL, wfc_list.size(), NumOrbitals);
     ratios_local.resize(wfc_list.size());
@@ -1159,7 +1161,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_recompute(const RefVectorWithLeader
     }
 
     // transfer host to device, total size 4, g(3) + l(1), skipping v
-    DET_ENGINE::mw_transferVGL_H2D(wfc_leader.det_engine_, psiM_vgl_list, 1, 4);
+    DET_ENGINE::mw_transferVGL_H2D(wfc_leader.det_engine_, wfc_leader.mw_res_handle_.getResource().engine_rsc, psiM_vgl_list, 1, 4);
   }
 }
 
@@ -1199,7 +1201,6 @@ void DiracDeterminantBatched<DET_ENGINE>::createResource(ResourceCollection& col
 {
   collection.addResource(std::make_unique<DiracDeterminantBatchedMultiWalkerResource>());
   Phi->createResource(collection);
-  det_engine_.createResource(collection);
   collection.addResource(std::make_unique<typename DET_ENGINE::DetInverter>());
 }
 
@@ -1221,7 +1222,6 @@ void DiracDeterminantBatched<DET_ENGINE>::acquireResource(
     mw_res.psiMinv_refs.push_back(det.psiMinv_);
   }
   wfc_leader.Phi->acquireResource(collection, phi_list);
-  wfc_leader.det_engine_.acquireResource(collection);
   wfc_leader.accel_inverter_ = collection.lendResource<typename DET_ENGINE::DetInverter>();
 }
 
@@ -1240,7 +1240,6 @@ void DiracDeterminantBatched<DET_ENGINE>::releaseResource(
     phi_list.push_back(*det.Phi);
   }
   wfc_leader.Phi->releaseResource(collection, phi_list);
-  wfc_leader.det_engine_.releaseResource(collection);
   collection.takebackResource(wfc_leader.accel_inverter_);
 }
 

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -25,7 +25,6 @@
 #include "QMCWaveFunctions/detail/CUDA/matrix_update_helper.hpp"
 #include "DualAllocatorAliases.hpp"
 #include "DiracMatrixComputeCUDA.hpp"
-#include "ResourceCollection.h"
 #include "WaveFunctionTypes.hpp"
 #include "QueueAliases.hpp"
 
@@ -69,8 +68,8 @@ public:
 
   struct MultiWalkerResource
   {
-  // CUDA stream, cublas handle object
-  CUDALinearAlgebraHandles cuda_handles;
+    // CUDA stream, cublas handle object
+    CUDALinearAlgebraHandles cuda_handles;
 
     // constant array value VALUE(1)
     UnpinnedDualVector<Value> cone_vec;
@@ -95,28 +94,26 @@ public:
     // scratch space for keeping one row of Ainv
     UnpinnedDualVector<Value> mw_rcopy;
 
-  /** a bad smell */
-  void resize_fill_constant_arrays(size_t nw)
-  {
-    if (cone_vec.size() < nw)
+    void resize_fill_constant_arrays(size_t nw)
     {
-      // cone
-      cone_vec.resize(nw);
-      std::fill_n(cone_vec.data(), nw, Value(1));
-      cone_vec.updateTo();
-      // cminusone
-      cminusone_vec.resize(nw);
-      std::fill_n(cminusone_vec.data(), nw, Value(-1));
-      cminusone_vec.updateTo();
-      // czero
-      czero_vec.resize(nw);
-      std::fill_n(czero_vec.data(), nw, Value(0));
-      czero_vec.updateTo();
+      if (cone_vec.size() < nw)
+      {
+        // cone
+        cone_vec.resize(nw);
+        std::fill_n(cone_vec.data(), nw, Value(1));
+        cone_vec.updateTo();
+        // cminusone
+        cminusone_vec.resize(nw);
+        std::fill_n(cminusone_vec.data(), nw, Value(-1));
+        cminusone_vec.updateTo();
+        // czero
+        czero_vec.resize(nw);
+        std::fill_n(czero_vec.data(), nw, Value(0));
+        czero_vec.updateTo();
+      }
     }
-  }
 
-CUDALinearAlgebraHandles& getLAhandles() { return cuda_handles; }
-
+    CUDALinearAlgebraHandles& getLAhandles() { return cuda_handles; }
   };
 
 private:
@@ -169,7 +166,8 @@ private:
    * @param Ainv inverse matrix
    * @param rowchanged the row id corresponding to the proposed electron
    */
-  static void mw_prepareInvRow(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
+  static void mw_prepareInvRow(const RefVectorWithLeader<This_t>& engines,
+                               MultiWalkerResource& mw_rsc,
                                const RefVector<DualMatrix<Value>>& psiMinv_refs,
                                const int rowchanged)
   {
@@ -252,7 +250,8 @@ private:
    *  \param[in] phi_vgl_v          multiple walker orbital VGL
    *  \param[inout] ratios
    */
-  static void mw_updateRow(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
+  static void mw_updateRow(const RefVectorWithLeader<This_t>& engines,
+                           MultiWalkerResource& mw_rsc,
                            const RefVector<DualMatrix<Value>>& psiMinv_refs,
                            const int rowchanged,
                            const std::vector<Value*>& psiM_g_list,
@@ -368,7 +367,8 @@ public:
 
   // prepare invRow and compute the old gradients.
   template<typename GT>
-  static void mw_evalGrad(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
+  static void mw_evalGrad(const RefVectorWithLeader<This_t>& engines,
+                          MultiWalkerResource& mw_rsc,
                           const RefVector<DualMatrix<Value>>& psiMinv_refs,
                           const std::vector<const Value*>& dpsiM_row_list,
                           const int rowchanged,
@@ -417,7 +417,8 @@ public:
   }
 
   template<typename GT>
-  static void mw_evalGradWithSpin(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
+  static void mw_evalGradWithSpin(const RefVectorWithLeader<This_t>& engines,
+                                  MultiWalkerResource& mw_rsc,
                                   const RefVector<DualMatrix<Value>>& psiMinv_refs,
                                   const std::vector<const Value*>& dpsiM_row_list,
                                   OffloadMatrix<Complex>& mw_dspin,
@@ -486,7 +487,8 @@ public:
    *  \param[in] phi_vgl_v          multiple walker orbital VGL
    *  \param[inout] ratios
    */
-  static void mw_accept_rejectRow(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
+  static void mw_accept_rejectRow(const RefVectorWithLeader<This_t>& engines,
+                                  MultiWalkerResource& mw_rsc,
                                   const RefVector<DualMatrix<Value>>& psiMinv_refs,
                                   const int rowchanged,
                                   const std::vector<Value*>& psiM_g_list,
@@ -626,7 +628,8 @@ public:
   /** update the full Ainv and reset delay_count
    * @param Ainv inverse matrix
    */
-  static void mw_updateInvMat(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
+  static void mw_updateInvMat(const RefVectorWithLeader<This_t>& engines,
+                              MultiWalkerResource& mw_rsc,
                               const RefVector<DualMatrix<Value>>& psiMinv_refs)
   {
     auto& engine_leader = engines.getLeader();
@@ -719,7 +722,8 @@ public:
   /** return invRow host or device pointers based on on_host request
    * prepare invRow if not already.
    */
-  static std::vector<const Value*> mw_getInvRow(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
+  static std::vector<const Value*> mw_getInvRow(const RefVectorWithLeader<This_t>& engines,
+                                                MultiWalkerResource& mw_rsc,
                                                 const RefVector<DualMatrix<Value>>& psiMinv_refs,
                                                 const int row_id,
                                                 bool on_host)
@@ -768,7 +772,8 @@ public:
   }
 
   /// transfer Ainv to the host
-  static void mw_transferAinv_D2H(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
+  static void mw_transferAinv_D2H(const RefVectorWithLeader<This_t>& engines,
+                                  MultiWalkerResource& mw_rsc,
                                   const RefVector<DualMatrix<Value>>& psiMinv_refs)
   {
     auto& engine_leader = engines.getLeader();
@@ -786,7 +791,8 @@ public:
    * @param row_begin first row to copy
    * @param row_size the number of rows to be copied
    */
-  static void mw_transferVGL_D2H(This_t& engine_leader, MultiWalkerResource& mw_rsc,
+  static void mw_transferVGL_D2H(This_t& engine_leader,
+                                 MultiWalkerResource& mw_rsc,
                                  const RefVector<DualVGLVector<Value>>& psiM_vgl_list,
                                  size_t row_begin,
                                  size_t row_size)
@@ -806,7 +812,8 @@ public:
    * @param row_begin first row to copy
    * @param row_size the number of rows to be copied
    */
-  static void mw_transferVGL_H2D(This_t& engine_leader, MultiWalkerResource& mw_rsc,
+  static void mw_transferVGL_H2D(This_t& engine_leader,
+                                 MultiWalkerResource& mw_rsc,
                                  const RefVector<DualVGLVector<Value>>& psiM_vgl_list,
                                  size_t row_begin,
                                  size_t row_size)

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -60,7 +60,7 @@ public:
   template<typename DT>
   using DualMatrix = Matrix<DT, PinnedDualAllocator<DT>>;
 
-  struct MatrixUpdateOMPTargetMultiWalkerMem : public Resource
+  struct MultiWalkerResource
   {
     // constant array value T(1)
     UnpinnedOffloadVector<Value> cone_vec;
@@ -77,41 +77,17 @@ public:
     // scratch space for keeping one row of Ainv
     UnpinnedOffloadVector<Value> mw_rcopy;
 
-
-    MatrixUpdateOMPTargetMultiWalkerMem() : Resource("MatrixUpdateOMPTargetMultiWalkerMem") {}
-
-    MatrixUpdateOMPTargetMultiWalkerMem(const MatrixUpdateOMPTargetMultiWalkerMem&)
-        : MatrixUpdateOMPTargetMultiWalkerMem()
-    {}
-
-    std::unique_ptr<Resource> makeClone() const override
-    {
-      return std::make_unique<MatrixUpdateOMPTargetMultiWalkerMem>(*this);
-    }
-  };
-
-  /// scratch space for rank-1 update
-  UnpinnedOffloadVector<Value> temp;
-  // scratch space for keeping one row of Ainv
-  UnpinnedOffloadVector<Value> rcopy;
-
-  // multi walker memory buffers
-  ResourceHandle<MatrixUpdateOMPTargetMultiWalkerMem> mw_mem_handle_;
-
-  typename DetInverter::HandleResource dummy;
-
   void resize_fill_constant_arrays(size_t nw)
   {
-    auto& mw_mem = mw_mem_handle_.getResource();
-    if (mw_mem.cone_vec.size() < nw)
+    if (cone_vec.size() < nw)
     {
-      mw_mem.cone_vec.resize(nw);
-      mw_mem.czero_vec.resize(nw);
-      std::fill_n(mw_mem.cone_vec.data(), nw, Value(1));
-      std::fill_n(mw_mem.czero_vec.data(), nw, Value(0));
-      Value* cone_ptr = mw_mem.cone_vec.data();
+      cone_vec.resize(nw);
+      czero_vec.resize(nw);
+      std::fill_n(cone_vec.data(), nw, Value(1));
+      std::fill_n(czero_vec.data(), nw, Value(0));
+      Value* cone_ptr = cone_vec.data();
       PRAGMA_OFFLOAD("omp target update to(cone_ptr[:nw])")
-      Value* czero_ptr = mw_mem.czero_vec.data();
+      Value* czero_ptr = czero_vec.data();
       PRAGMA_OFFLOAD("omp target update to(czero_ptr[:nw])")
     }
   }
@@ -119,13 +95,21 @@ public:
   void resize_scratch_arrays(int norb, size_t nw)
   {
     size_t total_size = norb * nw;
-    auto& mw_mem      = mw_mem_handle_.getResource();
-    if (mw_mem.mw_temp.size() < total_size)
+    if (mw_temp.size() < total_size)
     {
-      mw_mem.mw_temp.resize(total_size);
-      mw_mem.mw_rcopy.resize(total_size);
+      mw_temp.resize(total_size);
+      mw_rcopy.resize(total_size);
     }
   }
+
+  };
+
+  /// scratch space for rank-1 update
+  UnpinnedOffloadVector<Value> temp;
+  // scratch space for keeping one row of Ainv
+  UnpinnedOffloadVector<Value> rcopy;
+
+  typename DetInverter::HandleResource dummy;
 
 public:
   /** resize the internal storage
@@ -134,29 +118,16 @@ public:
    */
   inline void resize(int norb, int delay) {}
 
-  void createResource(ResourceCollection& collection) const
-  {
-    collection.addResource(std::make_unique<MatrixUpdateOMPTargetMultiWalkerMem>());
-  }
-
-  void acquireResource(ResourceCollection& collection)
-  {
-    mw_mem_handle_ = collection.lendResource<MatrixUpdateOMPTargetMultiWalkerMem>();
-  }
-
-  void releaseResource(ResourceCollection& collection) { collection.takebackResource(mw_mem_handle_); }
-
   template<typename GT>
-  static void mw_evalGrad(const RefVectorWithLeader<This_t>& engines,
+  static void mw_evalGrad(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
                           const RefVector<DualMatrix<Value>>& psiMinv_refs,
                           const std::vector<const Value*>& dpsiM_row_list,
                           int rowchanged,
                           std::vector<GT>& grad_now)
   {
     auto& engine_leader = engines.getLeader();
-    auto& mw_mem        = engine_leader.mw_mem_handle_.getResource();
-    auto& buffer_H2D    = mw_mem.buffer_H2D;
-    auto& grads_value_v = mw_mem.grads_value_v;
+    auto& buffer_H2D    = mw_rsc.buffer_H2D;
+    auto& grads_value_v = mw_rsc.grads_value_v;
 
     const int norb                   = psiMinv_refs[0].get().rows();
     const int nw                     = engines.size();
@@ -200,7 +171,7 @@ public:
   }
 
   template<typename GT>
-  static void mw_evalGradWithSpin(const RefVectorWithLeader<This_t>& engines,
+  static void mw_evalGradWithSpin(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
                                   const RefVector<DualMatrix<Value>>& psiMinv_refs,
                                   const std::vector<const Value*>& dpsiM_row_list,
                                   OffloadMatrix<Complex>& mw_dspin,
@@ -209,14 +180,13 @@ public:
                                   std::vector<Complex>& spingrad_now)
   {
     auto& engine_leader     = engines.getLeader();
-    auto& mw_mem            = engine_leader.mw_mem_handle_.getResource();
-    auto& buffer_H2D        = mw_mem.buffer_H2D;
-    auto& grads_value_v     = mw_mem.grads_value_v;
-    auto& spingrads_value_v = mw_mem.spingrads_value_v;
+    auto& buffer_H2D        = mw_rsc.buffer_H2D;
+    auto& grads_value_v     = mw_rsc.grads_value_v;
+    auto& spingrads_value_v = mw_rsc.spingrads_value_v;
 
     //Need to pack these into a transfer buffer since psiMinv and dpsiM_row_list are not multiwalker data
     //i.e. each engine has its own psiMinv which is an OffloadMatrix instead of the leader having the data for all the walkers in the crowd.
-    //Wouldn't have to do this if dpsiM and psiMinv were part of the mw_mem_handle_ with data across all walkers in the crowd and could just use use_device_ptr for the offload.
+    //Wouldn't have to do this if dpsiM and psiMinv were part of the mw_rsc_handle_ with data across all walkers in the crowd and could just use use_device_ptr for the offload.
     //That is how mw_dspin is handled below
     const int norb                   = psiMinv_refs[0].get().rows();
     const int nw                     = engines.size();
@@ -322,7 +292,7 @@ public:
 
   /** The potential for mayhem here without a unit test is great.
    */
-  static void mw_updateRow(const RefVectorWithLeader<This_t>& engines,
+  static void mw_updateRow(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
                            const RefVector<DualMatrix<Value>>& psiMinv_refs,
                            int rowchanged,
                            const std::vector<Value*>& psiM_g_list,
@@ -336,19 +306,18 @@ public:
       return;
 
     auto& engine_leader         = engines.getLeader();
-    auto& mw_mem                = engine_leader.mw_mem_handle_.getResource();
-    auto& buffer_H2D            = mw_mem.buffer_H2D;
-    auto& grads_value_v         = mw_mem.grads_value_v;
-    auto& cone_vec              = mw_mem.cone_vec;
-    auto& czero_vec             = mw_mem.czero_vec;
-    auto& mw_temp               = mw_mem.mw_temp;
-    auto& mw_rcopy              = mw_mem.mw_rcopy;
+    auto& buffer_H2D            = mw_rsc.buffer_H2D;
+    auto& grads_value_v         = mw_rsc.grads_value_v;
+    auto& cone_vec              = mw_rsc.cone_vec;
+    auto& czero_vec             = mw_rsc.czero_vec;
+    auto& mw_temp               = mw_rsc.mw_temp;
+    auto& mw_rcopy              = mw_rsc.mw_rcopy;
     const int norb              = psiMinv_refs[0].get().rows();
     const int lda               = psiMinv_refs[0].get().cols();
     const size_t nw             = isAccepted.size();
     const size_t phi_vgl_stride = nw * norb;
 
-    engine_leader.resize_scratch_arrays(norb, n_accepted);
+    mw_rsc.resize_scratch_arrays(norb, n_accepted);
 
     // to handle Value** of Ainv, psi_v, temp, rcopy
     constexpr size_t num_ptrs_packed = 6; // it must match packing and unpacking
@@ -375,7 +344,7 @@ public:
     int dummy_handle     = 0;
     int success          = 0;
     auto* buffer_H2D_ptr = buffer_H2D.data();
-    engine_leader.resize_fill_constant_arrays(n_accepted);
+    mw_rsc.resize_fill_constant_arrays(n_accepted);
     Value* cone_ptr  = cone_vec.data();
     Value* czero_ptr = czero_vec.data();
     PRAGMA_OFFLOAD("omp target data \
@@ -429,7 +398,7 @@ public:
     }
   }
 
-  static void mw_accept_rejectRow(const RefVectorWithLeader<This_t>& engines,
+  static void mw_accept_rejectRow(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
                                   const RefVector<DualMatrix<Value>>& psiMinv_refs,
                                   const int rowchanged,
                                   const std::vector<Value*>& psiM_g_list,
@@ -438,17 +407,17 @@ public:
                                   const OffloadMWVGLArray<Value>& phi_vgl_v,
                                   const std::vector<Value>& ratios)
   {
-    mw_updateRow(engines, psiMinv_refs, rowchanged, psiM_g_list, psiM_l_list, isAccepted, phi_vgl_v, ratios);
+    mw_updateRow(engines, mw_rsc, psiMinv_refs, rowchanged, psiM_g_list, psiM_l_list, isAccepted, phi_vgl_v, ratios);
   }
 
   /** update the full Ainv and reset delay_count
    * @param Ainv inverse matrix
    */
-  inline static void mw_updateInvMat(const RefVectorWithLeader<This_t>& engines,
+  inline static void mw_updateInvMat(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
                                      const RefVector<DualMatrix<Value>>& psiMinv_refs)
   {}
 
-  std::vector<const Value*> static mw_getInvRow(const RefVectorWithLeader<This_t>& engines,
+  std::vector<const Value*> static mw_getInvRow(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
                                                 const RefVector<DualMatrix<Value>>& psiMinv_refs,
                                                 const int row_id,
                                                 bool on_host)
@@ -471,7 +440,7 @@ public:
   }
 
   /// transfer Ainv to the host
-  static void mw_transferAinv_D2H(const RefVectorWithLeader<This_t>& engines,
+  static void mw_transferAinv_D2H(const RefVectorWithLeader<This_t>& engines, MultiWalkerResource& mw_rsc,
                                   const RefVector<DualMatrix<Value>>& psiMinv_refs)
   {
     for (DualMatrix<Value>& psiMinv : psiMinv_refs)
@@ -484,7 +453,7 @@ public:
    * @param row_begin first row to copy
    * @param row_size the number of rows to be copied
    */
-  static void mw_transferVGL_D2H(This_t& engine_leader,
+  static void mw_transferVGL_D2H(This_t& engine_leader, MultiWalkerResource& mw_rsc,
                                  const RefVector<OffloadVGLVector<Value>>& psiM_vgl_list,
                                  size_t row_begin,
                                  size_t row_size)
@@ -506,7 +475,7 @@ public:
    * @param row_begin first row to copy
    * @param row_size the number of rows to be copied
    */
-  static void mw_transferVGL_H2D(This_t& engine_leader,
+  static void mw_transferVGL_H2D(This_t& engine_leader, MultiWalkerResource& mw_rsc,
                                  const RefVector<OffloadVGLVector<Value>>& psiM_vgl_list,
                                  size_t row_begin,
                                  size_t row_size)

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -77,6 +77,8 @@ public:
     // scratch space for keeping one row of Ainv
     UnpinnedOffloadVector<Value> mw_rcopy;
 
+  typename DetInverter::HandleResource dummy;
+
   void resize_fill_constant_arrays(size_t nw)
   {
     if (cone_vec.size() < nw)
@@ -102,14 +104,13 @@ public:
     }
   }
 
+  auto& getLAhandles() { return dummy; }
   };
 
   /// scratch space for rank-1 update
   UnpinnedOffloadVector<Value> temp;
   // scratch space for keeping one row of Ainv
   UnpinnedOffloadVector<Value> rcopy;
-
-  typename DetInverter::HandleResource dummy;
 
 public:
   /** resize the internal storage
@@ -490,8 +491,6 @@ public:
     // The only tasks being waited on here are the psiM_vgl updates
     PRAGMA_OFFLOAD("omp taskwait")
   }
-
-  auto& getLAhandles() { return dummy; }
 };
 } // namespace qmcplusplus
 


### PR DESCRIPTION
## Proposed changes

Not fully done. Make resource consumed by delayed update engines explicit. Ownership goes to DiracDeterminantBatched.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'