### PR TITLE
Change num_crowds > num_threads handling and also decouple num_crowds from num_threads

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -387,7 +387,7 @@ void DMCBatched::process(xmlNodePtr node)
     QMCDriverNew::AdjustedWalkerCounts awc =
         adjustGlobalWalkerCount(*myComm, walker_configs_ref_.getActiveWalkers(), qmcdriver_input_.get_total_walkers(),
                                 qmcdriver_input_.get_walkers_per_rank(), dmcdriver_input_.get_reserve(),
-                                qmcdriver_input_.get_num_crowds());
+                                determintNumCrowds(qmcdriver_input_.get_num_crowds(), rngs_.size()));
 
     steps_per_block_ =
         determineStepsPerBlock(awc.global_walkers, qmcdriver_input_.get_requested_samples(),
@@ -567,6 +567,7 @@ bool DMCBatched::run()
  */
 void DMCBatched::createRngsStepContexts(int num_crowds)
 {
+  assert(num_crowds <= rngs_.size());
   step_contexts_.resize(num_crowds);
   for (int i = 0; i < num_crowds; ++i)
     step_contexts_[i] = std::make_unique<ContextForSteps>(rngs_[i]);

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -387,7 +387,7 @@ void DMCBatched::process(xmlNodePtr node)
     QMCDriverNew::AdjustedWalkerCounts awc =
         adjustGlobalWalkerCount(*myComm, walker_configs_ref_.getActiveWalkers(), qmcdriver_input_.get_total_walkers(),
                                 qmcdriver_input_.get_walkers_per_rank(), dmcdriver_input_.get_reserve(),
-                                determintNumCrowds(qmcdriver_input_.get_num_crowds(), rngs_.size()));
+                                determineNumCrowds(qmcdriver_input_.get_num_crowds(), rngs_.size()));
 
     steps_per_block_ =
         determineStepsPerBlock(awc.global_walkers, qmcdriver_input_.get_requested_samples(),

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -94,7 +94,9 @@ int QMCDriverNew::determintNumCrowds(const int requested_num_crowds, const int r
     num_crowds = rng_count;
   else if (requested_num_crowds > rng_count)
   {
-    app_warning() << "Capping the number of crowds to the count of driver-captured RNGs : " << rng_count << std::endl;
+    app_warning() << "Capping the number of crowds to the count of driver-captured RNGs : " << rng_count
+                  << ". This warning can be silenced by choosing 'crowds' in the range of [1, cap] or leaving it unset."
+                  << std::endl;
     num_crowds = rng_count;
   }
   return num_crowds;

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -87,7 +87,7 @@ QMCDriverNew::QMCDriverNew(const ProjectData& project_data,
 
 QMCDriverNew::~QMCDriverNew() = default;
 
-int QMCDriverNew::determintNumCrowds(const int requested_num_crowds, const int rng_count)
+int QMCDriverNew::determineNumCrowds(const int requested_num_crowds, const int rng_count)
 {
   int num_crowds = requested_num_crowds;
   if (requested_num_crowds == 0)

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -100,17 +100,6 @@ int QMCDriverNew::determintNumCrowds(const int requested_num_crowds, const int r
   return num_crowds;
 }
 
-void QMCDriverNew::checkNumCrowdsLTNumThreads(const int num_crowds)
-{
-  int num_threads(Concurrency::maxCapacity<>());
-  if (num_crowds > num_threads)
-  {
-    std::stringstream error_msg;
-    error_msg << "Bad Input: num_crowds (" << num_crowds << ") > num_threads (" << num_threads << ")\n";
-    throw UniformCommunicateError(error_msg.str());
-  }
-}
-
 void QMCDriverNew::initPopulationAndCrowds(const AdjustedWalkerCounts& awc)
 {
   app_summary() << QMCType << " Driver running with" << std::endl

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -87,6 +87,19 @@ QMCDriverNew::QMCDriverNew(const ProjectData& project_data,
 
 QMCDriverNew::~QMCDriverNew() = default;
 
+int QMCDriverNew::determintNumCrowds(const int requested_num_crowds, const int rng_count)
+{
+  int num_crowds = requested_num_crowds;
+  if (requested_num_crowds == 0)
+    num_crowds = rng_count;
+  else if (requested_num_crowds > rng_count)
+  {
+    app_warning() << "Capping the number of crowds to the count of driver-captured RNGs : " << rng_count << std::endl;
+    num_crowds = rng_count;
+  }
+  return num_crowds;
+}
+
 void QMCDriverNew::checkNumCrowdsLTNumThreads(const int num_crowds)
 {
   int num_threads(Concurrency::maxCapacity<>());
@@ -346,20 +359,17 @@ QMCDriverNew::AdjustedWalkerCounts QMCDriverNew::adjustGlobalWalkerCount(Communi
                                                                          const IndexType requested_total_walkers,
                                                                          const IndexType requested_walkers_per_rank,
                                                                          const RealType reserve_walkers,
-                                                                         int num_crowds)
+                                                                         const int num_crowds)
 {
+  assert(num_crowds > 0);
+
   const int num_ranks = comm.size();
   const int rank_id   = comm.rank();
-
-  // Step 1. set num_crowds by input and Concurrency::maxCapacity<>()
-  checkNumCrowdsLTNumThreads(num_crowds);
-  if (num_crowds == 0)
-    num_crowds = Concurrency::maxCapacity<>();
 
   AdjustedWalkerCounts awc{0, {}, {}, reserve_walkers};
   awc.walkers_per_rank.resize(num_ranks, 0);
 
-  // Step 2. decide awc.global_walkers and awc.walkers_per_rank based on input values
+  // Step 1. decide awc.global_walkers and awc.walkers_per_rank based on input values
   if (requested_total_walkers != 0)
   {
     if (requested_total_walkers < num_ranks)
@@ -395,7 +405,7 @@ QMCDriverNew::AdjustedWalkerCounts QMCDriverNew::adjustGlobalWalkerCount(Communi
     app_warning() << "TotalWalkers (" << awc.global_walkers << ") not divisible by number of ranks (" << num_ranks
                   << "). This will result in a loss of efficiency.\n";
 
-  // Step 3. decide awc.walkers_per_crowd
+  // Step 2. decide awc.walkers_per_crowd
   awc.walkers_per_crowd = fairDivide(awc.walkers_per_rank[rank_id], num_crowds);
 
   if (awc.walkers_per_rank[rank_id] % num_crowds)

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -294,6 +294,12 @@ public:
   /** }@ */
 
 protected:
+  /** pure function returning the number crowds
+   * @param requested_num_crowds requested "crowds" from pinput
+   * @param rng_size the count of captured RNGs
+   */
+  static int determintNumCrowds(const int requested_num_crowds, const int rng_count);
+
   /** pure function returning AdjustedWalkerCounts data structure 
    *
    *  The logic is now walker counts is fairly simple.

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -336,8 +336,6 @@ protected:
                                        IndexType requested_steps,
                                        IndexType blocks);
 
-  static void checkNumCrowdsLTNumThreads(const int num_crowds);
-
   /// check logpsi and grad and lap against values computed from scratch
   static void checkLogAndGL(Crowd& crowd, const std::string_view location, const bool serializing_crowd_walkers);
 

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -295,10 +295,10 @@ public:
 
 protected:
   /** pure function returning the number crowds
-   * @param requested_num_crowds requested "crowds" from pinput
+   * @param requested_num_crowds requested "crowds" from input
    * @param rng_size the count of captured RNGs
    */
-  static int determintNumCrowds(const int requested_num_crowds, const int rng_count);
+  static int determineNumCrowds(const int requested_num_crowds, const int rng_count);
 
   /** pure function returning AdjustedWalkerCounts data structure 
    *

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -277,7 +277,8 @@ void VMCBatched::process(xmlNodePtr node)
   {
     QMCDriverNew::AdjustedWalkerCounts awc =
         adjustGlobalWalkerCount(*myComm, walker_configs_ref_.getActiveWalkers(), qmcdriver_input_.get_total_walkers(),
-                                qmcdriver_input_.get_walkers_per_rank(), 1.0, qmcdriver_input_.get_num_crowds());
+                                qmcdriver_input_.get_walkers_per_rank(), 1.0,
+                                determintNumCrowds(qmcdriver_input_.get_num_crowds(), rngs_.size()));
 
     steps_per_block_ =
         determineStepsPerBlock(awc.global_walkers, qmcdriver_input_.get_requested_samples(),
@@ -481,6 +482,7 @@ bool VMCBatched::run()
  */
 void VMCBatched::createRngsStepContexts(int num_crowds)
 {
+  assert(num_crowds <= rngs_.size());
   step_contexts_.resize(num_crowds);
   for (int i = 0; i < num_crowds; ++i)
     step_contexts_[i] = std::make_unique<ContextForSteps>(rngs_[i]);

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -278,7 +278,7 @@ void VMCBatched::process(xmlNodePtr node)
     QMCDriverNew::AdjustedWalkerCounts awc =
         adjustGlobalWalkerCount(*myComm, walker_configs_ref_.getActiveWalkers(), qmcdriver_input_.get_total_walkers(),
                                 qmcdriver_input_.get_walkers_per_rank(), 1.0,
-                                determintNumCrowds(qmcdriver_input_.get_num_crowds(), rngs_.size()));
+                                determineNumCrowds(qmcdriver_input_.get_num_crowds(), rngs_.size()));
 
     steps_per_block_ =
         determineStepsPerBlock(awc.global_walkers, qmcdriver_input_.get_requested_samples(),

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -46,14 +46,15 @@ namespace qmcplusplus
 using MatrixOperators::product;
 
 
-QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(const ProjectData& project_data,
-                                                                         QMCDriverInput&& qmcdriver_input,
-                                                                         VMCDriverInput&& vmcdriver_input,
-                                                                         WalkerConfigurations& wc,
-                                                                         MCPopulation&& population,
-             const RefVector<RandomBase<FullPrecRealType>>& rng_refs,
-                                                                         SampleStack& samples,
-                                                                         Communicate* comm)
+QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(
+    const ProjectData& project_data,
+    QMCDriverInput&& qmcdriver_input,
+    VMCDriverInput&& vmcdriver_input,
+    WalkerConfigurations& wc,
+    MCPopulation&& population,
+    const RefVector<RandomBase<FullPrecRealType>>& rng_refs,
+    SampleStack& samples,
+    Communicate* comm)
     : QMCDriverNew(
           project_data,
           std::move(qmcdriver_input),
@@ -738,8 +739,7 @@ bool QMCFixedSampleLinearOptimizeBatched::processOptXML(xmlNodePtr opt_xml,
                                    std::move(vmcdriver_input_copy), walker_configs_ref_,
                                    MCPopulation(myComm->size(), myComm->rank(), &population_.get_golden_electrons(),
                                                 &population_.get_golden_twf(), &population_.get_golden_hamiltonian()),
-                                   rngs_,
-                                   samples_, myComm);
+                                   rngs_, samples_, myComm);
 
   vmcEngine->setUpdateMode(vmcMove[0] == 'p');
 
@@ -753,7 +753,8 @@ bool QMCFixedSampleLinearOptimizeBatched::processOptXML(xmlNodePtr opt_xml,
   auto& qmcdriver_input = vmcEngine->getQMCDriverInput();
   QMCDriverNew::AdjustedWalkerCounts awc =
       adjustGlobalWalkerCount(*myComm, walker_configs_ref_.getActiveWalkers(), qmcdriver_input_.get_total_walkers(),
-                              qmcdriver_input_.get_walkers_per_rank(), 1.0, qmcdriver_input_.get_num_crowds());
+                              qmcdriver_input_.get_walkers_per_rank(), 1.0,
+                              determintNumCrowds(qmcdriver_input_.get_num_crowds(), rngs_.size()));
 
 
   bool success = true;

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -754,7 +754,7 @@ bool QMCFixedSampleLinearOptimizeBatched::processOptXML(xmlNodePtr opt_xml,
   QMCDriverNew::AdjustedWalkerCounts awc =
       adjustGlobalWalkerCount(*myComm, walker_configs_ref_.getActiveWalkers(), qmcdriver_input_.get_total_walkers(),
                               qmcdriver_input_.get_walkers_per_rank(), 1.0,
-                              determintNumCrowds(qmcdriver_input_.get_num_crowds(), rngs_.size()));
+                              determineNumCrowds(qmcdriver_input_.get_num_crowds(), rngs_.size()));
 
 
   bool success = true;

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -57,7 +57,7 @@ public:
                                       VMCDriverInput&& vmcdriver_input,
                                       WalkerConfigurations& wc,
                                       MCPopulation&& population,
-             const RefVector<RandomBase<FullPrecRealType>>& rng_refs,
+                                      const RefVector<RandomBase<FullPrecRealType>>& rng_refs,
                                       SampleStack& samples,
                                       Communicate* comm);
 

--- a/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
+++ b/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
@@ -200,23 +200,6 @@ public:
   }
 };
 
-template<class CONCURRENCY>
-void QMCDriverNewTestWrapper::TestNumCrowdsVsNumThreads<CONCURRENCY>::operator()(int num_crowds)
-{}
-
-template<>
-void QMCDriverNewTestWrapper::TestNumCrowdsVsNumThreads<ParallelExecutor<Executor::OPENMP>>::operator()(int num_crowds)
-{
-  if (Concurrency::maxCapacity<>() != 8)
-    throw std::runtime_error("OMP_NUM_THREADS must be 8 for this test.");
-  if (num_crowds > 8)
-    CHECK_THROWS_AS(checkNumCrowdsLTNumThreads(num_crowds), UniformCommunicateError);
-  else
-    checkNumCrowdsLTNumThreads(num_crowds);
-  return;
-}
-
-
 } // namespace testing
 } // namespace qmcplusplus
 #endif

--- a/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
+++ b/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
@@ -168,9 +168,9 @@ public:
 
   void testDetermintNumCrowds()
   {
-    CHECK(determintNumCrowds(4, 8) == 4);
-    CHECK(determintNumCrowds(0, 8) == 8);
-    CHECK(determintNumCrowds(4, 2) == 2);
+    CHECK(determineNumCrowds(4, 8) == 4);
+    CHECK(determineNumCrowds(0, 8) == 8);
+    CHECK(determineNumCrowds(4, 2) == 2);
   }
 
   bool run() override { return false; }

--- a/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
+++ b/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
@@ -54,8 +54,8 @@ public:
   {
     // We want to test the reserve ability as well
     AdjustedWalkerCounts awc =
-        adjustGlobalWalkerCount(*myComm, 0, qmcdriver_input_.get_total_walkers(), qmcdriver_input_.get_walkers_per_rank(),
-                                1.0, qmcdriver_input_.get_num_crowds());
+        adjustGlobalWalkerCount(*myComm, 0, qmcdriver_input_.get_total_walkers(),
+                                qmcdriver_input_.get_walkers_per_rank(), 1.0, qmcdriver_input_.get_num_crowds());
 
     initPopulationAndCrowds(awc);
   }
@@ -65,7 +65,7 @@ public:
     AdjustedWalkerCounts awc;
     if (myComm->size() == 4)
     {
-      awc = adjustGlobalWalkerCount(*myComm, 0, 64, 0, 1.0, 0);
+      awc = adjustGlobalWalkerCount(*myComm, 0, 64, 0, 1.0, 8);
       if (myComm->rank() == 1)
       {
         CHECK(awc.global_walkers == 64);
@@ -76,7 +76,7 @@ public:
         CHECK(awc.walkers_per_crowd[7] == 2);
       }
 
-      awc = adjustGlobalWalkerCount(*myComm, 4, 0, 0, 1.0, 0);
+      awc = adjustGlobalWalkerCount(*myComm, 4, 0, 0, 1.0, 8);
       if (myComm->rank() == 1)
       {
         CHECK(awc.global_walkers == 16);
@@ -132,11 +132,10 @@ public:
 
     if (myComm->size() == 2)
     {
-      awc = adjustGlobalWalkerCount(*myComm, 0, 28, 0, 1.0, 0);
+      awc = adjustGlobalWalkerCount(*myComm, 0, 28, 0, 1.0, 8);
       if (myComm->rank() == 0)
       {
         CHECK(awc.global_walkers == 28);
-        CHECK(awc.walkers_per_crowd.size() == Concurrency::maxCapacity());
         CHECK(awc.walkers_per_rank.size() == 2);
         CHECK(awc.walkers_per_rank[0] == 14);
         // \todo for std::thread these will be ones
@@ -163,8 +162,15 @@ public:
     {
       // Ask for 14 total walkers on 16 ranks (inconsistent input)
       // results in fatal exception on all ranks.
-      CHECK_THROWS_AS(adjustGlobalWalkerCount(*myComm, 0, 14, 0, 0, 0), UniformCommunicateError);
+      CHECK_THROWS_AS(adjustGlobalWalkerCount(*myComm, 0, 14, 0, 0, 8), UniformCommunicateError);
     }
+  }
+
+  void testDetermintNumCrowds()
+  {
+    CHECK(determintNumCrowds(4, 8) == 4);
+    CHECK(determintNumCrowds(0, 8) == 8);
+    CHECK(determintNumCrowds(4, 2) == 2);
   }
 
   bool run() override { return false; }

--- a/src/QMCDrivers/tests/test_QMCDriverNew.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverNew.cpp
@@ -69,24 +69,6 @@ TEST_CASE("QMCDriverNew tiny case", "[drivers]")
   // What else should we expect after process
 }
 
-#ifdef _OPENMP
-TEST_CASE("QMCDriverNew more crowds than threads", "[drivers]")
-{
-  using namespace testing;
-
-  Concurrency::OverrideMaxCapacity<> override(8);
-  // test is a no op except for openmp, max threads is >> than num cores
-  // in other concurrency models.
-  if (Concurrency::maxCapacity<>() != 8)
-    throw std::runtime_error("Insufficient threads available to match test input");
-
-  QMCDriverNewTestWrapper::TestNumCrowdsVsNumThreads<ParallelExecutor<>> testNumCrowds;
-
-  testNumCrowds(9);
-  testNumCrowds(8);
-}
-#endif
-
 TEST_CASE("QMCDriverNew walker counts", "[drivers]")
 {
   using namespace testing;

--- a/src/QMCDrivers/tests/test_QMCDriverNew.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverNew.cpp
@@ -30,8 +30,6 @@ namespace qmcplusplus
 TEST_CASE("QMCDriverNew tiny case", "[drivers]")
 {
   using namespace testing;
-  Concurrency::OverrideMaxCapacity<> override(8);
-  RandomNumberGeneratorPool rng_pool(8);
   ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
   Communicate* comm = OHMMS::Controller;
   outputManager.pause();
@@ -48,6 +46,7 @@ TEST_CASE("QMCDriverNew tiny case", "[drivers]")
 
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   WalkerConfigurations walker_confs;
+  RandomNumberGeneratorPool rng_pool(1);
   QMCDriverNewTestWrapper qmcdriver(test_project, std::move(qmcdriver_input), walker_confs,
                                     MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
                                                  wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
@@ -86,12 +85,11 @@ TEST_CASE("QMCDriverNew more crowds than threads", "[drivers]")
   testNumCrowds(9);
   testNumCrowds(8);
 }
+#endif
 
 TEST_CASE("QMCDriverNew walker counts", "[drivers]")
 {
   using namespace testing;
-  Concurrency::OverrideMaxCapacity<> override(8);
-  RandomNumberGeneratorPool rng_pool(8);
   ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
   Communicate* comm = OHMMS::Controller;
   outputManager.pause();
@@ -108,30 +106,21 @@ TEST_CASE("QMCDriverNew walker counts", "[drivers]")
 
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
 
-  int num_crowds = 8;
-
-  if (Concurrency::maxCapacity<>() < 8)
-    num_crowds = Concurrency::maxCapacity<>();
-
-  if (num_crowds < 8)
-    throw std::runtime_error("Insufficient threads available to match test input");
-
   QMCDriverInput qmcdriver_copy(qmcdriver_input);
   WalkerConfigurations walker_confs;
+  RandomNumberGeneratorPool rng_pool(8);
   QMCDriverNewTestWrapper qmc_batched(test_project, std::move(qmcdriver_copy), walker_confs,
                                       MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
                                                    wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
                                       rng_pool.getRngRefs(), comm);
 
   qmc_batched.testAdjustGlobalWalkerCount();
+  qmc_batched.testDetermintNumCrowds();
 }
-#endif
 
 TEST_CASE("QMCDriverNew test driver operations", "[drivers]")
 {
   using namespace testing;
-  Concurrency::OverrideMaxCapacity<> override(8);
-  RandomNumberGeneratorPool rng_pool(8);
   ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
   Communicate* comm = OHMMS::Controller;
   outputManager.pause();
@@ -149,6 +138,7 @@ TEST_CASE("QMCDriverNew test driver operations", "[drivers]")
 
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   WalkerConfigurations walker_confs;
+  RandomNumberGeneratorPool rng_pool(1);
   QMCDriverNewTestWrapper qmcdriver(test_project, std::move(qmcdriver_input), walker_confs,
                                     MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
                                                  wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),


### PR DESCRIPTION
## Proposed changes
Previously we requires `num_crowds <= num_threads`. There is a bad entanglement between drivers and threads.
1) With this PR, the nature RNGs being part of parallel context gets directly reflected. We check the count of RNGs rather than `num_threads`.
2) When `num_crowds > num_rngs` previously `num_crowds > num_threads`, we just override `num_crowds` to `num_rngs` with a warning instead of a hard stop. It should be more user-friendly.
3) unit tests also benefit from this change. Many test setups become thread independent. With #5133 unit test can pick any number of RNGs.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)
- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted