### PR TITLE
Move Rng out of QMCDriver base class.

### DIFF
--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.h
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.h
@@ -51,13 +51,16 @@ private:
   int prevStepsBetweenSamples;
   ///blocks over which normalization factors are accumulated
   int equilBlocks;
+
+  ///driver copy of Random number generators
+  UPtrVector<RandomBase<QMCTraits::FullPrecRealType>> Rng;
+
   /// Copy Constructor (disabled)
   CSVMC(const CSVMC&) = delete;
   /// Copy operator (disabled).
   CSVMC& operator=(const CSVMC&) = delete;
 
   void resetRun();
-
 
   CSEnergyEstimator* multiEstimator;
   CSUpdateBase* Mover;

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -45,7 +45,7 @@ DMC::DMC(const ProjectData& project_data,
          MCWalkerConfiguration& w,
          TrialWaveFunction& psi,
          QMCHamiltonian& h,
-         UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs,
+         const UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs,
          Communicate* comm,
          bool enable_profiling)
     : QMCDriver(project_data, w, psi, h, comm, "DMC", enable_profiling),
@@ -91,7 +91,6 @@ void DMC::resetUpdateEngines()
     }
     //if(qmc_driver_mode[QMC_UPDATE_MODE]) W.clearAuxDataSet();
     Movers.resize(NumThreads, nullptr);
-    Rng.resize(NumThreads);
     estimatorClones.resize(NumThreads, nullptr);
     traceClones.resize(NumThreads, nullptr);
     wlog_collectors.resize(NumThreads);
@@ -133,14 +132,13 @@ void DMC::resetUpdateEngines()
       traceClones[ip] = Traces->makeClone();
 #endif
       wlog_collectors[ip] = wlog_manager_->makeCollector();
-      Rng[ip] = rngs_[ip]->makeClone();
-      hClones[ip]->setRandomGenerator(Rng[ip].get());
+      hClones[ip]->setRandomGenerator(rngs_[ip].get());
       if (W.isSpinor())
       {
         spinor = true;
         if (qmc_driver_mode[QMC_UPDATE_MODE])
         {
-          Movers[ip] = new SODMCUpdatePbyPWithRejectionFast(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
+          Movers[ip] = new SODMCUpdatePbyPWithRejectionFast(*wClones[ip], *psiClones[ip], *hClones[ip], *rngs_[ip]);
           Movers[ip]->setSpinMass(SpinMass);
           Movers[ip]->put(qmcNode);
           //Movers[ip]->resetRun(branchEngine.get(), estimatorClones[ip], traceClones[ip], DriftModifier);
@@ -157,9 +155,9 @@ void DMC::resetUpdateEngines()
         if (qmc_driver_mode[QMC_UPDATE_MODE])
         {
           if (L2 == "yes")
-            Movers[ip] = new DMCUpdatePbyPL2(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
+            Movers[ip] = new DMCUpdatePbyPL2(*wClones[ip], *psiClones[ip], *hClones[ip], *rngs_[ip]);
           else
-            Movers[ip] = new DMCUpdatePbyPWithRejectionFast(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
+            Movers[ip] = new DMCUpdatePbyPWithRejectionFast(*wClones[ip], *psiClones[ip], *hClones[ip], *rngs_[ip]);
 
           Movers[ip]->put(qmcNode);
           //Movers[ip]->resetRun(branchEngine.get(), estimatorClones[ip], traceClones[ip], DriftModifier);
@@ -169,9 +167,9 @@ void DMC::resetUpdateEngines()
         else
         {
           if (KillNodeCrossing)
-            Movers[ip] = new DMCUpdateAllWithKill(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
+            Movers[ip] = new DMCUpdateAllWithKill(*wClones[ip], *psiClones[ip], *hClones[ip], *rngs_[ip]);
           else
-            Movers[ip] = new DMCUpdateAllWithRejection(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
+            Movers[ip] = new DMCUpdateAllWithRejection(*wClones[ip], *psiClones[ip], *hClones[ip], *rngs_[ip]);
           Movers[ip]->put(qmcNode);
           //Movers[ip]->resetRun(branchEngine.get(), estimatorClones[ip], traceClones[ip], DriftModifier);
           Movers[ip]->resetRun2(branchEngine.get(), estimatorClones[ip], traceClones[ip],  wlog_collectors[ip].get(), DriftModifier);
@@ -299,11 +297,6 @@ bool DMC::run()
 #endif
     wlog_manager_->writeBuffers();
     block++;
-    if (DumpConfig && block % Period4CheckPoint == 0)
-    {
-      for (int ip = 0; ip < NumThreads; ip++)
-        rngs_[ip] = Rng[ip]->makeClone();
-    }
     recordBlock(block);
     dmc_loop.stop();
 
@@ -323,8 +316,6 @@ bool DMC::run()
 
   } while (block < nBlocks);
 
-  for (int ip = 0; ip < NumThreads; ip++)
-    rngs_[ip] = Rng[ip]->makeClone();
   Estimators->stop();
   for (int ip = 0; ip < NumThreads; ++ip)
     Movers[ip]->stopRun2();

--- a/src/QMCDrivers/DMC/DMC.h
+++ b/src/QMCDrivers/DMC/DMC.h
@@ -35,7 +35,7 @@ public:
       MCWalkerConfiguration& w,
       TrialWaveFunction& psi,
       QMCHamiltonian& h,
-      UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs,
+      const UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs,
       Communicate* comm,
       bool enable_profiling);
 
@@ -45,8 +45,8 @@ public:
   QMCRunType getRunType() override { return QMCRunType::DMC; }
 
 private:
-  //
-  UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs_;
+  ///driver copy of Random number generators
+  const UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs_;
   ///Index to determine what to do when node crossing is detected
   // does not appear to be used
   IndexType KillNodeCrossing;

--- a/src/QMCDrivers/DMC/DMC.h
+++ b/src/QMCDrivers/DMC/DMC.h
@@ -45,7 +45,7 @@ public:
   QMCRunType getRunType() override { return QMCRunType::DMC; }
 
 private:
-  ///driver copy of Random number generators
+  ///driver level reference of Random number generators
   const UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs_;
   ///Index to determine what to do when node crossing is detected
   // does not appear to be used

--- a/src/QMCDrivers/DMC/DMCFactory.cpp
+++ b/src/QMCDrivers/DMC/DMCFactory.cpp
@@ -28,7 +28,7 @@ std::unique_ptr<QMCDriver> DMCFactory::create(const ProjectData& project_data,
                                               Communicate* comm,
                                               bool enable_profiling)
 {
-  auto qmc = std::make_unique<DMC>(project_data, w, psi, h, RandomNumberControl::Children, comm, enable_profiling);
+  auto qmc = std::make_unique<DMC>(project_data, w, psi, h, RandomNumberControl::getChildren(), comm, enable_profiling);
   qmc->setUpdateMode(PbyPUpdate);
   return qmc;
 }

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -82,7 +82,6 @@ public:
 
   using Walker_t = MCWalkerConfiguration::Walker_t;
   using Buffer_t = Walker_t::Buffer_t;
-  using FullPrecRealType = QMCTraits::FullPrecRealType;
 
   /** bits to classify QMCDriver
    *
@@ -196,18 +195,6 @@ public:
 
   ///Traces manager
   std::unique_ptr<WalkerLogManager> wlog_manager_;
-
-  ///return the random generators
-  inline RefVector<RandomBase<FullPrecRealType>> getRngRefs() const
-  {
-    RefVector<RandomBase<FullPrecRealType>> RngRefs;
-    for (int i = 0; i < Rng.size(); ++i)
-      RngRefs.push_back(*Rng[i]);
-    return RngRefs;
-  }
-
-  ///return the i-th random generator
-  inline RandomBase<FullPrecRealType>& getRng(int i) override { return (*Rng[i]); }
 
   unsigned long getDriverMode() override { return qmc_driver_mode.to_ulong(); }
 
@@ -336,9 +323,6 @@ protected:
 
   ///a list of QMCHamiltonians for multiple method
   std::vector<QMCHamiltonian*> H1;
-
-  ///Random number generators
-  UPtrVector<RandomBase<FullPrecRealType>> Rng;
 
   ///a list of mcwalkerset element
   std::vector<xmlNodePtr> mcwalkerNodePtr;

--- a/src/QMCDrivers/QMCDriverInterface.h
+++ b/src/QMCDrivers/QMCDriverInterface.h
@@ -39,9 +39,6 @@ public:
   virtual bool put(xmlNodePtr cur)    = 0;
   virtual void recordBlock(int block) = 0;
 
-  ///return the i-th random generator
-  virtual RandomBase<FullPrecRealType>& getRng(int i) = 0;
-
   virtual void setStatus(const std::string& aname, const std::string& h5name, bool append) = 0;
 
   virtual void setUpdateMode(bool pbyp)                                 = 0;

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -220,9 +220,6 @@ public:
     return RngRefs;
   }
 
-  ///return the i-th random generator
-  inline RandomBase<FullPrecRealType>& getRng(int i) override { return (*Rng[i]); }
-
   /** intended for logging output and debugging
    *  you should base behavior on type preferably at compile time or if
    *  necessary at runtime using and protected by dynamic cast.

--- a/src/QMCDrivers/RMC/RMC.h
+++ b/src/QMCDrivers/RMC/RMC.h
@@ -59,6 +59,9 @@ private:
   std::vector<int> Action;
   std::vector<int> TransProb;
 
+  ///driver copy of Random number generators
+  UPtrVector<RandomBase<QMCTraits::FullPrecRealType>> Rng;
+
   ///check the run-time environments
   inline void resetVars()
   {

--- a/src/QMCDrivers/VMC/VMC.h
+++ b/src/QMCDrivers/VMC/VMC.h
@@ -52,7 +52,7 @@ private:
 
   ///option to enable/disable drift equation or RN for VMC
   std::string UseDrift;
-  ///driver copy of Random number generators
+  ///driver level reference of Random number generators
   const UPtrVector<RandomBase<FullPrecRealType>>& rngs_;
   ///check the run-time environments
   void resetRun();

--- a/src/QMCDrivers/VMC/VMC.h
+++ b/src/QMCDrivers/VMC/VMC.h
@@ -24,17 +24,27 @@ namespace qmcplusplus
 class VMC : public QMCDriver, public CloneManager
 {
 public:
+  using FullPrecRealType = QMCTraits::FullPrecRealType;
   /// Constructor.
   VMC(const ProjectData& project_data_,
       MCWalkerConfiguration& w,
       TrialWaveFunction& psi,
       QMCHamiltonian& h,
-      UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs,
+      const UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs,
       Communicate* comm,
       bool enable_profiling);
   bool run() override;
   bool put(xmlNodePtr cur) override;
   QMCRunType getRunType() override { return QMCRunType::VMC; }
+
+  ///return the random generators
+  inline RefVector<RandomBase<FullPrecRealType>> getRngRefs() const
+  {
+    RefVector<RandomBase<FullPrecRealType>> RngRefs;
+    for (int i = 0; i < rngs_.size(); ++i)
+      RngRefs.push_back(*rngs_[i]);
+    return RngRefs;
+  }
 
 private:
   int prevSteps;
@@ -42,8 +52,8 @@ private:
 
   ///option to enable/disable drift equation or RN for VMC
   std::string UseDrift;
-  //
-  UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs_;
+  ///driver copy of Random number generators
+  const UPtrVector<RandomBase<FullPrecRealType>>& rngs_;
   ///check the run-time environments
   void resetRun();
   ///copy constructor

--- a/src/QMCDrivers/VMC/VMCFactory.cpp
+++ b/src/QMCDrivers/VMC/VMCFactory.cpp
@@ -41,7 +41,7 @@ std::unique_ptr<QMCDriverInterface> VMCFactory::create(const ProjectData& projec
   std::unique_ptr<QMCDriverInterface> qmc;
   if (VMCMode == 0 || VMCMode == 1) //(0,0,0) (0,0,1)
   {
-    qmc = std::make_unique<VMC>(project_data, w, psi, h, RandomNumberControl::Children, comm, enable_profiling);
+    qmc = std::make_unique<VMC>(project_data, w, psi, h, RandomNumberControl::getChildren(), comm, enable_profiling);
   }
   else if (VMCMode == 2 || VMCMode == 3)
   {

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
@@ -32,6 +32,7 @@ namespace qmcplusplus
 {
 
 class GradientTest;
+class VMC;
 
 /** @ingroup QMCDrivers
  * @brief Implements wave-function optimization
@@ -223,7 +224,7 @@ private:
   ///target cost function to optimize
   std::unique_ptr<QMCCostFunctionBase> optTarget;
   ///vmc engine
-  std::unique_ptr<QMCDriver> vmcEngine;
+  std::unique_ptr<VMC> vmcEngine;
   ///xml node to be dumped
   xmlNodePtr wfNode;
 

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -21,7 +21,6 @@
 #include "QMCDrivers/QMCDriverNew.h"
 #include "QMCDrivers/QMCDriverInput.h"
 #include "QMCDrivers/VMC/VMCDriverInput.h"
-#include "QMCDrivers/VMC/VMCBatched.h"
 #include "Optimize/NRCOptimization.h"
 #include "Optimize/NRCOptimizationFunctionWrapper.h"
 #ifdef HAVE_LMY_ENGINE
@@ -45,7 +44,7 @@ namespace qmcplusplus
 
 ///forward declaration of a cost function
 class QMCCostFunctionBase;
-
+class VMCBatched;
 class GradientTest;
 
 

--- a/src/QMCDrivers/WaveFunctionTester.cpp
+++ b/src/QMCDrivers/WaveFunctionTester.cpp
@@ -112,8 +112,6 @@ bool WaveFunctionTester::run()
 
   auto Rng1 = std::make_unique<RandomGenerator>();
   H.setRandomGenerator(Rng1.get());
-  // Add to Rng so the object is eventually deleted
-  Rng.emplace_back(std::move(Rng1));
 
   if (checkSlaterDetOption == "no")
     checkSlaterDet = false;
@@ -1934,8 +1932,6 @@ void WaveFunctionTester::runDerivCloneTest()
   auto h_clone   = H.makeClone(*w_clone, *psi_clone);
   h_clone->setRandomGenerator(Rng2.get());
   H.setRandomGenerator(Rng1.get());
-  // Add to Rng so the object is eventually deleted
-  Rng.emplace_back(std::move(Rng1));
   h_clone->setPrimary(true);
   int nat = W.getTotalNum();
   ParticleSet::ParticlePos deltaR(nat);


### PR DESCRIPTION
## Proposed changes
Individual derived class should carry the know whether and how many RNGs to carry with.
I'm refactoring legacy drivers here and will later touch the batched drivers.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted