### PR TITLE
Nexus: small fix for  1RDM input generation

### DIFF
--- a/nexus/lib/qmcpack_input.py
+++ b/nexus/lib/qmcpack_input.py
@@ -5482,6 +5482,7 @@ def process_dm1b_estimator(dm,wfname,wf_elem):
     basis = []
     builder = None
     maxed = False
+    wf = wf_elem
     if reuse and 'basis' in dm and isinstance(dm.basis,sposet):
         spo = dm.basis
         # get sposet size
@@ -5496,7 +5497,6 @@ def process_dm1b_estimator(dm,wfname,wf_elem):
         #end if
         try:
             # get sposet from wavefunction
-            wf = wf_elem
             dets = wf.get('determinant')
             det  = dets.get_single()
             if 'sposet' in det:


### PR DESCRIPTION
One line fix for 1RDM input generation.  Fixes the case when "reuse" is not specified.

Issue reported by @annette-lopez.

## What type(s) of changes does this code introduce?

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'

