### PR TITLE
Print block and warmup timings

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -524,7 +524,9 @@ bool DMCBatched::run()
     if (!myComm->rank())
       stop_requested = runtimeControl.checkStop(dmc_loop);
     myComm->bcast(stop_requested);
-
+    // Progress messages before possibly stopping
+    if (!myComm->rank())
+      app_log() << runtimeControl.generateProgressMessage("DMCBatched", block, num_blocks);
     if (stop_requested)
     {
       if (!myComm->rank())
@@ -532,9 +534,6 @@ bool DMCBatched::run()
       run_time_manager.markStop();
       break;
     }
-    // Progress messages if not aborting
-    if (!myComm->rank())
-      app_log() << runtimeControl.generateProgressMessage("DMCBatched", block, num_blocks);
   }
 
   branch_engine_->printStatus();

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -532,6 +532,9 @@ bool DMCBatched::run()
       run_time_manager.markStop();
       break;
     }
+    // Progress messages if not aborting
+    if (!myComm->rank())
+      app_log() << runtimeControl.generateProgressMessage("DMCBatched", block, num_blocks);
   }
 
   branch_engine_->printStatus();

--- a/src/QMCDrivers/SFNBranch.cpp
+++ b/src/QMCDrivers/SFNBranch.cpp
@@ -235,7 +235,7 @@ void SFNBranch::printStatus() const
   if (BranchMode[B_RMC])
   {
     o << "====================================================";
-    o << "\n  End of a RMC block";
+    o << "\n  End of a RMC section";
     o << "\n    QMC counter                   = " << iParam[B_COUNTER];
     o << "\n    time step                     = " << vParam[SBVP::TAU];
     o << "\n    effective time step           = " << vParam[SBVP::TAUEFF];
@@ -248,7 +248,7 @@ void SFNBranch::printStatus() const
   else // running DMC
   {
     o << "====================================================";
-    o << "\n  End of a DMC block";
+    o << "\n  End of a DMC section";
     o << "\n    QMC counter                   = " << iParam[B_COUNTER];
     o << "\n    time step                     = " << vParam[SBVP::TAU];
     o << "\n    effective time step           = " << vParam[SBVP::TAUEFF];

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -415,7 +415,9 @@ bool VMCBatched::run()
     if (!myComm->rank())
       stop_requested = runtimeControl.checkStop(vmc_loop);
     myComm->bcast(stop_requested);
-
+    // Progress messages before possibly stopping
+    if (!myComm->rank())
+      app_log() << runtimeControl.generateProgressMessage("VMCBatched", block, num_blocks);
     if (stop_requested)
     {
       if (!myComm->rank())
@@ -423,9 +425,6 @@ bool VMCBatched::run()
       run_time_manager.markStop();
       break;
     }
-    // Progress messages if not aborting
-    if (!myComm->rank())
-      app_log() << runtimeControl.generateProgressMessage("VMCBatched", block, num_blocks);
   }
   // This is confusing logic from VMC.cpp want this functionality write documentation of this
   // and clean it up

--- a/src/Utilities/RunTimeManager.cpp
+++ b/src/Utilities/RunTimeManager.cpp
@@ -136,11 +136,12 @@ std::string RunTimeControl<CLOCK>::generateProgressMessage(const std::string& dr
                                                            int num_blocks) const
 {
   std::stringstream log;
-  if (block == 0 || block == num_blocks / 4 || block == num_blocks / 2 || block == (num_blocks * 3) / 4 ||
+  if (block == 0 || block + 1 == num_blocks / 4 || block + 1 == num_blocks / 2 || block + 1 == (num_blocks * 3) / 4 ||
       block + 1 == num_blocks)
   {
     log << "Completed block " << std::setw(4) << block + 1 << " of " << num_blocks << " average "
-        << std::setprecision(4) << m_loop_time << " secs/block after " << m_elapsed << " secs" << std::endl;
+        << std::setprecision(4) << m_loop_time << " secs/block after " << std::setprecision(4) << m_elapsed << " secs"
+        << std::endl;
   }
   return log.str();
 }

--- a/src/Utilities/RunTimeManager.cpp
+++ b/src/Utilities/RunTimeManager.cpp
@@ -17,6 +17,7 @@
 #include "RunTimeManager.h"
 #include <sstream>
 #include <fstream>
+#include <iomanip>
 #include <cstdio>
 
 namespace qmcplusplus
@@ -127,6 +128,21 @@ bool RunTimeControl<CLOCK>::checkStop(LoopTimer<CLOCK>& loop_timer)
   need_to_stop |= !enough_time_for_next_iteration(loop_timer);
   need_to_stop |= stop_file_requested();
   return need_to_stop;
+}
+
+template<class CLOCK>
+std::string RunTimeControl<CLOCK>::generateProgressMessage(const std::string& driverName,
+                                                           int block,
+                                                           int num_blocks) const
+{
+  std::stringstream log;
+  if (block == 0 || block == num_blocks / 4 || block == num_blocks / 2 || block == (num_blocks * 3) / 4 ||
+      block + 1 == num_blocks)
+  {
+    log << "Completed block " << std::setw(4) << block + 1 << " of " << num_blocks << " average "
+        << std::setprecision(4) << m_loop_time << " secs/block after " << m_elapsed << " secs" << std::endl;
+  }
+  return log.str();
 }
 
 template<class CLOCK>

--- a/src/Utilities/RunTimeManager.h
+++ b/src/Utilities/RunTimeManager.h
@@ -104,6 +104,8 @@ public:
    */
   bool checkStop(LoopTimer<CLOCK>& loop_timer);
 
+  /// generate terse progress messages
+  std::string generateProgressMessage(const std::string& driverName, int block, int num_blocks) const;
   /// generate stop message explaining why
   std::string generateStopMessage(const std::string& driverName, int block) const;
 


### PR DESCRIPTION
## Proposed changes

Improve progress monitoring by printing timings for warmup and blocks. Block timing and elapsed time given for first, last, and every ~25% progress. Max 5 timing lines printed.

Also changed output "End of a QMC block" to "End of a QMC section" for clarity.

Sample output:
```
658: VMC Warmup completed in 2.3138e-02 secs
658: =====================================================
658: --- Memory usage report : VMCBatched after Warmup ---
658: =====================================================
658: Available memory on node 0, free + buffers :   27749 MiB
658: Memory footprint by rank 0 on node 0       :     122 MiB
658: =====================================================
658: Completed block    1 of 100 average 0.01264 secs/block after 19.97 secs
658: Completed block   26 of 100 average 0.01644 secs/block after 20.39 secs
658: Completed block   51 of 100 average 0.01398 secs/block after 20.68 secs
658: Completed block   76 of 100 average 0.01492 secs/block after 21.1 secs
658: Completed block  100 of 100 average 0.01527 secs/block after 21.49 secs
658: ====================================================
658:   End of a VMC section
658:     QMC counter        = 5
658:     time step          = 0.5
```
## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop ubuntu 22 clang 15

## Checklist


- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
