### PR TITLE
Provide the minimum combined Listener values support EnergyDensityEstimator requires

### DIFF
--- a/src/QMCHamiltonians/CMakeLists.txt
+++ b/src/QMCHamiltonians/CMakeLists.txt
@@ -47,7 +47,8 @@ set(HAMSRCS
     LatticeDeviationEstimator.cpp
     SpaceWarpTransformation.cpp
     SelfHealingOverlapLegacy.cpp
-    ObservableHelper.cpp)
+    ObservableHelper.cpp
+    Listener.cpp)
 
 if(OHMMS_DIM MATCHES 3)
   set(HAMSRCS

--- a/src/QMCHamiltonians/Listener.cpp
+++ b/src/QMCHamiltonians/Listener.cpp
@@ -1,0 +1,56 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2024 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "Listener.hpp"
+#include <unordered_map>
+#include <OhmmsPETE/OhmmsVector.h>
+#include <string>
+
+namespace qmcplusplus
+{
+
+template void combinePerParticleEnergies<double>(const CrowdEnergyValues<double>& cev_in,
+                                                 std::vector<Vector<double>>& values_out);
+
+template void combinePerParticleEnergies<float>(const CrowdEnergyValues<float>& cev_in,
+                                                std::vector<Vector<float>>& values_out);
+
+template void combinePerParticleEnergies<std::complex<double>>(const CrowdEnergyValues<std::complex<double>>& cev_in,
+                                                               std::vector<Vector<std::complex<double>>>& values_out);
+
+template void combinePerParticleEnergies<std::complex<float>>(const CrowdEnergyValues<std::complex<float>>& cev_in,
+                                                              std::vector<Vector<std::complex<float>>>& values_out);
+
+template<typename T>
+void combinePerParticleEnergies(const CrowdEnergyValues<T>& cev_in, std::vector<Vector<T>>& values_out)
+{
+  const auto num_walkers = cev_in.begin()->second.size();
+  const auto num_particles = cev_in.begin()->second[0].size();
+
+  values_out.resize(num_walkers);
+  for (int iw = 0; iw < num_walkers; ++iw)
+    values_out[iw].resize(num_particles);
+
+  assert(cev_in.begin()->second.size() == values_out.size());
+  assert(cev_in.begin()->second[0].size() == values_out[0].size());
+
+  for (auto& [component, values] : cev_in)
+  {
+    for (int iw = 0; iw < values.size(); ++iw)
+    {
+      // using Vector operator+=
+      for (int ip = 0; ip < values[iw].size(); ++ip)
+        values_out[iw][ip] += values[iw][ip];
+    }
+  }
+}
+
+} // namespace qmcplusplus

--- a/src/QMCHamiltonians/Listener.cpp
+++ b/src/QMCHamiltonians/Listener.cpp
@@ -10,24 +10,9 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 #include "Listener.hpp"
-#include <unordered_map>
-#include <OhmmsPETE/OhmmsVector.h>
-#include <string>
 
 namespace qmcplusplus
 {
-
-template void combinePerParticleEnergies<double>(const CrowdEnergyValues<double>& cev_in,
-                                                 std::vector<Vector<double>>& values_out);
-
-template void combinePerParticleEnergies<float>(const CrowdEnergyValues<float>& cev_in,
-                                                std::vector<Vector<float>>& values_out);
-
-template void combinePerParticleEnergies<std::complex<double>>(const CrowdEnergyValues<std::complex<double>>& cev_in,
-                                                               std::vector<Vector<std::complex<double>>>& values_out);
-
-template void combinePerParticleEnergies<std::complex<float>>(const CrowdEnergyValues<std::complex<float>>& cev_in,
-                                                              std::vector<Vector<std::complex<float>>>& values_out);
 
 template<typename T>
 void combinePerParticleEnergies(const CrowdEnergyValues<T>& cev_in, std::vector<Vector<T>>& values_out)
@@ -53,4 +38,17 @@ void combinePerParticleEnergies(const CrowdEnergyValues<T>& cev_in, std::vector<
   }
 }
 
+template void combinePerParticleEnergies<double>(const CrowdEnergyValues<double>& cev_in,
+                                                 std::vector<Vector<double>>& values_out);
+
+template void combinePerParticleEnergies<float>(const CrowdEnergyValues<float>& cev_in,
+                                                std::vector<Vector<float>>& values_out);
+
+template void combinePerParticleEnergies<std::complex<double>>(const CrowdEnergyValues<std::complex<double>>& cev_in,
+                                                               std::vector<Vector<std::complex<double>>>& values_out);
+
+template void combinePerParticleEnergies<std::complex<float>>(const CrowdEnergyValues<std::complex<float>>& cev_in,
+                                                              std::vector<Vector<std::complex<float>>>& values_out);
+
+  
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/Listener.cpp
+++ b/src/QMCHamiltonians/Listener.cpp
@@ -32,7 +32,7 @@ template void combinePerParticleEnergies<std::complex<float>>(const CrowdEnergyV
 template<typename T>
 void combinePerParticleEnergies(const CrowdEnergyValues<T>& cev_in, std::vector<Vector<T>>& values_out)
 {
-  const auto num_walkers = cev_in.begin()->second.size();
+  const auto num_walkers   = cev_in.begin()->second.size();
   const auto num_particles = cev_in.begin()->second[0].size();
 
   values_out.resize(num_walkers);

--- a/src/QMCHamiltonians/Listener.hpp
+++ b/src/QMCHamiltonians/Listener.hpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2022 QMCPACK developers.
+// Copyright (c) 2024 QMCPACK developers.
 //
 // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
@@ -18,6 +18,7 @@
  *  implementation of observables that rely on per particle Hamiltonian values.
  */
 
+#include <complex>
 #include <functional>
 
 #include "type_traits/template_types.hpp"
@@ -82,6 +83,30 @@ struct ListenerOption
   const std::vector<ListenerVector<T>>& ion_values;
 };
 
+/// Type for representing per particle energy values at the Crowd scope.
+template<typename T>
+using CrowdEnergyValues = std::unordered_map<std::string, std::vector<Vector<T>>>;
+/** utility function to reduce over hamiltonian components for per particle energies.
+ *  i.e. overall all names for a particular walker in a CrowdEnergyValues.
+ *  \param[in]   cev_in        crowd energy values type
+ *  \param[out]  values_out    reduced walker vector of per particle values. assumed to have sizes for walker and particles commensurate with cev_in
+ */
+template<typename T>
+void combinePerParticleEnergies(const CrowdEnergyValues<T>& cev_in, std::vector<Vector<T>>& values_out);
+
+extern template void combinePerParticleEnergies<double>(const CrowdEnergyValues<double>& cev_in,
+                                                        std::vector<Vector<double>>& values_out);
+
+extern template void combinePerParticleEnergies<float>(const CrowdEnergyValues<float>& cev_in,
+                                                       std::vector<Vector<float>>& values_out);
+
+extern template void combinePerParticleEnergies<std::complex<double>>(
+    const CrowdEnergyValues<std::complex<double>>& cev_in,
+    std::vector<Vector<std::complex<double>>>& values_out);
+
+extern template void combinePerParticleEnergies<std::complex<float>>(
+    const CrowdEnergyValues<std::complex<float>>& cev_in,
+    std::vector<Vector<std::complex<float>>>& values_out);
 } // namespace qmcplusplus
 
 

--- a/src/QMCHamiltonians/Listener.hpp
+++ b/src/QMCHamiltonians/Listener.hpp
@@ -87,7 +87,7 @@ struct ListenerOption
 template<typename T>
 using CrowdEnergyValues = std::unordered_map<std::string, std::vector<Vector<T>>>;
 /** utility function to reduce over hamiltonian components for per particle energies.
- *  i.e. overall all names for a particular walker in a CrowdEnergyValues.
+ *  i.e. over all names for a particular walker in a CrowdEnergyValues.
  *  \param[in]   cev_in        crowd energy values type
  *  \param[out]  values_out    reduced walker vector of per particle values. assumed to have sizes for walker and particles commensurate with cev_in
  */

--- a/src/QMCHamiltonians/Listener.hpp
+++ b/src/QMCHamiltonians/Listener.hpp
@@ -20,10 +20,9 @@
 
 #include <complex>
 #include <functional>
-
+#include <string>
+#include <unordered_map>
 #include "type_traits/template_types.hpp"
-
-#include "OhmmsPETE/OhmmsMatrix.h"
 #include "OhmmsPETE/OhmmsVector.h"
 
 namespace qmcplusplus
@@ -83,9 +82,13 @@ struct ListenerOption
   const std::vector<ListenerVector<T>>& ion_values;
 };
 
-/// Type for representing per particle energy values at the Crowd scope.
+/** Type for representing per particle energy values at the Crowd scope.
+ *  key name of hamiltonian component
+ *  vector over walkers of Vector over particles.
+ */
 template<typename T>
 using CrowdEnergyValues = std::unordered_map<std::string, std::vector<Vector<T>>>;
+
 /** utility function to reduce over hamiltonian components for per particle energies.
  *  i.e. over all names for a particular walker in a CrowdEnergyValues.
  *  \param[in]   cev_in        crowd energy values type

--- a/src/QMCHamiltonians/tests/test_Listener.cpp
+++ b/src/QMCHamiltonians/tests/test_Listener.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2022 QMCPACK developers.
+// Copyright (c) 2024 QMCPACK developers.
 //
 // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
@@ -36,7 +36,10 @@ private:
 
 public:
   /** why move or not move */
-  void registerVector(ListenerVector<Real>&& listener_vector) { listener_vectors_.push_back(std::move(listener_vector)); }
+  void registerVector(ListenerVector<Real>&& listener_vector)
+  {
+    listener_vectors_.push_back(std::move(listener_vector));
+  }
   void reportVector()
   {
     Vector<Real> vec_part(4);
@@ -61,7 +64,6 @@ public:
     };
   }
   ListenerVector<Real> makeListener() { return {"kinetic", getParticularListener(receiver_vector_)}; }
-
   // For purposes of testing this is public.
   Vector<Real> receiver_vector_;
 };
@@ -77,6 +79,72 @@ TEST_CASE("ListenerVector", "[hamiltonian]")
   CHECK(mock_estimator.receiver_vector_[0] == 0);
   CHECK(mock_estimator.receiver_vector_[3] == 3);
 }
+
+class MockPerParticleEstimatorCrowd
+{
+public:
+  /** Return listener frunction that has captured an object data member.
+   *  returning a lambda allows access to the listening object controlled but allows a great deal of flexibility
+   *  in dealing with the vector report. In this case the receiver copies the reported data into a CrowdEnergyValues data boject.
+   */
+  auto getParticularListener(CrowdEnergyValues<Real>& crowd_energy_values)
+  {
+    auto local_values = crowd_energy_values;
+    return [&local_values](const int walker_index, const std::string& name, const Vector<Real>& inputV) {
+      if (walker_index >= local_values[name].size())
+        local_values[name].resize(walker_index + 1);
+      local_values[name][walker_index] = inputV;
+    };
+  }
+  ListenerVector<Real> makeListener() { return {"combiner", getParticularListener(crowd_energy_values_)}; }
+  // For purposes of testing this is public.
+  CrowdEnergyValues<Real> crowd_energy_values_;
+};
+
+class AnotherMockQMCHamiltonianAndReporter
+{
+private:
+  std::vector<ListenerVector<Real>> listener_vectors_;
+  const std::string name_{"PotentialA"};
+  const std::string name2_{"PotentialB"};
+
+public:
+  /** why move or not move */
+  void registerVector(ListenerVector<Real>&& listener_vector)
+  {
+    listener_vectors_.push_back(std::move(listener_vector));
+  }
+  void reportVector()
+  {
+    for (int walk_id : {0, 1, 2, 3})
+    {
+      Vector<Real> vec_part_(4);
+      std::iota(vec_part_.begin(), vec_part_.end(), 0.5);
+      for (auto& listener : listener_vectors_)
+        listener.report(walk_id, name_, vec_part_);
+      std::iota(vec_part_.begin(), vec_part_.end(), 0.75);
+      for (auto& listener : listener_vectors_)
+        listener.report(walk_id, name2_, vec_part_);
+    }
+  }
+};
+
+TEST_CASE("Listener::CrowdEnergyValues", "[hamiltonian]")
+{
+  AnotherMockQMCHamiltonianAndReporter another_mock_ham_reporter;
+  MockPerParticleEstimatorCrowd mock_estimator;
+
+  another_mock_ham_reporter.registerVector(mock_estimator.makeListener());
+  another_mock_ham_reporter.reportVector();
+
+  CHECK(mock_estimator.crowd_energy_values_["SomePotential"][0][0] == 0.5);
+  CHECK(mock_estimator.crowd_energy_values_["SomePotential"][0][3] == 3.5);
+
+  std::vector<Vector<Real>> reduced_over_reporters;
+  combinePerParticleEnergies(mock_estimator.crowd_energy_values_, reduced_over_reporters);
+  CHECK(reduced_over_reporters[0][0] == 1.25);
+}
+
 
 } // namespace testing
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/test_Listener.cpp
+++ b/src/QMCHamiltonians/tests/test_Listener.cpp
@@ -89,8 +89,8 @@ public:
    */
   auto getParticularListener(CrowdEnergyValues<Real>& crowd_energy_values)
   {
-    auto local_values = crowd_energy_values;
-    return [&local_values](const int walker_index, const std::string& name, const Vector<Real>& inputV) {
+    return [&crowd_energy_values](const int walker_index, const std::string& name, const Vector<Real>& inputV) {
+      auto& local_values = crowd_energy_values;
       if (walker_index >= local_values[name].size())
         local_values[name].resize(walker_index + 1);
       local_values[name][walker_index] = inputV;

--- a/src/QMCHamiltonians/tests/test_Listener.cpp
+++ b/src/QMCHamiltonians/tests/test_Listener.cpp
@@ -138,11 +138,18 @@ TEST_CASE("Listener::CrowdEnergyValues", "[hamiltonian]")
   another_mock_ham_reporter.reportVector();
 
   CHECK(mock_estimator.crowd_energy_values_["PotentialA"][0][0] == 0.5);
-  CHECK(mock_estimator.crowd_energy_values_["PotentialB"][0][3] == 3.75);
+  CHECK(mock_estimator.crowd_energy_values_["PotentialA"][0][1] == 1.5);
+  CHECK(mock_estimator.crowd_energy_values_["PotentialA"][0][2] == 2.5);
+  CHECK(mock_estimator.crowd_energy_values_["PotentialA"][0][3] == 3.5);
+  CHECK(mock_estimator.crowd_energy_values_["PotentialB"][1][0] == 0.75);
+  CHECK(mock_estimator.crowd_energy_values_["PotentialB"][1][3] == 3.75);
 
   std::vector<Vector<Real>> reduced_over_reporters;
   combinePerParticleEnergies(mock_estimator.crowd_energy_values_, reduced_over_reporters);
   CHECK(reduced_over_reporters[0][0] == 1.25);
+  CHECK(reduced_over_reporters[0][3] == 7.25);
+  CHECK(reduced_over_reporters[2][0] == 1.25);
+  CHECK(reduced_over_reporters[2][3] == 7.25);
 }
 
 

--- a/src/QMCHamiltonians/tests/test_Listener.cpp
+++ b/src/QMCHamiltonians/tests/test_Listener.cpp
@@ -137,8 +137,8 @@ TEST_CASE("Listener::CrowdEnergyValues", "[hamiltonian]")
   another_mock_ham_reporter.registerVector(mock_estimator.makeListener());
   another_mock_ham_reporter.reportVector();
 
-  CHECK(mock_estimator.crowd_energy_values_["SomePotential"][0][0] == 0.5);
-  CHECK(mock_estimator.crowd_energy_values_["SomePotential"][0][3] == 3.5);
+  CHECK(mock_estimator.crowd_energy_values_["PotentialA"][0][0] == 0.5);
+  CHECK(mock_estimator.crowd_energy_values_["PotentialB"][0][3] == 3.75);
 
   std::vector<Vector<Real>> reduced_over_reporters;
   combinePerParticleEnergies(mock_estimator.crowd_energy_values_, reduced_over_reporters);


### PR DESCRIPTION
## Proposed changes
Provide support functions to work with Listener CrowdEnergyValues that will be used by EnergyDensityEstimator.

TraceManager provided some elaborate ways to combine energy values from a named list of hamiltonian components. I've found we really just need to be able to combine all the different hamiltonian components per particle.  This provides support for that via some helper functions and tests it.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature
- or Refactoring (no functional changes, no api changes)
- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
ubuntu x86 v100

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
