### PR TITLE
Add syclBLAS gemv_batch and ger_batch

### DIFF
--- a/src/Platforms/SYCL/AccelBLAS_SYCL.hpp
+++ b/src/Platforms/SYCL/AccelBLAS_SYCL.hpp
@@ -72,7 +72,7 @@ inline void gemv_batched(BLASHandle<PlatformKind::SYCL>& handle,
                          const size_t batch_count)
 {
   try
-  {
+  { // calling makeshift version for now due to the lack of vendor optimized versions
     syclBLAS::gemv_batched(handle.queue_, trans, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
   }
   catch (sycl::exception& e)
@@ -95,7 +95,7 @@ inline void ger_batched(BLASHandle<PlatformKind::SYCL>& handle,
                         const size_t batch_count)
 {
   try
-  {
+  { // calling makeshift version for now due to the lack of vendor optimized versions
     syclBLAS::ger_batched(handle.queue_, m, n, alpha, x, incx, y, incy, A, lda, batch_count);
   }
   catch (sycl::exception& e)

--- a/src/Platforms/SYCL/AccelBLAS_SYCL.hpp
+++ b/src/Platforms/SYCL/AccelBLAS_SYCL.hpp
@@ -70,7 +70,16 @@ inline void gemv_batched(BLASHandle<PlatformKind::SYCL>& handle,
                          T* const y[],
                          const int incy,
                          const size_t batch_count)
-{}
+{
+  try
+  {
+    syclBLAS::gemv_batched(handle.queue_, trans, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
+  }
+  catch (sycl::exception& e)
+  {
+    throw std::runtime_error(std::string("AccelBLAS::gemv_batch exception: ") + e.what());
+  }
+}
 
 template<typename T>
 inline void ger_batched(BLASHandle<PlatformKind::SYCL>& handle,

--- a/src/Platforms/SYCL/AccelBLAS_SYCL.hpp
+++ b/src/Platforms/SYCL/AccelBLAS_SYCL.hpp
@@ -52,7 +52,7 @@ inline void gemm(BLASHandle<PlatformKind::SYCL>& handle,
   }
   catch (oneapi::mkl::exception& e)
   {
-    throw std::runtime_error(std::string("oneapi::mkl exception: ") + e.what());
+    throw std::runtime_error(std::string("AccelBLAS::gemm exception: ") + e.what());
   }
 }
 
@@ -84,7 +84,16 @@ inline void ger_batched(BLASHandle<PlatformKind::SYCL>& handle,
                         T* const A[],
                         const int lda,
                         const size_t batch_count)
-{}
+{
+  try
+  {
+    syclBLAS::ger_batched(handle.queue_, m, n, alpha, x, incx, y, incy, A, lda, batch_count);
+  }
+  catch (sycl::exception& e)
+  {
+    throw std::runtime_error(std::string("AccelBLAS::ger_batched exception: ") + e.what());
+  }
+}
 
 template<typename T>
 inline void copy_batched(BLASHandle<PlatformKind::SYCL>& handle,
@@ -140,7 +149,7 @@ inline void gemm_batched(BLASHandle<PlatformKind::SYCL>& handle,
   }
   catch (oneapi::mkl::exception& e)
   {
-    throw std::runtime_error(std::string("oneapi::mkl exception: ") + e.what());
+    throw std::runtime_error(std::string("AccelBLAS::gemm_batched  exception: ") + e.what());
   }
 }
 

--- a/src/Platforms/SYCL/syclBLAS.hpp
+++ b/src/Platforms/SYCL/syclBLAS.hpp
@@ -55,6 +55,22 @@ sycl::event gemv(sycl::queue& handle,
                  const std::vector<sycl::event>& events = {});
 
 template<typename T>
+sycl::event gemv_batched(sycl::queue& handle,
+                         const char trans,
+                         const int m,
+                         const int n,
+                         const T* alpha,
+                         const T* const A[],
+                         const int lda,
+                         const T* const x[],
+                         const int incx,
+                         const T* beta,
+                         T* const y[],
+                         const int incy,
+                         const size_t batch_count,
+                         const std::vector<sycl::event>& events = {});
+
+template<typename T>
 sycl::event gemm(sycl::queue& handle,
                  const char tA,
                  const char tB,

--- a/src/Platforms/SYCL/syclBLAS.hpp
+++ b/src/Platforms/SYCL/syclBLAS.hpp
@@ -71,6 +71,20 @@ sycl::event gemm(sycl::queue& handle,
                  const int ldc,
                  const std::vector<sycl::event>& events = {});
 
+template<typename T>
+sycl::event ger_batched(sycl::queue& handle,
+                        const int m,
+                        const int n,
+                        const T* alpha,
+                        const T* const x[],
+                        const int incx,
+                        const T* const y[],
+                        const int incy,
+                        T* const A[],
+                        const int lda,
+                        const size_t batch_count,
+                        const std::vector<sycl::event>& events = {});
+
 template<typename T1, typename T2>
 sycl::event transpose(sycl::queue& q,
                       const T1* in,

--- a/src/Platforms/SYCL/syclBLAS.hpp
+++ b/src/Platforms/SYCL/syclBLAS.hpp
@@ -54,6 +54,7 @@ sycl::event gemv(sycl::queue& handle,
                  const int incy,
                  const std::vector<sycl::event>& events = {});
 
+/// in-house version of gemv_batch implemented in SYCL. Can be dropped if we have vendor optimized versions
 template<typename T>
 sycl::event gemv_batched(sycl::queue& handle,
                          const char trans,
@@ -87,6 +88,7 @@ sycl::event gemm(sycl::queue& handle,
                  const int ldc,
                  const std::vector<sycl::event>& events = {});
 
+/// in-house version of ger_batch implemented in SYCL. Can be dropped if we have vendor optimized versions
 template<typename T>
 sycl::event ger_batched(sycl::queue& handle,
                         const int m,

--- a/src/Platforms/tests/test_AccelBLAS.cpp
+++ b/src/Platforms/tests/test_AccelBLAS.cpp
@@ -173,6 +173,347 @@ void test_gemm_cases()
 #endif
 }
 
+/*
+template<typename T>
+void test_gemv(const int M_b, const int N_b, const char trans)
+{
+  const int M = trans == 'T' ? M_b : N_b;
+  const int N = trans == 'T' ? N_b : M_b;
+
+  using vec_t = Vector<T, OMPallocator<T>>;
+  using mat_t = Matrix<T, OMPallocator<T>>;
+
+  ompBLAS::ompBLAS_handle handle;
+
+  vec_t A(N);        // Input vector
+  mat_t B(M_b, N_b); // Input matrix
+  vec_t C(M);        // Result vector ompBLAS
+  vec_t D(M);        // Result vector BLAS
+
+  // Fill data
+  for (int i = 0; i < N; i++)
+    A[i] = i;
+
+  for (int j = 0; j < M_b; j++)
+    for (int i = 0; i < N_b; i++)
+      B[j][i] = i + j * 2;
+
+  // Fill C and D with 0
+  for (int i = 0; i < M; i++)
+    C[i] = D[i] = T(0);
+
+  A.updateTo();
+  B.updateTo();
+  C.updateTo();
+
+  T alpha(1);
+  T beta(0);
+
+  // in Fortran, B[M][N] is viewed as B^T
+  // when trans == 'T', the actual calculation is B * A[N] = C[M]
+  // when trans == 'N', the actual calculation is B^T * A[M] = C[N]
+  ompBLAS::gemv(handle, trans, N_b, M_b, alpha, B.device_data(), N_b, A.device_data(), 1, beta, C.device_data(), 1);
+  C.updateFrom();
+
+  if (trans == 'T')
+    BLAS::gemv_trans(M_b, N_b, B.data(), A.data(), D.data());
+  else
+    BLAS::gemv(M_b, N_b, B.data(), A.data(), D.data());
+
+  for (int index = 0; index < M; index++)
+    CHECK(C[index] == D[index]);
+}
+*/
+
+template<PlatformKind PL, typename T>
+void test_one_gemv(const int M_b, const int N_b, const char trans, const int batch_count)
+{
+  const int M = trans == 'T' ? M_b : N_b;
+  const int N = trans == 'T' ? N_b : M_b;
+
+  using vec_t = Vector<T, PinnedDualAllocator<T>>;
+  using mat_t = Matrix<T, PinnedDualAllocator<T>>;
+
+  // Create input vector
+  std::vector<vec_t> As;
+  Vector<const T*, OMPallocator<const T*>> Aptrs;
+
+  // Create input matrix
+  std::vector<mat_t> Bs;
+  Vector<const T*, OMPallocator<const T*>> Bptrs;
+
+  // Create output vector (ompBLAS)
+  std::vector<vec_t> Cs;
+  Vector<T*, OMPallocator<T*>> Cptrs;
+
+  // Create output vector (BLAS)
+  std::vector<vec_t> Ds;
+  Vector<T*, OMPallocator<T*>> Dptrs;
+
+  // Resize pointer vectors
+  Aptrs.resize(batch_count);
+  Bptrs.resize(batch_count);
+  Cptrs.resize(batch_count);
+  Dptrs.resize(batch_count);
+
+  // Resize data vectors
+  As.resize(batch_count);
+  Bs.resize(batch_count);
+  Cs.resize(batch_count);
+  Ds.resize(batch_count);
+
+  // Fill data
+  for (int batch = 0; batch < batch_count; batch++)
+  {
+    As[batch].resize(N);
+    Aptrs[batch] = As[batch].device_data();
+
+    Bs[batch].resize(M_b, N_b);
+    Bptrs[batch] = Bs[batch].device_data();
+
+    Cs[batch].resize(M);
+    Cptrs[batch] = Cs[batch].device_data();
+
+    Ds[batch].resize(M);
+    Dptrs[batch] = Ds[batch].data();
+
+    for (int i = 0; i < N; i++)
+      As[batch][i] = i;
+
+    for (int j = 0; j < M_b; j++)
+      for (int i = 0; i < N_b; i++)
+        Bs[batch][j][i] = i + j * 2;
+
+    for (int i = 0; i < M; i++)
+      Cs[batch][i] = Ds[batch][i] = T(0);
+
+    As[batch].updateTo();
+    Bs[batch].updateTo();
+  }
+
+  Aptrs.updateTo();
+  Bptrs.updateTo();
+  Cptrs.updateTo();
+
+  // Run tests
+  Vector<T, OMPallocator<T>> alpha(batch_count);
+  Vector<T, OMPallocator<T>> beta(batch_count);
+  Vector<T, OMPallocator<T>> beta1(batch_count);
+
+  for (int batch = 0; batch < batch_count; batch++)
+  {
+    alpha[batch] = T(0.5);
+    beta[batch]  = T(0);
+    beta1[batch] = T(1);
+  }
+
+  alpha.updateTo();
+  beta.updateTo();
+  beta1.updateTo();
+
+  compute::Queue<PL> queue;
+  compute::BLASHandle<PL> h_blas(queue);
+  // alpha 0.5, beta 0
+  compute::BLAS::gemv_batched(h_blas, trans, N_b, M_b, alpha.device_data(), Bptrs.device_data(), N_b, Aptrs.device_data(), 1,
+                        beta.device_data(), Cptrs.device_data(), 1, batch_count);
+  // alpha 0.5, beta 1
+  compute::BLAS::gemv_batched(h_blas, trans, N_b, M_b, alpha.device_data(), Bptrs.device_data(), N_b, Aptrs.device_data(), 1,
+                        beta1.device_data(), Cptrs.device_data(), 1, batch_count);
+
+  queue.sync();
+
+  for (int batch = 0; batch < batch_count; batch++)
+  {
+    Cs[batch].updateFrom();
+    if (trans == 'T')
+      BLAS::gemv_trans(M_b, N_b, Bs[batch].data(), As[batch].data(), Ds[batch].data());
+    else
+      BLAS::gemv(M_b, N_b, Bs[batch].data(), As[batch].data(), Ds[batch].data());
+
+    // Check results
+    for (int index = 0; index < M; index++)
+      CHECK(Cs[batch][index] == Ds[batch][index]);
+  }
+}
+
+template<PlatformKind PL>
+void test_gemv_cases()
+{
+  const int M           = 137;
+  const int N           = 79;
+  const int batch_count = 23;
+
+  std::cout << "Testing NOTRANS gemv_batched" << std::endl;
+  test_one_gemv<PL, float>(M, N, 'N', batch_count);
+  test_one_gemv<PL, double>(M, N, 'N', batch_count);
+#if defined(QMC_COMPLEX)
+  test_one_gemv<PL, std::complex<float>>(N, M, 'N', batch_count);
+  test_one_gemv<PL, std::complex<double>>(N, M, 'N', batch_count);
+#endif
+  std::cout << "Testing TRANS gemv_batched" << std::endl;
+  test_one_gemv<PL, float>(M, N, 'T', batch_count);
+  test_one_gemv<PL, double>(M, N, 'T', batch_count);
+#if defined(QMC_COMPLEX)
+  test_one_gemv<PL, std::complex<float>>(N, M, 'T', batch_count);
+  test_one_gemv<PL, std::complex<double>>(N, M, 'T', batch_count);
+#endif
+}
+
+/*
+template<typename T>
+void test_ger(const int M, const int N)
+{
+  using vec_t = Vector<T, OMPallocator<T>>;
+  using mat_t = Matrix<T, OMPallocator<T>>;
+
+  ompBLAS::ompBLAS_handle handle;
+
+  mat_t Ah(M, N); // Input matrix
+  mat_t Ad(M, N); // Input matrix
+  vec_t x(M);     // Input vector
+  vec_t y(N);     // Input vector
+
+  // Fill data
+  for (int i = 0; i < M; i++)
+    x[i] = i;
+  for (int i = 0; i < N; i++)
+    y[i] = N - i;
+
+  for (int j = 0; j < M; j++)
+    for (int i = 0; i < N; i++)
+    {
+      Ah[j][i] = i + j * 2;
+      Ad[j][i] = i + j * 2;
+    }
+
+  Ad.updateTo();
+  x.updateTo();
+  y.updateTo();
+
+  T alpha(1);
+
+  // in Fortran, B[M][N] is viewed as B^T
+  ompBLAS::ger(handle, M, N, alpha, x.device_data(), 1, y.device_data(), 1, Ad.device_data(), M);
+  Ad.updateFrom();
+
+  BLAS::ger(M, N, alpha, x.data(), 1, y.data(), 1, Ah.data(), M);
+
+  for (int j = 0; j < M; j++)
+    for (int i = 0; i < N; i++)
+      CHECK(Ah[j][i] == Ad[j][i]);
+}
+*/
+
+template<PlatformKind PL, typename T>
+void test_one_ger(const int M, const int N, const int batch_count)
+{
+  using vec_t = Vector<T, PinnedDualAllocator<T>>;
+  using mat_t = Matrix<T, PinnedDualAllocator<T>>;
+
+  // Create input vector
+  std::vector<vec_t> Xs;
+  Vector<const T*, OMPallocator<const T*>> Xptrs;
+  std::vector<vec_t> Ys;
+  Vector<const T*, OMPallocator<const T*>> Yptrs;
+
+  // Create input matrix
+  std::vector<mat_t> Ahs;
+  Vector<T*, OMPallocator<T*>> Ahptrs;
+  std::vector<mat_t> Ads;
+  Vector<T*, OMPallocator<T*>> Adptrs;
+
+  // Resize pointer vectors
+  Xptrs.resize(batch_count);
+  Yptrs.resize(batch_count);
+  Ahptrs.resize(batch_count);
+  Adptrs.resize(batch_count);
+
+  // Resize data vectors
+  Xs.resize(batch_count);
+  Ys.resize(batch_count);
+  Ahs.resize(batch_count);
+  Ads.resize(batch_count);
+
+  // Fill data
+  for (int batch = 0; batch < batch_count; batch++)
+  {
+    Xs[batch].resize(M);
+    Xptrs[batch] = Xs[batch].device_data();
+
+    Ys[batch].resize(N);
+    Yptrs[batch] = Ys[batch].device_data();
+
+    Ads[batch].resize(M, N);
+    Adptrs[batch] = Ads[batch].device_data();
+
+    Ahs[batch].resize(M, N);
+    Ahptrs[batch] = Ahs[batch].data();
+
+    // Fill data
+    for (int i = 0; i < M; i++)
+      Xs[batch][i] = i;
+    for (int i = 0; i < N; i++)
+      Ys[batch][i] = N - i;
+
+    for (int j = 0; j < M; j++)
+      for (int i = 0; i < N; i++)
+      {
+        Ads[batch][j][i] = i + j * 2;
+        Ahs[batch][j][i] = i + j * 2;
+      }
+
+    Xs[batch].updateTo();
+    Ys[batch].updateTo();
+    Ads[batch].updateTo();
+  }
+
+  Adptrs.updateTo();
+  Xptrs.updateTo();
+  Yptrs.updateTo();
+
+  // Run tests
+  Vector<T, OMPallocator<T>> alpha(batch_count);
+
+  for (int batch = 0; batch < batch_count; batch++)
+    alpha[batch] = T(0.5);
+
+  alpha.updateTo();
+
+  compute::Queue<PL> queue;
+  compute::BLASHandle<PL> h_blas(queue);
+  compute::BLAS::ger_batched(h_blas, M, N, alpha.device_data(), Xptrs.device_data(), 1, Yptrs.device_data(), 1,
+                       Adptrs.device_data(), M, batch_count);
+  queue.sync();
+
+  for (int batch = 0; batch < batch_count; batch++)
+  {
+    Ads[batch].updateFrom();
+    BLAS::ger(M, N, alpha[batch], Xs[batch].data(), 1, Ys[batch].data(), 1, Ahs[batch].data(), M);
+
+    // Check results
+    for (int j = 0; j < M; j++)
+      for (int i = 0; i < N; i++)
+        CHECK(Ads[batch][j][i] == Ahs[batch][j][i]);
+  }
+}
+
+template<PlatformKind PL>
+void test_ger_cases()
+{
+  const int M           = 137;
+  const int N           = 79;
+  const int batch_count = 23;
+
+  // Batched Test
+  std::cout << "Testing ger_batched" << std::endl;
+  test_one_ger<PL, float>(M, N, batch_count);
+  test_one_ger<PL, double>(M, N, batch_count);
+#if defined(QMC_COMPLEX)
+  test_one_ger<PL, std::complex<float>>(N, M, batch_count);
+  test_one_ger<PL, std::complex<double>>(N, M, batch_count);
+#endif
+}
+
 TEST_CASE("AccelBLAS", "[BLAS]")
 {
   SECTION("gemm")
@@ -188,6 +529,38 @@ TEST_CASE("AccelBLAS", "[BLAS]")
 #if defined(ENABLE_OFFLOAD)
     std::cout << "Testing gemm<PlatformKind::OMPTARGET>" << std::endl;
     test_gemm_cases<PlatformKind::OMPTARGET>();
+#endif
+  }
+
+  SECTION("gemv")
+  {
+#if defined(ENABLE_CUDA)
+    std::cout << "Testing gemm<PlatformKind::CUDA>" << std::endl;
+    test_gemv_cases<PlatformKind::CUDA>();
+#endif
+#if defined(ENABLE_SYCL)
+    std::cout << "Testing gemm<PlatformKind::SYCL>" << std::endl;
+    test_gemv_cases<PlatformKind::SYCL>();
+#endif
+#if defined(ENABLE_OFFLOAD)
+    std::cout << "Testing gemm<PlatformKind::OMPTARGET>" << std::endl;
+    test_gemv_cases<PlatformKind::OMPTARGET>();
+#endif
+  }
+
+  SECTION("ger")
+  {
+#if defined(ENABLE_CUDA)
+    std::cout << "Testing ger<PlatformKind::CUDA>" << std::endl;
+    test_ger_cases<PlatformKind::CUDA>();
+#endif
+#if defined(ENABLE_SYCL)
+    std::cout << "Testing ger<PlatformKind::SYCL>" << std::endl;
+    test_ger_cases<PlatformKind::SYCL>();
+#endif
+#if defined(ENABLE_OFFLOAD)
+    std::cout << "Testing ger<PlatformKind::OMPTARGET>" << std::endl;
+    test_ger_cases<PlatformKind::OMPTARGET>();
 #endif
   }
 }

--- a/src/Platforms/tests/test_AccelBLAS.cpp
+++ b/src/Platforms/tests/test_AccelBLAS.cpp
@@ -180,8 +180,8 @@ void test_gemv(const int M_b, const int N_b, const char trans)
   const int M = trans == 'T' ? M_b : N_b;
   const int N = trans == 'T' ? N_b : M_b;
 
-  using vec_t = Vector<T, OMPallocator<T>>;
-  using mat_t = Matrix<T, OMPallocator<T>>;
+  using vec_t = Vector<T, PinnedDualAllocator<T>>;
+  using mat_t = Matrix<T, PinnedDualAllocator<T>>;
 
   ompBLAS::ompBLAS_handle handle;
 
@@ -236,19 +236,19 @@ void test_one_gemv(const int M_b, const int N_b, const char trans, const int bat
 
   // Create input vector
   std::vector<vec_t> As;
-  Vector<const T*, OMPallocator<const T*>> Aptrs;
+  Vector<const T*, PinnedDualAllocator<const T*>> Aptrs;
 
   // Create input matrix
   std::vector<mat_t> Bs;
-  Vector<const T*, OMPallocator<const T*>> Bptrs;
+  Vector<const T*, PinnedDualAllocator<const T*>> Bptrs;
 
   // Create output vector (ompBLAS)
   std::vector<vec_t> Cs;
-  Vector<T*, OMPallocator<T*>> Cptrs;
+  Vector<T*, PinnedDualAllocator<T*>> Cptrs;
 
   // Create output vector (BLAS)
   std::vector<vec_t> Ds;
-  Vector<T*, OMPallocator<T*>> Dptrs;
+  Vector<T*, PinnedDualAllocator<T*>> Dptrs;
 
   // Resize pointer vectors
   Aptrs.resize(batch_count);
@@ -296,9 +296,9 @@ void test_one_gemv(const int M_b, const int N_b, const char trans, const int bat
   Cptrs.updateTo();
 
   // Run tests
-  Vector<T, OMPallocator<T>> alpha(batch_count);
-  Vector<T, OMPallocator<T>> beta(batch_count);
-  Vector<T, OMPallocator<T>> beta1(batch_count);
+  Vector<T, PinnedDualAllocator<T>> alpha(batch_count);
+  Vector<T, PinnedDualAllocator<T>> beta(batch_count);
+  Vector<T, PinnedDualAllocator<T>> beta1(batch_count);
 
   for (int batch = 0; batch < batch_count; batch++)
   {
@@ -363,8 +363,8 @@ void test_gemv_cases()
 template<typename T>
 void test_ger(const int M, const int N)
 {
-  using vec_t = Vector<T, OMPallocator<T>>;
-  using mat_t = Matrix<T, OMPallocator<T>>;
+  using vec_t = Vector<T, PinnedDualAllocator<T>>;
+  using mat_t = Matrix<T, PinnedDualAllocator<T>>;
 
   ompBLAS::ompBLAS_handle handle;
 
@@ -412,15 +412,15 @@ void test_one_ger(const int M, const int N, const int batch_count)
 
   // Create input vector
   std::vector<vec_t> Xs;
-  Vector<const T*, OMPallocator<const T*>> Xptrs;
+  Vector<const T*, PinnedDualAllocator<const T*>> Xptrs;
   std::vector<vec_t> Ys;
-  Vector<const T*, OMPallocator<const T*>> Yptrs;
+  Vector<const T*, PinnedDualAllocator<const T*>> Yptrs;
 
   // Create input matrix
   std::vector<mat_t> Ahs;
-  Vector<T*, OMPallocator<T*>> Ahptrs;
+  Vector<T*, PinnedDualAllocator<T*>> Ahptrs;
   std::vector<mat_t> Ads;
-  Vector<T*, OMPallocator<T*>> Adptrs;
+  Vector<T*, PinnedDualAllocator<T*>> Adptrs;
 
   // Resize pointer vectors
   Xptrs.resize(batch_count);
@@ -472,7 +472,7 @@ void test_one_ger(const int M, const int N, const int batch_count)
   Yptrs.updateTo();
 
   // Run tests
-  Vector<T, OMPallocator<T>> alpha(batch_count);
+  Vector<T, PinnedDualAllocator<T>> alpha(batch_count);
 
   for (int batch = 0; batch < batch_count; batch++)
     alpha[batch] = T(0.5);


### PR DESCRIPTION
## Proposed changes
The gemv_batch of oneMKL doesn't meet our requirement that alpha and beta are vectors. Add our version like cuBLAS_missing_functions.
These are makeshift versions lacking tuning.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
sunspot

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted