### PR TITLE
Remove ENABLE_OFFLOAD_CLANG_DEBUG_O3 option in CMake and raise Clang minimal version to 16 when using offload

### DIFF
--- a/CMake/ClangCompilers.cmake
+++ b/CMake/ClangCompilers.cmake
@@ -1,7 +1,7 @@
 # Check compiler version
 if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
   message(STATUS "Compiler Version ${CMAKE_CXX_COMPILER_VERSION}")
-  message(FATAL_ERROR "Requires clang 7.0 or higher ")
+  message(FATAL_ERROR "Requires Clang 7.0 or higher.")
 endif()
 
 if(CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 11.0.0
@@ -16,6 +16,10 @@ if(QMC_OMP)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
 
   if(ENABLE_OFFLOAD)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16.0)
+      message(FATAL_ERROR "Requires Clang 16.0 or higher for OpenMP offload")
+    endif()
+
     if(DEFINED OFFLOAD_TARGET)
       set(OPENMP_OFFLOAD_COMPILE_OPTIONS "-fopenmp-targets=${OFFLOAD_TARGET}")
       if(DEFINED OFFLOAD_ARCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,19 +385,6 @@ if(QMC_OMP)
     endif()
   endif()
 
-  #--------------------------------------------------------------
-  # Workaround for breakage of OMP Target kernels at -O0 by Clang
-  #--------------------------------------------------------------
-  # When the build type is Debug, default -O0 compilation is broken by
-  # Clang 15 as of 5d2ce7663b10c107328a4ae0c678165209e64619.
-  # Previous compilers are not suggested for clang offload builds.
-  #
-  # You can set this option to false on the command line to check
-  # if this problem has been fixed.
-  if((${COMPILER} MATCHES "Clang") AND ENABLE_OFFLOAD)
-    option(ENABLE_OFFLOAD_CLANG_DEBUG_O3 "build OMP target kernels with -O3 in the build type Debug" ON)
-  endif()
-  mark_as_advanced(ENABLE_OFFLOAD_CLANG_DEBUG_O3)
   TestCXXMainCompiles("With_OpenMP")
 endif()
 

--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -59,8 +59,6 @@ add_library(qmcparticle_omptarget OBJECT ${PARTICLE_OMPTARGET_SRCS})
 target_include_directories(qmcparticle_omptarget PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcparticle_omptarget PUBLIC qmcutil containers)
 
-target_compile_options(qmcparticle_omptarget PRIVATE "$<$<BOOL:${ENABLE_OFFLOAD_CLANG_DEBUG_O3}>:$<$<CONFIG:DEBUG>:-O3>>")
-
 target_link_libraries(qmcparticle PUBLIC qmcparticle_omptarget)
 
 if(BUILD_UNIT_TESTS)

--- a/src/Platforms/OMPTarget/CMakeLists.txt
+++ b/src/Platforms/OMPTarget/CMakeLists.txt
@@ -24,9 +24,6 @@ endif()
 target_link_libraries(platform_omptarget_runtime PRIVATE platform_host_runtime)
 target_link_libraries(platform_omptarget_LA PUBLIC platform_omptarget_runtime)
 
-target_compile_options(platform_omptarget_LA
-                       PRIVATE "$<$<BOOL:${ENABLE_OFFLOAD_CLANG_DEBUG_O3}>:$<$<CONFIG:DEBUG>:-O3>>")
-
 if(ENABLE_CUDA AND QMC_OFFLOAD_MEM_ASSOCIATED)
   target_link_libraries(platform_omptarget_runtime PUBLIC platform_cuda_runtime)
 endif()

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -157,8 +157,6 @@ add_library(qmcwfs_omptarget OBJECT ${JASTROW_OMPTARGET_SRCS} ${FERMION_OMPTARGE
 target_include_directories(qmcwfs_omptarget PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcwfs_omptarget PUBLIC qmcutil qmcparticle containers platform_LA)
 
-target_compile_options(qmcwfs_omptarget PRIVATE "$<$<BOOL:${ENABLE_OFFLOAD_CLANG_DEBUG_O3}>:$<$<CONFIG:DEBUG>:-O3>>")
-
 target_link_libraries(qmcwfs PUBLIC qmcwfs_omptarget)
 
 if(ENABLE_CUDA)


### PR DESCRIPTION
## Proposed changes
I got nvlink failure when using llvm 15 but 16 was OK. So raise the minimal version to 16 when using offload.
Closes #5127. Debug build works fine with clang 16 without -O3.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
