### PR TITLE
Request numpy v1.26.4 for macos CI

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -166,7 +166,7 @@ jobs:
         run: |
           brew upgrade || brew link --overwrite python@3.12
           brew install ninja hdf5 fftw boost
-          python3 -m pip install numpy h5py pandas
+          python3 -m pip install numpy==1.26.4 h5py pandas
 
       - name: Configure
         run: tests/test_automation/github-actions/ci/run_step.sh configure


### PR DESCRIPTION
## Proposed changes

Workaround macos CI failure due to numpy v2 incompatibility (#5050) by requesting v1.26.4

## What type(s) of changes does this code introduce?

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None. CI needs to run and pass.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
