### PR TITLE
Move QMCDriveNew::rngs_/step_contexts_ to derived classes.

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -390,6 +390,7 @@ void DMCBatched::process(xmlNodePtr node)
                                qmcdriver_input_.get_requested_steps(), qmcdriver_input_.get_max_blocks());
 
     Base::initializeQMC(awc);
+    createRngsStepContexts(crowds_.size());
   }
   catch (const UniformCommunicateError& ue)
   {

--- a/src/QMCDrivers/DMC/DMCBatched.h
+++ b/src/QMCDrivers/DMC/DMCBatched.h
@@ -35,7 +35,6 @@ class DMCBatchedTest;
 class DMCBatched : public QMCDriverNew
 {
 public:
-  using Base              = QMCDriverNew;
   using FullPrecRealType  = QMCTraits::FullPrecRealType;
   using PosType           = QMCTraits::PosType;
   using ParticlePositions = PtclOnLatticeTraits::ParticlePos;

--- a/src/QMCDrivers/DMC/DMCBatched.h
+++ b/src/QMCDrivers/DMC/DMCBatched.h
@@ -135,6 +135,8 @@ private:
   const DMCDriverInput dmcdriver_input_;
   ///Random number generators
   const RefVector<RandomBase<FullPrecRealType>> rngs_;
+  /// Per crowd, driver-specific move contexts
+  UPtrVector<ContextForSteps> step_contexts_;
 
   /** I think its better if these have there own type and variable name
    */

--- a/src/QMCDrivers/DMC/DMCBatched.h
+++ b/src/QMCDrivers/DMC/DMCBatched.h
@@ -133,6 +133,8 @@ public:
 
 private:
   const DMCDriverInput dmcdriver_input_;
+  ///Random number generators
+  const RefVector<RandomBase<FullPrecRealType>> rngs_;
 
   /** I think its better if these have there own type and variable name
    */
@@ -143,6 +145,9 @@ private:
   std::unique_ptr<SFNBranch> branch_engine_;
   ///walker controller for load-balance
   std::unique_ptr<WalkerControl> walker_controller_;
+
+  // create Rngs and StepContests
+  void createRngsStepContexts(int num_crowds);
 
   template<CoordsType CT>
   static void advanceWalkers(const StateForThread& sft,

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -174,9 +174,6 @@ void QMCDriverNew::initializeQMC(const AdjustedWalkerCounts& awc)
   //now give walkers references to their walkers
   population_.redistributeWalkers(crowds_);
 
-  // Once they are created move contexts can be created.
-  createRngsStepContexts(crowds_.size());
-
   if (qmcdriver_input_.get_measure_imbalance())
     measureImbalance("Startup");
 }

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -116,10 +116,8 @@ void QMCDriverNew::checkNumCrowdsLTNumThreads(const int num_crowds)
   }
 }
 
-void QMCDriverNew::initializeQMC(const AdjustedWalkerCounts& awc)
+void QMCDriverNew::initPopulationAndCrowds(const AdjustedWalkerCounts& awc)
 {
-  ScopedTimer local_timer(timers_.startup_timer);
-
   app_summary() << QMCType << " Driver running with" << std::endl
                 << "             total_walkers     = " << awc.global_walkers << std::endl
                 << "             walkers_per_rank  = " << awc.walkers_per_rank << std::endl
@@ -173,9 +171,6 @@ void QMCDriverNew::initializeQMC(const AdjustedWalkerCounts& awc)
 
   //now give walkers references to their walkers
   population_.redistributeWalkers(crowds_);
-
-  if (qmcdriver_input_.get_measure_imbalance())
-    measureImbalance("Startup");
 }
 
 /** QMCDriverNew ignores h5name if you want to read and h5 config you have to explicitly

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -449,10 +449,6 @@ protected:
   ///record engine for walkers
   std::unique_ptr<HDFWalkerOutput> wOut;
 
-  /** Per crowd move contexts, this is where the DistanceTables etc. reside
-   */
-  UPtrVector<ContextForSteps> step_contexts_;
-
   ///a list of mcwalkerset element
   std::vector<xmlNodePtr> mcwalkerNodePtr;
 

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -125,9 +125,9 @@ protected:
   };
   /** Do common section starting tasks for VMC and DMC
    *
-   * set up population_, crowds_, rngs and step_contexts_
+   * set up population_, crowds_
    */
-  void initializeQMC(const AdjustedWalkerCounts& awc);
+  void initPopulationAndCrowds(const AdjustedWalkerCounts& awc);
 
   /// inject additional barrier and measure load imbalance.
   void measureImbalance(const std::string& tag) const;

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -208,17 +208,7 @@ public:
 
   void add_H_and_Psi(QMCHamiltonian* h, TrialWaveFunction* psi) override{};
 
-  void createRngsStepContexts(int num_crowds);
-
   void putWalkers(std::vector<xmlNodePtr>& wset) override;
-
-  inline RefVector<RandomBase<FullPrecRealType>> getRngRefs() const
-  {
-    RefVector<RandomBase<FullPrecRealType>> RngRefs;
-    for (int i = 0; i < Rng.size(); ++i)
-      RngRefs.push_back(*Rng[i]);
-    return RngRefs;
-  }
 
   /** intended for logging output and debugging
    *  you should base behavior on type preferably at compile time or if
@@ -462,9 +452,6 @@ protected:
   /** Per crowd move contexts, this is where the DistanceTables etc. reside
    */
   UPtrVector<ContextForSteps> step_contexts_;
-
-  ///Random number generators
-  UPtrVector<RandomBase<FullPrecRealType>> Rng;
 
   ///a list of mcwalkerset element
   std::vector<xmlNodePtr> mcwalkerNodePtr;

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -281,6 +281,7 @@ void VMCBatched::process(xmlNodePtr node)
                                qmcdriver_input_.get_requested_steps(), qmcdriver_input_.get_max_blocks());
 
     Base::initializeQMC(awc);
+    createRngsStepContexts(crowds_.size());
   }
   catch (const UniformCommunicateError& ue)
   {

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -131,6 +131,9 @@ private:
   VMCDriverInput vmcdriver_input_;
   ///Random number generators
   const RefVector<RandomBase<FullPrecRealType>> rngs_;
+  /// Per crowd, driver-specific move contexts
+  UPtrVector<ContextForSteps> step_contexts_;
+
 
   QMCRunType getRunType() override { return QMCRunType::VMC_BATCH; }
   /// Storage for samples (later used in optimizer)

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -82,6 +82,10 @@ public:
              MCPopulation&& pop,
              SampleStack& samples_,
              Communicate* comm);
+  /// Copy constructor
+  VMCBatched(const VMCBatched&) = delete;
+  /// Copy operator (disabled).
+  VMCBatched& operator=(const VMCBatched&) = delete;
 
   void process(xmlNodePtr node) override;
 
@@ -121,21 +125,22 @@ public:
    */
   void enable_sample_collection();
 
+  const RefVector<RandomBase<FullPrecRealType>>& getRngRefs() const { return rngs_; }
+
 private:
-  int prevSteps;
-  int prevStepsBetweenSamples;
   VMCDriverInput vmcdriver_input_;
+  ///Random number generators
+  const RefVector<RandomBase<FullPrecRealType>> rngs_;
+
   QMCRunType getRunType() override { return QMCRunType::VMC_BATCH; }
-  /// Copy constructor
-  VMCBatched(const VMCBatched&) = delete;
-  /// Copy operator (disabled).
-  VMCBatched& operator=(const VMCBatched&) = delete;
-
-
   /// Storage for samples (later used in optimizer)
   SampleStack& samples_;
   /// Sample collection flag
   bool collect_samples_;
+
+  // create Rngs and StepContests
+  void createRngsStepContexts(int num_crowds);
+
   /** function to calculate samples per MPI rank
    */
   static size_t compute_samples_per_rank(const size_t num_blocks,

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -34,7 +34,6 @@ class VMCBatchedTest;
 class VMCBatched : public QMCDriverNew
 {
 public:
-  using Base              = QMCDriverNew;
   using FullPrecRealType  = QMCTraits::FullPrecRealType;
   using PosType           = QMCTraits::PosType;
   using ParticlePositions = PtclOnLatticeTraits::ParticlePos;

--- a/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
+++ b/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
@@ -55,7 +55,7 @@ public:
         adjustGlobalWalkerCount(*myComm, 0, qmcdriver_input_.get_total_walkers(), qmcdriver_input_.get_walkers_per_rank(),
                                 1.0, qmcdriver_input_.get_num_crowds());
 
-    Base::initializeQMC(awc);
+    initPopulationAndCrowds(awc);
   }
 
   void testAdjustGlobalWalkerCount()

--- a/src/Utilities/RandomNumberControl.cpp
+++ b/src/Utilities/RandomNumberControl.cpp
@@ -48,6 +48,15 @@ UPtrVector<RandomNumberControl::Generator>& RandomNumberControl::getChildren()
   return Children;
 }
 
+RefVector<RandomNumberControl::Generator> RandomNumberControl::getChildrenRefs()
+{
+  auto& rngs_children = getChildren();
+  RefVector<Generator> rng_refs;
+  for (auto& child: rngs_children)
+    rng_refs.push_back(*child);
+  return rng_refs;
+}
+
 /// generic output
 bool RandomNumberControl::get(std::ostream& os) const
 {

--- a/src/Utilities/RandomNumberControl.h
+++ b/src/Utilities/RandomNumberControl.h
@@ -50,6 +50,8 @@ public:
 
   /// access RandomNumberControl::Children. If not initialized, make them first before return. Safe to use in unit tests.
   static UPtrVector<Generator>& getChildren();
+  /// access RandomNumberControl::Children as references of each child. If not initialized, make them first before return. Safe to use in unit tests.
+  static RefVector<Generator> getChildrenRefs();
 
   bool get(std::ostream& os) const override;
   bool put(std::istream& is) override;


### PR DESCRIPTION
## Proposed changes
Following #5122. Make RNGs driver specific object and remove the ownership motion of RNGs in VMC/DMC batched drivers.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
