### PR TITLE
Improve dryrun capabilty

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -16,14 +16,16 @@ QMCPACK offers several command line options that affect how calculations
 are performed. If the flag is absent, then the corresponding
 option is disabled:
 
-- ``--dryrun`` Validate the input file without performing the simulation. This is a good way to ensure that QMCPACK will do what you think it will.
+- ``--dryrun`` Validate the input file without performing the simulation. All the QMC and loop sections are skipped.
+  Wavefunctions and pseudopotentials will be loaded and processed. This option can be used to verify all the required
+  files are available or to check memory usage.
 
 - ``--enable-timers=none|coarse|medium|fine`` Control the timer granularity when the build option ``ENABLE_TIMERS`` is enabled.
 
-- ``help`` Print version information as well as a list of optional
+- ``--help`` Print version information as well as a list of optional
   command-line arguments.
 
-- ``noprint`` Do not print extra information on Jastrow or pseudopotential.
+- ``--noprint`` Do not print extra information on Jastrow or pseudopotential.
   If this flag is not present, QMCPACK will create several ``.dat`` files
   that contain information about pseudopotentials (one file per PP) and Jastrow
   factors (one per Jastrow factor). These file might be useful for visual inspection

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -246,85 +246,79 @@ bool QMCMain::execute()
   if (qmc_common.dryrun)
   {
     app_log() << "  dryrun == 1 : Skipping all QMC and loop elements " << std::endl;
+    return true;
   }
-  else
+  Timer t1;
+  qmc_common.qmc_counter = 0;
+  for (int qa = 0; qa < qmc_action_.size(); qa++)
   {
-    Timer t1;
-    qmc_common.qmc_counter = 0;
-    for (int qa = 0; qa < qmc_action_.size(); qa++)
+    if (run_time_manager.isStopNeeded())
+      break;
+    xmlNodePtr cur = qmc_action_[qa].first;
+    std::string cname((const char*)cur->name);
+    if (cname == "qmc" || cname == "optimize")
     {
-      if (run_time_manager.isStopNeeded())
-        break;
-      xmlNodePtr cur = qmc_action_[qa].first;
-      std::string cname((const char*)cur->name);
-      if (cname == "qmc" || cname == "optimize")
-      {
-        executeQMCSection(cur);
-        qmc_common.qmc_counter++; // increase the counter
-      }
-      else if (cname == "loop")
-      {
-        qmc_common.qmc_counter = 0;
-        executeLoop(cur);
-        qmc_common.qmc_counter = 0;
-      }
-      else if (cname == "cmc")
-      {
-        executeCMCSection(cur);
-      }
-      else if (cname == "debug")
-      {
-        executeDebugSection(cur);
-        app_log() << "  Debug is done. Skip the rest of the input " << std::endl;
-        break;
-      }
+      executeQMCSection(cur);
+      qmc_common.qmc_counter++; // increase the counter
     }
-    // free if m_qmcation owns the memory of xmlNodePtr before clearing
-    for (auto& qmcactionPair : qmc_action_)
-      if (!qmcactionPair.second)
-        xmlFreeNode(qmcactionPair.first);
+    else if (cname == "loop")
+    {
+      qmc_common.qmc_counter = 0;
+      executeLoop(cur);
+      qmc_common.qmc_counter = 0;
+    }
+    else if (cname == "cmc")
+    {
+      executeCMCSection(cur);
+    }
+    else if (cname == "debug")
+    {
+      executeDebugSection(cur);
+      app_log() << "  Debug is done. Skip the rest of the input " << std::endl;
+      break;
+    }
+  }
+  // free if m_qmcation owns the memory of xmlNodePtr before clearing
+  for (auto& qmcactionPair : qmc_action_)
+    if (!qmcactionPair.second)
+      xmlFreeNode(qmcactionPair.first);
 
-    qmc_action_.clear();
-    t2.stop();
-    app_log() << "  Total Execution time = " << std::setprecision(4) << t1.elapsed() << " secs" << std::endl;
-    if (is_manager())
+  qmc_action_.clear();
+  t2.stop();
+  app_log() << "  Total Execution time = " << std::setprecision(4) << t1.elapsed() << " secs" << std::endl;
+  if (is_manager())
+  {
+    //generate multiple files
+    xmlNodePtr mcptr = NULL;
+    if (walker_set_.size())
+      mcptr = walker_set_[0];
+    //remove input mcwalkerset but one
+    for (int i = 1; i < walker_set_.size(); i++)
     {
-      //generate multiple files
-      xmlNodePtr mcptr = NULL;
-      if (walker_set_.size())
-        mcptr = walker_set_[0];
-      //remove input mcwalkerset but one
-      for (int i = 1; i < walker_set_.size(); i++)
-      {
-        xmlUnlinkNode(walker_set_[i]);
-        xmlFreeNode(walker_set_[i]);
-      }
-      walker_set_.clear(); //empty the container
-      std::ostringstream np_str, v_str;
-      np_str << myComm->size();
-      HDFVersion cur_version;
-      v_str << cur_version[0] << " " << cur_version[1];
-      xmlNodePtr newmcptr = xmlNewNode(NULL, (const xmlChar*)"mcwalkerset");
-      xmlNewProp(newmcptr, (const xmlChar*)"fileroot", (const xmlChar*)my_project_.currentMainRoot().c_str());
-      xmlNewProp(newmcptr, (const xmlChar*)"node", (const xmlChar*)"-1");
-      xmlNewProp(newmcptr, (const xmlChar*)"nprocs", (const xmlChar*)np_str.str().c_str());
-      xmlNewProp(newmcptr, (const xmlChar*)"version", (const xmlChar*)v_str.str().c_str());
-      //#if defined(H5_HAVE_PARALLEL)
-      xmlNewProp(newmcptr, (const xmlChar*)"collected", (const xmlChar*)"yes");
-      //#else
-      //      xmlNewProp(newmcptr,(const xmlChar*)"collected",(const xmlChar*)"no");
-      //#endif
-      if (mcptr == NULL)
-      {
-        xmlAddNextSibling(last_input_node_, newmcptr);
-      }
-      else
-      {
-        xmlReplaceNode(mcptr, newmcptr);
-        xmlFreeNode(mcptr);
-      }
-      saveXml();
+      xmlUnlinkNode(walker_set_[i]);
+      xmlFreeNode(walker_set_[i]);
     }
+    walker_set_.clear(); //empty the container
+    std::ostringstream np_str, v_str;
+    np_str << myComm->size();
+    HDFVersion cur_version;
+    v_str << cur_version[0] << " " << cur_version[1];
+    xmlNodePtr newmcptr = xmlNewNode(NULL, (const xmlChar*)"mcwalkerset");
+    xmlNewProp(newmcptr, (const xmlChar*)"fileroot", (const xmlChar*)my_project_.currentMainRoot().c_str());
+    xmlNewProp(newmcptr, (const xmlChar*)"node", (const xmlChar*)"-1");
+    xmlNewProp(newmcptr, (const xmlChar*)"nprocs", (const xmlChar*)np_str.str().c_str());
+    xmlNewProp(newmcptr, (const xmlChar*)"version", (const xmlChar*)v_str.str().c_str());
+    xmlNewProp(newmcptr, (const xmlChar*)"collected", (const xmlChar*)"yes");
+    if (mcptr == NULL)
+    {
+      xmlAddNextSibling(last_input_node_, newmcptr);
+    }
+    else
+    {
+      xmlReplaceNode(mcptr, newmcptr);
+      xmlFreeNode(mcptr);
+    }
+    saveXml();
   }
   return true;
 }

--- a/src/Utilities/qmc_common.cpp
+++ b/src/Utilities/qmc_common.cpp
@@ -87,7 +87,7 @@ void QMCState::print_options(std::ostream& os)
 {
   os << "  Global options " << std::endl;
   if (dryrun)
-    os << "  dryrun : qmc sections will be ignored." << std::endl;
+    os << "  dryrun : All QMC and loop sections will be skipped." << std::endl;
 }
 
 void QMCState::print_memory_change(const std::string& who, size_t before)


### PR DESCRIPTION
## Proposed changes

dryrun will exit cleanly (zero error code) rather than QMCPACK aborting. Small edits to docs and comments.

```
  Hamiltonian h0
  Kinetic         Kinetic energy
  LocalECP        CoulombPBCAB potential source: ion0
  NonLocalECP     NonLocalECPotential: ion0
  ElecElec        CoulombPBCAA potential: e_e
  IonIon          CoulombPBCAA potential: ion0_ion0

  dryrun == 1 : Skipping all QMC and loop elements 

Use --enable-timers=<value> command line option to increase or decrease level of timing information
Stack timer profile
Timer      Inclusive_time  Exclusive_time  Calls       Time_per_call
  Startup    54.0524    54.0524              1      54.052436786

QMCPACK execution completed successfully

```
## What type(s) of changes does this code introduce?

- Bugfix
- New feature
- Documentation or build script changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 22.04 gcc 11.4.0

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
