### PR TITLE
Remove ComputeForces flag in NLPP

### DIFF
--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -121,7 +121,7 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
   if (hasNonLocalPot)
   {
     std::unique_ptr<NonLocalECPotential> apot =
-        std::make_unique<NonLocalECPotential>(IonConfig, targetPtcl, targetPsi, doForces, use_DLA == "yes");
+        std::make_unique<NonLocalECPotential>(IonConfig, targetPtcl, targetPsi, use_DLA == "yes");
 
     int nknot_max = 0;
     // These are actually NonLocalECPComponents

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -158,11 +158,6 @@ public:
 
   void registerObservables(std::vector<ObservableHelper>& h5list, hdf_archive& file) const override;
 
-  /** Set the flag whether to compute forces or not.
-   * @param val The boolean value for computing forces
-   */
-  inline void setComputeForces(bool val) override { ComputeForces = val; }
-
 protected:
   /** the actual implementation for batched walkers, used by mw_evaluate, mw_evaluateWithToperator
    *  mw_evaluatePerPaticleWithToperator

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -45,7 +45,7 @@ class NonLocalECPotential : public OperatorBase, public ForceBase
   struct NonLocalECPotentialMultiWalkerResource;
 
 public:
-  NonLocalECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi, bool computeForces, bool enable_DLA);
+  NonLocalECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi, bool enable_DLA);
   ~NonLocalECPotential() override;
 
   bool dependsOnWaveFunction() const override { return true; }
@@ -150,14 +150,6 @@ public:
    */
   void setRandomGenerator(RandomBase<FullPrecRealType>* rng) override { myRNG = rng; }
 
-  void addObservables(PropertySetType& plist, BufferType& collectables) override;
-
-  void setObservables(PropertySetType& plist) override;
-
-  void setParticlePropertyList(PropertySetType& plist, int offset) override;
-
-  void registerObservables(std::vector<ObservableHelper>& h5list, hdf_archive& file) const override;
-
 protected:
   /** the actual implementation for batched walkers, used by mw_evaluate, mw_evaluateWithToperator
    *  mw_evaluatePerPaticleWithToperator
@@ -184,8 +176,6 @@ protected:
   ParticleSet& IonConfig;
   ///target TrialWaveFunction
   TrialWaveFunction& Psi;
-  ///true if we should compute forces
-  bool ComputeForces;
   ///true, determinant localization approximation(DLA) is enabled
   bool use_DLA;
 

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -287,8 +287,6 @@ void OperatorBase::checkoutParticleQuantities(TraceManager& tm) {};
 void OperatorBase::deleteParticleQuantities() {};
 #endif
 
-void OperatorBase::setComputeForces(bool compute) {}
-
 void OperatorBase::setEnergyDomain(EnergyDomains edomain)
 {
   if (energyDomainValid(edomain))

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -552,8 +552,6 @@ protected:
   virtual void deleteParticleQuantities();
 #endif
 
-  virtual void setComputeForces(bool compute);
-
   /**
    * @brief Set the Energy Domain
    * 

--- a/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
@@ -125,10 +125,7 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
   TrialWaveFunction psi2(runtime_options);
   RefVectorWithLeader<TrialWaveFunction> twf_list(psi, {psi, psi2});
 
-  bool doForces = false;
-  bool use_DLA  = false;
-
-  NonLocalECPotential nl_ecp(ions, elec, psi, doForces, use_DLA);
+  NonLocalECPotential nl_ecp(ions, elec, psi, false /*use_DLA*/);
 
   int num_walkers = 2;
   int max_values  = 10;


### PR DESCRIPTION
## Proposed changes
Phasing out `ComputeForces` flag in Hamiltonian member classes. It was used to control force related calculation during Hamiltonian evaluation which is no longer needed. ACForce estimator calls evaluateIonDerivs explicitly for the force calculation. Similar change will be made in Coulomb classes with `ComputeForce`.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
