### PR TITLE
Move hdf5 suppressor into file scope.

### DIFF
--- a/src/Message/CMakeLists.txt
+++ b/src/Message/CMakeLists.txt
@@ -21,14 +21,14 @@ endif()
 
 add_library(catch_main catch_main.cpp)
 target_compile_definitions(catch_main PUBLIC "CATCH_CONFIG_ENABLE_BENCHMARKING")
-target_link_libraries(catch_main PUBLIC qmc_external_catch2 qmcio_hdf)
+target_link_libraries(catch_main PUBLIC qmc_external_catch2)
 target_link_libraries(catch_main PRIVATE message platform_runtime)
 if(HAVE_MPI)
   target_compile_definitions(catch_main PRIVATE "CATCH_MAIN_HAVE_MPI")
 endif()
 
 add_library(catch_main_no_mpi catch_main.cpp)
-target_link_libraries(catch_main_no_mpi PUBLIC qmc_external_catch2 qmcio_hdf)
+target_link_libraries(catch_main_no_mpi PUBLIC qmc_external_catch2)
 target_link_libraries(catch_main_no_mpi PRIVATE platform_runtime)
 
 if(BUILD_UNIT_TESTS)

--- a/src/Message/catch_main.cpp
+++ b/src/Message/catch_main.cpp
@@ -19,7 +19,6 @@
 #endif
 #include "Host/OutputManager.h"
 #include "MemoryUsage.h"
-#include "io/hdf/hdf_error_suppression.h"
 
 // Replacement unit test main function to ensure that MPI is finalized once
 // (and only once) at the end of the unit test.
@@ -33,7 +32,6 @@ std::string UTEST_HAMIL, UTEST_WFN;
 int main(int argc, char* argv[])
 {
   // Suppress HDF5 warning and error messages.
-  qmcplusplus::hdf_error_suppression hide_hdf_errors;
   Catch::Session session;
   using namespace Catch::clara;
   // Build command line parser.

--- a/src/Message/catch_main.cpp
+++ b/src/Message/catch_main.cpp
@@ -31,7 +31,6 @@ std::string UTEST_HAMIL, UTEST_WFN;
 
 int main(int argc, char* argv[])
 {
-  // Suppress HDF5 warning and error messages.
   Catch::Session session;
   using namespace Catch::clara;
   // Build command line parser.

--- a/src/Platforms/tests/CMakeLists.txt
+++ b/src/Platforms/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ set(UTEST_EXE test_platforms)
 set(UTEST_NAME deterministic-unit_${UTEST_EXE})
 
 add_executable(${UTEST_EXE} test_PlatformSelector.cpp test_AccelBLAS.cpp)
-target_link_libraries(${UTEST_EXE} platform_LA platform_runtime catch_main)
+target_link_libraries(${UTEST_EXE} platform_LA platform_runtime catch_main containers)
 
 if(USE_OBJECT_TARGET)
   target_link_libraries(${UTEST_EXE} platform_omptarget_LA)

--- a/src/QMCApp/QMCMain.h
+++ b/src/QMCApp/QMCMain.h
@@ -23,7 +23,6 @@
 #include "QMCApp/QMCAppBase.h"
 #include "QMCDrivers/QMCDriverFactory.h"
 #include "QMCDrivers/SimpleFixedNodeBranch.h"
-#include "hdf/hdf_error_suppression.h"
 
 namespace qmcplusplus
 {
@@ -69,9 +68,6 @@ private:
 
   /// last branch engine used by legacy drivers
   std::unique_ptr<SimpleFixedNodeBranch> last_branch_engine_legacy_driver_;
-
-  /// Suppress HDF5 warning and error messages.
-  hdf_error_suppression hide_hdf_errors;
 
   ///xml mcwalkerset elements for output
   std::vector<xmlNodePtr> walker_set_;

--- a/src/QMCTools/convert4qmc.cpp
+++ b/src/QMCTools/convert4qmc.cpp
@@ -33,8 +33,7 @@ int main(int argc, char** argv)
   mpi3::environment env(argc, argv);
   OHMMS::Controller = new Communicate(env.world());
 #endif
-  // Suppress HDF5 warning and error messages.
-  qmcplusplus::hdf_error_suppression hide_hdf_errors;
+
   if (argc < 2)
   {
     std::cout << "Usage: convert [-gaussian|-gamess|-orbitals|-dirac|-rmg] filename " << std::endl;

--- a/src/QMCTools/convertpw4qmc.cpp
+++ b/src/QMCTools/convertpw4qmc.cpp
@@ -46,9 +46,6 @@ int main(int argc, char* argv[])
   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
 #endif
 
-  // Suppress HDF5 warning and error messages.
-  qmcplusplus::hdf_error_suppression hide_hdf_errors;
-
   vector<string> vecParams;
   convertToVecStrings(argc, argv, vecParams);
   string fname;

--- a/src/QMCTools/qmc-extract-eshdf-kvectors.cpp
+++ b/src/QMCTools/qmc-extract-eshdf-kvectors.cpp
@@ -24,14 +24,13 @@ int main(int argc, char* argv[])
 #ifdef HAVE_MPI
   mpi3::environment env(argc, argv);
 #endif
+
   using namespace qmcplusplus;
   if (argc != 2)
   {
     std::cout << "Program must take as an argument a single input eshdf file to parse" << std::endl;
     return 1;
   }
-  // Suppress HDF5 warning and error messages.
-  qmcplusplus::hdf_error_suppression hide_hdf_errors;
   std::string fname(argv[1]);
   //cout << "Input file is: " << fname << std::endl;
   hdf_archive hin;

--- a/src/QMCTools/qmcfinitesize.cpp
+++ b/src/QMCTools/qmcfinitesize.cpp
@@ -56,9 +56,6 @@ int main(int argc, char** argv)
   std::cout.setf(std::ios::right, std::ios::adjustfield);
   std::cout.precision(12);
 
-  // Suppress HDF5 warning and error messages.
-  qmcplusplus::hdf_error_suppression hide_hdf_errors;
-
   std::unique_ptr<SkParserBase> skparser(nullptr);
 
   bool show_usage = false;

--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -49,8 +49,6 @@ int main(int argc, char** argv)
   mpi3::environment env(argc, argv);
   OHMMS::Controller->initialize(env);
 #endif
-  // Suppress HDF5 warning and error messages.
-  qmcplusplus::hdf_error_suppression hide_hdf_errors;
 
   Communicate* myComm = OHMMS::Controller;
 

--- a/src/io/hdf/hdf_archive.cpp
+++ b/src/io/hdf/hdf_archive.cpp
@@ -19,6 +19,9 @@
 
 namespace qmcplusplus
 {
+
+hdf_error_suppression hide_hdf_errors;
+
 hdf_archive::~hdf_archive()
 {
 #if defined(ENABLE_PHDF5)

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -42,6 +42,10 @@ class Communicate;
 
 namespace qmcplusplus
 {
+
+/// Suppress HDF5 warning and error messages.
+extern hdf_error_suppression hide_hdf_errors;
+
 /** class to handle hdf file
  */
 class hdf_archive


### PR DESCRIPTION
## Proposed changes
No need to add it to the "main" of every executable and simplify linking. A unit test that doesn't use hdf5 doesn't need to link hdf5.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'