### PR TITLE
Remove value assertion that caused false positive faiure

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -684,20 +684,6 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_evaluateGL(const RefVectorWithLea
     for (int iw = 0; iw < nw; iw++)
     {
       auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<PL, VT, FPVT>>(iw);
-
-#ifndef NDEBUG
-      // at this point, host and device should have exactly the same G and L values.
-      GradMatrix dpsiM_from_device     = det.dpsiM;
-      Matrix<Value> d2psiM_from_device = det.d2psiM;
-
-      auto& my_psiM_vgl  = det.psiM_vgl;
-      auto* psiM_vgl_ptr = my_psiM_vgl.data();
-      // transfer device to host, total size 4, g(3) + l(1)
-      PRAGMA_OFFLOAD("omp target update from(psiM_vgl_ptr[my_psiM_vgl.capacity():my_psiM_vgl.capacity()*4])")
-      assert(dpsiM_from_device == det.dpsiM);
-      assert(d2psiM_from_device == det.d2psiM);
-#endif
-
       det.UpdateMode = ORB_WALKER;
       det.computeGL(G_list[iw], L_list[iw]);
     }


### PR DESCRIPTION
## Proposed changes

closes https://github.com/QMCPACK/qmcpack/issues/5140

assertions are not robust against numerical round error. When evaluating LCAO, the batched and non-batched evaluation may differ slightly due to using gemm and gemv.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
jlse

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
