### PR TITLE
Capture RNG resource via batched driver constructor

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -33,7 +33,6 @@
 #include "TauParams.hpp"
 #include "WalkerLogManager.h"
 #include "CPU/math.hpp"
-#include "RandomNumberControl.h"
 
 namespace qmcplusplus
 {
@@ -51,17 +50,18 @@ DMCBatched::DMCBatched(const ProjectData& project_data,
                        DMCDriverInput&& input,
                        WalkerConfigurations& wc,
                        MCPopulation&& pop,
+                       const RefVector<RandomBase<FullPrecRealType>>& rng_refs,
                        Communicate* comm)
     : QMCDriverNew(project_data,
                    std::move(qmcdriver_input),
                    std::move(estimator_manager),
                    wc,
                    std::move(pop),
+                   rng_refs,
                    "DMCBatched::",
                    comm,
                    "DMCBatched"),
       dmcdriver_input_(input),
-      rngs_(RandomNumberControl::getChildrenRefs()),
       dmc_timers_("DMCBatched::")
 {}
 
@@ -384,7 +384,6 @@ void DMCBatched::process(xmlNodePtr node)
 
   try
   {
-
     QMCDriverNew::AdjustedWalkerCounts awc =
         adjustGlobalWalkerCount(*myComm, walker_configs_ref_.getActiveWalkers(), qmcdriver_input_.get_total_walkers(),
                                 qmcdriver_input_.get_walkers_per_rank(), dmcdriver_input_.get_reserve(),
@@ -556,9 +555,6 @@ bool DMCBatched::run()
 
   wlog_manager.stopRun();
   estimator_manager_->stopDriverRun();
-
-  if (qmcdriver_input_.get_dump_config())
-    RandomNumberControl::write(rngs_, get_root_name(), myComm);
 
   return finalize(num_blocks, true);
 }

--- a/src/QMCDrivers/DMC/DMCBatched.h
+++ b/src/QMCDrivers/DMC/DMCBatched.h
@@ -135,6 +135,8 @@ private:
   const DMCDriverInput dmcdriver_input_;
   ///Random number generators
   const RefVector<RandomBase<FullPrecRealType>> rngs_;
+  /// Per crowd, driver-specific move contexts
+  UPtrVector<ContextForSteps> step_contexts_;
 
   /** I think its better if these have there own type and variable name
    */

--- a/src/QMCDrivers/DMC/DMCBatched.h
+++ b/src/QMCDrivers/DMC/DMCBatched.h
@@ -133,6 +133,8 @@ public:
 
 private:
   const DMCDriverInput dmcdriver_input_;
+  ///Random number generators
+  const RefVector<RandomBase<FullPrecRealType>> rngs_;
 
   /** I think its better if these have there own type and variable name
    */
@@ -143,6 +145,9 @@ private:
   std::unique_ptr<SFNBranch> branch_engine_;
   ///walker controller for load-balance
   std::unique_ptr<WalkerControl> walker_controller_;
+
+  // create Rngs and StepContests
+  void createRngsStepContexts(int num_crowds);
 
   template<CoordsType CT>
   static void advanceWalkers(const StateForThread& sft,

--- a/src/QMCDrivers/DMC/DMCBatched.h
+++ b/src/QMCDrivers/DMC/DMCBatched.h
@@ -90,6 +90,7 @@ public:
              DMCDriverInput&& input,
              WalkerConfigurations& wc,
              MCPopulation&& pop,
+             const RefVector<RandomBase<FullPrecRealType>>& rng_refs,
              Communicate* comm);
 
   /// Copy Constructor (disabled)
@@ -133,8 +134,6 @@ public:
 
 private:
   const DMCDriverInput dmcdriver_input_;
-  ///Random number generators
-  const RefVector<RandomBase<FullPrecRealType>> rngs_;
   /// Per crowd, driver-specific move contexts
   UPtrVector<ContextForSteps> step_contexts_;
 

--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -45,6 +45,7 @@
 #include "Estimators/EstimatorInputDelegates.h"
 #include "Estimators/EstimatorManagerNew.h"
 #include "Message/UniformCommunicateError.h"
+#include "RandomNumberControl.h"
 
 namespace qmcplusplus
 {
@@ -273,7 +274,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
                                      makeEstimatorManager(emi, qmcdriver_input.get_estimator_manager_input()),
                                      std::move(vmcdriver_input), qmc_system,
                                      MCPopulation(comm->size(), comm->rank(), &qmc_system, primaryPsi, primaryH),
-                                     qmc_system.getSampleStack(), comm);
+                                     RandomNumberControl::getChildrenRefs(), qmc_system.getSampleStack(), comm);
 
     new_driver->setUpdateMode(1);
   }
@@ -305,7 +306,8 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
         std::make_unique<DMCBatched>(project_data_, std::move(qmcdriver_input),
                                      makeEstimatorManager(emi, qmcdriver_input.get_estimator_manager_input()),
                                      std::move(dmcdriver_input), qmc_system,
-                                     MCPopulation(comm->size(), comm->rank(), &qmc_system, primaryPsi, primaryH), comm);
+                                     MCPopulation(comm->size(), comm->rank(), &qmc_system, primaryPsi, primaryH),
+                                     RandomNumberControl::getChildrenRefs(), comm);
   }
   else if (das.new_run_type == QMCRunType::RMC)
   {
@@ -356,6 +358,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
                                                                      std::move(vmcdriver_input), qmc_system,
                                                                      MCPopulation(comm->size(), comm->rank(),
                                                                                   &qmc_system, primaryPsi, primaryH),
+                                                                     RandomNumberControl::getChildrenRefs(),
                                                                      qmc_system.getSampleStack(), comm);
     opt->setWaveFunctionNode(wavefunction_pool.getWaveFunctionNode("psi0"));
     new_driver = std::move(opt);

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -36,7 +36,7 @@
 #include "Message/UniformCommunicateError.h"
 #include "EstimatorInputDelegates.h"
 #include "WalkerLogManager.h"
-
+#include "RandomNumberControl.h"
 
 namespace qmcplusplus
 {
@@ -50,6 +50,7 @@ QMCDriverNew::QMCDriverNew(const ProjectData& project_data,
                            UPtr<EstimatorManagerNew>&& estimator_manager,
                            WalkerConfigurations& wc,
                            MCPopulation&& population,
+                           const RefVector<RandomBase<FullPrecRealType>>& rng_refs,
                            const std::string timer_prefix,
                            Communicate* comm,
                            const std::string& QMC_driver_type)
@@ -58,6 +59,7 @@ QMCDriverNew::QMCDriverNew(const ProjectData& project_data,
       QMCType(QMC_driver_type),
       population_(std::move(population)),
       serializing_crowd_walkers_(qmcdriver_input_.areWalkersSerialized()),
+      rngs_(rng_refs),
       timers_(timer_prefix),
       driver_scope_profiler_(qmcdriver_input_.get_scoped_profiling()),
       project_data_(project_data),
@@ -220,6 +222,9 @@ bool QMCDriverNew::finalize(int block, bool dumpwalkers)
 
   infoSummary.flush();
   infoLog.flush();
+
+  if (DumpConfig)
+    RandomNumberControl::write(rngs_, get_root_name(), myComm);
 
   return true;
 }

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -152,6 +152,7 @@ public:
                UPtr<EstimatorManagerNew>&& estimator_manager,
                WalkerConfigurations& wc,
                MCPopulation&& population,
+               const RefVector<RandomBase<FullPrecRealType>>& rng_refs,
                const std::string timer_prefix,
                Communicate* comm,
                const std::string& QMC_driver_type);
@@ -174,6 +175,8 @@ public:
   void makeLocalWalkers(int nwalkers, RealType reserve);
 
   DriftModifierBase& get_drift_modifier() const { return *drift_modifier_; }
+
+  const RefVector<RandomBase<FullPrecRealType>>& getRngRefs() const { return rngs_; }
 
   /** record the state of the block
    * @param block current block
@@ -448,6 +451,12 @@ protected:
 
   ///record engine for walkers
   std::unique_ptr<HDFWalkerOutput> wOut;
+
+  /** driver captured references of random number generators (RNGs)
+   * that all the uses of RNG within the driver should be based on.
+   * The number of crowds is restricted by the count of RNGs.
+   */
+  const RefVector<RandomBase<FullPrecRealType>> rngs_;
 
   ///a list of mcwalkerset element
   std::vector<xmlNodePtr> mcwalkerNodePtr;

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -449,10 +449,6 @@ protected:
   ///record engine for walkers
   std::unique_ptr<HDFWalkerOutput> wOut;
 
-  /** Per crowd move contexts, this is where the DistanceTables etc. reside
-   */
-  UPtrVector<ContextForSteps> step_contexts_;
-
   ///a list of mcwalkerset element
   std::vector<xmlNodePtr> mcwalkerNodePtr;
 

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -208,17 +208,7 @@ public:
 
   void add_H_and_Psi(QMCHamiltonian* h, TrialWaveFunction* psi) override{};
 
-  void createRngsStepContexts(int num_crowds);
-
   void putWalkers(std::vector<xmlNodePtr>& wset) override;
-
-  inline RefVector<RandomBase<FullPrecRealType>> getRngRefs() const
-  {
-    RefVector<RandomBase<FullPrecRealType>> RngRefs;
-    for (int i = 0; i < Rng.size(); ++i)
-      RngRefs.push_back(*Rng[i]);
-    return RngRefs;
-  }
 
   /** intended for logging output and debugging
    *  you should base behavior on type preferably at compile time or if
@@ -462,9 +452,6 @@ protected:
   /** Per crowd move contexts, this is where the DistanceTables etc. reside
    */
   UPtrVector<ContextForSteps> step_contexts_;
-
-  ///Random number generators
-  UPtrVector<RandomBase<FullPrecRealType>> Rng;
 
   ///a list of mcwalkerset element
   std::vector<xmlNodePtr> mcwalkerNodePtr;

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -25,7 +25,6 @@
 #include <Hdispatcher.h>
 #include "TauParams.hpp"
 #include "WalkerLogManager.h"
-#include "RandomNumberControl.h"
 
 namespace qmcplusplus
 {
@@ -37,18 +36,19 @@ VMCBatched::VMCBatched(const ProjectData& project_data,
                        VMCDriverInput&& input,
                        WalkerConfigurations& wc,
                        MCPopulation&& pop,
-		       SampleStack& samples,
+                       const RefVector<RandomBase<FullPrecRealType>>& rng_refs,
+                       SampleStack& samples,
                        Communicate* comm)
     : QMCDriverNew(project_data,
                    std::move(qmcdriver_input),
                    std::move(estimator_manager),
                    wc,
                    std::move(pop),
-		   "VMCBatched::",
+                   rng_refs,
+                   "VMCBatched::",
                    comm,
                    "VMCBatched"),
       vmcdriver_input_(input),
-      rngs_(RandomNumberControl::getChildrenRefs()),
       samples_(samples),
       collect_samples_(false)
 {}
@@ -469,9 +469,6 @@ bool VMCBatched::run()
 
   wlog_manager.stopRun();
   estimator_manager_->stopDriverRun();
-
-  if (qmcdriver_input_.get_dump_config())
-    RandomNumberControl::write(rngs_, get_root_name(), myComm);
 
   return finalize(num_blocks, true);
 }

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -131,6 +131,9 @@ private:
   VMCDriverInput vmcdriver_input_;
   ///Random number generators
   const RefVector<RandomBase<FullPrecRealType>> rngs_;
+  /// Per crowd, driver-specific move contexts
+  UPtrVector<ContextForSteps> step_contexts_;
+
 
   QMCRunType getRunType() override { return QMCRunType::VMC_BATCH; }
   /// Storage for samples (later used in optimizer)

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -80,6 +80,7 @@ public:
              VMCDriverInput&& input,
              WalkerConfigurations& wc,
              MCPopulation&& pop,
+             const RefVector<RandomBase<FullPrecRealType>>& rng_refs,
              SampleStack& samples_,
              Communicate* comm);
   /// Copy constructor
@@ -125,12 +126,8 @@ public:
    */
   void enable_sample_collection();
 
-  const RefVector<RandomBase<FullPrecRealType>>& getRngRefs() const { return rngs_; }
-
 private:
   VMCDriverInput vmcdriver_input_;
-  ///Random number generators
-  const RefVector<RandomBase<FullPrecRealType>> rngs_;
   /// Per crowd, driver-specific move contexts
   UPtrVector<ContextForSteps> step_contexts_;
 

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -82,6 +82,10 @@ public:
              MCPopulation&& pop,
              SampleStack& samples_,
              Communicate* comm);
+  /// Copy constructor
+  VMCBatched(const VMCBatched&) = delete;
+  /// Copy operator (disabled).
+  VMCBatched& operator=(const VMCBatched&) = delete;
 
   void process(xmlNodePtr node) override;
 
@@ -121,21 +125,22 @@ public:
    */
   void enable_sample_collection();
 
+  const RefVector<RandomBase<FullPrecRealType>>& getRngRefs() const { return rngs_; }
+
 private:
-  int prevSteps;
-  int prevStepsBetweenSamples;
   VMCDriverInput vmcdriver_input_;
+  ///Random number generators
+  const RefVector<RandomBase<FullPrecRealType>> rngs_;
+
   QMCRunType getRunType() override { return QMCRunType::VMC_BATCH; }
-  /// Copy constructor
-  VMCBatched(const VMCBatched&) = delete;
-  /// Copy operator (disabled).
-  VMCBatched& operator=(const VMCBatched&) = delete;
-
-
   /// Storage for samples (later used in optimizer)
   SampleStack& samples_;
   /// Sample collection flag
   bool collect_samples_;
+
+  // create Rngs and StepContests
+  void createRngsStepContexts(int num_crowds);
+
   /** function to calculate samples per MPI rank
    */
   static size_t compute_samples_per_rank(const size_t num_blocks,

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -51,6 +51,7 @@ QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(const P
                                                                          VMCDriverInput&& vmcdriver_input,
                                                                          WalkerConfigurations& wc,
                                                                          MCPopulation&& population,
+             const RefVector<RandomBase<FullPrecRealType>>& rng_refs,
                                                                          SampleStack& samples,
                                                                          Communicate* comm)
     : QMCDriverNew(
@@ -59,6 +60,7 @@ QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(const P
           nullptr, // this class is not a real QMCDriverNew as far as I can tell so we don't give it the actual EM
           wc,
           std::move(population),
+          rng_refs,
           "QMCLinearOptimizeBatched::",
           comm,
           "QMCLinearOptimizeBatched"),
@@ -736,6 +738,7 @@ bool QMCFixedSampleLinearOptimizeBatched::processOptXML(xmlNodePtr opt_xml,
                                    std::move(vmcdriver_input_copy), walker_configs_ref_,
                                    MCPopulation(myComm->size(), myComm->rank(), &population_.get_golden_electrons(),
                                                 &population_.get_golden_twf(), &population_.get_golden_hamiltonian()),
+                                   rngs_,
                                    samples_, myComm);
 
   vmcEngine->setUpdateMode(vmcMove[0] == 'p');

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -57,6 +57,7 @@ public:
                                       VMCDriverInput&& vmcdriver_input,
                                       WalkerConfigurations& wc,
                                       MCPopulation&& population,
+             const RefVector<RandomBase<FullPrecRealType>>& rng_refs,
                                       SampleStack& samples,
                                       Communicate* comm);
 

--- a/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
+++ b/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
@@ -33,12 +33,14 @@ public:
                           QMCDriverInput&& input,
                           WalkerConfigurations& wc,
                           MCPopulation&& population,
+                          const RefVector<RandomBase<FullPrecRealType>>& rng_refs,
                           Communicate* comm)
       : QMCDriverNew(test_project,
                      std::move(input),
                      nullptr,
                      wc,
                      std::move(population),
+                     rng_refs,
                      "QMCDriverTestWrapper::",
                      comm,
                      "QMCDriverNewTestWrapper")

--- a/src/QMCDrivers/tests/SetupDMCTest.h
+++ b/src/QMCDrivers/tests/SetupDMCTest.h
@@ -28,7 +28,7 @@ namespace testing
 class SetupDMCTest : public SetupPools
 {
 public:
-  SetupDMCTest(int nranks = 4) : num_ranks(nranks), qmcdrv_input()
+  SetupDMCTest(int nranks = 4) : rng_pool(Concurrency::maxCapacity<>()), num_ranks(nranks), qmcdrv_input()
   {
     if (Concurrency::maxCapacity<>() < 8)
       num_crowds = Concurrency::maxCapacity<>();
@@ -52,11 +52,14 @@ public:
             walker_confs,
             MCPopulation(comm->size(), comm->rank(), particle_pool->getParticleSet("e"),
                          wavefunction_pool->getPrimary(), hamiltonian_pool->getPrimary()),
+            rng_pool.getRngRefs(),
             comm};
   }
 
 private:
   ProjectData test_project;
+
+  RandomNumberGeneratorPool rng_pool;
 
 public:
   WalkerConfigurations walker_confs;

--- a/src/QMCDrivers/tests/SetupPools.cpp
+++ b/src/QMCDrivers/tests/SetupPools.cpp
@@ -36,5 +36,20 @@ SetupPools::SetupPools()
       MinimalHamiltonianPool::make_hamWithEE(comm, *particle_pool, *wavefunction_pool));
 }
 
+SetupPools::~SetupPools() = default;
+
+RandomNumberGeneratorPool::RandomNumberGeneratorPool(const size_t num) : rng_pool(num) {}
+
+RandomNumberGeneratorPool::~RandomNumberGeneratorPool() = default;
+
+RefVector<RandomBase<RandomNumberGeneratorPool::FullPrecRealType>> RandomNumberGeneratorPool::getRngRefs()
+{
+  RefVector<RandomBase<FullPrecRealType>> rng_refs;
+  rng_refs.reserve(rng_pool.size());
+  for (auto& rng : rng_pool)
+    rng_refs.push_back(rng);
+  return rng_refs;
+}
+
 } // namespace testing
 } // namespace qmcplusplus

--- a/src/QMCDrivers/tests/SetupPools.h
+++ b/src/QMCDrivers/tests/SetupPools.h
@@ -15,6 +15,8 @@
 #include "Message/Communicate.h"
 #include "type_traits/template_types.hpp"
 #include "OhmmsData/Libxml2Doc.h"
+#include "FakeRandom.h"
+#include "Configuration.h"
 
 namespace qmcplusplus
 {
@@ -29,6 +31,7 @@ class SetupPools
 {
 public:
   SetupPools();
+  ~SetupPools();
 
   UPtr<ParticleSetPool> particle_pool;
   UPtr<WaveFunctionPool> wavefunction_pool;
@@ -38,6 +41,20 @@ public:
   xmlNodePtr node;
 
   Communicate* comm;
+};
+
+class RandomNumberGeneratorPool
+{
+public:
+  using FullPrecRealType = QMCTraits::FullPrecRealType;
+
+  RandomNumberGeneratorPool(const size_t num);
+  ~RandomNumberGeneratorPool();
+
+  RefVector<RandomBase<FullPrecRealType>> getRngRefs();
+
+private:
+  std::vector<FakeRandom<FullPrecRealType>> rng_pool;
 };
 
 } // namespace testing

--- a/src/QMCDrivers/tests/test_DMCBatched.cpp
+++ b/src/QMCDrivers/tests/test_DMCBatched.cpp
@@ -20,6 +20,7 @@
 #include "Concurrency/Info.hpp"
 #include "Concurrency/UtilityFunctions.hpp"
 #include "Platforms/Host/OutputManager.h"
+#include "SetupPools.h"
 
 namespace qmcplusplus
 {
@@ -51,6 +52,7 @@ TEST_CASE("DMCDriver+QMCDriverNew integration", "[drivers]")
 {
   using namespace testing;
   Concurrency::OverrideMaxCapacity<> override(8);
+  RandomNumberGeneratorPool rng_pool(8);
   ProjectData test_project;
   Communicate* comm;
   comm = OHMMS::Controller;
@@ -75,7 +77,7 @@ TEST_CASE("DMCDriver+QMCDriverNew integration", "[drivers]")
   DMCBatched dmcdriver(test_project, std::move(qmcdriver_input), nullptr, std::move(dmcdriver_input), walker_confs,
                        MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
                                     wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
-                       comm);
+                       rng_pool.getRngRefs(), comm);
 
   // setStatus must be called before process
   std::string root_name{"Test"};

--- a/src/QMCDrivers/tests/test_QMCDriverNew.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverNew.cpp
@@ -23,6 +23,7 @@
 #include "QMCDrivers/MCPopulation.h"
 #include "Concurrency/Info.hpp"
 #include "Concurrency/UtilityFunctions.hpp"
+#include "SetupPools.h"
 
 namespace qmcplusplus
 {
@@ -30,6 +31,7 @@ TEST_CASE("QMCDriverNew tiny case", "[drivers]")
 {
   using namespace testing;
   Concurrency::OverrideMaxCapacity<> override(8);
+  RandomNumberGeneratorPool rng_pool(8);
   ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
   Communicate* comm = OHMMS::Controller;
   outputManager.pause();
@@ -49,7 +51,7 @@ TEST_CASE("QMCDriverNew tiny case", "[drivers]")
   QMCDriverNewTestWrapper qmcdriver(test_project, std::move(qmcdriver_input), walker_confs,
                                     MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
                                                  wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
-                                    comm);
+                                    rng_pool.getRngRefs(), comm);
 
   // setStatus must be called before process
   std::string root_name{"Test"};
@@ -74,36 +76,13 @@ TEST_CASE("QMCDriverNew more crowds than threads", "[drivers]")
   using namespace testing;
 
   Concurrency::OverrideMaxCapacity<> override(8);
-  ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
-  Communicate* comm = OHMMS::Controller;
-  outputManager.pause();
-
-  Libxml2Document doc;
-  bool okay = doc.parseFromString(valid_dmc_input_sections[valid_dmc_input_dmc_batch_index]);
-  REQUIRE(okay);
-  xmlNodePtr node = doc.getRoot();
-  QMCDriverInput qmcdriver_input;
-  qmcdriver_input.readXML(node);
-  auto particle_pool = MinimalParticlePool::make_diamondC_1x1x1(comm);
-  auto wavefunction_pool =
-      MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
-
-  auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
-
-  int num_crowds = 9;
-
   // test is a no op except for openmp, max threads is >> than num cores
   // in other concurrency models.
   if (Concurrency::maxCapacity<>() != 8)
     throw std::runtime_error("Insufficient threads available to match test input");
 
-  QMCDriverInput qmcdriver_copy(qmcdriver_input);
-  WalkerConfigurations walker_confs;
-  QMCDriverNewTestWrapper qmc_batched(test_project, std::move(qmcdriver_copy), walker_confs,
-                                      MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
-                                                   wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
-                                      comm);
   QMCDriverNewTestWrapper::TestNumCrowdsVsNumThreads<ParallelExecutor<>> testNumCrowds;
+
   testNumCrowds(9);
   testNumCrowds(8);
 }
@@ -112,6 +91,7 @@ TEST_CASE("QMCDriverNew walker counts", "[drivers]")
 {
   using namespace testing;
   Concurrency::OverrideMaxCapacity<> override(8);
+  RandomNumberGeneratorPool rng_pool(8);
   ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
   Communicate* comm = OHMMS::Controller;
   outputManager.pause();
@@ -141,7 +121,7 @@ TEST_CASE("QMCDriverNew walker counts", "[drivers]")
   QMCDriverNewTestWrapper qmc_batched(test_project, std::move(qmcdriver_copy), walker_confs,
                                       MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
                                                    wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
-                                      comm);
+                                      rng_pool.getRngRefs(), comm);
 
   qmc_batched.testAdjustGlobalWalkerCount();
 }
@@ -151,6 +131,7 @@ TEST_CASE("QMCDriverNew test driver operations", "[drivers]")
 {
   using namespace testing;
   Concurrency::OverrideMaxCapacity<> override(8);
+  RandomNumberGeneratorPool rng_pool(8);
   ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
   Communicate* comm = OHMMS::Controller;
   outputManager.pause();
@@ -171,7 +152,7 @@ TEST_CASE("QMCDriverNew test driver operations", "[drivers]")
   QMCDriverNewTestWrapper qmcdriver(test_project, std::move(qmcdriver_input), walker_confs,
                                     MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
                                                  wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
-                                    comm);
+                                    rng_pool.getRngRefs(), comm);
 
 
   auto tau       = 1.0;

--- a/src/Utilities/RandomNumberControl.cpp
+++ b/src/Utilities/RandomNumberControl.cpp
@@ -48,6 +48,15 @@ UPtrVector<RandomNumberControl::Generator>& RandomNumberControl::getChildren()
   return Children;
 }
 
+RefVector<RandomNumberControl::Generator> RandomNumberControl::getChildrenRefs()
+{
+  auto& rngs_children = getChildren();
+  RefVector<Generator> rng_refs;
+  for (auto& child: rngs_children)
+    rng_refs.push_back(*child);
+  return rng_refs;
+}
+
 /// generic output
 bool RandomNumberControl::get(std::ostream& os) const
 {

--- a/src/Utilities/RandomNumberControl.h
+++ b/src/Utilities/RandomNumberControl.h
@@ -50,6 +50,8 @@ public:
 
   /// access RandomNumberControl::Children. If not initialized, make them first before return. Safe to use in unit tests.
   static UPtrVector<Generator>& getChildren();
+  /// access RandomNumberControl::Children as references of each child. If not initialized, make them first before return. Safe to use in unit tests.
+  static RefVector<Generator> getChildrenRefs();
 
   bool get(std::ostream& os) const override;
   bool put(std::istream& is) override;


### PR DESCRIPTION
## Proposed changes
A step closer to clean up RNG handling in drivers.
1. Capture RNG resource via batched driver constructor. No longer directly access `RandomNumberControl::Children`.
2. Add a RandomNumberGeneratorPool helper class for unit test need of fake RNGs.
3. There are small changes moving step_contexts_ to VMC and DMC drivers that are unrelated to this topic but I was unable to take them out of this PR.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
