### PR TITLE
Fix diamond 2x1x1 unit test with mixed precision debug

### DIFF
--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -51,7 +51,7 @@ template<class DiracDet, class SPO_precision>
 void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitches& offload_switches)
 {
 #if defined(MIXED_PRECISION)
-  const double grad_precision  = 1.3e-4;
+  const double grad_precision  = 1e-3;
   const double ratio_precision = 2e-4;
 #else
   const double grad_precision  = std::is_same<SPO_precision, float_tag>::value ? 1.3e-4 : 1e-8;
@@ -227,8 +227,8 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
   CHECK(r_all_val == ComplexApprox(std::complex<RealType>(0.1248738460467855, 0)).epsilon(2e-5));
   CHECK(r_fermionic_val == ComplexApprox(std::complex<RealType>(0.1362181543980086, 0)).epsilon(2e-5));
 #else
-  CHECK(r_all_val == Approx(0.1248738460469678));
-  CHECK(r_fermionic_val == ValueApprox(0.1362181543982075));
+  CHECK(r_all_val == Approx(0.1248738460469678).epsilon(1e-4));
+  CHECK(r_fermionic_val == ValueApprox(0.1362181543982075).epsilon(1e-4));
 #endif
   CHECK(r_bosonic_val == ValueApprox(0.9167195562048454));
 
@@ -239,7 +239,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
 #if defined(QMC_COMPLEX)
   CHECK(psi.getLogPsi() == Approx(-6.626861768296886).epsilon(5e-5));
 #else
-  CHECK(psi.getLogPsi() == Approx(-8.013162503965223));
+  CHECK(psi.getLogPsi() == Approx(-8.013162503965223).epsilon(1e-4));
 #endif
 
   elec_.update(true);


### PR DESCRIPTION
## Proposed changes

Fix test failures in gcc13/14 debug mixed precision builds with added or increased tolerances
https://cdash.qmcpack.org/viewTest.php?onlyfailed&buildid=11547

Closes #4921 

Verified that complex mixed debug builds are also OK.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 24 with gcc13

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
