### PR TITLE
Allow directly select openmp offload code path.

### DIFF
--- a/docs/intro_wavefunction.rst
+++ b/docs/intro_wavefunction.rst
@@ -798,7 +798,7 @@ Additional information:
   The best ``delay_rank`` depends on the processor microarchitecture.
   GPU support is under development.
 
-- ``gpu`` This option is only effective when GPU features are built. Use the implementation with GPU acceleration if ``yes``.
+- ``gpu`` This option is only effective when GPU features are built. Default to using GPU. "omptarget", "cuda", "sycl", "cpu" can be set to target a specific implementation, "yes", "no" can be used to toggle on or off GPU acceleration.
 
 - ``batch`` The default value is ``yes`` if ``gpu=yes`` and ``no`` otherwise.
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -296,8 +296,12 @@ std::unique_ptr<DiracDeterminantBase> SlaterDetBuilder::putDeterminant(
 #else
   sdAttrib.add(use_batch, "batch", {"no", "yes"});
 #endif
-#if defined(ENABLE_CUDA) || defined(ENABLE_OFFLOAD)
-  sdAttrib.add(useGPU, "gpu", {"yes", "no"});
+#if defined(ENABLE_OFFLOAD)
+#if defined(ENABLE_CUDA) || defined(ENABLE_SYCL)
+  sdAttrib.add(useGPU, "gpu", CPUOMPTargetVendorSelector::candidate_values);
+#else
+  sdAttrib.add(useGPU, "gpu", PlatformSelector<SelectorKind::CPU_OMPTARGET>::candidate_values);
+#endif
 #endif
   sdAttrib.put(cur->parent);
 


### PR DESCRIPTION
## Proposed changes
Somehow this change should have been introduced when DiracDeterminantBatched was added.
`<slaterdeterminant gpu="omptarget">` can be used to hit the offload code path in a CUDA+OpenMP offload build. The CUDA one is default.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Polaris

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
