### PR TITLE
ReferenceDeterminant should only be used at evaluation not preparation.

### DIFF
--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -129,7 +129,7 @@ void MultiDiracDeterminant::createDetData(const int ref_det_id,
   auto& refdet_occup_ref(*refdet_occup);
   refdet_occup_ref.resize(NumPtcls);
   for (size_t i = 0; i < NumPtcls; i++)
-    refdet_occup_ref[i] = configlist_unsorted[ReferenceDeterminant].occup[i];
+    refdet_occup_ref[i] = configlist_unsorted[ref_det_id].occup[i];
 
   {
     ScopedTimer local_timer(transferH2D_timer);


### PR DESCRIPTION
## Proposed changes
Fixes https://github.com/QMCPACK/qmcpack/issues/4992 when the determinant with the largest coefficient is not the first one after the cutoff filtering.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'