### PR TITLE
Fix AFQMC compilation.

### DIFF
--- a/src/AFQMC/Matrix/matrix_emplace_wrapper.hpp
+++ b/src/AFQMC/Matrix/matrix_emplace_wrapper.hpp
@@ -45,12 +45,6 @@ public:
     buff.reserve(std::max(sz, std::size_t(0)));
   }
 
-  // not sure this makes sense, but needed for TTI
-  matrix_emplace_wrapper(matrix_emplace_wrapper const& other) : M(other.M), m(nullptr)
-  {
-    m = std::move(std::make_unique<shm_mutex>(other.m->scomm_));
-    buff.reserve(other.buff.size());
-  }
   matrix_emplace_wrapper operator=(matrix_emplace_wrapper const& other) = delete;
   matrix_emplace_wrapper(matrix_emplace_wrapper&& other)
   {


### PR DESCRIPTION
## Proposed changes
clang development seems tightening source code validation.

There is an unused constructor causing error
```
In file included from /scratch2/QMCPACK_CI_BUILDS_DO_NOT_REMOVE/qmcpack-develop/src/AFQMC/Matrix/csr_hdf5_readers.hpp:34:
/scratch2/QMCPACK_CI_BUILDS_DO_NOT_REMOVE/qmcpack-develop/src/AFQMC/Matrix/matrix_emplace_wrapper.hpp:51:56: error: 'scomm_' is a private member of 'boost::mpi3::shm::mutex'
   51 |     m = std::move(std::make_unique<shm_mutex>(other.m->scomm_));
      |                                                        ^
[CTest: warning matched] /scratch2/QMCPACK_CI_BUILDS_DO_NOT_REMOVE/qmcpack-develop/external_codes/mpi_wrapper/mpi3/include/mpi3/shm/mutex.hpp:14:29: note: implicitly declared private here
   14 |         mpi3::shared_communicator& scomm_;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
      |     
```

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'