### PR TITLE
MCPopulation now gives walkers useful walker and parent ids

### DIFF
--- a/src/QMCDrivers/MCPopulation.cpp
+++ b/src/QMCDrivers/MCPopulation.cpp
@@ -2,9 +2,10 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2020 QMCPACK developers.
+// Copyright (c) 2024 QMCPACK developers.
 //
 // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //
 // File refactored from: MCWalkerConfiguration.cpp, QMCUpdate.cpp
 //////////////////////////////////////////////////////////////////////////////////////
@@ -44,8 +45,43 @@ MCPopulation::MCPopulation(int num_ranks,
 
 MCPopulation::~MCPopulation() = default;
 
+void MCPopulation::fissionHighMultiplicityWalkers()
+{
+  // we need to do this because spawnWalker changes walkers_ so we
+  // can't just iterate on that collection.
+  auto good_walkers = convertUPtrToRefVector(walkers_);
+  for (MCPWalker& good_walker : good_walkers)
+  {
+    int num_copies = static_cast<int>(good_walker.Multiplicity);
+    while (num_copies > 1)
+    {
+      auto walker_elements = spawnWalker();
+      // In the batched version walker ids are set when walkers are born and are unique,
+      // parent ids are set to the walker that provided the initial configuration.
+      // If the amplified walker was a transfer from another rank its copys get its ID
+      // as their parent, Not the walker id the received walker had on its original rank.
+      // So walkers don't have to maintain state that they were transfers.
+      // We don't need branching here for transfered and nontransfered high multiplicity
+      // walkers. The walker assignment operator could avoid writing to the walker_id of
+      // left side walker but perhaps the assignment operator is surprising enough as is.
+      auto walker_id         = walker_elements.walker.getWalkerID();
+      walker_elements.walker = good_walker;
+      // copy the copied from walkers id to parent id.
+      walker_elements.walker.setParentID(walker_elements.walker.getWalkerID());
+      // put the walkers actual id back.
+      walker_elements.walker.setWalkerID(walker_id);
+      // fix the multiplicity of the new walker
+      walker_elements.walker.Multiplicity = 1.0;
+      // keep good walker valid.
+      good_walker.Multiplicity -= 1.0;
+      num_copies--;
+    }
+  }
+}
+
 void MCPopulation::createWalkers(IndexType num_walkers, const WalkerConfigurations& walker_configs, RealType reserve)
 {
+  assert(reserve >= 1.0);
   IndexType num_walkers_plus_reserve = static_cast<IndexType>(num_walkers * reserve);
 
   // Hack to hopefully insure no truly new walkers will be made by spawn, since I suspect that
@@ -64,18 +100,40 @@ void MCPopulation::createWalkers(IndexType num_walkers, const WalkerConfiguratio
 
   outputManager.pause();
 
-  //this part is time consuming, it must be threaded and calls should be thread-safe.
-#pragma omp parallel for
+  // nextWalkerID is not thread safe so we need to get our walker id's here
+  // before we enter a parallel section.
+  std::vector<long> walker_ids(num_walkers_plus_reserve, 0);
+  // notice we only get walker_ids for the number of walkers in the walker_configs
+  for (size_t iw = 0; iw < num_walkers; iw++)
+    walker_ids[iw] = nextWalkerID();
+
+  // this part is time consuming, it must be threaded and calls should be thread-safe.
+  // It would make more sense if it was over crowd threads as the thread locality of the walkers
+  // would at least initially be "optimal" Depending on the number of OMP threads and implementation
+  // this may be equivalent.
+#pragma omp parallel for shared(walker_ids)
   for (size_t iw = 0; iw < num_walkers_plus_reserve; iw++)
   {
-    walkers_[iw]             = std::make_unique<MCPWalker>(elec_particle_set_->getTotalNum());
+    int parent_id = 0;
+    walkers_[iw]             = std::make_unique<MCPWalker>(walker_ids[iw], parent_id, elec_particle_set_->getTotalNum() );
     walkers_[iw]->Properties = elec_particle_set_->Properties;
 
     // initialize coord
     if (const auto num_existing_walkers = walker_configs.getActiveWalkers())
+    {
+      // Save this walkers id.
+      auto this_walkers_id = walkers_[iw]->getWalkerID();
+      // the walker assignment operator is basically a simple copy so walker_id is overwritten with
+      // something meaningful only in another QMC section.
       *walkers_[iw] = *walker_configs[iw % num_existing_walkers];
+      // An outside section context parent ID is multiplied by -1.
+      walkers_[iw]->setParentID(-1 * walker_configs[iw % num_existing_walkers]->getWalkerID());
+      walkers_[iw]->setWalkerID(this_walkers_id);
+    }
     else
     {
+      // These walkers are orphans they don't get their intial configuration from a walkerconfig
+      // but from the golden particle set.  They get an walker ID of 0;
       walkers_[iw]->R          = elec_particle_set_->R;
       walkers_[iw]->spins      = elec_particle_set_->spins;
     }
@@ -91,18 +149,6 @@ void MCPopulation::createWalkers(IndexType num_walkers, const WalkerConfiguratio
 
   outputManager.resume();
 
-  int num_walkers_created = 0;
-  for (auto& walker_ptr : walkers_)
-  {
-    if (walker_ptr->getWalkerID() == 0)
-    {
-      // And so walker ID's start at one because 0 is magic.
-      // \todo This is C++ all indexes start at 0, make uninitialized ID = -1
-      walker_ptr->setWalkerID((num_walkers_created++) * num_ranks_ + rank_ + 1);
-      walker_ptr->setParentID(walker_ptr->getWalkerID());
-    }
-  }
-
   // kill and spawn walkers update the state variable num_local_walkers_
   // so it must start at the number of reserved walkers
   num_local_walkers_ = num_walkers_plus_reserve;
@@ -111,7 +157,10 @@ void MCPopulation::createWalkers(IndexType num_walkers, const WalkerConfiguratio
   // Now we kill the extra reserve walkers and elements that we made.
   for (int i = 0; i < extra_walkers; ++i)
     killLastWalker();
+  // And now num_local_walkers_ will be correct.
 }
+
+long MCPopulation::nextWalkerID() { return num_walkers_created_++ * num_ranks_ + rank_ + 1; }
 
 WalkerElementsRef MCPopulation::getWalkerElementsRef(const size_t index)
 {
@@ -130,10 +179,15 @@ std::vector<WalkerElementsRef> MCPopulation::get_walker_elements()
 
 /** creates a walker and returns a reference
  *
- *  Walkers are reused
- *  It would be better if this could be done just by
- *  reusing memory.
  *  Not thread safe.
+ *
+ *  In most cases Walkers that are reused have either died during DMC
+ *  or were created dead as a reserve. This is due to the dynamic allocation of the Walker
+ *  and walker elements being expensive in time.  If still true this is an important optimization.
+ *  I think its entirely possible that the walker elements are bloated and if they only included
+ *  necessary per walker mutable elements that this entire complication could be removed.
+ *
+ *  Walker ID's are handed out per independent trajectory (life) not per allocation.
  */
 WalkerElementsRef MCPopulation::spawnWalker()
 {
@@ -156,17 +210,19 @@ WalkerElementsRef MCPopulation::spawnWalker()
     walkers_.back()->Age                = 0;
     walkers_.back()->Multiplicity       = 1.0;
     walkers_.back()->Weight             = 1.0;
+    // this does count as a walker creation so it gets a new walker id
+    auto walker_id = nextWalkerID();
+    walkers_.back()->setWalkerID(walker_id);
   }
   else
   {
-    app_warning() << "Spawning walker number " << walkers_.size() + 1
-                  << " outside of reserves, this ideally should never happened." << std::endl;
-    walkers_.push_back(std::make_unique<MCPWalker>(*(walkers_.back())));
+    outputManager.resume();
+    auto walker_id = nextWalkerID();
+    app_warning() << "Spawning walker ID " << walker_id << " this is living walker number " << walkers_.size()
+                  << "which is beyond the allocated walker reserves, ideally this should never happen." << '\n';
+    walkers_.push_back(std::make_unique<MCPWalker>(*(walkers_.back()), walker_id, 0));
 
-    // There is no value in doing this here because its going to be wiped out
-    // When we load from the receive buffer. It also won't necessarily be correct
-    // Because the buffer is changed by Hamiltonians and wavefunctions that
-    // Add to the dataSet.
+    outputManager.pause();
 
     walker_elec_particle_sets_.emplace_back(std::make_unique<ParticleSet>(*elec_particle_set_));
     walker_trial_wavefunctions_.emplace_back(trial_wf_->makeClone(*walker_elec_particle_sets_.back()));
@@ -174,9 +230,7 @@ WalkerElementsRef MCPopulation::spawnWalker()
         hamiltonian_->makeClone(*walker_elec_particle_sets_.back(), *walker_trial_wavefunctions_.back()));
     walkers_.back()->Multiplicity = 1.0;
     walkers_.back()->Weight       = 1.0;
-    walkers_.back()->setWalkerID((walkers_.size() + 1) * num_ranks_ + rank_ + 1);
   }
-
   outputManager.resume();
   return {*walkers_.back().get(), *walker_elec_particle_sets_.back().get(), *walker_trial_wavefunctions_.back().get()};
 }
@@ -293,8 +347,16 @@ void MCPopulation::saveWalkerConfigurations(WalkerConfigurations& walker_configs
   walker_configs.resize(walker_elec_particle_sets_.size(), elec_particle_set_->getTotalNum());
   for (int iw = 0; iw < walker_elec_particle_sets_.size(); iw++)
   {
+    // The semantics of this call are not what would I would expecte.
+    // Are walkers's R's invalid here?
+    // you are not serializing the population walkers but the particle sets
+    // to the walker_configs walkers...
+    // So if you would like them to carry information between sections be careful
+    // you need to copy it in explicitly.
     walker_elec_particle_sets_[iw]->saveWalker(*walker_configs[iw]);
     walker_configs[iw]->Weight = walkers_[iw]->Weight;
+    walker_configs[iw]->setWalkerID(walkers_[iw]->getWalkerID());
+    walker_configs[iw]->setParentID(walkers_[iw]->getParentID());
   }
 }
 } // namespace qmcplusplus

--- a/src/QMCDrivers/tests/test_MCPopulation.cpp
+++ b/src/QMCDrivers/tests/test_MCPopulation.cpp
@@ -21,7 +21,7 @@
 #include "Particle/tests/MinimalParticlePool.h"
 #include "QMCWaveFunctions/tests/MinimalWaveFunctionPool.h"
 #include "QMCHamiltonians/tests/MinimalHamiltonianPool.h"
-#include "Utilities/RuntimeOptions.h"
+#include "Utilities/for_testing/NativeInitializerPrint.hpp"
 
 namespace qmcplusplus
 {
@@ -50,15 +50,18 @@ TEST_CASE("MCPopulation::createWalkers", "[particle][population]")
 
   MCPopulation population2(1, comm->rank(), particle_pool.getParticleSet("e"), &twf, hamiltonian_pool.getPrimary());
   // keep 3 only configurations.
-  walker_confs.resize(3, 0);
-  CHECK(walker_confs.getActiveWalkers() == 3);
+  WalkerConfigurations walker_confs2;
+  walker_confs2.resize(3, 0);
+  for(int iw = 0; iw < walker_confs2.getActiveWalkers(); ++iw)
+    *walker_confs2[iw] = *walker_confs[iw];
+  CHECK(walker_confs2.getActiveWalkers() == 3);
   auto old_R00 = walker_confs[0]->R[0][0];
   // first and second configurations are both copied from the gold particle set.
   // must be identical.
   CHECK(walker_confs[1]->R[0][0] == old_R00);
   // modify the first configuration
-  auto new_R00 = walker_confs[1]->R[0][0] = 0.3;
-  population2.createWalkers(8, walker_confs, 1.0);
+  auto new_R00 = walker_confs2[1]->R[0][0] = 0.3;
+  population2.createWalkers(8, walker_confs2, 1.0);
   CHECK(population2.get_walkers()[0]->R[0][0] == old_R00);
   CHECK(population2.get_walkers()[1]->R[0][0] == new_R00);
   CHECK(population2.get_walkers()[2]->R[0][0] == old_R00);
@@ -67,6 +70,10 @@ TEST_CASE("MCPopulation::createWalkers", "[particle][population]")
   CHECK(population2.get_walkers()[5]->R[0][0] == old_R00);
   CHECK(population2.get_walkers()[6]->R[0][0] == old_R00);
   CHECK(population2.get_walkers()[7]->R[0][0] == new_R00);
+
+  CHECK(population2.get_walkers()[0]->getParentID() == -1);
+  CHECK(population2.get_walkers()[1]->getParentID() == -2);
+  CHECK(population2.get_walkers()[2]->getParentID() == -3);
 }
 
 
@@ -90,6 +97,7 @@ TEST_CASE("MCPopulation::createWalkers_walker_ids", "[particle][population]")
     pops.emplace_back(num_ranks, i, particle_pool.getParticleSet("e"), &twf, hamiltonian_pool.getPrimary());
 
   std::vector<long> walker_ids;
+  std::array<std::vector<long>,3> per_rank_walker_ids;
   for (int i = 0; i < num_ranks; ++i)
   {
     pops[i].createWalkers(8, walker_confs, 2.0);
@@ -100,13 +108,15 @@ TEST_CASE("MCPopulation::createWalkers_walker_ids", "[particle][population]")
     for (WalkerElementsRef& wer : walker_elems)
     {
       walker_ids.push_back(wer.walker.getWalkerID());
+      per_rank_walker_ids[i].push_back(wer.walker.getWalkerID());
     }
   }
   std::sort(walker_ids.begin(), walker_ids.end());
-  // Walker IDs cannot collide
-  for (int i = 1; i < walker_ids.size(); ++i)
+  // Walker IDs cannot collide unless they are -1
+  for (int i = 1; i < walker_ids.size(); ++i) {
+    INFO(" i = " << i );
     CHECK(walker_ids[i - 1] != walker_ids[i]);
-
+  }
   int new_walkers = 3;
 
   for (int i = 0; i < num_ranks; ++i)
@@ -114,27 +124,29 @@ TEST_CASE("MCPopulation::createWalkers_walker_ids", "[particle][population]")
     {
       auto wer = pops[i].spawnWalker();
       walker_ids.push_back(wer.walker.getWalkerID());
+      per_rank_walker_ids[i].push_back(wer.walker.getWalkerID());
     }
 
   std::sort(walker_ids.begin(), walker_ids.end());
   // Walker IDs cannot collide
   for (int i = 1; i < walker_ids.size(); ++i)
+  {
+    INFO(" i = " << i);
     CHECK(walker_ids[i - 1] != walker_ids[i]);
+  }
+
+  std::vector<long> expected_walker_ids(33);
+  std::iota(expected_walker_ids.begin(), expected_walker_ids.end(), 1);
+  CHECK(expected_walker_ids == walker_ids);
+
+  for (int rank = 0; rank < num_ranks; ++rank)
+  {
+    std::vector<long> rank_expected_ids(11);
+    std::generate(rank_expected_ids.begin(), rank_expected_ids.end(),  [n = 0, rank, num_ranks] () mutable { return (n++) * num_ranks + rank + 1;});
+    CHECK(per_rank_walker_ids[rank] == rank_expected_ids);
+    std::cout << NativePrint(rank_expected_ids) << '\n';
+  }
 }
-
-
-// TEST_CASE("MCPopulation::createWalkers first touch", "[particle][population]")
-// {
-//   MCPopulation population(1, 2);
-//   ParticleAttrib<TinyVector<QMCTraits::RealType, 3>> some_pos(2);
-//   some_pos[0] = TinyVector<double, 3>(1.0, 0.0, 0.0);
-//   some_pos[1] = TinyVector<double, 3>(0.0, 1.0, 0.0);
-
-//   population.createWalkers(8, 2, 16, some_pos);
-//   REQUIRE(population.get_walkers().size() == 16);
-//   // Someday here we should use hwloc or similar to query that the memory is close to
-//   // each thread.
-// }
 
 TEST_CASE("MCPopulation::redistributeWalkers", "[particle][population]")
 {
@@ -168,5 +180,37 @@ TEST_CASE("MCPopulation::redistributeWalkers", "[particle][population]")
   REQUIRE((*walker_consumers_incommensurate[0]).walkers.size() == 3);
   REQUIRE((*walker_consumers_incommensurate[2]).walkers.size() == 2);
 }
+
+
+TEST_CASE("MCPopulation::fissionHighMultiplicityWalkers", "[particle][population]")
+{
+  using namespace testing;
+
+  RuntimeOptions runtime_options;
+  Communicate* comm = OHMMS::Controller;
+
+  auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
+  auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(runtime_options, comm, particle_pool);
+  auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
+  WalkerConfigurations walker_confs;
+  MCPopulation population(1, comm->rank(), particle_pool.getParticleSet("e"), wavefunction_pool.getPrimary(),
+                          hamiltonian_pool.getPrimary());
+
+  population.createWalkers(8, walker_confs);
+  auto& walkers = population.get_walkers();
+  CHECK(walkers.size() == 8);
+  walkers[0]->Multiplicity=4;
+  population.fissionHighMultiplicityWalkers();
+  CHECK(walkers.size() == 11);
+
+  walkers[2]->Multiplicity=3;
+  walkers[9]->Multiplicity=4;
+  population.fissionHighMultiplicityWalkers();
+  CHECK(walkers.size() == 16);
+
+  for(auto& walker : walkers)
+    CHECK(walker->Multiplicity == 1.0);
+}
+
 
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes
segment of #5010
`Walker`
* Fix bug with Walker constructor that ignored walker_id, parent_id arguments.
* Add useful documentation to Walker.h

`MCPopulation`
* Refactor into MCPopulation the fission of high multiplicity walkers into 2 or more walkers.
* Generate walker_ids for walkers for each trajectory they start. (i.e. a life)
* Assign parent id of new walkers in useful way.
* Expand in code documentation.

## What type(s) of changes does this code introduce?

- Bugfix
- New feature
- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation or build script changes

There is should be no user observable change except due to #5019 where walker_id's will be different but still undependable.

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
OSX laptop
linux x86 vm

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
