### PR TITLE
Prevent SOECP exact spin evaluation with multi slater determinant wave functions due to incomplete code paths

### DIFF
--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
@@ -653,7 +653,7 @@ void MultiSlaterDetTableMethod::evaluateSpinorRatios(const VirtualParticleSet& V
                                                      std::vector<ValueType>& ratios)
 {
   throw std::runtime_error("MultiSlaterDetTableMethod::evaluateSpinorRatios not implemented. To use SOECPs with MSD "
-                           "wave functions, please set spin_integrator=\"simpson\" in the qmcpack input file.");
+                           "wave functions, please set spin_integrator=\"simpson\" in the QMCPACK input file.");
 }
 
 void MultiSlaterDetTableMethod::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
@@ -648,6 +648,14 @@ void MultiSlaterDetTableMethod::evaluateRatios(const VirtualParticleSet& VP, std
   }
 }
 
+void MultiSlaterDetTableMethod::evaluateSpinorRatios(const VirtualParticleSet& VP,
+                                                     const std::pair<ValueVector, ValueVector>& spinor_multiplier,
+                                                     std::vector<ValueType>& ratios)
+{
+  throw std::runtime_error("MultiSlaterDetTableMethod::evaluateSpinorRatios not implemented. To use SOECPs with MSD "
+                           "wave functions, please set spin_integrator=\"simpson\" in the qmcpack input file.");
+}
+
 void MultiSlaterDetTableMethod::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
 {
   // this should depend on the type of update, ratio / ratioGrad
@@ -1004,7 +1012,7 @@ void MultiSlaterDetTableMethod::evaluateDerivativesWF(ParticleSet& P,
 
 void MultiSlaterDetTableMethod::calcIndividualDetRatios(Vector<ValueType>& ratios)
 {
-  ValueType psiinv       = static_cast<ValueType>(PsiValue(1.0) / psi_ratio_to_ref_det_);
+  ValueType psiinv = static_cast<ValueType>(PsiValue(1.0) / psi_ratio_to_ref_det_);
 
   // CI only for now
   assert(!csf_data_);
@@ -1027,12 +1035,13 @@ const std::vector<WaveFunctionComponent::ValueType>& MultiSlaterDetTableMethod::
 }
 
 
-void MultiSlaterDetTableMethod::evaluateDerivativesMSD(Vector<ValueType>& dlogpsi, std::optional<std::pair<unsigned, PsiValue>> move) const
+void MultiSlaterDetTableMethod::evaluateDerivativesMSD(Vector<ValueType>& dlogpsi,
+                                                       std::optional<std::pair<unsigned, PsiValue>> move) const
 {
   // when not using a new position, the result doesn't get affected by det_id, thus choose 0.
-  const unsigned det_id = move? move->first : 0;
-  const auto& detValues0 = move? Dets[det_id]->getNewRatiosToRefDet() : Dets[det_id]->getRatiosToRefDet();
-  const ValueType psiinv = static_cast<ValueType>(PsiValue(1.0) / (move? move->second : psi_ratio_to_ref_det_));
+  const unsigned det_id  = move ? move->first : 0;
+  const auto& detValues0 = move ? Dets[det_id]->getNewRatiosToRefDet() : Dets[det_id]->getRatiosToRefDet();
+  const ValueType psiinv = static_cast<ValueType>(PsiValue(1.0) / (move ? move->second : psi_ratio_to_ref_det_));
 
   if (csf_data_) // CSF
   {

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
@@ -157,6 +157,9 @@ public:
 
   void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios) override;
 
+  void evaluateSpinorRatios(const VirtualParticleSet& VP, const std::pair<ValueVector, ValueVector>& spinor_multiplier, std::vector<ValueType>& ratios) override;
+
+
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override
   {
     // the base class routine may probably work, just never tested.


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
Fixes a bug pointed out by @bkincaid256, which has to do with using SOECPs with multi slater determinants and getting the wrong total energies.  The exact spin integration method was only implemented for single determinants.  This PR prevents that code path. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
mac

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
