### PR TITLE
explicitly passing Tmove data as an argument to NonLocalECPComponent::evaluateOne

### DIFF
--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -22,7 +22,9 @@
 
 namespace qmcplusplus
 {
-NonLocalECPComponent::NonLocalECPComponent() : lmax(0), nchannel(0), nknot(0), Rmax(-1), VP(nullptr), do_randomize_grid_(true) {}
+NonLocalECPComponent::NonLocalECPComponent()
+    : lmax(0), nchannel(0), nknot(0), Rmax(-1), VP(nullptr), do_randomize_grid_(true)
+{}
 
 // unfortunately we continue the sloppy use of the default copy constructor followed by reassigning pointers.
 // This prevents use of smart pointers and concievably sets us up for trouble with double frees and the destructor.
@@ -43,10 +45,7 @@ NonLocalECPComponent::~NonLocalECPComponent()
     delete VP;
 }
 
-void NonLocalECPComponent::set_randomize_grid(bool do_randomize_grid)
-{
-  do_randomize_grid_ = do_randomize_grid;
-}
+void NonLocalECPComponent::set_randomize_grid(bool do_randomize_grid) { do_randomize_grid_ = do_randomize_grid; }
 
 void NonLocalECPComponent::initVirtualParticle(const ParticleSet& qp)
 {
@@ -133,6 +132,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOne(ParticleSet& W,
                                                                  int iel,
                                                                  RealType r,
                                                                  const PosType& dr,
+                                                                 const OptionalRef<std::vector<NonLocalData>> tmove_xy,
                                                                  bool use_DLA)
 {
   buildQuadraturePointDeltaPositions(r, dr, deltaV);
@@ -161,7 +161,12 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOne(ParticleSet& W,
     }
   }
 
-  return calculateProjector(r, dr);
+  const auto pairpot = calculateProjector(r, dr);
+
+  if (tmove_xy)
+    contributeTxy(iel, *tmove_xy);
+
+  return pairpot;
 }
 
 NonLocalECPComponent::RealType NonLocalECPComponent::calculateProjector(RealType r, const PosType& dr)
@@ -857,7 +862,7 @@ void NonLocalECPComponent::evaluateOneBodyOpMatrixdRContribution(ParticleSet& W,
       for (int iorb = 0; iorb < norbs; iorb++)
       {
         //this is for diagonal case.
-        //The GradType is necessary here, since rrotsgrid_m is real.  This dot() will only return the real part in this case.  
+        //The GradType is necessary here, since rrotsgrid_m is real.  This dot() will only return the real part in this case.
         //Does correct thing if both entries are complex.
         udotgradpsimat[j][iorb] = dot(gradphimat[j][iorb], GradType(rrotsgrid_m[j]));
         wfgradmat[j][iorb]      = gradphimat[j][iorb] - dr * (udotgradpsimat[j][iorb] * rinv);

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -17,7 +17,6 @@
 #ifndef QMCPLUSPLUS_NONLOCAL_ECPOTENTIAL_COMPONENT_H
 #define QMCPLUSPLUS_NONLOCAL_ECPOTENTIAL_COMPONENT_H
 
-#include <optional>
 #include "type_traits/OptionalRef.hpp"
 #include "QMCHamiltonians/OperatorBase.h"
 #include "QMCHamiltonians/RandomRotationMatrix.h"

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -16,6 +16,9 @@
 
 #ifndef QMCPLUSPLUS_NONLOCAL_ECPOTENTIAL_COMPONENT_H
 #define QMCPLUSPLUS_NONLOCAL_ECPOTENTIAL_COMPONENT_H
+
+#include <optional>
+#include "type_traits/OptionalRef.hpp"
 #include "QMCHamiltonians/OperatorBase.h"
 #include "QMCHamiltonians/RandomRotationMatrix.h"
 #include <ResourceCollection.h>
@@ -175,6 +178,7 @@ public:
                        int iel,
                        RealType r,
                        const PosType& dr,
+                       const OptionalRef<std::vector<NonLocalData>> tmove_xy,
                        bool use_DLA);
 
   /** @brief Evaluate the nonlocal pp contribution via randomized quadrature grid

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -175,7 +175,7 @@ void NonLocalECPotential::mw_evaluatePerParticleWithToperator(
 void NonLocalECPotential::evaluateImpl(ParticleSet& P, bool Tmove, bool keep_grid)
 {
   if (Tmove)
-    tmove_xy_.clear();
+    tmove_xy_all_.clear();
 
   value_ = 0.0;
 #if !defined(REMOVE_TRACEMANAGER)
@@ -216,7 +216,7 @@ void NonLocalECPotential::evaluateImpl(ParticleSet& P, bool Tmove, bool keep_gri
           {
             Real pairpot = PP[iat]->evaluateOneWithForces(P, iat, Psi, jel, dist[iat], -displ[iat], forces_[iat]);
             if (Tmove)
-              PP[iat]->contributeTxy(jel, tmove_xy_);
+              PP[iat]->contributeTxy(jel, tmove_xy_all_);
             value_ += pairpot;
             NeighborIons.push_back(iat);
             IonNeighborElecs.getNeighborList(iat).push_back(jel);
@@ -239,7 +239,7 @@ void NonLocalECPotential::evaluateImpl(ParticleSet& P, bool Tmove, bool keep_gri
           {
             Real pairpot = PP[iat]->evaluateOne(P, iat, Psi, jel, dist[iat], -displ[iat], use_DLA);
             if (Tmove)
-              PP[iat]->contributeTxy(jel, tmove_xy_);
+              PP[iat]->contributeTxy(jel, tmove_xy_all_);
 
             value_ += pairpot;
             NeighborIons.push_back(iat);
@@ -300,7 +300,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
     const ParticleSet& P(p_list[iw]);
 
     if (Tmove)
-      O.tmove_xy_.clear();
+      O.tmove_xy_all_.clear();
 
     if (!keep_grid)
       for (int ipp = 0; ipp < O.PPset.size(); ipp++)
@@ -411,7 +411,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
       {
         ecp_potential_list[j].get().value_ += pairpots[j];
         if (Tmove)
-          ecp_component_list[j].contributeTxy(batch_list[j].get().electron_id, ecp_potential_list[j].get().tmove_xy_);
+          ecp_component_list[j].contributeTxy(batch_list[j].get().electron_id, ecp_potential_list[j].get().tmove_xy_all_);
 
         if (listeners)
         {
@@ -595,7 +595,7 @@ int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P)
   auto& RandomGen(*myRNG);
   if (UseTMove == TMOVE_V0)
   {
-    const NonLocalData* oneTMove = nonLocalOps.selectMove(RandomGen(), tmove_xy_);
+    const NonLocalData* oneTMove = nonLocalOps.selectMove(RandomGen(), tmove_xy_all_);
     //make a non-local move
     if (oneTMove)
     {
@@ -637,7 +637,7 @@ int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P)
   else if (UseTMove == TMOVE_V3)
   {
     elecTMAffected.assign(P.getTotalNum(), false);
-    nonLocalOps.groupByElectron(P.getTotalNum(), tmove_xy_);
+    nonLocalOps.groupByElectron(P.getTotalNum(), tmove_xy_all_);
     GradType grad_iat;
     std::vector<NonLocalData> tmove_xy;
     //make a non-local move per particle

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -211,8 +211,8 @@ private:
   NonLocalTOperator nonLocalOps;
   ///Pulay force vector
   ParticleSet::ParticlePos PulayTerm;
-  // Tmove data
-  std::vector<NonLocalData> tmove_xy_;
+  /// Tmove data collected for all the electrons
+  std::vector<NonLocalData> tmove_xy_all_;
 #if !defined(REMOVE_TRACEMANAGER)
   ///single particle trace samples
 

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -226,10 +226,10 @@ private:
 
   /** the actual implementation, used by evaluate and evaluateWithToperator
    * @param P particle set
-   * @param Tmove whether Txy for Tmove is updated
+   * @param tmove_xy_all when has_value, compute Txy for all the electrons.
    * @param keepGrid.  If true, does not randomize the quadrature grid before evaluation.  
    */
-  void evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid = false);
+  void evaluateImpl(ParticleSet& P, const std::optional<std::reference_wrapper<std::vector<NonLocalData>>> tmove_xy_all, bool keepGrid = false);
 
   /** compute the T move transition probability for a given electron
    * member variable nonLocalOps.Txy is updated

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -235,8 +235,9 @@ private:
    * member variable nonLocalOps.Txy is updated
    * @param P particle set
    * @param ref_elec reference electron id
+   * @param tmove_xy off-diagonal terms for one electron.
    */
-  void computeOneElectronTxy(ParticleSet& P, const int ref_elec);
+  void computeOneElectronTxy(ParticleSet& P, const int ref_elec, std::vector<NonLocalData>& tmove_xy);
 
   /** mark all the electrons affected by Tmoves and update ElecNeighborIons and IonNeighborElecs
    * @param myTable electron ion distance table

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -22,6 +22,8 @@
 #include "QMCHamiltonians/ForceBase.h"
 #include "QMCHamiltonians/OperatorBase.h"
 #include "Particle/NeighborLists.h"
+#include "type_traits/OptionalRef.hpp"
+
 namespace qmcplusplus
 {
 class NonLocalECPComponent;
@@ -229,7 +231,7 @@ private:
    * @param tmove_xy_all when has_value, compute Txy for all the electrons.
    * @param keepGrid.  If true, does not randomize the quadrature grid before evaluation.  
    */
-  void evaluateImpl(ParticleSet& P, const std::optional<std::reference_wrapper<std::vector<NonLocalData>>> tmove_xy_all, bool keepGrid = false);
+  void evaluateImpl(ParticleSet& P, const OptionalRef<std::vector<NonLocalData>> tmove_xy_all, bool keepGrid = false);
 
   /** compute the T move transition probability for a given electron
    * member variable nonLocalOps.Txy is updated

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -287,7 +287,7 @@ TEST_CASE("Evaluate_ecp", "[hamiltonian]")
       const auto& displ = myTable.getDisplRow(jel);
       for (int iat = 0; iat < ions.getTotalNum(); iat++)
         if (nlpp != nullptr && dist[iat] < nlpp->getRmax())
-          Value1 += nlpp->evaluateOne(elec, iat, psi, jel, dist[iat], -displ[iat], false);
+          Value1 += nlpp->evaluateOne(elec, iat, psi, jel, dist[iat], -displ[iat], std::nullopt, false);
     }
     //These numbers are validated against an alternate code path via wavefunction tester.
     CHECK(Value1 == Approx(6.9015710211e-02));


### PR DESCRIPTION
## Proposed changes
I'm only touching the single walker API in this PR. The batched API will be modified in a later PR.

NonLocalECPComponent::tmove_xy_ is renamed to tmove_xy_all_ because it is intended for all the electrons not one. I tried to reduce direct access to tmove_xy_all_ but more relying on passing via function argument.

old code does
```
PP[iat]->evaluateOne(P, iat, Psi, ref_elec, dist[iat], -displ[iat], use_DLA);
if(Tmove)
  PP[iat]->contributeTxy(ref_elec, tmove_xy_);
```
two steps. The new code uses a single function and handles the tmove logic inside evaluateOne.
```
    PP[iat]->evaluateOne(P, iat, Psi, ref_elec, dist[iat], -displ[iat], tmove_xy_, use_DLA);
```
This facilitates DLTM implementation.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
