### PR TITLE
Use GCC14 and macos-14 in macOS CI

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -143,7 +143,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   macos:
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       GH_JOBNAME: ${{ matrix.jobname }}
       GH_OS: macOS

--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jobname: [macOS-GCC12-NoMPI-Real]
+        jobname: [macOS-GCC14-NoMPI-Real]
 
     steps:
       - name: Checkout Action
@@ -165,7 +165,7 @@ jobs:
       - name: Setup Dependencies
         run: |
           brew upgrade || brew link --overwrite python@3.12
-          brew install ninja hdf5 fftw boost
+          brew install gcc@14 ninja hdf5 fftw boost
           python3 -m pip install numpy==1.26.4 h5py pandas
 
       - name: Configure

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -281,11 +281,11 @@ case "$1" in
               -DQMC_DATA=$QMC_DATA_DIR \
               ${GITHUB_WORKSPACE}
       ;;
-      *"macOS-GCC12-NoMPI-Real"*)
-        echo 'Configure for building on macOS using gcc12'
+      *"macOS-GCC14-NoMPI-Real"*)
+        echo 'Configure for building on macOS using gcc14'
         cmake -GNinja \
-              -DCMAKE_C_COMPILER=gcc-12 \
-              -DCMAKE_CXX_COMPILER=g++-12 \
+              -DCMAKE_C_COMPILER=gcc-14 \
+              -DCMAKE_CXX_COMPILER=g++-14 \
               -DCMAKE_EXE_LINKER_FLAGS="-Wl,-ld_classic" \
               -DQMC_MPI=0 \
               -DQMC_COMPLEX=$IS_COMPLEX \


### PR DESCRIPTION
## Proposed changes

Try GCC 14 to avoid macOS CI failure

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None. CI needs to run.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
