### PR TITLE
explicitly passing Tmove data as an argument to NonLocalECPComponent::mw_evaluateOne

### DIFF
--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -211,6 +211,7 @@ void NonLocalECPComponent::mw_evaluateOne(const RefVectorWithLeader<NonLocalECPC
                                           const RefVectorWithLeader<TrialWaveFunction>& psi_list,
                                           const RefVector<const NLPPJob<RealType>>& joblist,
                                           std::vector<RealType>& pairpots,
+                                          const RefVector<std::vector<NonLocalData>>& tmove_xy_all_list,
                                           ResourceCollection& collection,
                                           bool use_DLA)
 {
@@ -276,11 +277,16 @@ void NonLocalECPComponent::mw_evaluateOne(const RefVectorWithLeader<NonLocalECPC
     }
   }
 
+  if (!tmove_xy_all_list.empty())
+    assert(tmove_xy_all_list.size() == ecp_component_list.size());
+
   for (size_t i = 0; i < p_list.size(); i++)
   {
     NonLocalECPComponent& component(ecp_component_list[i]);
-    const NLPPJob<RealType>& job = joblist[i];
-    pairpots[i]                  = component.calculateProjector(job.ion_elec_dist, job.ion_elec_displ);
+    const NLPPJob<RealType>& job(joblist[i]);
+    pairpots[i] = component.calculateProjector(job.ion_elec_dist, job.ion_elec_displ);
+    if (!tmove_xy_all_list.empty())
+      component.contributeTxy(job.electron_id, tmove_xy_all_list[i]);
   }
 }
 

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -167,6 +167,7 @@ public:
    * @param iel index of electron
    * @param r the distance between ion iat and electron iel.
    * @param dr displacement from ion iat to electron iel.
+   * @param tmove_xy when has_value, compute and collect Txy for the given electron ion pair.
    * @param use_DLA if ture, use determinant localization approximation (DLA).
    *
    * @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
@@ -188,6 +189,7 @@ public:
    * @param psi_list a list of trial wave function object
    * @param joblist a list of ion-electron pairs
    * @param pairpots a list of contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
+   * @param tmove_xy_all_list if not empty, calculate and accumulate Txy.
    * @param use_DLA if ture, use determinant localization approximation (DLA).
    *
    * Note: ecp_component_list allows including different NLPP component for different walkers.

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -116,6 +116,9 @@ private:
   ///virtual particle set: delayed initialization
   VirtualParticleSet* VP;
 
+  /// Can disable grid randomization for testing
+  bool do_randomize_grid_;
+
   /// build QP position deltas from the reference electron using internally stored random grid points
   void buildQuadraturePointDeltaPositions(RealType r, const PosType& dr, std::vector<PosType>& deltaV) const;
 
@@ -123,8 +126,11 @@ private:
    */
   RealType calculateProjector(RealType r, const PosType& dr);
 
-  /// Can disable grid randomization for testing
-  bool do_randomize_grid_;
+  /** contribute local non-local move data
+   * @param iel reference electron id.
+   * @param Txy nonlocal move data.
+   */
+  void contributeTxy(int iel, std::vector<NonLocalData>& Txy) const;
 
 public:
   NonLocalECPComponent();
@@ -151,12 +157,6 @@ public:
   void rotateQuadratureGrid(const TensorType& rmat);
   template<typename T>
   void rotateQuadratureGrid(std::vector<T>& sphere, const TensorType& rmat);
-
-  /** contribute local non-local move data
-   * @param iel reference electron id.
-   * @param Txy nonlocal move data.
-   */
-  void contributeTxy(int iel, std::vector<NonLocalData>& Txy) const;
 
   /** @brief Evaluate the nonlocal pp contribution via randomized quadrature grid
    * to total energy from ion "iat" and electron "iel".

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -198,6 +198,7 @@ public:
                              const RefVectorWithLeader<TrialWaveFunction>& psi_list,
                              const RefVector<const NLPPJob<RealType>>& joblist,
                              std::vector<RealType>& pairpots,
+                             const RefVector<std::vector<NonLocalData>>& tmove_xy_all_list,
                              ResourceCollection& collection,
                              bool use_DLA);
 

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -156,13 +156,13 @@ protected:
    * @param o_list     the list of NonLocalECPotential in a walker batch
    * @param wf_list    the list of TrialWaveFunction in a walker batch
    * @param p_list     the list of ParticleSet in a walker batch
-   * @param Tmove      whether Txy for Tmove is updated
+   * @param compute_txy_all whether to compute Txy for all the electrons affected by NLPP
    * @param listeners  optional listeners which allow per particle and reduced to share impl
    */
   static void mw_evaluateImpl(const RefVectorWithLeader<OperatorBase>& o_list,
                               const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                               const RefVectorWithLeader<ParticleSet>& p_list,
-                              bool Tmove,
+                              bool compute_txy_all,
                               std::optional<ListenerOption<Real>> listeners,
                               bool keepGrid = false);
 
@@ -213,10 +213,10 @@ private:
 
   /** the actual implementation, used by evaluate and evaluateWithToperator
    * @param P particle set
-   * @param tmove_xy_all when has_value, compute Txy for all the electrons.
+   * @param compute_txy_all whether to compute Txy for all the electrons affected by NLPP
    * @param keepGrid.  If true, does not randomize the quadrature grid before evaluation.  
    */
-  void evaluateImpl(ParticleSet& P, const OptionalRef<std::vector<NonLocalData>> tmove_xy_all, bool keepGrid = false);
+  void evaluateImpl(ParticleSet& P, bool compute_txy_all, bool keepGrid = false);
 
   /** compute the T move transition probability for a given electron
    * member variable nonLocalOps.Txy is updated


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
Similarly to https://github.com/QMCPACK/qmcpack/pull/5091, updated batched APIs.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted