### PR TITLE
Implements mw_ version of exact spin integration in SOECPs

### DIFF
--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -215,7 +215,6 @@ SOECPComponent::RealType SOECPComponent::calculateProjector(RealType r, const Po
 
 void SOECPComponent::setupExactSpinProjector(RealType r, const PosType& dr, RealType sold)
 {
-
   auto& up_row = spinor_multiplier_.first;
   auto& dn_row = spinor_multiplier_.second;
 
@@ -271,7 +270,7 @@ SOECPComponent::RealType SOECPComponent::evaluateOneExactSpinIntegration(Particl
     pairpot += psiratio_[iq];
   return std::real(pairpot);
 #else
-  throw std::runtime_error("SOECPComponent::evaluateOneBodyOpMatrixContribution only implemented in complex build");
+  throw std::runtime_error("SOECPComponent::evaluateOneExactSpinIntegration only implemented in complex build");
 #endif
 }
 
@@ -357,6 +356,7 @@ void SOECPComponent::mw_evaluateOneExactSpinIntegration(const RefVectorWithLeade
                                                         std::vector<RealType>& pairpots,
                                                         ResourceCollection& collection)
 {
+#ifdef QMC_COMPLEX
   auto& soecp_component_leader = soecp_component_list.getLeader();
   // Compute ratios with VP
   RefVectorWithLeader<VirtualParticleSet> vp_list(*soecp_component_leader.vp_);
@@ -398,7 +398,7 @@ void SOECPComponent::mw_evaluateOneExactSpinIntegration(const RefVectorWithLeade
   }
 
   TrialWaveFunction::mw_evaluateSpinorRatios(psi_list, const_vp_list, spinor_multiplier_list, psiratios_list);
-  
+
   for (size_t i = 0; i < p_list.size(); i++)
   {
     pairpots[i] = 0;
@@ -407,6 +407,9 @@ void SOECPComponent::mw_evaluateOneExactSpinIntegration(const RefVectorWithLeade
     for (int iq = 0; iq < component.nknot_; iq++)
       pairpots[i] += std::real(psiratio[iq]);
   }
+#else
+  throw std::runtime_error("SOECPComponent::mw_evaluateOneExactSpinIntegration only implemented in complex build");
+#endif
 }
 
 SOECPComponent::RealType SOECPComponent::evaluateValueAndDerivatives(ParticleSet& W,

--- a/src/QMCHamiltonians/SOECPComponent.h
+++ b/src/QMCHamiltonians/SOECPComponent.h
@@ -118,7 +118,12 @@ public:
 
   RealType calculateProjector(RealType r, const PosType& dr, RealType sold);
 
-  RealType evaluateOneExactSpinIntegration(ParticleSet& W, const int iat, const TrialWaveFunction& psi, const int iel, const RealType r, const PosType& dr);
+  RealType evaluateOneExactSpinIntegration(ParticleSet& W,
+                                           const int iat,
+                                           const TrialWaveFunction& psi,
+                                           const int iel,
+                                           const RealType r,
+                                           const PosType& dr);
 
   static void mw_evaluateOne(const RefVectorWithLeader<SOECPComponent>& soecp_component_list,
                              const RefVectorWithLeader<ParticleSet>& p_list,
@@ -126,6 +131,13 @@ public:
                              const RefVector<const NLPPJob<RealType>>& joblist,
                              std::vector<RealType>& pairpots,
                              ResourceCollection& collection);
+
+  static void mw_evaluateOneExactSpinIntegration(const RefVectorWithLeader<SOECPComponent>& soecp_component_list,
+                                                 const RefVectorWithLeader<ParticleSet>& p_list,
+                                                 const RefVectorWithLeader<TrialWaveFunction>& psi_list,
+                                                 const RefVector<const NLPPJob<RealType>>& joblist,
+                                                 std::vector<RealType>& pairpots,
+                                                 ResourceCollection& collection);
 
   RealType evaluateValueAndDerivatives(ParticleSet& P,
                                        int iat,

--- a/src/QMCHamiltonians/SOECPComponent.h
+++ b/src/QMCHamiltonians/SOECPComponent.h
@@ -118,6 +118,8 @@ public:
   RealType evaluateOne(ParticleSet& W, int iat, TrialWaveFunction& Psi, int iel, RealType r, const PosType& dr);
 
   RealType calculateProjector(RealType r, const PosType& dr, RealType sold);
+
+  // sets up all the data needed for the exact spin integration. Essentially setting spinor_multiplier_
   void setupExactSpinProjector(RealType r, const PosType& dr, RealType sold);
 
   RealType evaluateOneExactSpinIntegration(ParticleSet& W,

--- a/src/QMCHamiltonians/SOECPComponent.h
+++ b/src/QMCHamiltonians/SOECPComponent.h
@@ -79,6 +79,7 @@ private:
   Matrix<ValueType> dratio_;
   Vector<ValueType> dlogpsi_vp_;
   VirtualParticleSet* vp_;
+  std::pair<SPOSet::ValueVector, SPOSet::ValueVector> spinor_multiplier_;
 
   //This builds the full quadrature grid for the Simpsons rule used for spin integrals as well as
   //the spatial quadrature. In this function, it specifies the deltaS_ and deltaV_ for all the quadrature points and sets the interal weights
@@ -117,6 +118,7 @@ public:
   RealType evaluateOne(ParticleSet& W, int iat, TrialWaveFunction& Psi, int iel, RealType r, const PosType& dr);
 
   RealType calculateProjector(RealType r, const PosType& dr, RealType sold);
+  void setupExactSpinProjector(RealType r, const PosType& dr, RealType sold);
 
   RealType evaluateOneExactSpinIntegration(ParticleSet& W,
                                            const int iat,

--- a/src/QMCHamiltonians/SOECPotential.cpp
+++ b/src/QMCHamiltonians/SOECPotential.cpp
@@ -138,7 +138,7 @@ void SOECPotential::mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
                                 const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                 const RefVectorWithLeader<ParticleSet>& p_list) const
 {
-  mw_evaluateImpl(o_list, wf_list, p_list, std::nullopt);
+  mw_evaluateImpl(o_list, wf_list, p_list, std::nullopt, false, use_exact_spin_);
 }
 
 void SOECPotential::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
@@ -148,14 +148,15 @@ void SOECPotential::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBas
                                            const std::vector<ListenerVector<Real>>& listeners_ions) const
 {
   std::optional<ListenerOption<Real>> l_opt(std::in_place, listeners, listeners_ions);
-  mw_evaluateImpl(o_list, wf_list, p_list, l_opt);
+  mw_evaluateImpl(o_list, wf_list, p_list, l_opt, false, use_exact_spin_);
 }
 
 void SOECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase>& o_list,
                                     const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                     const RefVectorWithLeader<ParticleSet>& p_list,
                                     const std::optional<ListenerOption<Real>> listeners,
-                                    bool keep_grid)
+                                    bool keep_grid, 
+                                    bool exact_spin)
 {
   auto& O_leader           = o_list.getCastedLeader<SOECPotential>();
   ParticleSet& pset_leader = p_list.getLeader();
@@ -261,8 +262,12 @@ void SOECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase>& o_l
         }
       }
 
-      SOECPComponent::mw_evaluateOne(soecp_component_list, pset_list, psi_list, batch_list, pairpots,
-                                     O_leader.mw_res_handle_.getResource().collection);
+      if (exact_spin)
+        SOECPComponent::mw_evaluateOneExactSpinIntegration(soecp_component_list, pset_list, psi_list, batch_list,
+                                                           pairpots, O_leader.mw_res_handle_.getResource().collection);
+      else
+        SOECPComponent::mw_evaluateOne(soecp_component_list, pset_list, psi_list, batch_list, pairpots,
+                                       O_leader.mw_res_handle_.getResource().collection);
 
       for (size_t j = 0; j < soecp_potential_list.size(); j++)
       {

--- a/src/QMCHamiltonians/SOECPotential.h
+++ b/src/QMCHamiltonians/SOECPotential.h
@@ -89,7 +89,8 @@ protected:
                               const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                               const RefVectorWithLeader<ParticleSet>& p_list,
                               std::optional<ListenerOption<Real>> listeners,
-                              bool keep_grid = false);
+                              bool keep_grid = false, 
+                              bool exact_spin = false);
 
 private:
   ///number of ions

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -1043,7 +1043,9 @@ void TrialWaveFunction::evaluateRatios(const VirtualParticleSet& VP, std::vector
     }
 }
 
-void TrialWaveFunction::evaluateSpinorRatios(const VirtualParticleSet& VP, const std::pair<ValueVector, ValueVector>& spinor_multiplier, std::vector<ValueType>& ratios) const
+void TrialWaveFunction::evaluateSpinorRatios(const VirtualParticleSet& VP,
+                                             const std::pair<ValueVector, ValueVector>& spinor_multiplier,
+                                             std::vector<ValueType>& ratios) const
 {
   ScopedTimer local_timer(TWF_timers_[NL_TIMER]);
   assert(VP.getTotalNum() == ratios.size());
@@ -1051,10 +1053,10 @@ void TrialWaveFunction::evaluateSpinorRatios(const VirtualParticleSet& VP, const
   std::fill(ratios.begin(), ratios.end(), 1.0);
   for (int i = 0; i < Z.size(); ++i)
   {
-      ScopedTimer z_timer(WFC_timers_[NL_TIMER + TIMER_SKIP * i]);
-      Z[i]->evaluateSpinorRatios(VP, spinor_multiplier, t);
-      for (int j = 0; j < ratios.size(); ++j)
-        ratios[j] *= t[j];
+    ScopedTimer z_timer(WFC_timers_[NL_TIMER + TIMER_SKIP * i]);
+    Z[i]->evaluateSpinorRatios(VP, spinor_multiplier, t);
+    for (int j = 0; j < ratios.size(); ++j)
+      ratios[j] *= t[j];
   }
 }
 
@@ -1089,6 +1091,38 @@ void TrialWaveFunction::mw_evaluateRatios(const RefVectorWithLeader<TrialWaveFun
           ratios[j] *= t[iw][j];
       }
     }
+}
+
+void TrialWaveFunction::mw_evaluateSpinorRatios(
+    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+    const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+    const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+    const RefVector<std::vector<ValueType>>& ratios_list)
+{
+  auto& wf_leader = wf_list.getLeader();
+  ScopedTimer local_timer(wf_leader.TWF_timers_[NL_TIMER]);
+  auto& wavefunction_components = wf_leader.Z;
+  std::vector<std::vector<ValueType>> t(ratios_list.size());
+  for (int iw = 0; iw < wf_list.size(); iw++)
+  {
+    std::vector<ValueType>& ratios = ratios_list[iw];
+    assert(vp_list[iw].getTotalNum() == ratios.size());
+    std::fill(ratios.begin(), ratios.end(), 1.0);
+    t[iw].resize(ratios.size());
+  }
+
+  for (int i = 0; i < wavefunction_components.size(); i++)
+  {
+    ScopedTimer z_timer(wf_leader.WFC_timers_[NL_TIMER + TIMER_SKIP * i]);
+    const auto wfc_list(extractWFCRefList(wf_list, i));
+    wavefunction_components[i]->mw_evaluateSpinorRatios(wfc_list, vp_list, spinor_multiplier_list, t);
+    for (int iw = 0; iw < wf_list.size(); iw++)
+    {
+      std::vector<ValueType>& ratios = ratios_list[iw];
+      for (int j = 0; j < ratios.size(); ++j)
+        ratios[j] *= t[iw][j];
+    }
+  }
 }
 
 void TrialWaveFunction::evaluateDerivRatios(const VirtualParticleSet& VP,

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -302,7 +302,9 @@ public:
 
   /** Used by SOECPComponent to do faster SOC evaluation
    */
-  void evaluateSpinorRatios(const VirtualParticleSet& VP, const std::pair<ValueVector, ValueVector>& spinor_multiplier, std::vector<ValueType>& ratios) const;
+  void evaluateSpinorRatios(const VirtualParticleSet& VP,
+                            const std::pair<ValueVector, ValueVector>& spinor_multiplier,
+                            std::vector<ValueType>& ratios) const;
 
   /** batched version of evaluateRatios
    * Note: unlike other mw_ static functions, *this is the batch leader instead of wf_list[0].
@@ -311,6 +313,12 @@ public:
                                 const RefVectorWithLeader<const VirtualParticleSet>& Vp_list,
                                 const RefVector<std::vector<ValueType>>& ratios_list,
                                 ComputeType ct = ComputeType::ALL);
+
+  static void mw_evaluateSpinorRatios(
+      const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+      const RefVectorWithLeader<const VirtualParticleSet>& Vp_list,
+      const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+      const RefVector<std::vector<ValueType>>& ratios_list);
 
   /** compute both ratios and deriatives of ratio with respect to the optimizables*/
   void evaluateDerivRatios(const VirtualParticleSet& VP,

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -314,6 +314,7 @@ public:
                                 const RefVector<std::vector<ValueType>>& ratios_list,
                                 ComputeType ct = ComputeType::ALL);
 
+  // batched version of evaluateSpinorRatios
   static void mw_evaluateSpinorRatios(
       const RefVectorWithLeader<TrialWaveFunction>& wf_list,
       const RefVectorWithLeader<const VirtualParticleSet>& Vp_list,

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -242,7 +242,9 @@ void WaveFunctionComponent::evaluateRatios(const VirtualParticleSet& P, std::vec
   APP_ABORT(o.str());
 }
 
-void WaveFunctionComponent::evaluateSpinorRatios(const VirtualParticleSet& P, const std::pair<ValueVector, ValueVector>& spinor_multiplier, std::vector<ValueType>& ratios)
+void WaveFunctionComponent::evaluateSpinorRatios(const VirtualParticleSet& P,
+                                                 const std::pair<ValueVector, ValueVector>& spinor_multiplier,
+                                                 std::vector<ValueType>& ratios)
 {
   evaluateRatios(P, ratios);
 }
@@ -254,6 +256,17 @@ void WaveFunctionComponent::mw_evaluateRatios(const RefVectorWithLeader<WaveFunc
   assert(this == &wfc_list.getLeader());
   for (int iw = 0; iw < wfc_list.size(); iw++)
     wfc_list[iw].evaluateRatios(vp_list[iw], ratios[iw]);
+}
+
+void WaveFunctionComponent::mw_evaluateSpinorRatios(
+    const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+    const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+    const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+    std::vector<std::vector<ValueType>>& ratios) const
+{
+  assert(this == &wfc_list.getLeader());
+  for (int iw = 0; iw < wfc_list.size(); iw++)
+    wfc_list[iw].evaluateSpinorRatios(vp_list[iw], spinor_multiplier_list[iw], ratios[iw]);
 }
 
 void WaveFunctionComponent::evaluateDerivRatios(const VirtualParticleSet& VP,

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -515,7 +515,9 @@ public:
 
   /** Used by SOECPComponent for faster SOC evaluation
    */
-  virtual void evaluateSpinorRatios(const VirtualParticleSet& VP, const std::pair<ValueVector, ValueVector>& spinor_multiplier, std::vector<ValueType>& ratios);
+  virtual void evaluateSpinorRatios(const VirtualParticleSet& VP,
+                                    const std::pair<ValueVector, ValueVector>& spinor_multiplier,
+                                    std::vector<ValueType>& ratios);
 
   /** evaluate ratios to evaluate the non-local PP multiple walkers
    * @param wfc_list the list of WaveFunctionComponent references of the same component in a walker batch
@@ -525,6 +527,11 @@ public:
   virtual void mw_evaluateRatios(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                                  const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
                                  std::vector<std::vector<ValueType>>& ratios) const;
+
+  virtual void mw_evaluateSpinorRatios(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                       const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+                                       const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+                                       std::vector<std::vector<ValueType>>& ratios) const;
 
   /** evaluate ratios to evaluate the non-local PP
    * @param VP VirtualParticleSet
@@ -563,7 +570,6 @@ public:
                                     std::vector<PsiValue>& ratios,
                                     std::vector<GradType>& grad_new,
                                     std::vector<ComplexType>& spingrad_new) const;
-
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -528,6 +528,7 @@ public:
                                  const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
                                  std::vector<std::vector<ValueType>>& ratios) const;
 
+  // Batched version of evaluateSpinorRatios
   virtual void mw_evaluateSpinorRatios(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                                        const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
                                        const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
This adds the mw_ version of the fast/exact spin integration of SOECPs, which was originally implemented in #4933. 

Note: This only handles what is needed by the actual hamiltonian...the necessary wave function APIs only add the fall back to the single walker versions. Will need to follow up with mw_evaluateSpinorRatios specializations for DiracDeterminants in a later PR. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
mac

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
