### PR TITLE
Split QMCDriverNew::initializeQMC

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -390,6 +390,7 @@ void DMCBatched::process(xmlNodePtr node)
                                qmcdriver_input_.get_requested_steps(), qmcdriver_input_.get_max_blocks());
 
     Base::initializeQMC(awc);
+    createRngsStepContexts(crowds_.size());
   }
   catch (const UniformCommunicateError& ue)
   {

--- a/src/QMCDrivers/DMC/DMCBatched.h
+++ b/src/QMCDrivers/DMC/DMCBatched.h
@@ -35,7 +35,6 @@ class DMCBatchedTest;
 class DMCBatched : public QMCDriverNew
 {
 public:
-  using Base              = QMCDriverNew;
   using FullPrecRealType  = QMCTraits::FullPrecRealType;
   using PosType           = QMCTraits::PosType;
   using ParticlePositions = PtclOnLatticeTraits::ParticlePos;

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -174,9 +174,6 @@ void QMCDriverNew::initializeQMC(const AdjustedWalkerCounts& awc)
   //now give walkers references to their walkers
   population_.redistributeWalkers(crowds_);
 
-  // Once they are created move contexts can be created.
-  createRngsStepContexts(crowds_.size());
-
   if (qmcdriver_input_.get_measure_imbalance())
     measureImbalance("Startup");
 }

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -116,10 +116,8 @@ void QMCDriverNew::checkNumCrowdsLTNumThreads(const int num_crowds)
   }
 }
 
-void QMCDriverNew::initializeQMC(const AdjustedWalkerCounts& awc)
+void QMCDriverNew::initPopulationAndCrowds(const AdjustedWalkerCounts& awc)
 {
-  ScopedTimer local_timer(timers_.startup_timer);
-
   app_summary() << QMCType << " Driver running with" << std::endl
                 << "             total_walkers     = " << awc.global_walkers << std::endl
                 << "             walkers_per_rank  = " << awc.walkers_per_rank << std::endl
@@ -173,9 +171,6 @@ void QMCDriverNew::initializeQMC(const AdjustedWalkerCounts& awc)
 
   //now give walkers references to their walkers
   population_.redistributeWalkers(crowds_);
-
-  if (qmcdriver_input_.get_measure_imbalance())
-    measureImbalance("Startup");
 }
 
 /** QMCDriverNew ignores h5name if you want to read and h5 config you have to explicitly

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -125,9 +125,9 @@ protected:
   };
   /** Do common section starting tasks for VMC and DMC
    *
-   * set up population_, crowds_, rngs and step_contexts_
+   * set up population_, crowds_
    */
-  void initializeQMC(const AdjustedWalkerCounts& awc);
+  void initPopulationAndCrowds(const AdjustedWalkerCounts& awc);
 
   /// inject additional barrier and measure load imbalance.
   void measureImbalance(const std::string& tag) const;

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -281,6 +281,7 @@ void VMCBatched::process(xmlNodePtr node)
                                qmcdriver_input_.get_requested_steps(), qmcdriver_input_.get_max_blocks());
 
     Base::initializeQMC(awc);
+    createRngsStepContexts(crowds_.size());
   }
   catch (const UniformCommunicateError& ue)
   {

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -34,7 +34,6 @@ class VMCBatchedTest;
 class VMCBatched : public QMCDriverNew
 {
 public:
-  using Base              = QMCDriverNew;
   using FullPrecRealType  = QMCTraits::FullPrecRealType;
   using PosType           = QMCTraits::PosType;
   using ParticlePositions = PtclOnLatticeTraits::ParticlePos;

--- a/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
+++ b/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
@@ -55,7 +55,7 @@ public:
         adjustGlobalWalkerCount(*myComm, 0, qmcdriver_input_.get_total_walkers(), qmcdriver_input_.get_walkers_per_rank(),
                                 1.0, qmcdriver_input_.get_num_crowds());
 
-    Base::initializeQMC(awc);
+    initPopulationAndCrowds(awc);
   }
 
   void testAdjustGlobalWalkerCount()


### PR DESCRIPTION
# Proposed changes
`QMCDriverNew::initializeQMC` creates Crowds and StepContexts. Consider the StepContexts is driver specific. I need to move them out of the base class and create driver-specific variants. For this reason, split `initializeQMC`

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted