### PR TITLE
Tidy EinsplineSetBuilder

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
@@ -256,7 +256,7 @@ protected:
    * @param N number of state
    * @param root true if it is the i/o node
    */
-  void bcastSortBands(int splin, int N, bool root);
+  void bcastSortedBands(std::vector<BandInfo>& sorted_bands) const;
 
   /** a specific but clean code path in createSPOSetFromXML, for PBC, double, ESHDF
    * @param cur the current xml node

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
@@ -220,7 +220,7 @@ public:
     std::vector<TinyVector<double, OHMMS_DIM>> ion_pos;
     int Ncenters;
 
-    CenterInfo() : Ncenters(0){};
+    CenterInfo() : Ncenters(0) {};
 
     void resize(int ncenters)
     {
@@ -251,11 +251,6 @@ public:
   bool makeRotations;
 
 protected:
-  /** broadcast sorted bands
-   * @param sorted_bands intended set
-   */
-  void bcastSortedBands(std::vector<BandInfo>& sorted_bands) const;
-
   /** a specific but clean code path in createSPOSetFromXML, for PBC, double, ESHDF
    * @param cur the current xml node
    */
@@ -283,7 +278,16 @@ private:
    * @param[out] bandinfo_set sorted and stored bandinfo
    * @return the number disinct bands
    */
-  int OccupyBands_ESHDF(hdf_archive& h5, int spin, int sortBands, int numOrbs, std::vector<BandInfo>& bandinfo_set) const;
+  int OccupyBands_ESHDF(hdf_archive& h5,
+                        int spin,
+                        int sortBands,
+                        int numOrbs,
+                        std::vector<BandInfo>& bandinfo_set) const;
+
+  /** broadcast sorted bands
+   * @param sorted_bands intended set
+   */
+  void bcastSortedBands(std::vector<BandInfo>& sorted_bands) const;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
@@ -167,8 +167,8 @@ public:
   TinyVector<int, 3> Version;
   std::string parameterGroup, ionsGroup, eigenstatesGroup;
   std::vector<int> Occ;
-  bool ReadOrbitalInfo(bool skipChecks = false);
-  bool ReadOrbitalInfo_ESHDF(bool skipChecks = false);
+  void ReadOrbitalInfo(bool skipChecks = false);
+  void ReadOrbitalInfo_ESHDF(bool skipChecks = false);
   void BroadcastOrbitalInfo();
   bool CheckLattice();
 

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
@@ -157,13 +157,6 @@ public:
   //////////////////////////////////////
   hdf_archive H5File;
   std::filesystem::path H5FileName;
-  // HDF5 orbital file version
-  typedef enum
-  {
-    QMCPACK,
-    ESHDF
-  } FormatType;
-  FormatType Format;
   TinyVector<int, 3> Version;
   std::string parameterGroup, ionsGroup, eigenstatesGroup;
   std::vector<int> Occ;

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
@@ -209,7 +209,6 @@ public:
   bool TwistPair(PosType a, PosType b) const;
   void TileIons();
   void OccupyBands(int spin, int sortBands, int numOrbs, bool skipChecks = false);
-  void OccupyBands_ESHDF(int spin, int sortBands, int numOrbs);
 
   ////////////////////////////////
   // Atomic orbital information //
@@ -252,9 +251,8 @@ public:
   bool makeRotations;
 
 protected:
-  /** broadcast SortBands
-   * @param N number of state
-   * @param root true if it is the i/o node
+  /** broadcast sorted bands
+   * @param sorted_bands intended set
    */
   void bcastSortedBands(std::vector<BandInfo>& sorted_bands) const;
 
@@ -276,6 +274,16 @@ protected:
   static constexpr int TWISTNUM_NO_INPUT = -9999;
   /// twist_inp[i] <= -9999 to indicate no given input after parsing XML
   static constexpr double TWIST_NO_INPUT = -9999;
+
+private:
+  /** read band info from h5, sort it and decide occupation
+   * @param[in] h5 file to read band info
+   * @param[in] spin the intended spin set
+   * @param[in] numOrbs the number of needed bands
+   * @param[out] bandinfo_set sorted and stored bandinfo
+   * @return the number disinct bands
+   */
+  int OccupyBands_ESHDF(hdf_archive& h5, int spin, int sortBands, int numOrbs, std::vector<BandInfo>& bandinfo_set) const;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
@@ -287,7 +287,7 @@ private:
   /** broadcast sorted bands
    * @param sorted_bands intended set
    */
-  void bcastSortedBands(std::vector<BandInfo>& sorted_bands) const;
+  void bcastBandInfoSet(std::vector<BandInfo>& sorted_bands) const;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilderCommon.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilderCommon.cpp
@@ -125,7 +125,7 @@ void EinsplineSetBuilder::BroadcastOrbitalInfo()
   int numDensityGvecs = TargetPtcl.DensityReducedGvecs.size();
   PooledData<double> abuffer;
   PooledData<int> aibuffer;
-  aibuffer.add(Version.begin(), Version.end()); //myComm->bcast(Version);
+  aibuffer.add(Version.begin(), Version.end());          //myComm->bcast(Version);
   abuffer.add(Lattice.begin(), Lattice.end());           //myComm->bcast(Lattice);
   abuffer.add(RecipLattice.begin(), RecipLattice.end()); //myComm->bcast(RecipLattice);
   abuffer.add(SuperLattice.begin(), SuperLattice.end()); //myComm->bcast(SuperLattice);
@@ -617,23 +617,24 @@ void EinsplineSetBuilder::OccupyBands(int spin, int sortBands, int numOrbs, bool
   {
     std::ostringstream msg;
     msg << "To developer: User is requesting for orbitals in an invalid spin group " << spin
-                << ". Current h5 file only contains spin groups " << "[0.." << NumSpins - 1 << "]." << std::endl;
+        << ". Current h5 file only contains spin groups " << "[0.." << NumSpins - 1 << "]." << std::endl;
     msg << "To user: Orbital H5 file contains no spin down data and is appropriate only for spin unpolarized "
-                   "calculations. "
-                << "If this is your intent, please replace 'spindataset=1' with 'spindataset=0' in the input file."
-                << std::endl;
+           "calculations. "
+        << "If this is your intent, please replace 'spindataset=1' with 'spindataset=0' in the input file."
+        << std::endl;
     myComm->barrier_and_abort(msg.str());
   }
 
   std::string exception_msg;
-  try {
+  try
+  {
     if (myComm->rank() == 0)
       NumDistinctOrbitals = OccupyBands_ESHDF(H5File, spin, sortBands, numOrbs, *FullBands[spin]);
   }
   catch (std::exception& e)
   {
     NumDistinctOrbitals = 0;
-    exception_msg = e.what();
+    exception_msg       = e.what();
   }
 
   myComm->bcast(NumDistinctOrbitals);
@@ -644,7 +645,7 @@ void EinsplineSetBuilder::OccupyBands(int spin, int sortBands, int numOrbs, bool
 void EinsplineSetBuilder::bcastSortedBands(std::vector<BandInfo>& sorted_bands) const
 {
   const bool root = myComm->rank() == 0;
-  int nbands = sorted_bands.size();
+  int nbands      = sorted_bands.size();
   myComm->bcast(nbands);
 
   //buffer to serialize BandInfo

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilderCommon.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilderCommon.cpp
@@ -640,9 +640,11 @@ void EinsplineSetBuilder::OccupyBands(int spin, int sortBands, int numOrbs, bool
   myComm->bcast(NumDistinctOrbitals);
   if (NumDistinctOrbitals == 0)
     myComm->barrier_and_abort(exception_msg);
+
+  bcastBandInfoSet(*FullBands[spin]);
 }
 
-void EinsplineSetBuilder::bcastSortedBands(std::vector<BandInfo>& sorted_bands) const
+void EinsplineSetBuilder::bcastBandInfoSet(std::vector<BandInfo>& sorted_bands) const
 {
   const bool root = myComm->rank() == 0;
   int nbands      = sorted_bands.size();

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilderESHDF.fft.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilderESHDF.fft.cpp
@@ -43,14 +43,17 @@ bool sortByIndex(BandInfo leftB, BandInfo rightB)
 void EinsplineSetBuilder::ReadOrbitalInfo(bool skipChecks)
 {
   if (!H5File.open(H5FileName, H5F_ACC_RDONLY))
-    throw std::runtime_error("Could not open HDF5 file \"" + std::string(H5FileName) + "\" in EinsplineSetBuilder::ReadOrbitalInfo.\n");
+    throw std::runtime_error("Could not open HDF5 file \"" + std::string(H5FileName) +
+                             "\" in EinsplineSetBuilder::ReadOrbitalInfo.\n");
 
   {
     // Read format
     std::string format;
     H5File.read(format, "/format");
     if (format.find("ES") == std::string::npos)
-      throw std::runtime_error("Format string input \"" + format + "\" doesn't contain \"ES\" keyword. h5 file format is too old or it is not a bspline orbital file!");
+      throw std::runtime_error(
+          "Format string input \"" + format +
+          "\" doesn't contain \"ES\" keyword. h5 file format is too old or it is not a bspline orbital file!");
     H5File.read(Version, "/version");
     app_log() << "  HDF5 orbital file version " << Version[0] << "." << Version[1] << "." << Version[2] << std::endl;
   }
@@ -473,7 +476,11 @@ bool EinsplineSetBuilder::ReadGvectors_ESHDF()
   return hasPsig;
 }
 
-int EinsplineSetBuilder::OccupyBands_ESHDF(hdf_archive& h5, int spin, int sortBands, int numOrbs, std::vector<BandInfo>& bandinfo_set) const
+int EinsplineSetBuilder::OccupyBands_ESHDF(hdf_archive& h5,
+                                           int spin,
+                                           int sortBands,
+                                           int numOrbs,
+                                           std::vector<BandInfo>& bandinfo_set) const
 {
   std::vector<BandInfo>& SortBands(bandinfo_set);
   SortBands.clear(); //??? can exit if SortBands is already made?

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilderESHDF.fft.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilderESHDF.fft.cpp
@@ -51,7 +51,6 @@ void EinsplineSetBuilder::ReadOrbitalInfo(bool skipChecks)
     H5File.read(format, "/format");
     if (format.find("ES") == std::string::npos)
       throw std::runtime_error("Format string input \"" + format + "\" doesn't contain \"ES\" keyword. h5 file format is too old or it is not a bspline orbital file!");
-    Format = ESHDF;
     H5File.read(Version, "/version");
     app_log() << "  HDF5 orbital file version " << Version[0] << "." << Version[1] << "." << Version[2] << std::endl;
   }

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilderESHDF.fft.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilderESHDF.fft.cpp
@@ -40,37 +40,26 @@ bool sortByIndex(BandInfo leftB, BandInfo rightB)
     return (leftB.BandIndex < rightB.BandIndex);
 };
 
-bool EinsplineSetBuilder::ReadOrbitalInfo(bool skipChecks)
+void EinsplineSetBuilder::ReadOrbitalInfo(bool skipChecks)
 {
   if (!H5File.open(H5FileName, H5F_ACC_RDONLY))
-  {
-    app_error() << "Could not open HDF5 file \"" << H5FileName << "\" in EinsplineSetBuilder::ReadOrbitalInfo.\n";
-    return false;
-  }
+    throw std::runtime_error("Could not open HDF5 file \"" + std::string(H5FileName) + "\" in EinsplineSetBuilder::ReadOrbitalInfo.\n");
 
-  try
   {
     // Read format
     std::string format;
     H5File.read(format, "/format");
     if (format.find("ES") == std::string::npos)
-      throw std::runtime_error("Format string input \"" + format + "\" doesn't contain \"ES\" keyword.");
+      throw std::runtime_error("Format string input \"" + format + "\" doesn't contain \"ES\" keyword. h5 file format is too old or it is not a bspline orbital file!");
     Format = ESHDF;
     H5File.read(Version, "/version");
     app_log() << "  HDF5 orbital file version " << Version[0] << "." << Version[1] << "." << Version[2] << std::endl;
   }
-  catch (const std::exception& e)
-  {
-    app_error() << e.what() << std::endl
-                << "EinsplineSetBuilder::ReadOrbitalInfo h5 file format is too old or it is not a bspline orbital file!"
-                << std::endl;
-    return false;
-  }
 
-  return ReadOrbitalInfo_ESHDF(skipChecks);
+  ReadOrbitalInfo_ESHDF(skipChecks);
 }
 
-bool EinsplineSetBuilder::ReadOrbitalInfo_ESHDF(bool skipChecks)
+void EinsplineSetBuilder::ReadOrbitalInfo_ESHDF(bool skipChecks)
 {
   app_log() << "  Reading orbital file in ESHDF format.\n";
   H5File.read(Version, "/version");
@@ -360,10 +349,7 @@ bool EinsplineSetBuilder::ReadOrbitalInfo_ESHDF(bool skipChecks)
     }
   }
   else
-  {
     app_log() << "   Skip initialization of the density" << std::endl;
-  }
-  return true;
 }
 
 bool EinsplineSetBuilder::ReadGvectors_ESHDF()

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
@@ -264,9 +264,6 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   }
 
   MixedSplineReader->setCommon(XMLRoot);
-  // temporary disable the following function call, Ye Luo
-  // RotateBands_ESHDF(spinSet, dynamic_cast<EinsplineSetExtended<std::complex<double> >*>(OrbitalSet));
-  bcastSortedBands(*FullBands[spinSet]);
   auto OrbitalSet = MixedSplineReader->create_spline_set(spinSet, spo_cur);
   if (!OrbitalSet)
     myComm->barrier_and_abort("Failed to create SPOSet*");

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
@@ -239,6 +239,7 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   Timer mytimer;
   mytimer.restart();
   OccupyBands(spinSet, sortBands, numOrbs, skipChecks);
+  myComm->bcast(NumDistinctOrbitals);
   if (spinSet == 0)
     TileIons();
 
@@ -266,7 +267,7 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   MixedSplineReader->setCommon(XMLRoot);
   // temporary disable the following function call, Ye Luo
   // RotateBands_ESHDF(spinSet, dynamic_cast<EinsplineSetExtended<std::complex<double> >*>(OrbitalSet));
-  bcastSortBands(spinSet, NumDistinctOrbitals, myComm->rank() == 0);
+  bcastSortedBands(*FullBands[spinSet]);
   auto OrbitalSet = MixedSplineReader->create_spline_set(spinSet, spo_cur);
   if (!OrbitalSet)
     myComm->barrier_and_abort("Failed to create SPOSet*");

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
@@ -84,8 +84,7 @@ void EinsplineSetBuilder::set_metadata(int numOrbs,
   /////////////////////////////////////////////////////////////////
   orb_info_timer.restart();
   if (myComm->rank() == 0)
-    if (!ReadOrbitalInfo(skipChecks))
-      throw std::runtime_error("EinsplineSetBuilder::set_metadata Error reading orbital info from HDF5 file.");
+    ReadOrbitalInfo(skipChecks);
   app_log() << "TIMER  EinsplineSetBuilder::ReadOrbitalInfo " << orb_info_timer.elapsed() << std::endl;
   myComm->barrier();
 

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
@@ -239,7 +239,6 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   Timer mytimer;
   mytimer.restart();
   OccupyBands(spinSet, sortBands, numOrbs, skipChecks);
-  myComm->bcast(NumDistinctOrbitals);
   if (spinSet == 0)
     TileIons();
 

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
@@ -193,13 +193,11 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
   MixedSplineReader->setRotate(false);
 
   //Make the up spin set.
-  bcastSortedBands(*FullBands[spinSet]);
   auto bspline_zd_u = MixedSplineReader->create_spline_set(spinSet, spo_cur);
   bspline_zd_u->finalizeConstruction();
 
   //Make the down spin set.
   OccupyBands(spinSet2, sortBands, numOrbs, skipChecks);
-  bcastSortedBands(*FullBands[spinSet2]);
   auto bspline_zd_d = MixedSplineReader->create_spline_set(spinSet2, spo_cur);
   bspline_zd_d->finalizeConstruction();
 

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
@@ -162,7 +162,6 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
   Timer mytimer;
   mytimer.restart();
   OccupyBands(spinSet, sortBands, numOrbs, skipChecks);
-  myComm->bcast(NumDistinctOrbitals);
   if (spinSet == 0)
     TileIons();
 
@@ -200,7 +199,6 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
 
   //Make the down spin set.
   OccupyBands(spinSet2, sortBands, numOrbs, skipChecks);
-  myComm->bcast(NumDistinctOrbitals);
   bcastSortedBands(*FullBands[spinSet2]);
   auto bspline_zd_d = MixedSplineReader->create_spline_set(spinSet2, spo_cur);
   bspline_zd_d->finalizeConstruction();

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
@@ -162,6 +162,7 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
   Timer mytimer;
   mytimer.restart();
   OccupyBands(spinSet, sortBands, numOrbs, skipChecks);
+  myComm->bcast(NumDistinctOrbitals);
   if (spinSet == 0)
     TileIons();
 
@@ -193,13 +194,14 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
   MixedSplineReader->setRotate(false);
 
   //Make the up spin set.
-  bcastSortBands(spinSet, NumDistinctOrbitals, myComm->rank() == 0);
+  bcastSortedBands(*FullBands[spinSet]);
   auto bspline_zd_u = MixedSplineReader->create_spline_set(spinSet, spo_cur);
   bspline_zd_u->finalizeConstruction();
 
   //Make the down spin set.
   OccupyBands(spinSet2, sortBands, numOrbs, skipChecks);
-  bcastSortBands(spinSet2, NumDistinctOrbitals, myComm->rank() == 0);
+  myComm->bcast(NumDistinctOrbitals);
+  bcastSortedBands(*FullBands[spinSet2]);
   auto bspline_zd_d = MixedSplineReader->create_spline_set(spinSet2, spo_cur);
   bspline_zd_d->finalizeConstruction();
 


### PR DESCRIPTION
## Proposed changes
1. ReadOrbitalInfo and ReadOrbitalInfo returning bool removed. Use exception
2. Remove codes related to `Format != ESHDF` already inaccessible.
3. Concentrate bcastBandInfoSet calls
4. Fix OccupyBands_ESHDF hang when error occurs and make it const.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'