### PR TITLE
Enable ahead-of-time compilation when using oneapi

### DIFF
--- a/CMake/IntelCompilers.cmake
+++ b/CMake/IntelCompilers.cmake
@@ -17,10 +17,20 @@ endif()
 if(QMC_OMP)
   if(CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
     if(ENABLE_OFFLOAD)
-      set(OFFLOAD_TARGET
-          "spir64"
-          CACHE STRING "Offload target architecture")
-      set(OPENMP_OFFLOAD_COMPILE_OPTIONS "-fopenmp-targets=${OFFLOAD_TARGET}")
+      if(DEFINED OFFLOAD_ARCH OR QMC_GPU_ARCHS)
+        # for ahead-of-time compilation and linking
+        set(OPENMP_OFFLOAD_COMPILE_OPTIONS "-fopenmp-targets=spir64_gen")
+        if(DEFINED OFFLOAD_ARCH)
+          set(OpenMP_OFFLOAD_LINKER_FLAGS "-Xopenmp-target-backend \"-device ${OFFLOAD_ARCH}\"")
+        else()
+          set(OpenMP_OFFLOAD_LINKER_FLAGS "-Xopenmp-target-backend \"-device ${QMC_GPU_ARCHS}\"")
+        endif()
+      else()
+        set(OFFLOAD_TARGET
+            "spir64"
+            CACHE STRING "Offload target architecture")
+        set(OPENMP_OFFLOAD_COMPILE_OPTIONS "-fopenmp-targets=${OFFLOAD_TARGET}")
+      endif()
     endif(ENABLE_OFFLOAD)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fiopenmp")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fiopenmp")

--- a/CMake/IntelCompilers.cmake
+++ b/CMake/IntelCompilers.cmake
@@ -21,9 +21,9 @@ if(QMC_OMP)
         # for ahead-of-time compilation and linking
         set(OPENMP_OFFLOAD_COMPILE_OPTIONS "-fopenmp-targets=spir64_gen")
         if(DEFINED OFFLOAD_ARCH)
-          set(OpenMP_OFFLOAD_LINKER_FLAGS "-Xopenmp-target-backend \"-device ${OFFLOAD_ARCH}\"")
+          set(OpenMP_OFFLOAD_LINKER_FLAGS "-Xs \"-device ${OFFLOAD_ARCH}\"")
         else()
-          set(OpenMP_OFFLOAD_LINKER_FLAGS "-Xopenmp-target-backend \"-device ${QMC_GPU_ARCHS}\"")
+          set(OpenMP_OFFLOAD_LINKER_FLAGS "-Xs \"-device ${QMC_GPU_ARCHS}\"")
         endif()
       else()
         set(OFFLOAD_TARGET

--- a/CMake/IntelDPCPPConfig-modified.cmake
+++ b/CMake/IntelDPCPPConfig-modified.cmake
@@ -239,7 +239,7 @@ if(WIN32)
   list(APPEND SYCL_FLAGS "/EHsc")
 endif()
 
-set(SYCL_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SYCL_FLAGS}")
+set(SYCL_CXX_FLAGS "${SYCL_FLAGS}")
 
 # And now test the assumptions.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,6 +380,9 @@ if(QMC_OMP)
   if(ENABLE_OFFLOAD AND DEFINED OPENMP_OFFLOAD_COMPILE_OPTIONS)
     message(STATUS "OpenMP offload CXX flags: ${OPENMP_OFFLOAD_COMPILE_OPTIONS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPENMP_OFFLOAD_COMPILE_OPTIONS}")
+    if(DEFINED OpenMP_OFFLOAD_LINKER_FLAGS)
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_OFFLOAD_LINKER_FLAGS}")
+    endif()
   endif()
 
   #--------------------------------------------------------------

--- a/config/build_alcf_aurora_icpx.sh
+++ b/config/build_alcf_aurora_icpx.sh
@@ -58,7 +58,7 @@ if [[ $name == *"_MP"* ]]; then
 fi
 
 if [[ $name == *"offload"* ]]; then
-  CMAKE_FLAGS="$CMAKE_FLAGS -DENABLE_OFFLOAD=ON"
+  CMAKE_FLAGS="$CMAKE_FLAGS -DENABLE_OFFLOAD=ON -DQMC_GPU_ARCHS=pvc"
   CMAKE_CXX_FLAGS="-mllvm -vpo-paropt-atomic-free-reduction-slm=true"
 fi
 

--- a/config/build_alcf_sunspot_icpx.sh
+++ b/config/build_alcf_sunspot_icpx.sh
@@ -58,7 +58,7 @@ if [[ $name == *"_MP"* ]]; then
 fi
 
 if [[ $name == *"offload"* ]]; then
-  CMAKE_FLAGS="$CMAKE_FLAGS -DENABLE_OFFLOAD=ON"
+  CMAKE_FLAGS="$CMAKE_FLAGS -DENABLE_OFFLOAD=ON -DQMC_GPU_ARCHS=pvc"
   CMAKE_CXX_FLAGS="-mllvm -vpo-paropt-atomic-free-reduction-slm=true"
 fi
 


### PR DESCRIPTION
## Proposed changes
Enable ahead-of-time reduces initialization time by skipping the JIT compilation.

## What type(s) of changes does this code introduce?
- Build related changes
- Documentation or build script changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Aurora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'