### PR TITLE
Simplify evaluateIonDerivs used by force calculation.

### DIFF
--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -110,9 +110,9 @@ ACForce::Return_t ACForce::evaluate(ParticleSet& P)
   //This function returns d/dR of the sum of all observables in the physical hamiltonian.
   //Note that the sign will be flipped based on definition of force = -d/dR.
   if (fastDerivatives_)
-    ham_.evaluateIonDerivsDeterministicFast(P, ions_, psi_, psi_wrapper_, hf_force_, wf_grad_);
+    ham_.evaluateIonDerivsFast(P, ions_, psi_, psi_wrapper_, hf_force_, wf_grad_);
   else
-    ham_.evaluateIonDerivsDeterministic(P, ions_, psi_, hf_force_, pulay_force_, wf_grad_);
+    ham_.evaluateIonDerivs(P, ions_, psi_, hf_force_, pulay_force_, wf_grad_);
 
   if (useSpaceWarp_)
   {

--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -110,9 +110,9 @@ ACForce::Return_t ACForce::evaluate(ParticleSet& P)
   //This function returns d/dR of the sum of all observables in the physical hamiltonian.
   //Note that the sign will be flipped based on definition of force = -d/dR.
   if (fastDerivatives_)
-    value_ = ham_.evaluateIonDerivsDeterministicFast(P, ions_, psi_, psi_wrapper_, hf_force_, wf_grad_);
+    ham_.evaluateIonDerivsDeterministicFast(P, ions_, psi_, psi_wrapper_, hf_force_, wf_grad_);
   else
-    value_ = ham_.evaluateIonDerivsDeterministic(P, ions_, psi_, hf_force_, pulay_force_, wf_grad_);
+    ham_.evaluateIonDerivsDeterministic(P, ions_, psi_, hf_force_, pulay_force_, wf_grad_);
 
   if (useSpaceWarp_)
   {
@@ -129,7 +129,6 @@ ACForce::Return_t ACForce::evaluate(ParticleSet& P)
   //IS ALREADY UP TO DATE FOR THIS CONFIGURATION.
 
   f_epsilon_ = compute_regularizer_f(psi_.G, reg_epsilon_);
-
 
   return 0.0;
 };
@@ -160,6 +159,7 @@ void ACForce::addObservables(PropertySetType& plist, BufferType& collectables)
     }
   }
 };
+
 void ACForce::setObservables(PropertySetType& plist)
 {
   // TODO : bounds check for plist
@@ -173,7 +173,7 @@ void ACForce::setObservables(PropertySetType& plist)
       // add the minus one to be a force.
       plist[myindex++] = -hf_force_[iat][iondim] * f_epsilon_;
       plist[myindex++] = -(pulay_force_[iat][iondim] + sw_pulay_[iat][iondim]) * f_epsilon_;
-      plist[myindex++] = -value_ * (wf_grad_[iat][iondim] + sw_grad_[iat][iondim]) * f_epsilon_;
+      plist[myindex++] = -ham_.getLocalEnergy() * (wf_grad_[iat][iondim] + sw_grad_[iat][iondim]) * f_epsilon_;
       plist[myindex++] = -(wf_grad_[iat][iondim] + sw_grad_[iat][iondim]) * f_epsilon_;
     }
   }
@@ -187,7 +187,7 @@ void ACForce::setParticlePropertyList(PropertySetType& plist, int offset)
     {
       plist[myindex++] = -hf_force_[iat][iondim] * f_epsilon_;
       plist[myindex++] = -(pulay_force_[iat][iondim] + sw_pulay_[iat][iondim]) * f_epsilon_;
-      plist[myindex++] = -value_ * (wf_grad_[iat][iondim] + sw_grad_[iat][iondim]) * f_epsilon_;
+      plist[myindex++] = -ham_.getLocalEnergy() * (wf_grad_[iat][iondim] + sw_grad_[iat][iondim]) * f_epsilon_;
       plist[myindex++] = -(wf_grad_[iat][iondim] + sw_grad_[iat][iondim]) * f_epsilon_;
     }
   }

--- a/src/QMCHamiltonians/BareKineticEnergy.cpp
+++ b/src/QMCHamiltonians/BareKineticEnergy.cpp
@@ -180,7 +180,7 @@ void BareKineticEnergy::mw_evaluateWithParameterDerivatives(const RefVectorWithL
  * @return Value of kinetic energy operator at electron/ion positions given by P and ions.  The force contributions from
  *          this operator are added into hf_terms and pulay_terms.
  */
-Return_t BareKineticEnergy::evaluateWithIonDerivs(ParticleSet& P,
+Return_t BareKineticEnergy::evaluateWithIonDerivsDeterministic(ParticleSet& P,
                                                   ParticleSet& ions,
                                                   TrialWaveFunction& psi,
                                                   ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/BareKineticEnergy.cpp
+++ b/src/QMCHamiltonians/BareKineticEnergy.cpp
@@ -180,7 +180,7 @@ void BareKineticEnergy::mw_evaluateWithParameterDerivatives(const RefVectorWithL
  * @return Value of kinetic energy operator at electron/ion positions given by P and ions.  The force contributions from
  *          this operator are added into hf_terms and pulay_terms.
  */
-Return_t BareKineticEnergy::evaluateWithIonDerivsDeterministic(ParticleSet& P,
+Return_t BareKineticEnergy::evaluateWithIonDerivs(ParticleSet& P,
                                                   ParticleSet& ions,
                                                   TrialWaveFunction& psi,
                                                   ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/BareKineticEnergy.cpp
+++ b/src/QMCHamiltonians/BareKineticEnergy.cpp
@@ -258,28 +258,24 @@ void BareKineticEnergy::evaluateIonDerivs(ParticleSet& P,
     convertToReal(pulaytmp_[iat], pulaytmpreal_[iat]);
   }
 
-  Return_t value_local;
   if (same_mass_)
   {
-    value_local = Dot(P.G, P.G) + Sum(P.L);
-    value_local *= -one_over_2m_;
+    value_ = Dot(P.G, P.G) + Sum(P.L);
+    value_ *= -one_over_2m_;
   }
   else
   {
-    value_local = 0.0;
+    value_ = 0.0;
     for (int i = 0; i < minus_over_2m_.size(); ++i)
     {
       Return_t x = 0.0;
       for (int j = P.first(i); j < P.last(i); ++j)
         x += laplacian(P.G[j], P.L[j]);
-      value_local += x * minus_over_2m_[i];
+      value_ += x * minus_over_2m_[i];
     }
   }
 
-  // sanity check
-  assert(value_ == value_local);
-
-  pulaytmpreal_ -= value_local * iongradpsireal_;
+  pulaytmpreal_ -= value_ * iongradpsireal_;
   pulay_terms += pulaytmpreal_;
 }
 

--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -98,27 +98,25 @@ public:
                                            const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
   /**@brief Function to compute the value, direct ionic gradient terms, and pulay terms for the local kinetic energy.
- *  
- *  This general function represents the OperatorBase interface for computing.  For an operator \hat{O}, this
- *  function will return \frac{\hat{O}\Psi_T}{\Psi_T},  \frac{\partial(\hat{O})\Psi_T}{\Psi_T}, and 
- *  \frac{\hat{O}\partial\Psi_T}{\Psi_T} - \frac{\hat{O}\Psi_T}{\Psi_T}\frac{\partial \Psi_T}{\Psi_T}.  These are 
- *  referred to as Value, HF term, and pulay term respectively.
- *
- * @param P electron particle set.
- * @param ions ion particle set
- * @param psi Trial wave function object.
- * @param hf_terms 3Nion dimensional object. All direct force terms, or ionic gradient of operator itself.
- *                 Contribution of this operator is ADDED onto hf_terms.
- * @param pulay_terms The terms coming from ionic gradients of trial wavefunction.  Contribution of this operator is
- *                 ADDED onto pulay_terms.
- * @return Value of kinetic energy operator at electron/ion positions given by P and ions.  The force contributions from
- *          this operator are added into hf_terms and pulay_terms.
- */
-  Return_t evaluateWithIonDerivs(ParticleSet& P,
-                                 ParticleSet& ions,
-                                 TrialWaveFunction& psi,
-                                 ParticleSet::ParticlePos& hf_terms,
-                                 ParticleSet::ParticlePos& pulay_terms) override;
+  *  
+  *  This general function represents the OperatorBase interface for computing.  For an operator \hat{O}, this
+  *  function will return \frac{\hat{O}\Psi_T}{\Psi_T},  \frac{\partial(\hat{O})\Psi_T}{\Psi_T}, and 
+  *  \frac{\hat{O}\partial\Psi_T}{\Psi_T} - \frac{\hat{O}\Psi_T}{\Psi_T}\frac{\partial \Psi_T}{\Psi_T}.  These are 
+  *  referred to as Value, HF term, and pulay term respectively.
+  *
+  * @param P electron particle set.
+  * @param ions ion particle set
+  * @param psi Trial wave function object.
+  * @param hf_terms 3Nion dimensional object. All direct force terms, or ionic gradient of operator itself.
+  *                 Contribution of this operator is ADDED onto hf_terms.
+  * @param pulay_terms The terms coming from ionic gradients of trial wavefunction.  Contribution of this operator is
+  *                 ADDED onto pulay_terms.
+  */
+  void evaluateIonDerivs(ParticleSet& P,
+                         ParticleSet& ions,
+                         TrialWaveFunction& psi,
+                         ParticleSet::ParticlePos& hf_terms,
+                         ParticleSet::ParticlePos& pulay_terms) override;
 
   void evaluateOneBodyOpMatrix(ParticleSet& P, const TWFFastDerivWrapper& psi, std::vector<ValueMatrix>& B) override;
 

--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -114,7 +114,7 @@ public:
  * @return Value of kinetic energy operator at electron/ion positions given by P and ions.  The force contributions from
  *          this operator are added into hf_terms and pulay_terms.
  */
-  Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
+  Return_t evaluateWithIonDerivs(ParticleSet& P,
                                  ParticleSet& ions,
                                  TrialWaveFunction& psi,
                                  ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -114,7 +114,7 @@ public:
  * @return Value of kinetic energy operator at electron/ion positions given by P and ions.  The force contributions from
  *          this operator are added into hf_terms and pulay_terms.
  */
-  Return_t evaluateWithIonDerivs(ParticleSet& P,
+  Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
                                  ParticleSet& ions,
                                  TrialWaveFunction& psi,
                                  ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -327,7 +327,7 @@ void CoulombPBCAA::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase
   }
 }
 
-CoulombPBCAA::Return_t CoulombPBCAA::evaluateWithIonDerivs(ParticleSet& P,
+CoulombPBCAA::Return_t CoulombPBCAA::evaluateWithIonDerivsDeterministic(ParticleSet& P,
                                                            ParticleSet& ions,
                                                            TrialWaveFunction& psi,
                                                            ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -327,7 +327,7 @@ void CoulombPBCAA::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase
   }
 }
 
-CoulombPBCAA::Return_t CoulombPBCAA::evaluateWithIonDerivsDeterministic(ParticleSet& P,
+CoulombPBCAA::Return_t CoulombPBCAA::evaluateWithIonDerivs(ParticleSet& P,
                                                            ParticleSet& ions,
                                                            TrialWaveFunction& psi,
                                                            ParticleSet::ParticlePos& hf_terms,
@@ -459,9 +459,9 @@ void CoulombPBCAA::initBreakup(ParticleSet& P)
   myRcut  = AA->get_rc(); //Basis.get_rc();
 
   auto myGrid = LinearGrid<RealType>();
-  int ng = P.getLattice().num_ewald_grid_points;
-  app_log() << "    CoulombPBCAA::initBreakup\n  Setting a linear grid=[0,"
-            << myRcut << ") number of grid points =" << ng << std::endl;
+  int ng      = P.getLattice().num_ewald_grid_points;
+  app_log() << "    CoulombPBCAA::initBreakup\n  Setting a linear grid=[0," << myRcut
+            << ") number of grid points =" << ng << std::endl;
   myGrid.set(0, myRcut, ng);
 
   if (rVs == nullptr)

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -327,16 +327,15 @@ void CoulombPBCAA::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase
   }
 }
 
-CoulombPBCAA::Return_t CoulombPBCAA::evaluateWithIonDerivs(ParticleSet& P,
-                                                           ParticleSet& ions,
-                                                           TrialWaveFunction& psi,
-                                                           ParticleSet::ParticlePos& hf_terms,
-                                                           ParticleSet::ParticlePos& pulay_terms)
+void CoulombPBCAA::evaluateIonDerivs(ParticleSet& P,
+                                     ParticleSet& ions,
+                                     TrialWaveFunction& psi,
+                                     ParticleSet::ParticlePos& hf_terms,
+                                     ParticleSet::ParticlePos& pulay_terms)
 {
   if (ComputeForces and !is_active)
     hf_terms -= forces_;
   //No pulay term.
-  return value_;
 }
 
 #if !defined(REMOVE_TRACEMANAGER)
@@ -777,7 +776,7 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalLR(ParticleSet& P)
           temp *= 0.5;
         res += Z1 * Zspec[spec2] * temp;
       } //spec2
-    }   //spec1
+    } //spec1
   }
   return res;
 }

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -114,7 +114,7 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
                               const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
 
-  Return_t evaluateWithIonDerivs(ParticleSet& P,
+  Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
                                  ParticleSet& ions,
                                  TrialWaveFunction& psi,
                                  ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -114,7 +114,7 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
                               const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
 
-  Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
+  Return_t evaluateWithIonDerivs(ParticleSet& P,
                                  ParticleSet& ions,
                                  TrialWaveFunction& psi,
                                  ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -114,11 +114,11 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
                               const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
 
-  Return_t evaluateWithIonDerivs(ParticleSet& P,
-                                 ParticleSet& ions,
-                                 TrialWaveFunction& psi,
-                                 ParticleSet::ParticlePos& hf_terms,
-                                 ParticleSet::ParticlePos& pulay_terms) override;
+  void evaluateIonDerivs(ParticleSet& P,
+                         ParticleSet& ions,
+                         TrialWaveFunction& psi,
+                         ParticleSet::ParticlePos& hf_terms,
+                         ParticleSet::ParticlePos& pulay_terms) override;
   void updateSource(ParticleSet& s) override;
 
   /** Do nothing */

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -136,11 +136,11 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate(ParticleSet& P)
   return value_;
 }
 
-CoulombPBCAB::Return_t CoulombPBCAB::evaluateWithIonDerivs(ParticleSet& P,
-                                                           ParticleSet& ions,
-                                                           TrialWaveFunction& psi,
-                                                           ParticleSet::ParticlePos& hf_terms,
-                                                           ParticleSet::ParticlePos& pulay_terms)
+void CoulombPBCAB::evaluateIonDerivs(ParticleSet& P,
+                                     ParticleSet& ions,
+                                     TrialWaveFunction& psi,
+                                     ParticleSet::ParticlePos& hf_terms,
+                                     ParticleSet::ParticlePos& pulay_terms)
 {
   if (ComputeForces)
   {
@@ -149,9 +149,6 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluateWithIonDerivs(ParticleSet& P,
     hf_terms -= forces_;
     //And no Pulay contribution.
   }
-  else
-    value_ = evalLR(P) + evalSR(P) + myConst;
-  return value_;
 }
 
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -136,7 +136,7 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate(ParticleSet& P)
   return value_;
 }
 
-CoulombPBCAB::Return_t CoulombPBCAB::evaluateWithIonDerivs(ParticleSet& P,
+CoulombPBCAB::Return_t CoulombPBCAB::evaluateWithIonDerivsDeterministic(ParticleSet& P,
                                                            ParticleSet& ions,
                                                            TrialWaveFunction& psi,
                                                            ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -136,7 +136,7 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate(ParticleSet& P)
   return value_;
 }
 
-CoulombPBCAB::Return_t CoulombPBCAB::evaluateWithIonDerivsDeterministic(ParticleSet& P,
+CoulombPBCAB::Return_t CoulombPBCAB::evaluateWithIonDerivs(ParticleSet& P,
                                                            ParticleSet& ions,
                                                            TrialWaveFunction& psi,
                                                            ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -153,7 +153,7 @@ public:
                               const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
 
-  Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
+  Return_t evaluateWithIonDerivs(ParticleSet& P,
                                  ParticleSet& ions,
                                  TrialWaveFunction& psi,
                                  ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -153,7 +153,7 @@ public:
                               const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
 
-  Return_t evaluateWithIonDerivs(ParticleSet& P,
+  Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
                                  ParticleSet& ions,
                                  TrialWaveFunction& psi,
                                  ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -153,11 +153,11 @@ public:
                               const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
 
-  Return_t evaluateWithIonDerivs(ParticleSet& P,
-                                 ParticleSet& ions,
-                                 TrialWaveFunction& psi,
-                                 ParticleSet::ParticlePos& hf_terms,
-                                 ParticleSet::ParticlePos& pulay_terms) override;
+  void evaluateIonDerivs(ParticleSet& P,
+                         ParticleSet& ions,
+                         TrialWaveFunction& psi,
+                         ParticleSet::ParticlePos& hf_terms,
+                         ParticleSet::ParticlePos& pulay_terms) override;
 
   /** Do nothing */
   bool put(xmlNodePtr cur) override { return true; }

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -340,17 +340,15 @@ struct CoulombPotential : public OperatorBase, public ForceBase
     return value_;
   }
 
-  inline Return_t evaluateWithIonDerivs(ParticleSet& P,
-                                        ParticleSet& ions,
-                                        TrialWaveFunction& psi,
-                                        ParticleSet::ParticlePos& hf_terms,
-                                        ParticleSet::ParticlePos& pulay_terms) override
+  inline void evaluateIonDerivs(ParticleSet& P,
+                                ParticleSet& ions,
+                                TrialWaveFunction& psi,
+                                ParticleSet::ParticlePos& hf_terms,
+                                ParticleSet::ParticlePos& pulay_terms) override
   {
-    if (is_active)
-      value_ = evaluate(P); // No forces for the active
-    else
-      hf_terms -= forces_; // No Pulay here
-    return value_;
+    if (!is_active)
+      hf_terms -= forces_;
+    // No Pulay here
   }
 
   bool put(xmlNodePtr cur) override { return true; }

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -74,7 +74,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
     setEnergyDomain(POTENTIAL);
     twoBodyQuantumDomain(s, s);
     nCenters = s.getTotalNum();
-    prefix_   = "F_AA";
+    prefix_  = "F_AA";
 
     if (!is_active) //precompute the value
     {
@@ -340,7 +340,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
     return value_;
   }
 
-  inline Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
+  inline Return_t evaluateWithIonDerivs(ParticleSet& P,
                                         ParticleSet& ions,
                                         TrialWaveFunction& psi,
                                         ParticleSet::ParticlePos& hf_terms,
@@ -349,7 +349,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
     if (is_active)
       value_ = evaluate(P); // No forces for the active
     else
-      hf_terms -= forces_;   // No Pulay here
+      hf_terms -= forces_; // No Pulay here
     return value_;
   }
 

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -340,7 +340,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
     return value_;
   }
 
-  inline Return_t evaluateWithIonDerivs(ParticleSet& P,
+  inline Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
                                         ParticleSet& ions,
                                         TrialWaveFunction& psi,
                                         ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -112,8 +112,8 @@ void LocalECPotential::evaluateIonDerivs(ParticleSet& P,
                                          ParticleSet::ParticlePos& pulay_terms)
 {
   const auto& d_table(P.getDistTableAB(myTableIndex));
-  Return_t value_local = 0.0;
-  const size_t Nelec   = P.getTotalNum();
+  value_             = 0.0;
+  const size_t Nelec = P.getTotalNum();
   for (size_t iel = 0; iel < Nelec; ++iel)
   {
     const auto& dist = d_table.getDistRow(iel);
@@ -135,12 +135,8 @@ void LocalECPotential::evaluateIonDerivs(ParticleSet& P,
         esum += -Zeff[iat] * v * rinv;
       }
     }
-    value_local += esum;
+    value_ += esum;
   }
-
-  // sanity check
-  assert(value_ == value_local);
-  value_ = value_local; // prevent unused-but-set-variable warning
 }
 
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -105,7 +105,7 @@ LocalECPotential::Return_t LocalECPotential::evaluate(ParticleSet& P)
   return value_;
 }
 
-LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivsDeterministic(ParticleSet& P,
+LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivs(ParticleSet& P,
                                                                    ParticleSet& ions,
                                                                    TrialWaveFunction& psi,
                                                                    ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -105,15 +105,15 @@ LocalECPotential::Return_t LocalECPotential::evaluate(ParticleSet& P)
   return value_;
 }
 
-LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivs(ParticleSet& P,
-                                                                   ParticleSet& ions,
-                                                                   TrialWaveFunction& psi,
-                                                                   ParticleSet::ParticlePos& hf_terms,
-                                                                   ParticleSet::ParticlePos& pulay_terms)
+void LocalECPotential::evaluateIonDerivs(ParticleSet& P,
+                                         ParticleSet& ions,
+                                         TrialWaveFunction& psi,
+                                         ParticleSet::ParticlePos& hf_terms,
+                                         ParticleSet::ParticlePos& pulay_terms)
 {
   const auto& d_table(P.getDistTableAB(myTableIndex));
-  value_             = 0.0;
-  const size_t Nelec = P.getTotalNum();
+  Return_t value_local = 0.0;
+  const size_t Nelec   = P.getTotalNum();
   for (size_t iel = 0; iel < Nelec; ++iel)
   {
     const auto& dist = d_table.getDistRow(iel);
@@ -135,9 +135,12 @@ LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivs(ParticleSet& 
         esum += -Zeff[iat] * v * rinv;
       }
     }
-    value_ += esum;
+    value_local += esum;
   }
-  return value_;
+
+  // sanity check
+  assert(value_ == value_local);
+  value_ = value_local; // prevent unused-but-set-variable warning
 }
 
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -105,7 +105,7 @@ LocalECPotential::Return_t LocalECPotential::evaluate(ParticleSet& P)
   return value_;
 }
 
-LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivs(ParticleSet& P,
+LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivsDeterministic(ParticleSet& P,
                                                                    ParticleSet& ions,
                                                                    TrialWaveFunction& psi,
                                                                    ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/LocalECPotential.h
+++ b/src/QMCHamiltonians/LocalECPotential.h
@@ -75,11 +75,11 @@ struct LocalECPotential : public OperatorBase
 
   Return_t evaluate(ParticleSet& P) override;
 
-  Return_t evaluateWithIonDerivs(ParticleSet& P,
-                                 ParticleSet& ions,
-                                 TrialWaveFunction& psi,
-                                 ParticleSet::ParticlePos& hf_terms,
-                                 ParticleSet::ParticlePos& pulay_terms) override;
+  void evaluateIonDerivs(ParticleSet& P,
+                         ParticleSet& ions,
+                         TrialWaveFunction& psi,
+                         ParticleSet::ParticlePos& hf_terms,
+                         ParticleSet::ParticlePos& pulay_terms) override;
 
 
   Return_t evaluate_orig(ParticleSet& P);

--- a/src/QMCHamiltonians/LocalECPotential.h
+++ b/src/QMCHamiltonians/LocalECPotential.h
@@ -75,7 +75,7 @@ struct LocalECPotential : public OperatorBase
 
   Return_t evaluate(ParticleSet& P) override;
 
-  Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
+  Return_t evaluateWithIonDerivs(ParticleSet& P,
                                  ParticleSet& ions,
                                  TrialWaveFunction& psi,
                                  ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/LocalECPotential.h
+++ b/src/QMCHamiltonians/LocalECPotential.h
@@ -75,7 +75,7 @@ struct LocalECPotential : public OperatorBase
 
   Return_t evaluate(ParticleSet& P) override;
 
-  Return_t evaluateWithIonDerivs(ParticleSet& P,
+  Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
                                  ParticleSet& ions,
                                  TrialWaveFunction& psi,
                                  ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -513,16 +513,6 @@ void NonLocalECPotential::evalIonDerivsImpl(ParticleSet& P,
   pulay_terms -= PulayTerm;
 }
 
-NonLocalECPotential::Return_t NonLocalECPotential::evaluateWithIonDerivs(ParticleSet& P,
-                                                                         ParticleSet& ions,
-                                                                         TrialWaveFunction& psi,
-                                                                         ParticleSet::ParticlePos& hf_terms,
-                                                                         ParticleSet::ParticlePos& pulay_terms)
-{
-  evalIonDerivsImpl(P, ions, psi, hf_terms, pulay_terms);
-  return value_;
-}
-
 NonLocalECPotential::Return_t NonLocalECPotential::evaluateWithIonDerivsDeterministic(
     ParticleSet& P,
     ParticleSet& ions,

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -465,9 +465,6 @@ void NonLocalECPotential::evaluateIonDerivs(ParticleSet& P,
 {
   //We're going to ignore psi and use the internal Psi.
 
-  Return_t value_local = 0.0;
-  forces_              = 0;
-  PulayTerm            = 0;
   //loop over all the ions
   const auto& myTable = P.getDistTableAB(myTableIndex);
   // clear all the electron and ion neighbor lists
@@ -476,6 +473,9 @@ void NonLocalECPotential::evaluateIonDerivs(ParticleSet& P,
   for (int jel = 0; jel < P.getTotalNum(); jel++)
     ElecNeighborIons.getNeighborList(jel).clear();
 
+  value_    = 0.0;
+  forces_   = 0;
+  PulayTerm = 0;
   for (int ig = 0; ig < P.groups(); ++ig) //loop over species
   {
     Psi.prepareGroup(P, ig);
@@ -487,7 +487,7 @@ void NonLocalECPotential::evaluateIonDerivs(ParticleSet& P,
       for (int iat = 0; iat < NumIons; iat++)
         if (PP[iat] != nullptr && dist[iat] < PP[iat]->getRmax())
         {
-          value_local +=
+          value_ +=
               PP[iat]->evaluateOneWithForces(P, ions, iat, Psi, jel, dist[iat], -displ[iat], forces_[iat], PulayTerm);
           NeighborIons.push_back(iat);
           IonNeighborElecs.getNeighborList(iat).push_back(jel);
@@ -497,10 +497,6 @@ void NonLocalECPotential::evaluateIonDerivs(ParticleSet& P,
 
   hf_terms -= forces_;
   pulay_terms -= PulayTerm;
-
-  // sanity check
-  assert(value_ == value_local);
-  value_ = value_local; // prevent unused-but-set-variable warning
 }
 
 void NonLocalECPotential::computeOneElectronTxy(ParticleSet& P, const int ref_elec)

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -457,15 +457,15 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
   }
 }
 
-NonLocalECPotential::Return_t  NonLocalECPotential::evaluateWithIonDerivsDeterministic(ParticleSet& P,
-                                            ParticleSet& ions,
-                                            TrialWaveFunction& psi,
-                                            ParticleSet::ParticlePos& hf_terms,
-                                            ParticleSet::ParticlePos& pulay_terms)
+NonLocalECPotential::Return_t NonLocalECPotential::evaluateWithIonDerivs(ParticleSet& P,
+                                                                         ParticleSet& ions,
+                                                                         TrialWaveFunction& psi,
+                                                                         ParticleSet::ParticlePos& hf_terms,
+                                                                         ParticleSet::ParticlePos& pulay_terms)
 {
   //We're going to ignore psi and use the internal Psi.
 
-  value_ = 0.0;
+  value_    = 0.0;
   forces_   = 0;
   PulayTerm = 0;
   //loop over all the ions

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -457,29 +457,17 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
   }
 }
 
-
-void NonLocalECPotential::evalIonDerivsImpl(ParticleSet& P,
+NonLocalECPotential::Return_t  NonLocalECPotential::evaluateWithIonDerivsDeterministic(ParticleSet& P,
                                             ParticleSet& ions,
                                             TrialWaveFunction& psi,
                                             ParticleSet::ParticlePos& hf_terms,
-                                            ParticleSet::ParticlePos& pulay_terms,
-                                            bool keepGrid)
+                                            ParticleSet::ParticlePos& pulay_terms)
 {
   //We're going to ignore psi and use the internal Psi.
-  //
-  //Dummy vector for now.  Tmoves not implemented
-  bool Tmove = false;
-
-  forces_   = 0;
-  PulayTerm = 0;
 
   value_ = 0.0;
-  if (!keepGrid)
-  {
-    for (int ipp = 0; ipp < PPset.size(); ipp++)
-      if (PPset[ipp])
-        PPset[ipp]->rotateQuadratureGrid(generateRandomRotationMatrix(*myRNG));
-  }
+  forces_   = 0;
+  PulayTerm = 0;
   //loop over all the ions
   const auto& myTable = P.getDistTableAB(myTableIndex);
   // clear all the electron and ion neighbor lists
@@ -501,8 +489,6 @@ void NonLocalECPotential::evalIonDerivsImpl(ParticleSet& P,
         {
           value_ +=
               PP[iat]->evaluateOneWithForces(P, ions, iat, Psi, jel, dist[iat], -displ[iat], forces_[iat], PulayTerm);
-          if (Tmove)
-            PP[iat]->contributeTxy(jel, tmove_xy_);
           NeighborIons.push_back(iat);
           IonNeighborElecs.getNeighborList(iat).push_back(jel);
         }
@@ -511,16 +497,6 @@ void NonLocalECPotential::evalIonDerivsImpl(ParticleSet& P,
 
   hf_terms -= forces_;
   pulay_terms -= PulayTerm;
-}
-
-NonLocalECPotential::Return_t NonLocalECPotential::evaluateWithIonDerivsDeterministic(
-    ParticleSet& P,
-    ParticleSet& ions,
-    TrialWaveFunction& psi,
-    ParticleSet::ParticlePos& hf_terms,
-    ParticleSet::ParticlePos& pulay_terms)
-{
-  evalIonDerivsImpl(P, ions, psi, hf_terms, pulay_terms, true);
   return value_;
 }
 

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -80,11 +80,11 @@ public:
                                            const std::vector<ListenerVector<Real>>& listeners,
                                            const std::vector<ListenerVector<Real>>& listeners_ions) const override;
 
-  Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
-                                              ParticleSet& ions,
-                                              TrialWaveFunction& psi,
-                                              ParticleSet::ParticlePos& hf_terms,
-                                              ParticleSet::ParticlePos& pulay_terms) override;
+  Return_t evaluateWithIonDerivs(ParticleSet& P,
+                                 ParticleSet& ions,
+                                 TrialWaveFunction& psi,
+                                 ParticleSet::ParticlePos& hf_terms,
+                                 ParticleSet::ParticlePos& pulay_terms) override;
 
   void evaluateOneBodyOpMatrix(ParticleSet& P, const TWFFastDerivWrapper& psi, std::vector<ValueMatrix>& B) override;
 

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -80,11 +80,11 @@ public:
                                            const std::vector<ListenerVector<Real>>& listeners,
                                            const std::vector<ListenerVector<Real>>& listeners_ions) const override;
 
-  Return_t evaluateWithIonDerivs(ParticleSet& P,
-                                 ParticleSet& ions,
-                                 TrialWaveFunction& psi,
-                                 ParticleSet::ParticlePos& hf_terms,
-                                 ParticleSet::ParticlePos& pulay_terms) override;
+  void evaluateIonDerivs(ParticleSet& P,
+                         ParticleSet& ions,
+                         TrialWaveFunction& psi,
+                         ParticleSet::ParticlePos& hf_terms,
+                         ParticleSet::ParticlePos& pulay_terms) override;
 
   void evaluateOneBodyOpMatrix(ParticleSet& P, const TWFFastDerivWrapper& psi, std::vector<ValueMatrix>& B) override;
 

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -80,12 +80,6 @@ public:
                                            const std::vector<ListenerVector<Real>>& listeners,
                                            const std::vector<ListenerVector<Real>>& listeners_ions) const override;
 
-  Return_t evaluateWithIonDerivs(ParticleSet& P,
-                                 ParticleSet& ions,
-                                 TrialWaveFunction& psi,
-                                 ParticleSet::ParticlePos& hf_terms,
-                                 ParticleSet::ParticlePos& pulay_terms) override;
-
   Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
                                               ParticleSet& ions,
                                               TrialWaveFunction& psi,

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -231,12 +231,6 @@ private:
    */
   void evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid = false);
 
-  void evalIonDerivsImpl(ParticleSet& P,
-                         ParticleSet& ions,
-                         TrialWaveFunction& psi,
-                         ParticleSet::ParticlePos& hf_terms,
-                         ParticleSet::ParticlePos& pulay_terms,
-                         bool keepGrid = false);
   /** compute the T move transition probability for a given electron
    * member variable nonLocalOps.Txy is updated
    * @param P particle set

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -178,11 +178,11 @@ OperatorBase::Return_t OperatorBase::evaluateValueAndDerivatives(ParticleSet& P,
   return evaluate(P);
 }
 
-OperatorBase::Return_t OperatorBase::evaluateWithIonDerivsDeterministic(ParticleSet& P,
-                                                                        ParticleSet& ions,
-                                                                        TrialWaveFunction& psi,
-                                                                        ParticleSet::ParticlePos& hf_term,
-                                                                        ParticleSet::ParticlePos& pulay_term)
+OperatorBase::Return_t OperatorBase::evaluateWithIonDerivs(ParticleSet& P,
+                                                           ParticleSet& ions,
+                                                           TrialWaveFunction& psi,
+                                                           ParticleSet::ParticlePos& hf_term,
+                                                           ParticleSet::ParticlePos& pulay_term)
 {
   return evaluate(P);
 }

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -178,22 +178,13 @@ OperatorBase::Return_t OperatorBase::evaluateValueAndDerivatives(ParticleSet& P,
   return evaluate(P);
 }
 
-OperatorBase::Return_t OperatorBase::evaluateWithIonDerivs(ParticleSet& P,
-                                                           ParticleSet& ions,
-                                                           TrialWaveFunction& psi,
-                                                           ParticleSet::ParticlePos& hf_term,
-                                                           ParticleSet::ParticlePos& pulay_term)
-{
-  return evaluate(P);
-}
-
 OperatorBase::Return_t OperatorBase::evaluateWithIonDerivsDeterministic(ParticleSet& P,
                                                                         ParticleSet& ions,
                                                                         TrialWaveFunction& psi,
                                                                         ParticleSet::ParticlePos& hf_term,
                                                                         ParticleSet::ParticlePos& pulay_term)
 {
-  return evaluateWithIonDerivs(P, ions, psi, hf_term, pulay_term);
+  return evaluate(P);
 }
 
 void OperatorBase::updateSource(ParticleSet& s) {}

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -178,14 +178,12 @@ OperatorBase::Return_t OperatorBase::evaluateValueAndDerivatives(ParticleSet& P,
   return evaluate(P);
 }
 
-OperatorBase::Return_t OperatorBase::evaluateWithIonDerivs(ParticleSet& P,
-                                                           ParticleSet& ions,
-                                                           TrialWaveFunction& psi,
-                                                           ParticleSet::ParticlePos& hf_term,
-                                                           ParticleSet::ParticlePos& pulay_term)
-{
-  return evaluate(P);
-}
+void OperatorBase::evaluateIonDerivs(ParticleSet& P,
+                                     ParticleSet& ions,
+                                     TrialWaveFunction& psi,
+                                     ParticleSet::ParticlePos& hf_term,
+                                     ParticleSet::ParticlePos& pulay_term)
+{}
 
 void OperatorBase::updateSource(ParticleSet& s) {}
 
@@ -213,7 +211,7 @@ void OperatorBase::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCH
 }
 
 #if !defined(REMOVE_TRACEMANAGER)
-void OperatorBase::getRequiredTraces(TraceManager& tm){};
+void OperatorBase::getRequiredTraces(TraceManager& tm) {};
 #endif
 
 // END  FUNCTIONS //
@@ -284,9 +282,9 @@ void OperatorBase::deleteScalarQuantities()
     delete value_sample_;
 }
 
-void OperatorBase::contributeParticleQuantities(){};
-void OperatorBase::checkoutParticleQuantities(TraceManager& tm){};
-void OperatorBase::deleteParticleQuantities(){};
+void OperatorBase::contributeParticleQuantities() {};
+void OperatorBase::checkoutParticleQuantities(TraceManager& tm) {};
+void OperatorBase::deleteParticleQuantities() {};
 #endif
 
 void OperatorBase::setComputeForces(bool compute) {}

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -343,22 +343,6 @@ public:
                                                Vector<ValueType>& dhpsioverpsi);
 
   /** 
-   * @brief Evaluate contribution to local energy  and derivatives w.r.t ionic coordinates from OperatorBase.  
-
-   * @param P target particle set (electrons)
-   * @param ions source particle set (ions)
-   * @param psi Trial wave function
-   * @param hf_terms  Adds OperatorBase's contribution to Re [(dH)Psi]/Psi
-   * @param pulay_terms Adds OperatorBase's contribution to Re [(H-E_L)dPsi]/Psi 
-   * @return Contribution of OperatorBase to Local Energy.
-   */
-  virtual Return_t evaluateWithIonDerivs(ParticleSet& P,
-                                         ParticleSet& ions,
-                                         TrialWaveFunction& psi,
-                                         ParticleSet::ParticlePos& hf_term,
-                                         ParticleSet::ParticlePos& pulay_term);
-
-  /** 
    * @brief Evaluate contribution to local energy  and derivatives w.r.t ionic coordinates from OperatorBase.
    * If there's no stochastic component, defaults to evaluateWithIonDerivs.
    * If not otherwise specified, this defaults to evaluate().

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -354,11 +354,11 @@ public:
    * @param pulay_terms Adds OperatorBase's contribution to Re [(H-E_L)dPsi]/Psi 
    * @return Contribution of OperatorBase to Local Energy.
    */
-  virtual Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
-                                                      ParticleSet& ions,
-                                                      TrialWaveFunction& psi,
-                                                      ParticleSet::ParticlePos& hf_term,
-                                                      ParticleSet::ParticlePos& pulay_term);
+  virtual Return_t evaluateWithIonDerivs(ParticleSet& P,
+                                         ParticleSet& ions,
+                                         TrialWaveFunction& psi,
+                                         ParticleSet::ParticlePos& hf_term,
+                                         ParticleSet::ParticlePos& pulay_term);
 
   /** 
    * @brief Evaluate "B" matrix for observable.  Filippi scheme for computing fast derivatives.

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -344,7 +344,7 @@ public:
 
   /** 
    * @brief Evaluate contribution to local energy  and derivatives w.r.t ionic coordinates from OperatorBase.
-   * If there's no stochastic component, defaults to evaluateWithIonDerivs.
+   * If there's no stochastic component, defaults to evaluateIonDerivs.
    * If not otherwise specified, this defaults to evaluate().
 
    * @param P target particle set (electrons)
@@ -352,13 +352,12 @@ public:
    * @param psi Trial wave function
    * @param hf_terms  Adds OperatorBase's contribution to Re [(dH)Psi]/Psi
    * @param pulay_terms Adds OperatorBase's contribution to Re [(H-E_L)dPsi]/Psi 
-   * @return Contribution of OperatorBase to Local Energy.
    */
-  virtual Return_t evaluateWithIonDerivs(ParticleSet& P,
-                                         ParticleSet& ions,
-                                         TrialWaveFunction& psi,
-                                         ParticleSet::ParticlePos& hf_term,
-                                         ParticleSet::ParticlePos& pulay_term);
+  virtual void evaluateIonDerivs(ParticleSet& P,
+                                 ParticleSet& ions,
+                                 TrialWaveFunction& psi,
+                                 ParticleSet::ParticlePos& hf_term,
+                                 ParticleSet::ParticlePos& pulay_term);
 
   /** 
    * @brief Evaluate "B" matrix for observable.  Filippi scheme for computing fast derivatives.

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -55,7 +55,7 @@ QMCHamiltonian::QMCHamiltonian(const std::string& aname)
       ham_timer_(createGlobalTimer("Hamiltonian:" + aname + "::evaluate", timer_level_medium)),
       eval_vals_derivs_timer_(createGlobalTimer("Hamiltonian:" + aname + "::ValueParamDerivs", timer_level_medium)),
       eval_ion_derivs_fast_timer_(
-          createGlobalTimer("Hamiltonian:" + aname + ":::evaluateIonDerivsDeterministicFast", timer_level_medium))
+          createGlobalTimer("Hamiltonian:" + aname + ":::evaluateIonDerivsFast", timer_level_medium))
 #if !defined(REMOVE_TRACEMANAGER)
       ,
       streaming_position(false),
@@ -898,15 +898,15 @@ void QMCHamiltonian::evaluateElecGrad(ParticleSet& P,
   }
 }
 
-void QMCHamiltonian::evaluateIonDerivsDeterministic(ParticleSet& P,
-                                                                                ParticleSet& ions,
-                                                                                TrialWaveFunction& psi,
-                                                                                ParticleSet::ParticlePos& hf_term,
-                                                                                ParticleSet::ParticlePos& pulay_terms,
-                                                                                ParticleSet::ParticlePos& wf_grad)
+void QMCHamiltonian::evaluateIonDerivs(ParticleSet& P,
+                                       ParticleSet& ions,
+                                       TrialWaveFunction& psi,
+                                       ParticleSet::ParticlePos& hf_term,
+                                       ParticleSet::ParticlePos& pulay_terms,
+                                       ParticleSet::ParticlePos& wf_grad)
 {
   ParticleSet::ParticleGradient wfgradraw_(ions.getTotalNum());
-  wfgradraw_           = 0.0;
+  wfgradraw_ = 0.0;
 
   for (int i = 0; i < H.size(); ++i)
     H[i]->evaluateWithIonDerivs(P, ions, psi, hf_term, pulay_terms);
@@ -1071,12 +1071,12 @@ RefVectorWithLeader<OperatorBase> QMCHamiltonian::extract_HC_list(const RefVecto
   return HC_list;
 }
 
-void QMCHamiltonian::evaluateIonDerivsDeterministicFast(ParticleSet& P,
-                                                                                    ParticleSet& ions,
-                                                                                    TrialWaveFunction& psi_in,
-                                                                                    TWFFastDerivWrapper& psi_wrapper_in,
-                                                                                    ParticleSet::ParticlePos& dEdR,
-                                                                                    ParticleSet::ParticlePos& wf_grad)
+void QMCHamiltonian::evaluateIonDerivsFast(ParticleSet& P,
+                                           ParticleSet& ions,
+                                           TrialWaveFunction& psi_in,
+                                           TWFFastDerivWrapper& psi_wrapper_in,
+                                           ParticleSet::ParticlePos& dEdR,
+                                           ParticleSet::ParticlePos& wf_grad)
 {
   ScopedTimer local_timer(eval_ion_derivs_fast_timer_);
   P.update();
@@ -1167,7 +1167,7 @@ void QMCHamiltonian::evaluateIonDerivsDeterministicFast(ParticleSet& P,
   ParticleSet::ParticleGradient dedr_complex(ions.getTotalNum());
   ParticleSet::ParticlePos pulayterms_(ions.getTotalNum());
   ParticleSet::ParticlePos hfdiag_(ions.getTotalNum());
-  wfgradraw_           = 0.0;
+  wfgradraw_ = 0.0;
 
   {
     psi_wrapper_in.getM(P, M_);

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -897,27 +897,6 @@ void QMCHamiltonian::evaluateElecGrad(ParticleSet& P,
     }
   }
 }
-QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateIonDerivs(ParticleSet& P,
-                                                                   ParticleSet& ions,
-                                                                   TrialWaveFunction& psi,
-                                                                   ParticleSet::ParticlePos& hf_term,
-                                                                   ParticleSet::ParticlePos& pulay_terms,
-                                                                   ParticleSet::ParticlePos& wf_grad)
-{
-  ParticleSet::ParticleGradient wfgradraw_(ions.getTotalNum());
-  wfgradraw_           = 0.0;
-  RealType localEnergy = 0.0;
-
-  for (int i = 0; i < H.size(); ++i)
-    localEnergy += H[i]->evaluateWithIonDerivs(P, ions, psi, hf_term, pulay_terms);
-
-  for (int iat = 0; iat < ions.getTotalNum(); iat++)
-  {
-    wfgradraw_[iat] = psi.evalGradSource(P, ions, iat);
-    convertToReal(wfgradraw_[iat], wf_grad[iat]);
-  }
-  return localEnergy;
-}
 
 QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateIonDerivsDeterministic(ParticleSet& P,
                                                                                 ParticleSet& ions,

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -910,7 +910,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateIonDerivsDeterministic(
   RealType localEnergy = 0.0;
 
   for (int i = 0; i < H.size(); ++i)
-    localEnergy += H[i]->evaluateWithIonDerivsDeterministic(P, ions, psi, hf_term, pulay_terms);
+    localEnergy += H[i]->evaluateWithIonDerivs(P, ions, psi, hf_term, pulay_terms);
 
   for (int iat = 0; iat < ions.getTotalNum(); iat++)
   {
@@ -1188,7 +1188,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateIonDerivsDeterministicF
     }
     else
     {
-      localEnergy += H[i]->evaluateWithIonDerivsDeterministic(P, ions, psi_in, hfdiag_, pulayterms_);
+      localEnergy += H[i]->evaluateWithIonDerivs(P, ions, psi_in, hfdiag_, pulayterms_);
     }
   }
 

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -909,7 +909,7 @@ void QMCHamiltonian::evaluateIonDerivs(ParticleSet& P,
   wfgradraw_ = 0.0;
 
   for (int i = 0; i < H.size(); ++i)
-    H[i]->evaluateWithIonDerivs(P, ions, psi, hf_term, pulay_terms);
+    H[i]->evaluateIonDerivs(P, ions, psi, hf_term, pulay_terms);
 
   for (int iat = 0; iat < ions.getTotalNum(); iat++)
   {
@@ -1180,7 +1180,7 @@ void QMCHamiltonian::evaluateIonDerivsFast(ParticleSet& P,
     if (H[i]->dependsOnWaveFunction())
       H[i]->evaluateOneBodyOpMatrix(P, psi_wrapper_in, B_);
     else
-      H[i]->evaluateWithIonDerivs(P, ions, psi_in, hfdiag_, pulayterms_);
+      H[i]->evaluateIonDerivs(P, ions, psi_in, hfdiag_, pulayterms_);
 
 
   {

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -296,7 +296,7 @@ public:
   * @param wf_grad  Re (dPsi/Psi)
   * @return Local Energy.
   */
-  FullPrecRealType evaluateIonDerivsDeterministicFast(ParticleSet& P,
+  void evaluateIonDerivsDeterministicFast(ParticleSet& P,
                                                       ParticleSet& ions,
                                                       TrialWaveFunction& psi_in,
                                                       TWFFastDerivWrapper& psi_wrapper,
@@ -321,7 +321,7 @@ public:
   * @param wf_grad  Re (dPsi/Psi)
   * @return Local Energy.
   */
-  FullPrecRealType evaluateIonDerivsDeterministic(ParticleSet& P,
+  void evaluateIonDerivsDeterministic(ParticleSet& P,
                                                   ParticleSet& ions,
                                                   TrialWaveFunction& psi,
                                                   ParticleSet::ParticlePos& hf_terms,

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -319,7 +319,6 @@ public:
   * @param hf_terms  Re [(dH)Psi]/Psi
   * @param pulay_terms Re [(H-E_L)dPsi]/Psi 
   * @param wf_grad  Re (dPsi/Psi)
-  * @return Local Energy.
   */
   void evaluateIonDerivs(ParticleSet& P,
                          ParticleSet& ions,

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -296,12 +296,12 @@ public:
   * @param wf_grad  Re (dPsi/Psi)
   * @return Local Energy.
   */
-  void evaluateIonDerivsDeterministicFast(ParticleSet& P,
-                                                      ParticleSet& ions,
-                                                      TrialWaveFunction& psi_in,
-                                                      TWFFastDerivWrapper& psi_wrapper,
-                                                      ParticleSet::ParticlePos& dedr,
-                                                      ParticleSet::ParticlePos& wf_grad);
+  void evaluateIonDerivsFast(ParticleSet& P,
+                             ParticleSet& ions,
+                             TrialWaveFunction& psi_in,
+                             TWFFastDerivWrapper& psi_wrapper,
+                             ParticleSet::ParticlePos& dedr,
+                             ParticleSet::ParticlePos& wf_grad);
 
   /** Evaluate the electron gradient of the local energy.
   * @param psi Trial Wave Function
@@ -321,12 +321,12 @@ public:
   * @param wf_grad  Re (dPsi/Psi)
   * @return Local Energy.
   */
-  void evaluateIonDerivsDeterministic(ParticleSet& P,
-                                                  ParticleSet& ions,
-                                                  TrialWaveFunction& psi,
-                                                  ParticleSet::ParticlePos& hf_terms,
-                                                  ParticleSet::ParticlePos& pulay_terms,
-                                                  ParticleSet::ParticlePos& wf_grad);
+  void evaluateIonDerivs(ParticleSet& P,
+                         ParticleSet& ions,
+                         TrialWaveFunction& psi,
+                         ParticleSet::ParticlePos& hf_terms,
+                         ParticleSet::ParticlePos& pulay_terms,
+                         ParticleSet::ParticlePos& wf_grad);
   /** set non local moves options
    * @param cur the xml input
    */

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -312,23 +312,7 @@ public:
   */
   void evaluateElecGrad(ParticleSet& P, TrialWaveFunction& psi, ParticleSet::ParticlePos& EGrad, RealType delta = 1e-5);
 
-  /** evaluate local energy and derivatives w.r.t ionic coordinates.  
-  * @param P target particle set (electrons)
-  * @param ions source particle set (ions)
-  * @param psi Trial wave function
-  * @param hf_terms  Re [(dH)Psi]/Psi
-  * @param pulay_terms Re [(H-E_L)dPsi]/Psi 
-  * @param wf_grad  Re (dPsi/Psi)
-  * @return Local Energy.
-  */
-  FullPrecRealType evaluateIonDerivs(ParticleSet& P,
-                                     ParticleSet& ions,
-                                     TrialWaveFunction& psi,
-                                     ParticleSet::ParticlePos& hf_terms,
-                                     ParticleSet::ParticlePos& pulay_terms,
-                                     ParticleSet::ParticlePos& wf_grad);
-
-  /** evaluate local energy and derivatives w.r.t ionic coordinates, but deterministically.  
+  /** evaluate local energy and derivatives w.r.t ionic coordinates without randomizing the quadrature point grid.
   * @param P target particle set (electrons)
   * @param ions source particle set (ions)
   * @param psi Trial wave function

--- a/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
+++ b/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
@@ -209,9 +209,8 @@ TEST_CASE("Bare KE Pulay PBC", "[hamiltonian]")
   HFTerm.resize(ions.getTotalNum());
   PulayTerm.resize(ions.getTotalNum());
 
-  RealType keval2 = bare_ke.evaluateWithIonDerivs(elec, ions, psi, HFTerm, PulayTerm);
+  bare_ke.evaluateIonDerivs(elec, ions, psi, HFTerm, PulayTerm);
 
-  CHECK(keval2 == Approx(-0.147507745));
   //These are validated against finite differences (delta=1e-6).
   CHECK(PulayTerm[0][0] == Approx(-0.13166));
   CHECK(PulayTerm[0][1] == Approx(0.0));

--- a/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
+++ b/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
@@ -209,7 +209,7 @@ TEST_CASE("Bare KE Pulay PBC", "[hamiltonian]")
   HFTerm.resize(ions.getTotalNum());
   PulayTerm.resize(ions.getTotalNum());
 
-  RealType keval2 = bare_ke.evaluateWithIonDerivs(elec, ions, psi, HFTerm, PulayTerm);
+  RealType keval2 = bare_ke.evaluateWithIonDerivsDeterministic(elec, ions, psi, HFTerm, PulayTerm);
 
   CHECK(keval2 == Approx(-0.147507745));
   //These are validated against finite differences (delta=1e-6).

--- a/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
+++ b/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
@@ -209,7 +209,7 @@ TEST_CASE("Bare KE Pulay PBC", "[hamiltonian]")
   HFTerm.resize(ions.getTotalNum());
   PulayTerm.resize(ions.getTotalNum());
 
-  RealType keval2 = bare_ke.evaluateWithIonDerivsDeterministic(elec, ions, psi, HFTerm, PulayTerm);
+  RealType keval2 = bare_ke.evaluateWithIonDerivs(elec, ions, psi, HFTerm, PulayTerm);
 
   CHECK(keval2 == Approx(-0.147507745));
   //These are validated against finite differences (delta=1e-6).

--- a/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
+++ b/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
@@ -201,15 +201,16 @@ TEST_CASE("Bare KE Pulay PBC", "[hamiltonian]")
   RealType logpsi = psi.evaluateLog(elec);
 
   RealType keval = bare_ke.evaluate(elec);
-
   //This is validated against an alternate code path (waveefunction tester for local energy).
   CHECK(keval == Approx(-0.147507745));
+  CHECK(keval == Approx(bare_ke.getValue()));
 
   ParticleSet::ParticlePos HFTerm, PulayTerm;
   HFTerm.resize(ions.getTotalNum());
   PulayTerm.resize(ions.getTotalNum());
 
   bare_ke.evaluateIonDerivs(elec, ions, psi, HFTerm, PulayTerm);
+  CHECK(keval == Approx(bare_ke.getValue()));
 
   //These are validated against finite differences (delta=1e-6).
   CHECK(PulayTerm[0][0] == Approx(-0.13166));

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -220,7 +220,7 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
   ions3.createSK();
   ions3.resetGroups();
 
-  // Namely, sending in incompatible force arrays to evaluateWithIonDerivs is not
+  // Namely, sending in incompatible force arrays to evaluateWithIonDerivsDeterministic is not
   // supposed to do harm, IF
   // 1) forces are not enabled
   CoulombPBCAA noIonForce(ions3, false, false, false);
@@ -234,9 +234,9 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
   // Probably fine for a test but if this type of behavior was needed in
   // production code in the future, a different solution would be needed.
   auto noElecForces = noElecForce.getForces();
-  noIonForce.evaluateWithIonDerivs(ions3, ions3, psi, noElecForces, noElecForces);
+  noIonForce.evaluateWithIonDerivsDeterministic(ions3, ions3, psi, noElecForces, noElecForces);
   auto noIonForces = noIonForce.getForces();
-  noElecForce.evaluateWithIonDerivs(elec, ions3, psi, noIonForces, noIonForces);
+  noElecForce.evaluateWithIonDerivsDeterministic(elec, ions3, psi, noIonForces, noIonForces);
 
   // It seems a bit silly to test the makeClone method
   // but this class does not use the compiler's copy constructor and

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -220,7 +220,7 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
   ions3.createSK();
   ions3.resetGroups();
 
-  // Namely, sending in incompatible force arrays to evaluateWithIonDerivs is not
+  // Namely, sending in incompatible force arrays to evaluateIonDerivs is not
   // supposed to do harm, IF
   // 1) forces are not enabled
   CoulombPBCAA noIonForce(ions3, false, false, false);
@@ -234,9 +234,9 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
   // Probably fine for a test but if this type of behavior was needed in
   // production code in the future, a different solution would be needed.
   auto noElecForces = noElecForce.getForces();
-  noIonForce.evaluateWithIonDerivs(ions3, ions3, psi, noElecForces, noElecForces);
+  noIonForce.evaluateIonDerivs(ions3, ions3, psi, noElecForces, noElecForces);
   auto noIonForces = noIonForce.getForces();
-  noElecForce.evaluateWithIonDerivs(elec, ions3, psi, noIonForces, noIonForces);
+  noElecForce.evaluateIonDerivs(elec, ions3, psi, noIonForces, noIonForces);
 
   // It seems a bit silly to test the makeClone method
   // but this class does not use the compiler's copy constructor and

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -220,7 +220,7 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
   ions3.createSK();
   ions3.resetGroups();
 
-  // Namely, sending in incompatible force arrays to evaluateWithIonDerivsDeterministic is not
+  // Namely, sending in incompatible force arrays to evaluateWithIonDerivs is not
   // supposed to do harm, IF
   // 1) forces are not enabled
   CoulombPBCAA noIonForce(ions3, false, false, false);
@@ -234,9 +234,9 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
   // Probably fine for a test but if this type of behavior was needed in
   // production code in the future, a different solution would be needed.
   auto noElecForces = noElecForce.getForces();
-  noIonForce.evaluateWithIonDerivsDeterministic(ions3, ions3, psi, noElecForces, noElecForces);
+  noIonForce.evaluateWithIonDerivs(ions3, ions3, psi, noElecForces, noElecForces);
   auto noIonForces = noIonForce.getForces();
-  noElecForce.evaluateWithIonDerivsDeterministic(elec, ions3, psi, noIonForces, noIonForces);
+  noElecForce.evaluateWithIonDerivs(elec, ions3, psi, noIonForces, noIonForces);
 
   // It seems a bit silly to test the makeClone method
   // but this class does not use the compiler's copy constructor and

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -312,21 +312,6 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   CHECK(dot(hf_term[1], hf_term[1]) != Approx(0));
   CHECK(dot(pulay_term[1], pulay_term[1]) != Approx(0));
   CHECK(dot(wf_grad[1], wf_grad[1]) != Approx(0));
-
-  hf_term    = 0.0;
-  pulay_term = 0.0;
-  wf_grad    = 0.0;
-  RandomGenerator myrng;
-  ham.setRandomGenerator(&myrng);
-  ham.evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term, wf_grad);
-
-  CHECK(dot(hf_term[0], hf_term[0]) != Approx(0));
-  CHECK(dot(pulay_term[0], pulay_term[0]) != Approx(0));
-  CHECK(dot(wf_grad[0], wf_grad[0]) != Approx(0));
-
-  CHECK(dot(hf_term[1], hf_term[1]) != Approx(0));
-  CHECK(dot(pulay_term[1], pulay_term[1]) != Approx(0));
-  CHECK(dot(wf_grad[1], wf_grad[1]) != Approx(0));
 }
 
 TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
@@ -472,21 +457,6 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   pulay_term = 0.0;
   wf_grad    = 0.0;
   ham.evaluateIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term, wf_grad);
-
-  CHECK(dot(hf_term[0], hf_term[0]) != Approx(0));
-  CHECK(dot(pulay_term[0], pulay_term[0]) != Approx(0));
-  CHECK(dot(wf_grad[0], wf_grad[0]) != Approx(0));
-
-  CHECK(dot(hf_term[1], hf_term[1]) != Approx(0));
-  CHECK(dot(pulay_term[1], pulay_term[1]) != Approx(0));
-  CHECK(dot(wf_grad[1], wf_grad[1]) != Approx(0));
-
-  hf_term    = 0.0;
-  pulay_term = 0.0;
-  wf_grad    = 0.0;
-  RandomGenerator myrng;
-  ham.setRandomGenerator(&myrng);
-  ham.evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term, wf_grad);
 
   CHECK(dot(hf_term[0], hf_term[0]) != Approx(0));
   CHECK(dot(pulay_term[0], pulay_term[0]) != Approx(0));
@@ -1776,22 +1746,6 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   CHECK(dot(hf_term[1],hf_term[1]) != Approx(0));
   CHECK(dot(pulay_term[1],pulay_term[1]) != Approx(0));
   CHECK(dot(wf_grad[1],wf_grad[1]) != Approx(0));
- 
-  hf_term    = 0.0;
-  pulay_term = 0.0;
-  wf_grad    = 0.0;
-  RandomGenerator myrng;
-  ham.setRandomGenerator(&myrng);
-  ham.evaluateIonDerivs(elec,ions,*psi,hf_term,pulay_term,wf_grad);
-  
-  CHECK(dot(hf_term[0],hf_term[0]) != Approx(0));
-  CHECK(dot(pulay_term[0],pulay_term[0]) != Approx(0));
-  CHECK(dot(wf_grad[0],wf_grad[0]) != Approx(0));
- 
-  CHECK(dot(hf_term[1],hf_term[1]) != Approx(0));
-  CHECK(dot(pulay_term[1],pulay_term[1]) != Approx(0));
-  CHECK(dot(wf_grad[1],wf_grad[1]) != Approx(0));
- 
 }*/
 
 /*TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -256,9 +256,12 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   CHECK(wf_grad[1][2] == Approx(0.1440176276013005));
 
   //Kinetic Force
-  hf_term    = 0.0;
-  pulay_term = 0.0;
-  (ham.getHamiltonian(KINETIC))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  hf_term       = 0.0;
+  pulay_term    = 0.0;
+  auto& ham_ke  = *ham.getHamiltonian(KINETIC);
+  auto ke_saved = ham_ke.getValue();
+  ham_ke.evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  CHECK(ke_saved == Approx(ham_ke.getValue()));
 #if defined(MIXED_PRECISION)
   CHECK(hf_term[0][0] + pulay_term[0][0] == Approx(1.0852823603357820).epsilon(1e-4));
   CHECK(hf_term[0][1] + pulay_term[0][1] == Approx(24.2154119471038562).epsilon(1e-4));
@@ -275,9 +278,12 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   CHECK(hf_term[1][2] + pulay_term[1][2] == Approx(7.5625192454964454));
 #endif
   //NLPP Force
-  hf_term    = 0.0;
-  pulay_term = 0.0;
-  (ham.getHamiltonian(NONLOCALECP))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  hf_term               = 0.0;
+  pulay_term            = 0.0;
+  auto& ham_nonlocalpp  = *ham.getHamiltonian(NONLOCALECP);
+  auto nonlocalpp_saved = ham_nonlocalpp.getValue();
+  ham_nonlocalpp.evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  CHECK(nonlocalpp_saved == Approx(ham_nonlocalpp.getValue()));
 
 //MP fails the first REQUIRE with 24.22544.  Just bypass the checks in those builds.
 #if defined(MIXED_PRECISION)
@@ -409,9 +415,12 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   CHECK(wf_grad[1][2] == Approx(-1.5197874544625731));
 
   //Kinetic Force
-  hf_term    = 0.0;
-  pulay_term = 0.0;
-  (ham.getHamiltonian(KINETIC))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  hf_term       = 0.0;
+  pulay_term    = 0.0;
+  auto& ham_ke  = *ham.getHamiltonian(KINETIC);
+  auto ke_saved = ham_ke.getValue();
+  ham_ke.evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  CHECK(ke_saved == Approx(ham_ke.getValue()));
 #if defined(MIXED_PRECISION)
   CHECK(hf_term[0][0] + pulay_term[0][0] == Approx(-3.3359153349010735).epsilon(1e-4));
   CHECK(hf_term[0][1] + pulay_term[0][1] == Approx(30.0487085581835309).epsilon(1e-4));
@@ -427,10 +436,20 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   CHECK(hf_term[1][1] + pulay_term[1][1] == Approx(-3.5321234918228579));
   CHECK(hf_term[1][2] + pulay_term[1][2] == Approx(5.8844148870917925));
 #endif
+
+  //Local PP Force
+  auto& ham_localpp  = *ham.getHamiltonian(LOCALECP);
+  auto localpp_saved = ham_localpp.getValue();
+  ham_localpp.evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  CHECK(localpp_saved == Approx(ham_localpp.getValue()));
+
   //NLPP Force
-  hf_term    = 0.0;
-  pulay_term = 0.0;
-  (ham.getHamiltonian(NONLOCALECP))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  hf_term               = 0.0;
+  pulay_term            = 0.0;
+  auto& ham_nonlocalpp  = *ham.getHamiltonian(NONLOCALECP);
+  auto nonlocalpp_saved = ham_nonlocalpp.getValue();
+  ham_nonlocalpp.evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  CHECK(nonlocalpp_saved == Approx(ham_nonlocalpp.getValue()));
 //MP fails the first REQUIRE with 27.15313.  Just bypass the checks in those builds.
 #if defined(MIXED_PRECISION)
   CHECK(hf_term[0][0] + pulay_term[0][0] == Approx(27.1517161490208956).epsilon(2e-4));

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -258,7 +258,7 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   //Kinetic Force
   hf_term    = 0.0;
   pulay_term = 0.0;
-  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION)
   CHECK(hf_term[0][0] + pulay_term[0][0] == Approx(1.0852823603357820).epsilon(1e-4));
   CHECK(hf_term[0][1] + pulay_term[0][1] == Approx(24.2154119471038562).epsilon(1e-4));
@@ -277,8 +277,7 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   //NLPP Force
   hf_term    = 0.0;
   pulay_term = 0.0;
-  double val =
-      (ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+  double val = (ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 
 //MP fails the first REQUIRE with 24.22544.  Just bypass the checks in those builds.
 #if defined(MIXED_PRECISION)
@@ -412,7 +411,7 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   //Kinetic Force
   hf_term    = 0.0;
   pulay_term = 0.0;
-  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION)
   CHECK(hf_term[0][0] + pulay_term[0][0] == Approx(-3.3359153349010735).epsilon(1e-4));
   CHECK(hf_term[0][1] + pulay_term[0][1] == Approx(30.0487085581835309).epsilon(1e-4));
@@ -431,8 +430,7 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   //NLPP Force
   hf_term    = 0.0;
   pulay_term = 0.0;
-  double val =
-      (ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+  double val = (ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 //MP fails the first REQUIRE with 27.15313.  Just bypass the checks in those builds.
 #if defined(MIXED_PRECISION)
   CHECK(hf_term[0][0] + pulay_term[0][0] == Approx(27.1517161490208956).epsilon(2e-4));
@@ -568,7 +566,7 @@ TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")
   //Kinetic Force
   /*  hf_term=0.0;
   pulay_term=0.0;
-  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION) 
   CHECK( hf_term[0][0]+pulay_term[0][0] == Approx( 7.4631825180304636).epsilon(1e-4));
   CHECK( hf_term[0][1]+pulay_term[0][1] == Approx( 26.0975954772035799).epsilon(1e-4));
@@ -588,7 +586,7 @@ TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")
   //NLPP Force
   /*  hf_term=0.0;
   pulay_term=0.0;
-  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION)
   CHECK( hf_term[0][0]+pulay_term[0][0] == Approx( 18.9414437404167302).epsilon(2e-4));
   CHECK( hf_term[0][1]+pulay_term[0][1] == Approx(-42.9017371899931277).epsilon(2e-4));
@@ -707,7 +705,7 @@ TEST_CASE("Eloc_Derivatives:multislater_wj", "[hamiltonian]")
   //Kinetic Force
   /*  hf_term=0.0;
   pulay_term=0.0;
-  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION)
   CHECK( hf_term[0][0]+pulay_term[0][0] == Approx(  4.1783687883878429).epsilon(1e-4));
   CHECK( hf_term[0][1]+pulay_term[0][1] == Approx( 32.2193450745800192).epsilon(1e-4));
@@ -727,7 +725,7 @@ TEST_CASE("Eloc_Derivatives:multislater_wj", "[hamiltonian]")
   //NLPP Force
   /*  hf_term=0.0;
   pulay_term=0.0;
-  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION)
   CHECK( hf_term[0][0]+pulay_term[0][0] == Approx( 21.6829856774403140).epsilon(2e-4));
   CHECK( hf_term[0][1]+pulay_term[0][1] == Approx(-43.4432406419382673).epsilon(2e-4));
@@ -1693,7 +1691,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   //Kinetic Force
   hf_term    = 0.0;
   pulay_term = 0.0;
-  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION)
   CHECK(hf_term[0][0] + pulay_term[0][0] == Approx(-3.3359153349010735).epsilon(1e-4));
   CHECK(hf_term[0][1] + pulay_term[0][1] == Approx(30.0487085581835309).epsilon(1e-4));
@@ -1713,7 +1711,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   hf_term    = 0.0;
   pulay_term = 0.0;
   double val =
-      (ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+      (ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 //MP fails the first CHECK with 27.15313.  Just bypass the checks in those builds.
 #if defined(MIXED_PRECISION)
   CHECK(hf_term[0][0] + pulay_term[0][0] == Approx(27.1517161490208956).epsilon(2e-4));
@@ -1865,7 +1863,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   //Kinetic Force
   //hf_term=0.0;
   //pulay_term=0.0;
-  //(ham.getHamiltonian(KINETIC))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+  //(ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 //#if defined(MIXED_PRECISION) 
   //CHECK( hf_term[0][0]+pulay_term[0][0] == Approx( 7.4631825180304636).epsilon(1e-4));
   //CHECK( hf_term[0][1]+pulay_term[0][1] == Approx( 26.0975954772035799).epsilon(1e-4));
@@ -1885,7 +1883,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   //NLPP Force
  // hf_term=0.0;
 //  pulay_term=0.0;
-//  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+//  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 //#if defined(MIXED_PRECISION)
 //  CHECK( hf_term[0][0]+pulay_term[0][0] == Approx( 18.9414437404167302).epsilon(2e-4));
 //  CHECK( hf_term[0][1]+pulay_term[0][1] == Approx(-42.9017371899931277).epsilon(2e-4));
@@ -2020,7 +2018,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   //Kinetic Force
 //  hf_term=0.0;
 //  pulay_term=0.0;
-//  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+//  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 //#if defined(MIXED_PRECISION)
 //  CHECK( hf_term[0][0]+pulay_term[0][0] == Approx(  4.1783687883878429).epsilon(1e-4));
 //  CHECK( hf_term[0][1]+pulay_term[0][1] == Approx( 32.2193450745800192).epsilon(1e-4));
@@ -2040,7 +2038,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   //NLPP Force
 //  hf_term=0.0;
 //  pulay_term=0.0;
-//  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term);
+//  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 //#if defined(MIXED_PRECISION)
 //  CHECK( hf_term[0][0]+pulay_term[0][0] == Approx( 21.6829856774403140).epsilon(2e-4));
 //  CHECK( hf_term[0][1]+pulay_term[0][1] == Approx(-43.4432406419382673).epsilon(2e-4));

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -258,7 +258,7 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   //Kinetic Force
   hf_term    = 0.0;
   pulay_term = 0.0;
-  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  (ham.getHamiltonian(KINETIC))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION)
   CHECK(hf_term[0][0] + pulay_term[0][0] == Approx(1.0852823603357820).epsilon(1e-4));
   CHECK(hf_term[0][1] + pulay_term[0][1] == Approx(24.2154119471038562).epsilon(1e-4));
@@ -277,7 +277,7 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   //NLPP Force
   hf_term    = 0.0;
   pulay_term = 0.0;
-  double val = (ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  (ham.getHamiltonian(NONLOCALECP))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 
 //MP fails the first REQUIRE with 24.22544.  Just bypass the checks in those builds.
 #if defined(MIXED_PRECISION)
@@ -411,7 +411,7 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   //Kinetic Force
   hf_term    = 0.0;
   pulay_term = 0.0;
-  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  (ham.getHamiltonian(KINETIC))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION)
   CHECK(hf_term[0][0] + pulay_term[0][0] == Approx(-3.3359153349010735).epsilon(1e-4));
   CHECK(hf_term[0][1] + pulay_term[0][1] == Approx(30.0487085581835309).epsilon(1e-4));
@@ -430,7 +430,7 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   //NLPP Force
   hf_term    = 0.0;
   pulay_term = 0.0;
-  double val = (ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  (ham.getHamiltonian(NONLOCALECP))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 //MP fails the first REQUIRE with 27.15313.  Just bypass the checks in those builds.
 #if defined(MIXED_PRECISION)
   CHECK(hf_term[0][0] + pulay_term[0][0] == Approx(27.1517161490208956).epsilon(2e-4));
@@ -566,7 +566,7 @@ TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")
   //Kinetic Force
   /*  hf_term=0.0;
   pulay_term=0.0;
-  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  (ham.getHamiltonian(KINETIC))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION) 
   CHECK( hf_term[0][0]+pulay_term[0][0] == Approx( 7.4631825180304636).epsilon(1e-4));
   CHECK( hf_term[0][1]+pulay_term[0][1] == Approx( 26.0975954772035799).epsilon(1e-4));
@@ -586,7 +586,7 @@ TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")
   //NLPP Force
   /*  hf_term=0.0;
   pulay_term=0.0;
-  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION)
   CHECK( hf_term[0][0]+pulay_term[0][0] == Approx( 18.9414437404167302).epsilon(2e-4));
   CHECK( hf_term[0][1]+pulay_term[0][1] == Approx(-42.9017371899931277).epsilon(2e-4));
@@ -705,7 +705,7 @@ TEST_CASE("Eloc_Derivatives:multislater_wj", "[hamiltonian]")
   //Kinetic Force
   /*  hf_term=0.0;
   pulay_term=0.0;
-  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  (ham.getHamiltonian(KINETIC))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION)
   CHECK( hf_term[0][0]+pulay_term[0][0] == Approx(  4.1783687883878429).epsilon(1e-4));
   CHECK( hf_term[0][1]+pulay_term[0][1] == Approx( 32.2193450745800192).epsilon(1e-4));
@@ -725,7 +725,7 @@ TEST_CASE("Eloc_Derivatives:multislater_wj", "[hamiltonian]")
   //NLPP Force
   /*  hf_term=0.0;
   pulay_term=0.0;
-  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION)
   CHECK( hf_term[0][0]+pulay_term[0][0] == Approx( 21.6829856774403140).epsilon(2e-4));
   CHECK( hf_term[0][1]+pulay_term[0][1] == Approx(-43.4432406419382673).epsilon(2e-4));
@@ -1691,7 +1691,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   //Kinetic Force
   hf_term    = 0.0;
   pulay_term = 0.0;
-  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  (ham.getHamiltonian(KINETIC))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 #if defined(MIXED_PRECISION)
   CHECK(hf_term[0][0] + pulay_term[0][0] == Approx(-3.3359153349010735).epsilon(1e-4));
   CHECK(hf_term[0][1] + pulay_term[0][1] == Approx(30.0487085581835309).epsilon(1e-4));
@@ -1711,7 +1711,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   hf_term    = 0.0;
   pulay_term = 0.0;
   double val =
-      (ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+      (ham.getHamiltonian(NONLOCALECP))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 //MP fails the first CHECK with 27.15313.  Just bypass the checks in those builds.
 #if defined(MIXED_PRECISION)
   CHECK(hf_term[0][0] + pulay_term[0][0] == Approx(27.1517161490208956).epsilon(2e-4));
@@ -1863,7 +1863,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   //Kinetic Force
   //hf_term=0.0;
   //pulay_term=0.0;
-  //(ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+  //(ham.getHamiltonian(KINETIC))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 //#if defined(MIXED_PRECISION) 
   //CHECK( hf_term[0][0]+pulay_term[0][0] == Approx( 7.4631825180304636).epsilon(1e-4));
   //CHECK( hf_term[0][1]+pulay_term[0][1] == Approx( 26.0975954772035799).epsilon(1e-4));
@@ -1883,7 +1883,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   //NLPP Force
  // hf_term=0.0;
 //  pulay_term=0.0;
-//  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+//  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 //#if defined(MIXED_PRECISION)
 //  CHECK( hf_term[0][0]+pulay_term[0][0] == Approx( 18.9414437404167302).epsilon(2e-4));
 //  CHECK( hf_term[0][1]+pulay_term[0][1] == Approx(-42.9017371899931277).epsilon(2e-4));
@@ -2018,7 +2018,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   //Kinetic Force
 //  hf_term=0.0;
 //  pulay_term=0.0;
-//  (ham.getHamiltonian(KINETIC))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+//  (ham.getHamiltonian(KINETIC))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 //#if defined(MIXED_PRECISION)
 //  CHECK( hf_term[0][0]+pulay_term[0][0] == Approx(  4.1783687883878429).epsilon(1e-4));
 //  CHECK( hf_term[0][1]+pulay_term[0][1] == Approx( 32.2193450745800192).epsilon(1e-4));
@@ -2038,7 +2038,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   //NLPP Force
 //  hf_term=0.0;
 //  pulay_term=0.0;
-//  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateWithIonDerivs(elec, ions, *psi, hf_term, pulay_term);
+//  double val=(ham.getHamiltonian(NONLOCALECP))->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term);
 //#if defined(MIXED_PRECISION)
 //  CHECK( hf_term[0][0]+pulay_term[0][0] == Approx( 21.6829856774403140).epsilon(2e-4));
 //  CHECK( hf_term[0][1]+pulay_term[0][1] == Approx(-43.4432406419382673).epsilon(2e-4));

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -296,13 +296,13 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   CHECK(hf_term[1][2] + pulay_term[1][2] == Approx(-5.2293234395150989));
 #endif
 
-  //End of deterministic tests.  Let's call evaluateIonDerivs and evaluateIonDerivsDeterministic at the
+  //End of deterministic tests.  Let's call evaluateIonDerivs and evaluateIonDerivs at the
   //QMCHamiltonian level to make sure there are no crashes.
 
   hf_term    = 0.0;
   pulay_term = 0.0;
   wf_grad    = 0.0;
-  ham.evaluateIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term, wf_grad);
+  ham.evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term, wf_grad);
 
   CHECK(dot(hf_term[0], hf_term[0]) != Approx(0));
   CHECK(dot(pulay_term[0], pulay_term[0]) != Approx(0));
@@ -448,13 +448,13 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   CHECK(hf_term[1][2] + pulay_term[1][2] == Approx(-4.5825638607333019));
 #endif
 
-  //End of deterministic tests.  Let's call evaluateIonDerivs and evaluateIonDerivsDeterministic at the
+  //End of deterministic tests.  Let's call evaluateIonDerivs and evaluateIonDerivs at the
   //QMCHamiltonian level to make sure there are no crashes.
 
   hf_term    = 0.0;
   pulay_term = 0.0;
   wf_grad    = 0.0;
-  ham.evaluateIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term, wf_grad);
+  ham.evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term, wf_grad);
 
   CHECK(dot(hf_term[0], hf_term[0]) != Approx(0));
   CHECK(dot(pulay_term[0], pulay_term[0]) != Approx(0));
@@ -1264,7 +1264,7 @@ TEST_CASE("Eloc_Derivatives:proto_sd_wj", "[hamiltonian]")
   //This is to test the fast force API in QMCHamiltonian.
   ParticleSet::ParticlePos dedr(ions.getTotalNum());
   ParticleSet::ParticlePos dpsidr(ions.getTotalNum());
-  ham.evaluateIonDerivsDeterministicFast(elec, ions, *psi, twf, dedr, dpsidr);
+  ham.evaluateIonDerivsFast(elec, ions, *psi, twf, dedr, dpsidr);
 }
 
 //This will be very similar to the previous tests, but we will check its behavior
@@ -1574,7 +1574,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   CHECK(fnlpp[1][2] == Approx(0.0252567500));
 #endif
 
-  //  ham.evaluateIonDerivsDeterministicFast(elec, ions, *psi, twf,hf_term, wf_grad);*/
+  //  ham.evaluateIonDerivsFast(elec, ions, *psi, twf,hf_term, wf_grad);*/
 }
 #endif
 /*TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
@@ -1729,13 +1729,13 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
   CHECK(hf_term[1][2] + pulay_term[1][2] == Approx(-4.5825638607333019));
 #endif
 
- //End of deterministic tests.  Let's call evaluateIonDerivs and evaluateIonDerivsDeterministic at the
+ //End of deterministic tests.  Let's call evaluateIonDerivs and evaluateIonDerivs at the
  //QMCHamiltonian level to make sure there are no crashes.  
  
   hf_term    = 0.0;
   pulay_term = 0.0;
   wf_grad    = 0.0;
-  ham.evaluateIonDerivsDeterministic(elec,ions,*psi,hf_term,pulay_term,wf_grad);
+  ham.evaluateIonDerivs(elec,ions,*psi,hf_term,pulay_term,wf_grad);
  
   CHECK(dot(hf_term[0],hf_term[0]) != Approx(0));
   CHECK(dot(pulay_term[0],pulay_term[0]) != Approx(0));


### PR DESCRIPTION
## Proposed changes
Under the assumption that the force is evaluated after energy.
1. There is no need to recompute/return energy during a derivative calculation. Thus name `H::evaluateWithIonDerivs` to `H::evaluateIonDerivs` with the return value removed.
2. No need to keep versions that randomize quadrature grid. Thus remove the non-deterministic variants and remove `Deterministic` in the function names, all the APIs are deterministic.

## What type(s) of changes does this code introduce?
- Other (please describe): remove unused and simplify existing code paths. 

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'