### PR TITLE
qmc-fit help keys are auto-populated correctly

### DIFF
--- a/nexus/bin/qmc-fit
+++ b/nexus/bin/qmc-fit
@@ -652,8 +652,9 @@ def parse_args():
     parser.add_argument('fit_type', choices=['ts', 'u', 'eos'], default = 'ts',
                         help='One dimensional parameter used to fit QMC local energies. Options are ts for timestep and u for hubbard_u parameter fitting'
                         ) 
+    valid_fit_functions = set([j for i in all_fit_functions.keys() for j in all_fit_functions[i].keys()])
     parser.add_argument('-f','--fit',dest='fit_function',default='linear',
-                        help='Fitting function, options are {0}.'.format(sorted(fit_functions.keys()))
+                        help='Fitting function, options are {0}.'.format(sorted(valid_fit_functions))
                         )                        
     # List of 1-D parameters, mutually exclusive
     parameters = parser.add_mutually_exclusive_group(required=True)


### PR DESCRIPTION
## Proposed changes
A minor fix that autogenerates the valid keys for `qmc-fit`.
```
# Before
  -f FIT_FUNCTION, --fit FIT_FUNCTION
                        Fitting function, options are []. (default: linear)
# After
  -f FIT_FUNCTION, --fit FIT_FUNCTION
                        Fitting function, options are ['birch', 'cubic',
                        'linear', 'morse', 'murnaghan', 'quadratic',
                        'quartic', 'sqrt', 'vinet']. (default: linear)
 ```

## What type(s) of changes does this code introduce?


- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
local workstation

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
