### PR TITLE
Using explicit template for inverter implementation classes

### DIFF
--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -132,7 +132,12 @@ set(FERMION_SRCS
     TWFFastDerivWrapper.cpp
     TWFGrads.cpp
     WaveFunctionFactory.cpp)
-set(FERMION_OMPTARGET_SRCS ${FERMION_OMPTARGET_SRCS} Fermion/MultiSlaterDetTableMethod.cpp)
+
+set(FERMION_OMPTARGET_SRCS ${FERMION_OMPTARGET_SRCS} Fermion/MultiSlaterDetTableMethod.cpp Fermion/DiracMatrixComputeOMPTarget.cpp)
+
+if(ENABLE_CUDA)
+  set(FERMION_SRCS ${FERMION_SRCS} Fermion/DiracMatrixComputeCUDA.cpp)
+endif()
 
 ####################################
 # create libqmcwfs

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -124,38 +124,15 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_invertPsiM(const RefVectorWithLea
   ScopedTimer inverse_timer(wfc_leader.InverseTimer);
   const auto nw = wfc_list.size();
 
-  if (wfc_leader.matrix_inverter_kind_ == DetMatInvertor::ACCEL)
+  mw_res.log_values.resize(nw);
+
+  wfc_leader.accel_inverter_.getResource().mw_invert_transpose(mw_res.engine_rsc.queue, logdetT_list, a_inv_list,
+                                                               mw_res.log_values);
+
+  for (int iw = 0; iw < nw; ++iw)
   {
-    RefVectorWithLeader<UpdateEngine> engine_list(wfc_leader.det_engine_);
-    engine_list.reserve(nw);
-
-    mw_res.log_values.resize(nw);
-
-    for (int iw = 0; iw < nw; iw++)
-    {
-      auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<PL, VT, FPVT>>(iw);
-      engine_list.push_back(det.det_engine_);
-      mw_res.log_values[iw] = {0.0, 0.0};
-    }
-
-    wfc_leader.accel_inverter_.getResource().mw_invert_transpose(mw_res.engine_rsc.queue, logdetT_list, a_inv_list,
-                                                                 mw_res.log_values);
-
-    for (int iw = 0; iw < nw; ++iw)
-    {
-      auto& det      = wfc_list.getCastedElement<DiracDeterminantBatched<PL, VT, FPVT>>(iw);
-      det.log_value_ = mw_res.log_values[iw];
-    }
-  }
-  else
-  {
-    for (int iw = 0; iw < nw; iw++)
-    {
-      auto& det                  = wfc_list.getCastedElement<DiracDeterminantBatched<PL, VT, FPVT>>(iw);
-      DualMatrix<Value>& psiMinv = a_inv_list[iw];
-      det.host_inverter_.invert_transpose(logdetT_list[iw].get(), psiMinv, det.log_value_);
-      psiMinv.updateTo();
-    }
+    auto& det      = wfc_list.getCastedElement<DiracDeterminantBatched<PL, VT, FPVT>>(iw);
+    det.log_value_ = mw_res.log_values[iw];
   }
 
 #ifndef NDEBUG
@@ -1238,10 +1215,12 @@ std::unique_ptr<DiracDeterminantBase> DiracDeterminantBatched<PL, VT, FPVT>::mak
 template<PlatformKind PL, typename VT, typename FPVT>
 void DiracDeterminantBatched<PL, VT, FPVT>::createResource(ResourceCollection& collection) const
 {
-  using DetInverter = typename DetInverterSelector<PL, FPVT, VT>::Inverter;
   collection.addResource(std::make_unique<DiracDeterminantBatchedMultiWalkerResource>());
   Phi->createResource(collection);
-  collection.addResource(std::make_unique<DetInverter>());
+  if (matrix_inverter_kind_ == DetMatInvertor::ACCEL)
+    collection.addResource(std::make_unique<typename DetInverterSelector<PL, FPVT, VT>::Inverter>());
+  else
+    collection.addResource(std::make_unique<DiracMatrixComputeOMPTarget<FPVT, VT>>());
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.cpp
@@ -1,0 +1,19 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2024 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "DiracMatrixComputeCUDA.hpp"
+
+namespace qmcplusplus
+{
+
+template class DiracMatrixComputeCUDA<QMCTraits::QTFull::ValueType, QMCTraits::ValueType>;
+
+} // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.cpp
@@ -13,7 +13,8 @@
 
 namespace qmcplusplus
 {
-
-template class DiracMatrixComputeCUDA<QMCTraits::QTFull::ValueType, QMCTraits::ValueType>;
-
+template class DiracMatrixComputeCUDA<double, float>;
+template class DiracMatrixComputeCUDA<double, double>;
+template class DiracMatrixComputeCUDA<std::complex<double>, std::complex<float>>;
+template class DiracMatrixComputeCUDA<std::complex<double>, std::complex<double>>;
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
@@ -370,7 +370,10 @@ public:
 #endif
 };
 
-extern template class DiracMatrixComputeCUDA<QMCTraits::QTFull::ValueType, QMCTraits::ValueType>;
+extern template class DiracMatrixComputeCUDA<double, float>;
+extern template class DiracMatrixComputeCUDA<double, double>;
+extern template class DiracMatrixComputeCUDA<std::complex<double>, std::complex<float>>;
+extern template class DiracMatrixComputeCUDA<std::complex<double>, std::complex<double>>;
 } // namespace qmcplusplus
 
 #endif //QMCPLUSPLUS_DIRAC_MATRIX_COMPUTE_CUDA_H

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
@@ -14,12 +14,14 @@
 
 #include <type_traits>
 
+#include "Configuration.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "DualAllocatorAliases.hpp"
 #include "Platforms/CUDA/cuBLAS.hpp"
 #include "Platforms/CUDA/QueueCUDA.hpp"
 #include "detail/CUDA/cuBLAS_LU.hpp"
 #include "type_traits/complex_help.hpp"
+#include "type_traits/template_types.hpp"
 #include "Concurrency/OpenMP.h"
 #include "CPU/SIMD/algorithm.hpp"
 #if defined(ENABLE_OFFLOAD)
@@ -368,6 +370,7 @@ public:
 #endif
 };
 
+extern template class DiracMatrixComputeCUDA<QMCTraits::QTFull::ValueType, QMCTraits::ValueType>;
 } // namespace qmcplusplus
 
 #endif //QMCPLUSPLUS_DIRAC_MATRIX_COMPUTE_CUDA_H

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.cpp
@@ -13,7 +13,8 @@
 
 namespace qmcplusplus
 {
-
-template class DiracMatrixComputeOMPTarget<QMCTraits::QTFull::ValueType, QMCTraits::ValueType>;
-
+template class DiracMatrixComputeOMPTarget<double, float>;
+template class DiracMatrixComputeOMPTarget<double, double>;
+template class DiracMatrixComputeOMPTarget<std::complex<double>, std::complex<float>>;
+template class DiracMatrixComputeOMPTarget<std::complex<double>, std::complex<double>>;
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.cpp
@@ -1,0 +1,19 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2024 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "DiracMatrixComputeOMPTarget.hpp"
+
+namespace qmcplusplus
+{
+
+template class DiracMatrixComputeOMPTarget<QMCTraits::QTFull::ValueType, QMCTraits::ValueType>;
+
+} // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
@@ -12,6 +12,7 @@
 #ifndef QMCPLUSPLUS_DIRAC_MATRIX_COMPUTE_OMPTARGET_H
 #define QMCPLUSPLUS_DIRAC_MATRIX_COMPUTE_OMPTARGET_H
 
+#include "Configuration.h"
 #include "CPU/Blasf.h"
 #include "CPU/BlasThreadingEnv.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
@@ -97,24 +98,6 @@ public:
       detEng_.invert_transpose(a_mats[iw].get(), Ainv, log_values[iw]);
       Ainv.updateTo();
     }
-
-    /* FIXME
-    const int nw     = a_mats.size();
-    const size_t n   = a_mats[0].get().rows();
-    const size_t lda = a_mats[0].get().cols();
-    const size_t ldb = inv_a_mats[0].get().cols();
-
-    size_t nsqr{n * n};
-    psiM_fp_.resize(n * lda * nw);
-    for (int iw = 0; iw < nw; ++iw)
-      simd::transpose(a_mats[iw].get().data(), n, lda, psiM_fp_.data() + nsqr * iw, n, lda);
-
-    computeInvertAndLog(psiM_fp_, n, lda, log_values);
-    for (int iw = 0; iw < nw; ++iw)
-    {
-      simd::remapCopy(n, n, psiM_fp_.data() + nsqr * iw, lda, inv_a_mats[iw].get().data(), ldb);
-    }
-    */
   }
 
   void mw_invert_transpose(compute::QueueBase& queue_ignored,
@@ -125,6 +108,8 @@ public:
     mw_invertTranspose(a_mats, inv_a_mats, log_values);
   }
 };
+
+extern template class DiracMatrixComputeOMPTarget<QMCTraits::QTFull::ValueType, QMCTraits::ValueType>;
 } // namespace qmcplusplus
 
 #endif // QMCPLUSPLUS_DIRAC_MATRIX_COMPUTE_OMPTARGET_H

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
@@ -55,106 +55,11 @@ public:
   using OffloadPinnedVector = Vector<T, OffloadPinnedAllocator<T>>;
 
 private:
-  aligned_vector<VALUE_FP> m_work_;
-  int lwork_;
-
-  /// Matrices held in memory matrices n^2 * nw  elements
-  OffloadPinnedVector<VALUE_FP> psiM_fp_;
-  OffloadPinnedVector<VALUE_FP> LU_diags_fp_;
-  OffloadPinnedVector<int> pivots_;
-  OffloadPinnedVector<int> infos_;
-
-  /** reset internal work space.
-   *  My understanding might be off.
-   *
-   *  it smells that this is so complex.
-   */
-  inline void reset(OffloadPinnedVector<VALUE_FP>& psi_Ms, const int n, const int lda, const int batch_size)
-  {
-    const int nw = batch_size;
-    pivots_.resize(lda * nw);
-    for (int iw = 0; iw < nw; ++iw)
-    {
-      lwork_ = -1;
-      VALUE_FP tmp;
-      FullPrecReal lw;
-      auto psi_M_ptr = psi_Ms.data() + iw * n * n;
-      Xgetri(lda, psi_M_ptr, lda, pivots_.data() + iw * n, &tmp, lwork_);
-      convert(tmp, lw);
-      lwork_ = static_cast<int>(lw);
-      m_work_.resize(lwork_);
-    }
-  }
-
-  /** reset internal work space for single walker case
-   *  My understanding might be off.
-   *
-   *  it smells that this is so complex.
-   */
-  inline void reset(OffloadPinnedMatrix<VALUE_FP>& psi_M, const int n, const int lda)
-  {
-    pivots_.resize(lda);
-    LU_diags_fp_.resize(lda);
-    lwork_ = -1;
-    VALUE_FP tmp;
-    FullPrecReal lw;
-    Xgetri(lda, psi_M.data(), lda, pivots_.data(), &tmp, lwork_);
-    lw     = std::real(tmp);
-    lwork_ = static_cast<int>(lw);
-    m_work_.resize(lwork_);
-  }
-
-  /** compute the inverse of invMat (in place) and the log value of determinant
-   * \tparam TMAT value type of matrix
-   * \param[inout] a_mat      the matrix
-   * \param[in]    n          actual dimension of square matrix (no guarantee it really has full column rank)
-   * \param[in]    lda        leading dimension of Matrix container
-   * \param[out]   log_value  log a_mat before inversion
-   */
-  template<typename TMAT>
-  inline void computeInvertAndLog(OffloadPinnedMatrix<TMAT>& a_mat, const int n, const int lda, LogValue& log_value)
-  {
-    BlasThreadingEnv knob(getNextLevelNumThreads());
-    if (lwork_ < lda)
-      reset(a_mat, n, lda);
-    Xgetrf(n, n, a_mat.data(), lda, pivots_.data());
-    for (int i = 0; i < n; i++)
-      LU_diags_fp_[i] = a_mat.data()[i * lda + i];
-    log_value = {0.0, 0.0};
-    computeLogDet(LU_diags_fp_.data(), n, pivots_.data(), log_value);
-    Xgetri(n, a_mat.data(), lda, pivots_.data(), m_work_.data(), lwork_);
-  }
-
-  template<typename TMAT>
-  inline void computeInvertAndLog(OffloadPinnedVector<TMAT>& psi_Ms,
-                                  const int n,
-                                  const int lda,
-                                  OffloadPinnedVector<LogValue>& log_values)
-  {
-    const int nw = log_values.size();
-    BlasThreadingEnv knob(getNextLevelNumThreads());
-    if (lwork_ < lda)
-      reset(psi_Ms, n, lda, nw);
-    pivots_.resize(n * nw);
-    LU_diags_fp_.resize(n * nw);
-    for (int iw = 0; iw < nw; ++iw)
-    {
-      VALUE_FP* LU_M = psi_Ms.data() + iw * n * n;
-      Xgetrf(n, n, LU_M, lda, pivots_.data() + iw * n);
-      for (int i = 0; i < n; i++)
-        *(LU_diags_fp_.data() + iw * n + i) = LU_M[i * lda + i];
-      LogValue log_value{0.0, 0.0};
-      computeLogDet(LU_diags_fp_.data() + iw * n, n, pivots_.data() + iw * n, log_value);
-      log_values[iw] = log_value;
-      Xgetri(n, LU_M, lda, pivots_.data() + iw * n, m_work_.data(), lwork_);
-    }
-  }
-
   /// matrix inversion engine
   DiracMatrix<VALUE_FP> detEng_;
 
 public:
-  DiracMatrixComputeOMPTarget() : DiracMatrixInverter<VALUE_FP, VALUE>("DiracMatrixComputeOMPTarget"), lwork_(0) {}
+  DiracMatrixComputeOMPTarget() : DiracMatrixInverter<VALUE_FP, VALUE>("DiracMatrixComputeOMPTarget") {}
 
   std::unique_ptr<Resource> makeClone() const override { return std::make_unique<DiracMatrixComputeOMPTarget>(*this); }
 
@@ -169,43 +74,12 @@ public:
    *                                  DiracMatrixComputeCUDA but is fine for OMPTarget        
    */
   template<typename TMAT>
-  inline std::enable_if_t<std::is_same<VALUE_FP, TMAT>::value> invert_transpose(const OffloadPinnedMatrix<TMAT>& a_mat,
-                                                                                OffloadPinnedMatrix<TMAT>& inv_a_mat,
-                                                                                LogValue& log_value)
+  inline void invert_transpose(const OffloadPinnedMatrix<TMAT>& a_mat,
+                               OffloadPinnedMatrix<TMAT>& inv_a_mat,
+                               LogValue& log_value)
   {
-    const int n   = a_mat.rows();
-    const int lda = a_mat.cols();
-    const int ldb = inv_a_mat.cols();
-    simd::transpose(a_mat.data(), n, lda, inv_a_mat.data(), n, ldb);
-    // In this case we just pass the value since
-    // that makes sense for a single walker API
-    computeInvertAndLog(inv_a_mat, n, ldb, log_value);
-  }
-
-  /** compute the inverse of the transpose of matrix A and its determinant value in log
-   * when VALUE_FP and TMAT are the different
-   * @tparam TMAT matrix value type
-   * @tparam TREAL real type
-   */
-  template<typename TMAT>
-  inline std::enable_if_t<!std::is_same<VALUE_FP, TMAT>::value> invert_transpose(const OffloadPinnedMatrix<TMAT>& a_mat,
-                                                                                 OffloadPinnedMatrix<TMAT>& inv_a_mat,
-                                                                                 LogValue& log_value)
-  {
-    const int n   = a_mat.rows();
-    const int lda = a_mat.cols();
-    const int ldb = inv_a_mat.cols();
-
-    psiM_fp_.resize(n * lda);
-    simd::transpose(a_mat.data(), n, lda, psiM_fp_.data(), n, lda);
-    OffloadPinnedMatrix<VALUE_FP> psiM_fp_view(psiM_fp_, psiM_fp_.data(), n, lda);
-    computeInvertAndLog(psiM_fp_view, n, lda, log_value);
-
-    //Matrix<TMAT> data_ref_matrix;
-    //maybe n, lda
-    //data_ref_matrix.attachReference(psiM_fp_.data(), n, n);
-    //Because inv_a_mat is "aligned" this is unlikely to work.
-    simd::remapCopy(n, n, psiM_fp_.data(), lda, inv_a_mat.data(), ldb);
+    detEng_.invert_transpose(a_mat, inv_a_mat, log_value);
+    inv_a_mat.updateTo();
   }
 
   /** This covers both mixed and Full precision case.

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
@@ -109,7 +109,10 @@ public:
   }
 };
 
-extern template class DiracMatrixComputeOMPTarget<QMCTraits::QTFull::ValueType, QMCTraits::ValueType>;
+extern template class DiracMatrixComputeOMPTarget<double, float>;
+extern template class DiracMatrixComputeOMPTarget<double, double>;
+extern template class DiracMatrixComputeOMPTarget<std::complex<double>, std::complex<float>>;
+extern template class DiracMatrixComputeOMPTarget<std::complex<double>, std::complex<double>>;
 } // namespace qmcplusplus
 
 #endif // QMCPLUSPLUS_DIRAC_MATRIX_COMPUTE_OMPTARGET_H

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixInverter.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixInverter.hpp
@@ -12,9 +12,10 @@
 #ifndef QMCPLUSPLUS_DIRAC_MATRIX_INVERTER_H
 #define QMCPLUSPLUS_DIRAC_MATRIX_INVERTER_H
 
+#include "type_traits/template_types.hpp"
+#include "type_traits/complex_help.hpp"
 #include "OhmmsPETE/OhmmsVector.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
-#include "type_traits/complex_help.hpp"
 #include "Queue.hpp"
 #include "OMPTarget/OffloadAlignedAllocators.hpp"
 #include "ResourceCollection.h"


### PR DESCRIPTION
## Proposed changes
This is the last part of https://github.com/QMCPACK/qmcpack/pull/5061
All the template variants are explicitly compiled. This is now prepared for the final (long term) target with all the build variants fused.
Explicit template exposed that a few functions of DiracMatrixComputeOMPTarget cannot be compiled and hence I tried to keep a minimal DiracMatrixComputeOMPTarget.
Since DiracMatrixComputeOMPTarget is indeed a fallback running on host, I simplified the code in  `DiracDeterminantBatched::mw_invertPsiM`

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'