### PR TITLE
Split eigenvalue solve from eigenvalue selection and add choice of solvers

### DIFF
--- a/src/QMCDrivers/WFOpt/LinearMethod.cpp
+++ b/src/QMCDrivers/WFOpt/LinearMethod.cpp
@@ -27,6 +27,96 @@
 namespace qmcplusplus
 {
 
+LinearMethod::Real LinearMethod::getLowestEigenvector_Inv(Matrix<Real>& A, Matrix<Real>& B, std::vector<Real>& ev)
+{
+  int Nl(ev.size());
+  std::vector<Real> alphar(Nl);
+  Matrix<Real> eigenT(Nl, Nl);
+  Real zerozero = A(0, 0);
+  solveGeneralizedEigenvalues_Inv(A, B, alphar, eigenT);
+  return selectEigenvalue(alphar, eigenT, zerozero, ev);
+}
+
+LinearMethod::Real LinearMethod::getLowestEigenvector_Gen(Matrix<Real>& A, Matrix<Real>& B, std::vector<Real>& ev)
+{
+  int Nl(ev.size());
+  std::vector<Real> alphar(Nl);
+  Matrix<Real> eigenT(Nl, Nl);
+  Real zerozero = A(0, 0);
+  solveGeneralizedEigenvalues(A, B, alphar, eigenT);
+  return selectEigenvalue(alphar, eigenT, zerozero, ev);
+}
+
+// Input
+//  -eigenvals
+//  -eigenvectors
+//  Returns selected eigenvalue
+//   - ev - scaled eigenvector corresponding to selected eigenvalue
+
+LinearMethod::Real LinearMethod::selectEigenvalue(std::vector<Real>& eigenvals,
+                                                  Matrix<Real>& eigenvectors,
+                                                  Real zerozero,
+                                                  std::vector<Real>& ev)
+{
+  // Filter and sort to find desired eigenvalue.
+  // Filter accepts eigenvalues between E_0 and E_0 - 100.0,
+  // where E_0 is H(0,0), the current estimate for the VMC energy.
+  // Sort searches for eigenvalue closest to E_0 - 2.0
+  int Nl = eigenvals.size();
+
+  bool found_any_eigenvalue = false;
+  std::vector<std::pair<Real, int>> mappedEigenvalues(Nl);
+  for (int i = 0; i < Nl; i++)
+  {
+    Real evi(eigenvals[i]);
+    if ((evi < zerozero) && (evi > (zerozero - 1e2)))
+    {
+      mappedEigenvalues[i].first  = (evi - zerozero + 2.0) * (evi - zerozero + 2.0);
+      mappedEigenvalues[i].second = i;
+      found_any_eigenvalue        = true;
+    }
+    else
+    {
+      mappedEigenvalues[i].first  = std::numeric_limits<Real>::max();
+      mappedEigenvalues[i].second = i;
+    }
+  }
+
+  // Sometimes there is no eigenvalue less than E_0, but there is one slightly higher.
+  // Run filter and sort again, except this time accept eigenvalues between E_0 + 100.0 and E_0 - 100.0.
+  // Since it's already been determined there are no eigenvalues below E_0, the sort
+  // finds the eigenvalue closest to E_0.
+  if (!found_any_eigenvalue)
+  {
+    app_log() << "No eigenvalues passed initial filter. Trying broader 100 a.u. filter" << std::endl;
+
+    bool found_higher_eigenvalue;
+    for (int i = 0; i < Nl; i++)
+    {
+      Real evi(eigenvals[i]);
+      if ((evi < zerozero + 1e2) && (evi > (zerozero - 1e2)))
+      {
+        mappedEigenvalues[i].first  = (evi - zerozero + 2.0) * (evi - zerozero + 2.0);
+        mappedEigenvalues[i].second = i;
+        found_higher_eigenvalue     = true;
+      }
+      else
+      {
+        mappedEigenvalues[i].first  = std::numeric_limits<Real>::max();
+        mappedEigenvalues[i].second = i;
+      }
+    }
+    if (!found_higher_eigenvalue)
+    {
+      app_log() << "No eigenvalues passed second filter. Optimization is likely to fail." << std::endl;
+    }
+  }
+  std::sort(mappedEigenvalues.begin(), mappedEigenvalues.end());
+  //         for (int i=0; i<4; i++) app_log()<<i<<": "<<alphar[mappedEigenvalues[i].second]<< std::endl;
+  for (int i = 0; i < Nl; i++)
+    ev[i] = eigenvectors(mappedEigenvalues[0].second, i) / eigenvectors(mappedEigenvalues[0].second, 0);
+  return eigenvals[mappedEigenvalues[0].second];
+}
 
 // A - Hamiltonian
 // B - Overlap
@@ -125,51 +215,6 @@ void LinearMethod::solveGeneralizedEigenvalues_Inv(Matrix<Real>& A,
   }
 }
 
-
-LinearMethod::Real LinearMethod::getLowestEigenvector(Matrix<Real>& A, Matrix<Real>& B, std::vector<Real>& ev) const
-{
-  int Nl(ev.size());
-  //   Getting the optimal worksize
-  char jl('N');
-  char jr('V');
-  std::vector<Real> alphar(Nl), alphai(Nl), beta(Nl);
-  Matrix<Real> eigenT(Nl, Nl);
-  int info;
-  int lwork(-1);
-  std::vector<Real> work(1);
-  Real tt(0);
-  int t(1);
-  LAPACK::ggev(&jl, &jr, &Nl, A.data(), &Nl, B.data(), &Nl, &alphar[0], &alphai[0], &beta[0], &tt, &t, eigenT.data(),
-               &Nl, &work[0], &lwork, &info);
-  lwork = int(work[0]);
-  work.resize(lwork);
-
-  LAPACK::ggev(&jl, &jr, &Nl, A.data(), &Nl, B.data(), &Nl, &alphar[0], &alphai[0], &beta[0], &tt, &t, eigenT.data(),
-               &Nl, &work[0], &lwork, &info);
-  if (info != 0)
-  {
-    APP_ABORT("Invalid Matrix Diagonalization Function!");
-  }
-  std::vector<std::pair<Real, int>> mappedEigenvalues(Nl);
-  for (int i = 0; i < Nl; i++)
-  {
-    Real evi(alphar[i] / beta[i]);
-    if (std::abs(evi) < 1e10)
-    {
-      mappedEigenvalues[i].first  = evi;
-      mappedEigenvalues[i].second = i;
-    }
-    else
-    {
-      mappedEigenvalues[i].first  = std::numeric_limits<Real>::max();
-      mappedEigenvalues[i].second = i;
-    }
-  }
-  std::sort(mappedEigenvalues.begin(), mappedEigenvalues.end());
-  for (int i = 0; i < Nl; i++)
-    ev[i] = eigenT(mappedEigenvalues[0].second, i) / eigenT(mappedEigenvalues[0].second, 0);
-  return mappedEigenvalues[0].first;
-}
 
 LinearMethod::Real LinearMethod::getLowestEigenvector(Matrix<Real>& A, std::vector<Real>& ev) const
 {

--- a/src/QMCDrivers/WFOpt/LinearMethod.h
+++ b/src/QMCDrivers/WFOpt/LinearMethod.h
@@ -44,9 +44,9 @@ public:
    *
    */
   static void solveGeneralizedEigenvalues(Matrix<Real>& A,
-                                   Matrix<Real>& B,
-                                   std::vector<Real>& eigenvals,
-                                   Matrix<Real>& eigenvectors);
+                                          Matrix<Real>& B,
+                                          std::vector<Real>& eigenvals,
+                                          Matrix<Real>& eigenvectors);
 
   /** Solve by explicitly inverting the overlap matrix
    *  @param[in]  A Hamiltonian matrix
@@ -56,12 +56,42 @@ public:
    *
    */
   static void solveGeneralizedEigenvalues_Inv(Matrix<Real>& A,
-                                       Matrix<Real>& B,
-                                       std::vector<Real>& eigenvals,
-                                       Matrix<Real>& eigenvectors);
+                                              Matrix<Real>& B,
+                                              std::vector<Real>& eigenvals,
+                                              Matrix<Real>& eigenvectors);
 
-  //asymmetric generalized EV
-  Real getLowestEigenvector(Matrix<Real>& A, Matrix<Real>& B, std::vector<Real>& ev) const;
+  /** Select eigenvalue and return corresponding scaled eigenvector
+   *  @param[in] eigenvals Eigenvalues
+   *  @param[in] eigenvectors Eigenvectors
+   *  @param[in] zerozero The H(0,0) element, used to guide eigenvalue selection
+   *  @param[out] ev The eigenvector scaled by the reciprocal of the first element
+   *  @return The selected eigenvalue
+   */
+  static Real selectEigenvalue(std::vector<Real>& eigenvals,
+                               Matrix<Real>& eigenvectors,
+                               Real zerozero,
+                               std::vector<Real>& ev);
+
+  /** Solve the generalized eigenvalue problem and return a scaled eigenvector corresponding to the selected eigenvalue
+   * @param[in] A Hamiltonian matrix
+   * @param[in] B Overlap matrix
+   * @param[out] ev Scaled eigenvector
+   *
+   * This uses a regular eigenvalue solver for B^-1 A (LAPACK geev).
+   * In theory using the generalized eigenvalue solver is more numerically stable, but
+   * in practice this solver is sufficiently stable, and is faster than the generalized solver.
+   */
+  static Real getLowestEigenvector_Inv(Matrix<Real>& A, Matrix<Real>& B, std::vector<Real>& ev);
+
+  /** Solve the generalized eigenvalue problem and return a scaled eigenvector corresponding to the selected eigenvalue
+   * @param[in] A Hamiltonian matrix
+   * @param[in] B Overlap matrix
+   * @param[out] ev Scaled eigenvector
+   *
+   * This uses a generalized eigenvalue solver (LAPACK ggev).
+   */
+  static Real getLowestEigenvector_Gen(Matrix<Real>& A, Matrix<Real>& B, std::vector<Real>& ev);
+
   //asymmetric EV
   Real getLowestEigenvector(Matrix<Real>& A, std::vector<Real>& ev) const;
   // compute a rescale factor. Ye: Where is the method from?

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -576,6 +576,11 @@ void QMCFixedSampleLinearOptimizeBatched::process(xmlNodePtr q)
   m_param.add(OutputMatricesHDF, "output_matrices_hdf", {"no", "yes"});
   m_param.add(FreezeParameters, "freeze_parameters", {"no", "yes"});
 
+  m_param.add(ev_solver_, "ev_solver",
+      {"inverse",  // Inverse + nonsymmetric eigenvalue solver
+       "general"   // General eigenvalue problem solver
+      });
+
   oAttrib.put(q);
   m_param.put(q);
 
@@ -1619,7 +1624,7 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
       output_hamiltonian_.output(hamMat);
     }
 
-    if (do_output_matrices_hdf_)
+    if (do_output_matrices_hdf_ && is_manager())
     {
       std::string newh5 = get_root_name() + ".linear_matrices.h5";
       hout.create(newh5, H5F_ACC_TRUNC);
@@ -1632,7 +1637,8 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
               << std::endl;
   }
 
-  {
+  // Solve eigenvalue problem on one rank.
+  if (is_manager()) {
     ScopedTimer local(eigenvalue_timer_);
     Timer t_eigen;
     app_log() << std::endl
@@ -1649,28 +1655,24 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
         invMat(i, i) = bestShift_i * bestShift_s;
     }
 
-    // compute the inverse of the overlap matrix
-    {
-      ScopedTimer local(invert_olvmat_timer_);
-      invert_matrix(invMat, false);
-    }
-
     // apply the overlap shift
     for (int i = 1; i < N; i++)
       for (int j = 1; j < N; j++)
         hamMat(i, j) += bestShift_s * ovlMat(i, j);
 
-    // multiply the shifted hamiltonian matrix by the inverse of the overlap matrix
-    qmcplusplus::MatrixOperators::product(invMat, hamMat, prdMat);
+    RealType lowestEV;
+    // compute the lowest eigenvalue and the corresponding eigenvector
+    if (ev_solver_ == "general") {
+      app_log() << "  Using generalized eigenvalue solver (ggev)" << std::endl;
+      lowestEV = getLowestEigenvector_Gen(hamMat, invMat, parameterDirections);
+    } else if (ev_solver_ == "inverse") {
+      app_log() << "  Using inverse + regular eigenvalue solver (geev)" << std::endl;
+      lowestEV = getLowestEigenvector_Inv(hamMat, invMat, parameterDirections);
+    } else {
+      throw std::runtime_error("Unknown eigenvalue solver: " + ev_solver_);
+    }
 
-    // transpose the result (why?)
-    for (int i = 0; i < N; i++)
-      for (int j = i + 1; j < N; j++)
-        std::swap(prdMat(i, j), prdMat(j, i));
-
-    // compute the lowest eigenvalue of the product matrix and the corresponding eigenvector
-    RealType lowestEV = 0.;
-    lowestEV          = getLowestEigenvector(prdMat, parameterDirections);
+    app_log() << "  Execution time (eigenvalue) = " << std::setprecision(4) << t_eigen.elapsed() << std::endl;
 
     // compute the scaling constant to apply to the update
     objFuncWrapper_.Lambda = getNonLinearRescale(parameterDirections, ovlMat, *optTarget);
@@ -1682,12 +1684,13 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
       hout.write(objFuncWrapper_.Lambda, "non_linear_rescale");
       hout.close();
     }
-    app_log() << "  Execution time (eigenvalue) = " << std::setprecision(4) << t_eigen.elapsed() << std::endl;
-  }
 
-  // scale the update by the scaling constant
-  for (int i = 0; i < numParams; i++)
-    parameterDirections.at(i + 1) *= objFuncWrapper_.Lambda;
+    // scale the update by the scaling constant
+    for (int i = 0; i < numParams; i++)
+      parameterDirections.at(i + 1) *= objFuncWrapper_.Lambda;
+
+  }
+  myComm->bcast(parameterDirections);
 
   // now that we are done building the matrices, prevent further computation of derivative vectors
   optTarget->setneedGrads(false);

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -576,7 +576,7 @@ void QMCFixedSampleLinearOptimizeBatched::process(xmlNodePtr q)
   m_param.add(OutputMatricesHDF, "output_matrices_hdf", {"no", "yes"});
   m_param.add(FreezeParameters, "freeze_parameters", {"no", "yes"});
 
-  m_param.add(ev_solver_, "ev_solver",
+  m_param.add(eigensolver_, "eigensolver",
       {"inverse",  // Inverse + nonsymmetric eigenvalue solver
        "general"   // General eigenvalue problem solver
       });
@@ -1662,14 +1662,14 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
 
     RealType lowestEV;
     // compute the lowest eigenvalue and the corresponding eigenvector
-    if (ev_solver_ == "general") {
+    if (eigensolver_ == "general") {
       app_log() << "  Using generalized eigenvalue solver (ggev)" << std::endl;
       lowestEV = getLowestEigenvector_Gen(hamMat, invMat, parameterDirections);
-    } else if (ev_solver_ == "inverse") {
+    } else if (eigensolver_ == "inverse") {
       app_log() << "  Using inverse + regular eigenvalue solver (geev)" << std::endl;
       lowestEV = getLowestEigenvector_Inv(hamMat, invMat, parameterDirections);
     } else {
-      throw std::runtime_error("Unknown eigenvalue solver: " + ev_solver_);
+      throw std::runtime_error("Unknown eigenvalue solver: " + eigensolver_);
     }
 
     app_log() << "  Execution time (eigenvalue) = " << std::setprecision(4) << t_eigen.elapsed() << std::endl;

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -180,6 +180,8 @@ private:
   RealType param_tol;
   //-------------------------------------
 
+  /// Choice of eigenvalue solver
+  std::string ev_solver_;
 
   ///Number of iterations maximum before generating new configurations.
   int nstabilizers;

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -181,7 +181,7 @@ private:
   //-------------------------------------
 
   /// Choice of eigenvalue solver
-  std::string ev_solver_;
+  std::string eigensolver_;
 
   ///Number of iterations maximum before generating new configurations.
   int nstabilizers;

--- a/src/QMCDrivers/tests/test_LinearMethod.cpp
+++ b/src/QMCDrivers/tests/test_LinearMethod.cpp
@@ -146,4 +146,28 @@ TEST_CASE("solveGeneralizedEigenvaluesCompare", "[drivers]")
   }
 }
 
+TEST_CASE("selectEigenvalues", "[drivers]")
+{
+  LinearMethod lm;
+  const int Ne = 4; // Number of eigenvalues
+  const int Nv = 4; // Size of eigenvectors
+
+  // For direct solvers, Ne == Nv, but for iterative solvers we may have Ne <= Nv;
+
+  Matrix<Real> evecs(Ne, Nv);
+  evecs       = 1.0;
+  evecs(0, 0) = 2.0;
+  evecs(1, 0) = 3.0;
+  std::vector<Real> evals{-1.2, -1.5}; // size Ne
+  std::vector<Real> selected_evec(Nv);
+  Real zerozero      = -1.0;
+  Real selected_eval = lm.selectEigenvalue(evals, evecs, zerozero, selected_evec);
+
+  // Selects the closest to zerozero - 2.0
+  CHECK(selected_eval == Approx(-1.5));
+
+  CHECK(selected_evec[0] == Approx(1.0));
+  CHECK(selected_evec[1] == Approx(1.0 / 3.0));
+}
+
 } // namespace qmcplusplus


### PR DESCRIPTION
Move the eigenvalue selection code to a separate function, so it can be re-used with different solvers.

Add an "ev_solver" parameter to allow switching between the two implemented solution methods.
The choice of eigenvalue solvers is only implemented for the "one shift only" optimizer in the batched driver.

Prior to this PR, the code using the generalized eigensolver existed in the code, but was not connected.   More importantly, these changes are paving the way for a larger selection of eigenvalue solvers.

One change in logic is the eigenvalue problem is solved on one rank and the resulting change in parameters is broadcast to the other ranks. Previously, the eigenvalue problem was solved on each rank separately.  This is looking forward to different solvers which may not produce exactly the same answer when run multiple times.  The amount of data broadcast is small, so the effect on performance should be minimal.
The broadcast is here:
https://github.com/QMCPACK/qmcpack/blob/355302fe9da8dbb73e555b09b4b9f20ade6d5688/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp#L1693

I can add documentation (and more tests) if the code is okay.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Not yet. Documentation has been added (if appropriate)
