### PR TITLE
Introduce DiracMatrixInverter abstraction

### DIFF
--- a/src/Platforms/CUDA/QueueCUDA.hpp
+++ b/src/Platforms/CUDA/QueueCUDA.hpp
@@ -22,7 +22,7 @@ namespace compute
 {
 
 template<>
-class Queue<PlatformKind::CUDA>
+class Queue<PlatformKind::CUDA> : public QueueBase
 {
 public:
   Queue() { cudaErrorCheck(cudaStreamCreate(&hstream_), "cudaStreamCreate failed!"); }

--- a/src/Platforms/OMPTarget/QueueOMPTarget.hpp
+++ b/src/Platforms/OMPTarget/QueueOMPTarget.hpp
@@ -21,7 +21,7 @@ namespace compute
 {
 
 template<>
-class Queue<PlatformKind::OMPTARGET>
+class Queue<PlatformKind::OMPTARGET> : public QueueBase
 {
 public:
   // dualspace container

--- a/src/Platforms/Queue.hpp
+++ b/src/Platforms/Queue.hpp
@@ -23,7 +23,13 @@ namespace compute
 template<PlatformKind PL>
 class Queue;
 
-}
+class QueueBase
+{
+public:
+  virtual ~QueueBase() = default;
+};
+
+} // namespace compute
 
 } // namespace qmcplusplus
 

--- a/src/Platforms/SYCL/QueueSYCL.hpp
+++ b/src/Platforms/SYCL/QueueSYCL.hpp
@@ -22,7 +22,7 @@ namespace compute
 {
 
 template<>
-class Queue<PlatformKind::SYCL>
+class Queue<PlatformKind::SYCL> : public QueueBase
 {
 public:
   Queue() : queue_(createSYCLInOrderQueueOnDefaultDevice()) {}

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
@@ -22,7 +22,9 @@
 #include "type_traits/complex_help.hpp"
 #include "Concurrency/OpenMP.h"
 #include "CPU/SIMD/algorithm.hpp"
-#include "ResourceCollection.h"
+#if defined(ENABLE_OFFLOAD)
+#include "DiracMatrixInverter.hpp"
+#endif
 
 namespace qmcplusplus
 {
@@ -45,8 +47,11 @@ namespace qmcplusplus
  *  We don't need to actively synchronize the old stream because it gets synchronized right after each use.
  *
  */
-template<typename VALUE_FP>
-class DiracMatrixComputeCUDA : public Resource
+template<typename VALUE_FP, typename VALUE = VALUE_FP>
+class DiracMatrixComputeCUDA
+#if defined(ENABLE_OFFLOAD)
+    : public DiracMatrixInverter<VALUE_FP, VALUE>
+#endif
 {
   using FullPrecReal = RealAlias<VALUE_FP>;
   using LogValue     = std::complex<FullPrecReal>;
@@ -217,19 +222,27 @@ class DiracMatrixComputeCUDA : public Resource
   }
 
 public:
-  DiracMatrixComputeCUDA() : Resource("DiracMatrixComputeCUDA")
+  DiracMatrixComputeCUDA()
+#if defined(ENABLE_OFFLOAD)
+      : DiracMatrixInverter<VALUE_FP, VALUE>("DiracMatrixComputeCUDA")
+#endif
   {
     cublasErrorCheck(cublasCreate(&h_cublas_), "cublasCreate failed!");
   }
 
-  DiracMatrixComputeCUDA(const DiracMatrixComputeCUDA& other) : Resource(other.getName())
+  DiracMatrixComputeCUDA(const DiracMatrixComputeCUDA& other)
+#if defined(ENABLE_OFFLOAD)
+      : DiracMatrixInverter<VALUE_FP, VALUE>(other.getName())
+#endif
   {
     cublasErrorCheck(cublasCreate(&h_cublas_), "cublasCreate failed!");
   }
 
   ~DiracMatrixComputeCUDA() { cublasErrorCheck(cublasDestroy(h_cublas_), "cublasDestroy failed!"); }
 
+#if defined(ENABLE_OFFLOAD)
   std::unique_ptr<Resource> makeClone() const override { return std::make_unique<DiracMatrixComputeCUDA>(*this); }
+#endif
 
   /** Given a_mat returns inverted amit and log determinant of a_matches.
    *  \param [in] a_mat a matrix input
@@ -342,6 +355,17 @@ public:
     const int n = a_mats[0].get().rows();
     mw_computeInvertAndLog(queue, a_mats, inv_a_mats, n, log_values);
   }
+
+#if defined(ENABLE_OFFLOAD)
+  void mw_invert_transpose(compute::QueueBase& queue,
+                           const RefVector<const DualMatrix<VALUE>>& a_mats,
+                           const RefVector<DualMatrix<VALUE>>& inv_a_mats,
+                           DualVector<LogValue>& log_values) override
+  {
+    auto& queue_cuda = dynamic_cast<compute::Queue<PlatformKind::CUDA>&>(queue);
+    mw_invertTranspose(queue_cuda, a_mats, inv_a_mats, log_values);
+  }
+#endif
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
@@ -54,9 +54,6 @@ public:
   template<typename T>
   using OffloadPinnedVector = Vector<T, OffloadPinnedAllocator<T>>;
 
-  // maybe you'll want a resource someday, then change here.
-  using HandleResource = compute::Queue<PlatformKind::OMPTARGET>;
-
 private:
   aligned_vector<VALUE_FP> m_work_;
   int lwork_;
@@ -172,8 +169,7 @@ public:
    *                                  DiracMatrixComputeCUDA but is fine for OMPTarget        
    */
   template<typename TMAT>
-  inline std::enable_if_t<std::is_same<VALUE_FP, TMAT>::value> invert_transpose(HandleResource& resource,
-                                                                                const OffloadPinnedMatrix<TMAT>& a_mat,
+  inline std::enable_if_t<std::is_same<VALUE_FP, TMAT>::value> invert_transpose(const OffloadPinnedMatrix<TMAT>& a_mat,
                                                                                 OffloadPinnedMatrix<TMAT>& inv_a_mat,
                                                                                 LogValue& log_value)
   {
@@ -192,8 +188,7 @@ public:
    * @tparam TREAL real type
    */
   template<typename TMAT>
-  inline std::enable_if_t<!std::is_same<VALUE_FP, TMAT>::value> invert_transpose(HandleResource& resource,
-                                                                                 const OffloadPinnedMatrix<TMAT>& a_mat,
+  inline std::enable_if_t<!std::is_same<VALUE_FP, TMAT>::value> invert_transpose(const OffloadPinnedMatrix<TMAT>& a_mat,
                                                                                  OffloadPinnedMatrix<TMAT>& inv_a_mat,
                                                                                  LogValue& log_value)
   {
@@ -218,8 +213,7 @@ public:
    *  \todo measure if using the a_mats without a copy to contiguous vector is better.
    */
   template<typename TMAT>
-  inline void mw_invertTranspose(HandleResource& resource,
-                                 const RefVector<const OffloadPinnedMatrix<TMAT>>& a_mats,
+  inline void mw_invertTranspose(const RefVector<const OffloadPinnedMatrix<TMAT>>& a_mats,
                                  const RefVector<OffloadPinnedMatrix<TMAT>>& inv_a_mats,
                                  OffloadPinnedVector<LogValue>& log_values)
   {
@@ -254,8 +248,7 @@ public:
                            const RefVector<OffloadPinnedMatrix<VALUE>>& inv_a_mats,
                            OffloadPinnedVector<LogValue>& log_values) override
   {
-    HandleResource resource;
-    mw_invertTranspose(resource, a_mats, inv_a_mats, log_values);
+    mw_invertTranspose(a_mats, inv_a_mats, log_values);
   }
 };
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixInverter.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixInverter.hpp
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2024 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_DIRAC_MATRIX_INVERTER_H
+#define QMCPLUSPLUS_DIRAC_MATRIX_INVERTER_H
+
+#include "OhmmsPETE/OhmmsVector.h"
+#include "OhmmsPETE/OhmmsMatrix.h"
+#include "type_traits/complex_help.hpp"
+#include "Queue.hpp"
+#include "OMPTarget/OffloadAlignedAllocators.hpp"
+#include "ResourceCollection.h"
+
+namespace qmcplusplus
+{
+
+template<typename VALUE_INVERTER, typename VALUE>
+class DiracMatrixInverter : public Resource
+{
+  using InverterPrecReal = RealAlias<VALUE_INVERTER>;
+  using LogValue         = std::complex<InverterPrecReal>;
+
+  template<typename T>
+  using OffloadPinnedMatrix = Matrix<T, OffloadPinnedAllocator<T>>;
+  template<typename T>
+  using OffloadPinnedVector = Vector<T, OffloadPinnedAllocator<T>>;
+
+public:
+  DiracMatrixInverter(const std::string& name) : Resource(name) {}
+
+  virtual void mw_invert_transpose(compute::QueueBase& queue,
+                                   const RefVector<const OffloadPinnedMatrix<VALUE>>& a_mats,
+                                   const RefVector<OffloadPinnedMatrix<VALUE>>& inv_a_mats,
+                                   OffloadPinnedVector<LogValue>& log_values) = 0;
+};
+
+} // namespace qmcplusplus
+
+#endif // QMCPLUSPLUS_DIRAC_MATRIX_INVERTER_H

--- a/src/QMCWaveFunctions/tests/test_DiracMatrixComputeOMPTarget.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracMatrixComputeOMPTarget.cpp
@@ -49,9 +49,8 @@ TEST_CASE("DiracMatrixComputeOMPTarget_different_batch_sizes", "[wavefunction][f
   inv_mat_a.resize(4, 4);
   DiracMatrixComputeOMPTarget<double> dmc_omp;
 
-  compute::Queue<PlatformKind::OMPTARGET> queue;
   std::complex<double> log_value;
-  dmc_omp.invert_transpose(queue, mat_a, inv_mat_a, log_value);
+  dmc_omp.invert_transpose(mat_a, inv_mat_a, log_value);
   CHECK(log_value == LogComplexApprox(std::complex<double>{5.267858159063328, 6.283185307179586}));
 
 
@@ -74,7 +73,7 @@ TEST_CASE("DiracMatrixComputeOMPTarget_different_batch_sizes", "[wavefunction][f
   RefVector<OffloadPinnedMatrix<double>> inv_a_mats{inv_mat_a, inv_mat_a2};
 
   log_values.resize(2);
-  dmc_omp.mw_invertTranspose(queue, a_mats, inv_a_mats, log_values);
+  dmc_omp.mw_invertTranspose(a_mats, inv_a_mats, log_values);
 
   check_matrix_result = checkMatrix(inv_mat_a, mat_b);
   CHECKED_ELSE(check_matrix_result.result) { FAIL(check_matrix_result.result_message); }
@@ -96,7 +95,7 @@ TEST_CASE("DiracMatrixComputeOMPTarget_different_batch_sizes", "[wavefunction][f
   RefVector<OffloadPinnedMatrix<double>> inv_a_mats3{inv_mat_a, inv_mat_a2, inv_mat_a3};
 
   log_values.resize(3);
-  dmc_omp.mw_invertTranspose(queue, a_mats3, inv_a_mats3, log_values);
+  dmc_omp.mw_invertTranspose(a_mats3, inv_a_mats3, log_values);
 
   check_matrix_result = checkMatrix(inv_mat_a, mat_b);
   CHECKED_ELSE(check_matrix_result.result) { FAIL(check_matrix_result.result_message); }
@@ -149,8 +148,7 @@ TEST_CASE("DiracMatrixComputeOMPTarget_large_determinants_against_legacy", "[wav
   RefVector<const OffloadPinnedMatrix<double>> a_mats{mat_a, mat_a2};
   RefVector<OffloadPinnedMatrix<double>> inv_a_mats{inv_mat_a, inv_mat_a2};
 
-  compute::Queue<PlatformKind::OMPTARGET> queue;
-  dmc_omp.mw_invertTranspose(queue, a_mats, inv_a_mats, log_values);
+  dmc_omp.mw_invertTranspose(a_mats, inv_a_mats, log_values);
 
   DiracMatrix<double> dmat;
   Matrix<double> inv_mat_test(n, n);


### PR DESCRIPTION
## Proposed changes
Introduce DiracMatrixInverter base class to avoid exposing all the inverters via DiracDeteriminantBatched.h

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted