### PR TITLE
Decouple inverter blas handle with DelayedUpdateBatched

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DelayedUpdateBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DelayedUpdateBatched.h
@@ -106,8 +106,6 @@ public:
         czero_vec.updateTo();
       }
     }
-
-    auto& getLAhandles() { return blas_handle; }
   };
 
 private:

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -119,8 +119,8 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_invertPsiM(const RefVectorWithLea
       mw_res.log_values[iw] = {0.0, 0.0};
     }
 
-    wfc_leader.accel_inverter_.getResource().mw_invertTranspose(mw_res.engine_rsc.getLAhandles(), logdetT_list,
-                                                                a_inv_list, mw_res.log_values);
+    wfc_leader.accel_inverter_.getResource().mw_invertTranspose(mw_res.engine_rsc.queue, logdetT_list, a_inv_list,
+                                                                mw_res.log_values);
 
     for (int iw = 0; iw < nw; ++iw)
     {

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
@@ -39,6 +39,11 @@ namespace qmcplusplus
  *  to the per walker DiracDeterminantBatched.
  *  Resources used by this object but owned by the
  *  surrounding scope are passed as arguments.
+ *
+ *  All the public APIs are synchronous. The asynchronous queue argument gets synchronized before return.
+ *  rocBLAS, indirectly used via hipBLAS, requires synchronizing the old stream before setting a new one.
+ *  We don't need to actively synchronize the old stream because it gets synchronized right after each use.
+ *
  */
 template<typename VALUE_FP>
 class DiracMatrixComputeCUDA : public Resource

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
@@ -58,7 +58,7 @@ public:
   using OffloadPinnedVector = Vector<T, OffloadPinnedAllocator<T>>;
 
   // maybe you'll want a resource someday, then change here.
-  using HandleResource = compute::BLASHandle<PlatformKind::OMPTARGET>;
+  using HandleResource = compute::Queue<PlatformKind::OMPTARGET>;
 
 private:
   aligned_vector<VALUE_FP> m_work_;
@@ -221,13 +221,11 @@ public:
    *  \todo measure if using the a_mats without a copy to contiguous vector is better.
    */
   template<typename TMAT, PlatformKind PL>
-  inline void mw_invertTranspose(compute::BLASHandle<PL>& resource_ignored,
+  inline void mw_invertTranspose(compute::Queue<PL>& resource_ignored,
                                  const RefVector<const OffloadPinnedMatrix<TMAT>>& a_mats,
                                  const RefVector<OffloadPinnedMatrix<TMAT>>& inv_a_mats,
                                  OffloadPinnedVector<LogValue>& log_values)
   {
-    compute::Queue<PlatformKind::OMPTARGET> queue;
-    HandleResource resource(queue);
     for (int iw = 0; iw < a_mats.size(); iw++)
     {
       auto& Ainv = inv_a_mats[iw].get();

--- a/src/QMCWaveFunctions/tests/benchmark_DiracMatrixComputeCUDA.cpp
+++ b/src/QMCWaveFunctions/tests/benchmark_DiracMatrixComputeCUDA.cpp
@@ -30,7 +30,6 @@
 #include "Utilities/for_testing/RandomForTest.h"
 #include "Platforms/DualAllocatorAliases.hpp"
 #include "Platforms/CUDA/QueueCUDA.hpp"
-#include "Platforms/CUDA/AccelBLAS_CUDA.hpp"
 
 // Legacy CPU inversion for temporary testing
 #include "QMCWaveFunctions/Fermion/DiracMatrix.h"
@@ -74,7 +73,6 @@ TEST_CASE("DiracMatrixComputeCUDA_large_determinants_benchmark_legacy_1024_4", "
   params.batch_size = 4;
 
   compute::Queue<PlatformKind::CUDA> queue;
-  compute::BLASHandle<PlatformKind::CUDA> cuda_handles(queue);
   DiracMatrixComputeCUDA<double> dmcc;
 
   std::vector<Matrix<double>> spd_mats(params.batch_size, {params.n, params.n});
@@ -99,7 +97,7 @@ TEST_CASE("DiracMatrixComputeCUDA_large_determinants_benchmark_legacy_1024_4", "
   std::vector<bool> compute_mask(params.batch_size, true);
   BENCHMARK_ADVANCED(params.str())(Catch::Benchmark::Chronometer meter)
   {
-    meter.measure([&] { dmcc.mw_invertTranspose(cuda_handles, a_mats, inv_a_mats, log_values); });
+    meter.measure([&] { dmcc.mw_invertTranspose(queue, a_mats, inv_a_mats, log_values); });
   };
 
   DiracMatrix<double> dmat;
@@ -127,7 +125,6 @@ TEST_CASE("benchmark_DiracMatrixComputeCUDA_vs_legacy_256_10", "[wavefunction][f
   params.batch_size = 10;
 
   compute::Queue<PlatformKind::CUDA> queue;
-  compute::BLASHandle<PlatformKind::CUDA> cuda_handles(queue);
   DiracMatrixComputeCUDA<double> dmcc;
 
   std::vector<Matrix<double>> spd_mats(params.batch_size, {params.n, params.n});
@@ -152,7 +149,7 @@ TEST_CASE("benchmark_DiracMatrixComputeCUDA_vs_legacy_256_10", "[wavefunction][f
   std::vector<bool> compute_mask(params.batch_size, true);
   BENCHMARK_ADVANCED(params.str())(Catch::Benchmark::Chronometer meter)
   {
-    meter.measure([&] { dmcc.mw_invertTranspose(cuda_handles, a_mats, inv_a_mats, log_values); });
+    meter.measure([&] { dmcc.mw_invertTranspose(queue, a_mats, inv_a_mats, log_values); });
   };
 
 
@@ -181,7 +178,6 @@ TEST_CASE("benchmark_DiracMatrixComputeCUDASingle_vs_legacy_256_10", "[wavefunct
   params.batch_size = 10;
 
   compute::Queue<PlatformKind::CUDA> queue;
-  compute::BLASHandle<PlatformKind::CUDA> cuda_handles(queue);
   DiracMatrixComputeCUDA<double> dmcc;
 
   std::vector<Matrix<double>> spd_mats(params.batch_size, {params.n, params.n});
@@ -210,14 +206,13 @@ TEST_CASE("benchmark_DiracMatrixComputeCUDASingle_vs_legacy_256_10", "[wavefunct
   {
     meter.measure([&] {
       for (int im = 0; im < params.batch_size; ++im)
-        dmcc.invert_transpose(cuda_handles, pinned_spd_mats[im], pinned_inv_mats[im], log_values[im]);
+        dmcc.invert_transpose(queue, pinned_spd_mats[im], pinned_inv_mats[im], log_values[im]);
     });
   };
 
 
   DiracMatrix<double> dmat;
   std::vector<Matrix<double>> inv_mats_test(params.batch_size, {params.n, params.n});
-  ;
   std::vector<std::complex<double>> log_values_test(params.batch_size);
 
   params.name = "legacy CPU";
@@ -240,7 +235,6 @@ TEST_CASE("benchmark_DiracMatrixComputeCUDASingle_vs_legacy_1024_4", "[wavefunct
   params.batch_size = 4;
 
   compute::Queue<PlatformKind::CUDA> queue;
-  compute::BLASHandle<PlatformKind::CUDA> cuda_handles(queue);
   DiracMatrixComputeCUDA<double> dmcc;
 
   std::vector<Matrix<double>> spd_mats(params.batch_size, {params.n, params.n});
@@ -270,7 +264,7 @@ TEST_CASE("benchmark_DiracMatrixComputeCUDASingle_vs_legacy_1024_4", "[wavefunct
   {
     meter.measure([&] {
       for (int im = 0; im < params.batch_size; ++im)
-        dmcc.invert_transpose(cuda_handles, pinned_spd_mats[im], pinned_inv_mats[im], log_values[im]);
+        dmcc.invert_transpose(queue, pinned_spd_mats[im], pinned_inv_mats[im], log_values[im]);
     });
   };
 

--- a/src/QMCWaveFunctions/tests/test_DiracMatrixComputeCUDA.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracMatrixComputeCUDA.cpp
@@ -71,10 +71,9 @@ TEST_CASE("DiracMatrixComputeCUDA_different_batch_sizes", "[wavefunction][fermio
   OffloadPinnedMatrix<double> inv_mat_a;
   inv_mat_a.resize(4, 4);
   compute::Queue<PlatformKind::CUDA> queue;
-  compute::BLASHandle<PlatformKind::CUDA> cuda_handles(queue);
   DiracMatrixComputeCUDA<double> dmcc;
 
-  dmcc.invert_transpose(cuda_handles, mat_a, inv_mat_a, log_values);
+  dmcc.invert_transpose(queue, mat_a, inv_mat_a, log_values);
 
 
   OffloadPinnedMatrix<double> mat_b;
@@ -96,7 +95,7 @@ TEST_CASE("DiracMatrixComputeCUDA_different_batch_sizes", "[wavefunction][fermio
   RefVector<OffloadPinnedMatrix<double>> inv_a_mats{inv_mat_a, inv_mat_a2};
 
   log_values.resize(2);
-  dmcc.mw_invertTranspose(cuda_handles, a_mats, inv_a_mats, log_values);
+  dmcc.mw_invertTranspose(queue, a_mats, inv_a_mats, log_values);
 
   check_matrix_result = checkMatrix(inv_mat_a, mat_b);
   CHECKED_ELSE(check_matrix_result.result) { FAIL(check_matrix_result.result_message); }
@@ -118,7 +117,7 @@ TEST_CASE("DiracMatrixComputeCUDA_different_batch_sizes", "[wavefunction][fermio
   RefVector<OffloadPinnedMatrix<double>> inv_a_mats3{inv_mat_a, inv_mat_a2, inv_mat_a3};
 
   log_values.resize(3);
-  dmcc.mw_invertTranspose(cuda_handles, a_mats3, inv_a_mats3, log_values);
+  dmcc.mw_invertTranspose(queue, a_mats3, inv_a_mats3, log_values);
 
   check_matrix_result = checkMatrix(inv_mat_a, mat_b);
   CHECKED_ELSE(check_matrix_result.result) { FAIL(check_matrix_result.result_message); }
@@ -136,7 +135,6 @@ TEST_CASE("DiracMatrixComputeCUDA_complex_determinants_against_legacy", "[wavefu
 {
   int n = 64;
   compute::Queue<PlatformKind::CUDA> queue;
-  compute::BLASHandle<PlatformKind::CUDA> cuda_handles(queue);
 
   DiracMatrixComputeCUDA<std::complex<double>> dmcc;
 
@@ -173,7 +171,7 @@ TEST_CASE("DiracMatrixComputeCUDA_complex_determinants_against_legacy", "[wavefu
   RefVector<const OffloadPinnedMatrix<std::complex<double>>> a_mats{mat_a, mat_a2};
   RefVector<OffloadPinnedMatrix<std::complex<double>>> inv_a_mats{inv_mat_a, inv_mat_a2};
 
-  dmcc.mw_invertTranspose(cuda_handles, a_mats, inv_a_mats, log_values);
+  dmcc.mw_invertTranspose(queue, a_mats, inv_a_mats, log_values);
 
   DiracMatrix<std::complex<double>> dmat;
   Matrix<std::complex<double>> inv_mat_test(n, n);
@@ -192,7 +190,6 @@ TEST_CASE("DiracMatrixComputeCUDA_large_determinants_against_legacy", "[wavefunc
 {
   int n = 64;
   compute::Queue<PlatformKind::CUDA> queue;
-  compute::BLASHandle<PlatformKind::CUDA> cuda_handles(queue);
   DiracMatrixComputeCUDA<double> dmcc;
 
   Matrix<double> mat_spd;
@@ -228,7 +225,7 @@ TEST_CASE("DiracMatrixComputeCUDA_large_determinants_against_legacy", "[wavefunc
   RefVector<const OffloadPinnedMatrix<double>> a_mats{mat_a, mat_a2};
   RefVector<OffloadPinnedMatrix<double>> inv_a_mats{inv_mat_a, inv_mat_a2};
 
-  dmcc.mw_invertTranspose(cuda_handles, a_mats, inv_a_mats, log_values);
+  dmcc.mw_invertTranspose(queue, a_mats, inv_a_mats, log_values);
 
   DiracMatrix<double> dmat;
   Matrix<double> inv_mat_test(n, n);

--- a/src/QMCWaveFunctions/tests/test_DiracMatrixComputeOMPTarget.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracMatrixComputeOMPTarget.cpp
@@ -50,9 +50,8 @@ TEST_CASE("DiracMatrixComputeOMPTarget_different_batch_sizes", "[wavefunction][f
   DiracMatrixComputeOMPTarget<double> dmc_omp;
 
   compute::Queue<PlatformKind::OMPTARGET> queue;
-  compute::BLASHandle<PlatformKind::OMPTARGET> dummy(queue);
   std::complex<double> log_value;
-  dmc_omp.invert_transpose(dummy, mat_a, inv_mat_a, log_value);
+  dmc_omp.invert_transpose(queue, mat_a, inv_mat_a, log_value);
   CHECK(log_value == LogComplexApprox(std::complex<double>{5.267858159063328, 6.283185307179586}));
 
 
@@ -75,8 +74,7 @@ TEST_CASE("DiracMatrixComputeOMPTarget_different_batch_sizes", "[wavefunction][f
   RefVector<OffloadPinnedMatrix<double>> inv_a_mats{inv_mat_a, inv_mat_a2};
 
   log_values.resize(2);
-  compute::BLASHandle<PlatformKind::OMPTARGET> dummy_res(queue);
-  dmc_omp.mw_invertTranspose(dummy_res, a_mats, inv_a_mats, log_values);
+  dmc_omp.mw_invertTranspose(queue, a_mats, inv_a_mats, log_values);
 
   check_matrix_result = checkMatrix(inv_mat_a, mat_b);
   CHECKED_ELSE(check_matrix_result.result) { FAIL(check_matrix_result.result_message); }
@@ -98,7 +96,7 @@ TEST_CASE("DiracMatrixComputeOMPTarget_different_batch_sizes", "[wavefunction][f
   RefVector<OffloadPinnedMatrix<double>> inv_a_mats3{inv_mat_a, inv_mat_a2, inv_mat_a3};
 
   log_values.resize(3);
-  dmc_omp.mw_invertTranspose(dummy_res, a_mats3, inv_a_mats3, log_values);
+  dmc_omp.mw_invertTranspose(queue, a_mats3, inv_a_mats3, log_values);
 
   check_matrix_result = checkMatrix(inv_mat_a, mat_b);
   CHECKED_ELSE(check_matrix_result.result) { FAIL(check_matrix_result.result_message); }
@@ -152,8 +150,7 @@ TEST_CASE("DiracMatrixComputeOMPTarget_large_determinants_against_legacy", "[wav
   RefVector<OffloadPinnedMatrix<double>> inv_a_mats{inv_mat_a, inv_mat_a2};
 
   compute::Queue<PlatformKind::OMPTARGET> queue;
-  compute::BLASHandle<PlatformKind::OMPTARGET> dummy_res(queue);
-  dmc_omp.mw_invertTranspose(dummy_res, a_mats, inv_a_mats, log_values);
+  dmc_omp.mw_invertTranspose(queue, a_mats, inv_a_mats, log_values);
 
   DiracMatrix<double> dmat;
   Matrix<double> inv_mat_test(n, n);


### PR DESCRIPTION
## Proposed changes
Part 1 of #5061
Previously, all the dirac matrix batched inverters borrow the blas handle from DelayedUpdateBatched resource.
This PR make inverters owing their own blas handles although the compute::Queue remains being shared.
Much less entangled code.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted