### PR TITLE
Cleanup NonLocalTOperator constructor.

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -44,7 +44,7 @@ using PsiValue = TrialWaveFunction::PsiValue;
 class DMCBatched::DMCContextForSteps : public ContextForSteps
 {
 public:
-  DMCContextForSteps(RandomBase<FullPrecRealType>& random_gen, const NonLocalTOperator& non_local_ops)
+  DMCContextForSteps(RandomBase<FullPrecRealType>& random_gen, NonLocalTOperator&& non_local_ops)
       : ContextForSteps(random_gen), non_local_ops(non_local_ops)
   {}
 
@@ -577,12 +577,14 @@ void DMCBatched::createStepContexts(int num_crowds)
 {
   assert(num_crowds <= rngs_.size());
   step_contexts_.resize(num_crowds);
-  NonLocalTOperator non_local_ops;
-  if (population_.get_golden_hamiltonian().hasPhysicalNLPP())
-    non_local_ops.thingsThatShouldBeInMyConstructor(dmcdriver_input_.get_non_local_move(), qmcdriver_input_.get_tau(),
-                                                    dmcdriver_input_.get_alpha(), dmcdriver_input_.get_gamma());
   for (int i = 0; i < num_crowds; ++i)
-    step_contexts_[i] = std::make_unique<DMCContextForSteps>(rngs_[i], non_local_ops);
+    step_contexts_[i] =
+        std::make_unique<DMCContextForSteps>(rngs_[i],
+                                             NonLocalTOperator(population_.get_golden_hamiltonian().hasPhysicalNLPP()
+                                                                   ? dmcdriver_input_.get_non_local_move()
+                                                                   : TmoveKind::OFF,
+                                                               qmcdriver_input_.get_tau(), dmcdriver_input_.get_alpha(),
+                                                               dmcdriver_input_.get_gamma()));
 }
 
 } // namespace qmcplusplus

--- a/src/QMCDrivers/DMC/DMCDriverInput.cpp
+++ b/src/QMCDrivers/DMC/DMCDriverInput.cpp
@@ -20,9 +20,8 @@ void DMCDriverInput::readXML(xmlNodePtr node)
   ParameterSet parameter_set_;
   std::string reconfig_str;
   std::string refE_update_scheme_str;
+  std::string nonlocalmove_str;
   parameter_set_.add(reconfig_str, "reconfiguration", {"no", "yes", "runwhileincorrect"});
-  parameter_set_.add(NonLocalMove, "nonlocalmove", {"no", "yes", "v0", "v1", "v3"});
-  parameter_set_.add(NonLocalMove, "nonlocalmoves", {"no", "yes", "v0", "v1", "v3"});
   parameter_set_.add(max_age_, "MaxAge");
   parameter_set_.add(feedback_, "feedback");
   parameter_set_.add(refE_update_scheme_str, "refenergy_update_scheme", {"unlimited_history", "limited_history"});
@@ -34,11 +33,12 @@ void DMCDriverInput::readXML(xmlNodePtr node)
   parameter_set_.add(branch_interval_, "subStep");
   parameter_set_.add(branch_interval_, "sub_stepd");
 
-  //from NonLocalTOperator.cpp
+  //for NonLocalTOperator
   parameter_set_.add(alpha_, "alpha");
   parameter_set_.add(gamma_, "gamma");
-
   parameter_set_.add(reserve_, "reserve");
+  parameter_set_.add(nonlocalmove_str, "nonlocalmove", {"no", "yes", "v0", "v1", "v3"});
+  parameter_set_.add(nonlocalmove_str, "nonlocalmoves", {"no", "yes", "v0", "v1", "v3"});
 
   parameter_set_.put(node);
 
@@ -49,14 +49,26 @@ void DMCDriverInput::readXML(xmlNodePtr node)
                              "is still desired, set reconfiguration to \"runwhileincorrect\" instead of \"yes\".");
   reconfiguration_ = (reconfig_str == "yes");
 
-  if (NonLocalMove == "yes" || NonLocalMove == "v0")
+  if (nonlocalmove_str == "yes" || nonlocalmove_str == "v0")
+  {
     app_summary() << "  Using Non-local T-moves v0, M. Casula, PRB 74, 161102(R) (2006)";
-  else if (NonLocalMove == "v1")
+    tmove_kind_ = TmoveKind::V0;
+  }
+  else if (nonlocalmove_str == "v1")
+  {
     app_summary() << "  Using Non-local T-moves v1, M. Casula et al., JCP 132, 154113 (2010)";
-  else if (NonLocalMove == "v3")
+    tmove_kind_ = TmoveKind::V1;
+  }
+  else if (nonlocalmove_str == "v3")
+  {
     app_summary() << "  Using Non-local T-moves v3, an approximation to v1";
+    tmove_kind_ = TmoveKind::V3;
+  }
   else
+  {
     app_summary() << "  Using Locality Approximation";
+    tmove_kind_ = TmoveKind::OFF;
+  }
   app_summary() << std::endl;
 
   // TODO: similar check for alpha and gamma

--- a/src/QMCDrivers/DMC/DMCDriverInput.h
+++ b/src/QMCDrivers/DMC/DMCDriverInput.h
@@ -15,6 +15,7 @@
 #include "Configuration.h"
 #include "OhmmsData/ParameterSet.h"
 #include "DMC/DMCRefEnergyScheme.h"
+#include "TmoveKind.h"
 
 namespace qmcplusplus
 {
@@ -35,7 +36,7 @@ public:
   IndexType get_branch_interval() const { return branch_interval_; }
   double get_feedback() const { return feedback_; }
   DMCRefEnergyScheme get_refenergy_update_scheme() const { return refenergy_update_scheme_; }
-  const std::string& get_non_local_move() const { return NonLocalMove; }
+  TmoveKind get_non_local_move() const { return tmove_kind_; }
   double get_alpha() const { return alpha_; }
   double get_gamma() const { return gamma_; }
   RealType get_reserve() const { return reserve_; }
@@ -59,8 +60,8 @@ private:
   std::string SwapWalkers;
   /// reconfiguration flag
   bool reconfiguration_ = true;
-  ///input std::string to determine to use nonlocal move
-  std::string NonLocalMove;
+  ///input to control Tmove
+  TmoveKind tmove_kind_ = TmoveKind::OFF;
   ///input to control maximum age allowed for walkers.
   IndexType max_age_ = 10;
   /// reserved walkers for population growth

--- a/src/QMCHamiltonians/NonLocalTOperator.cpp
+++ b/src/QMCHamiltonians/NonLocalTOperator.cpp
@@ -71,28 +71,14 @@ void NonLocalTOperator::put(xmlNodePtr cur)
   app_log() << o.str() << std::endl;
 }
 
-void NonLocalTOperator::thingsThatShouldBeInMyConstructor(const std::string& non_local_move_option,
-                                                          const double tau,
-                                                          const double alpha,
-                                                          const double gamma)
+NonLocalTOperator::NonLocalTOperator(const TmoveKind non_local_move_option,
+                                     const double tau,
+                                     const double alpha,
+                                     const double gamma)
+    : move_kind_(non_local_move_option), tau_(tau), alpha_(alpha), gamma_(gamma)
 {
-  tau_        = tau;
-  alpha_      = alpha;
-  gamma_      = gamma;
   plusFactor  = tau_ * gamma_;
   minusFactor = -tau_ * (1.0 - alpha_ * (1.0 + gamma_));
-  move_kind_  = TmoveKind::OFF;
-
-  if (non_local_move_option == "no")
-    move_kind_ = TmoveKind::OFF;
-  else if (non_local_move_option == "yes" || non_local_move_option == "v0")
-    move_kind_ = TmoveKind::V0;
-  else if (non_local_move_option == "v1")
-    move_kind_ = TmoveKind::V1;
-  else if (non_local_move_option == "v3")
-    move_kind_ = TmoveKind::V3;
-  else
-    throw std::runtime_error("NonLocalTOperator::put unknown nonlocalmove option " + non_local_move_option);
 }
 
 const NonLocalData* NonLocalTOperator::selectMove(RealType prob, const std::vector<NonLocalData>& txy)

--- a/src/QMCHamiltonians/NonLocalTOperator.h
+++ b/src/QMCHamiltonians/NonLocalTOperator.h
@@ -21,19 +21,11 @@
 #ifndef QMCPLUSPLUS_NONLOCALTRANSITIONOPERATOR_H
 #define QMCPLUSPLUS_NONLOCALTRANSITIONOPERATOR_H
 
+#include "TmoveKind.h"
 #include "NonLocalData.h"
 
 namespace qmcplusplus
 {
-/// Tmove options
-enum class TmoveKind
-{
-  OFF = 0, // no Tmove
-  V0,      // M. Casula, PRB 74, 161102(R) (2006)
-  V1,      // version 1, M. Casula et al., JCP 132, 154113 (2010)
-  V3,      // an approximation to version 1 but much faster.
-};
-
 class NonLocalTOperator
 {
 public:
@@ -41,16 +33,13 @@ public:
   using PosType  = NonLocalData::PosType;
 
   NonLocalTOperator();
-
-  TmoveKind getMoveKind() const { return move_kind_; }
-
   /** replacement for put because wouldn't it be cool to know what the classes configuration actually
    *  is.
    */
-  void thingsThatShouldBeInMyConstructor(const std::string& non_local_move_option,
-                                         const double tau,
-                                         const double alpha,
-                                         const double gamma);
+  NonLocalTOperator(const TmoveKind non_local_move_option, const double tau, const double alpha, const double gamma);
+
+  TmoveKind getMoveKind() const { return move_kind_; }
+
   /** initialize the parameters */
   void put(xmlNodePtr cur);
 

--- a/src/QMCHamiltonians/TmoveKind.h
+++ b/src/QMCHamiltonians/TmoveKind.h
@@ -1,0 +1,27 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2024 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_TMOVEKIND_H
+#define QMCPLUSPLUS_TMOVEKIND_H
+
+namespace qmcplusplus
+{
+/// Tmove options
+enum class TmoveKind
+{
+  OFF = 0, // no Tmove
+  V0,      // M. Casula, PRB 74, 161102(R) (2006)
+  V1,      // version 1, M. Casula et al., JCP 132, 154113 (2010)
+  V3,      // an approximation to version 1 but much faster.
+};
+} // namespace qmcplusplus
+#endif

--- a/src/QMCHamiltonians/tests/test_NonLocalTOperator.cpp
+++ b/src/QMCHamiltonians/tests/test_NonLocalTOperator.cpp
@@ -21,8 +21,7 @@ TEST_CASE("NonLocalTOperator", "[hamiltonian]")
 {
   using RealType = QMCTraits::RealType;
   using PosType  = QMCTraits::PosType;
-  NonLocalTOperator t_op;
-  t_op.thingsThatShouldBeInMyConstructor("v0", 1.0, 0.0, 0.0);
+  NonLocalTOperator t_op(TmoveKind::V0, 1.0, 0.0, 0.0);
 
   std::vector<NonLocalData> Txy;
   Txy.emplace_back(0, 0.4, PosType(0.1, 0.2, 0.3));


### PR DESCRIPTION
## Proposed changes
Clean up the function `thingsThatShouldBeInMyConstructor`. Move the string to enum conversion into the input class.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'