### PR TITLE
Fix 4975 via increased tolerance

### DIFF
--- a/src/Particle/Lattice/LatticeAnalyzer.h
+++ b/src/Particle/Lattice/LatticeAnalyzer.h
@@ -221,7 +221,7 @@ inline bool found_shorter_base(TinyVector<TinyVector<T, 3>, 3>& rb)
   }
 
   T rmax = std::sqrt(r2max);
-  T tol  = 2.0 * rmax * eps; //Error propagation for x^2
+  T tol  = 4.0 * rmax * eps; // Error propagation for x^2
 
   TinyVector<TinyVector<T, 3>, 4> rb_new;
   rb_new[0] = rb[0] + rb[1] - rb[2];


### PR DESCRIPTION
## Proposed changes

Closes #4975 

For the reported supercell, the basis mapping was failing after 10K attempts due to numerical tolerance issues when Intel 2021.1 was used on the old CADES system . Tolerance was increased conservatively. Was unable to reproduce the problem with recent GCC, Clang etc. on other systems. Fix was verified with a generic (vs AVX512) build since I was using different nodes.

I will PR an updated build script when an updated cmake is installed by the admins.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

ORNL CADES SHPC Condo. https://docs.cades.ornl.gov/#condos/overview/

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
