### PR TITLE
Call cheaper TrialWaveFunction::mw_evaluateParameterDerivativesWF in SR

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -546,7 +546,7 @@ void QMCCostFunctionBatched::checkConfigurationsSR(EngineHandle& handle)
         // get energy_list
         energy_list = QMCHamiltonian::mw_evaluate(h_list, wf_list, p_list);
         // get dlogpsi from TWF
-        TrialWaveFunction::mw_evaluateParameterDerivatives(wf_list, p_list, optVars, dlogpsi_array, dhpsioverpsi_array);
+        TrialWaveFunction::mw_evaluateParameterDerivativesWF(wf_list, p_list, optVars, dlogpsi_array);
 
         handle.takeSample(energy_list, dlogpsi_array, dhpsioverpsi_array, base_sample_index);
 

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -1206,6 +1206,19 @@ void TrialWaveFunction::evaluateDerivativesWF(ParticleSet& P,
   }
 }
 
+void TrialWaveFunction::mw_evaluateParameterDerivativesWF(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                                          const RefVectorWithLeader<ParticleSet>& p_list,
+                                                          const opt_variables_type& optvars,
+                                                          RecordArray<ValueType>& dlogpsi)
+{
+  const int nparam = dlogpsi.getNumOfParams();
+  for (int iw = 0; iw < wf_list.size(); iw++)
+  {
+    Vector<ValueType> dlogpsi_record_view(dlogpsi[iw], nparam);
+    wf_list[iw].evaluateDerivativesWF(p_list[iw], optvars, dlogpsi_record_view);
+  }
+}
+
 void TrialWaveFunction::evaluateGradDerivatives(const ParticleSet::ParticleGradient& G_in,
                                                 std::vector<ValueType>& dgradlogpsi)
 {

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -315,11 +315,10 @@ public:
                                 ComputeType ct = ComputeType::ALL);
 
   // batched version of evaluateSpinorRatios
-  static void mw_evaluateSpinorRatios(
-      const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-      const RefVectorWithLeader<const VirtualParticleSet>& Vp_list,
-      const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
-      const RefVector<std::vector<ValueType>>& ratios_list);
+  static void mw_evaluateSpinorRatios(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                      const RefVectorWithLeader<const VirtualParticleSet>& Vp_list,
+                                      const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+                                      const RefVector<std::vector<ValueType>>& ratios_list);
 
   /** compute both ratios and deriatives of ratio with respect to the optimizables*/
   void evaluateDerivRatios(const VirtualParticleSet& VP,
@@ -473,6 +472,10 @@ public:
                                               RecordArray<ValueType>& dhpsioverpsi);
 
   void evaluateDerivativesWF(ParticleSet& P, const opt_variables_type& optvars, Vector<ValueType>& dlogpsi);
+  static void mw_evaluateParameterDerivativesWF(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                                const RefVectorWithLeader<ParticleSet>& p_list,
+                                                const opt_variables_type& optvars,
+                                                RecordArray<ValueType>& dlogpsi);
 
   void evaluateGradDerivatives(const ParticleSet::ParticleGradient& G_in, std::vector<ValueType>& dgradlogpsi);
 

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -471,7 +471,16 @@ public:
                                               RecordArray<ValueType>& dlogpsi,
                                               RecordArray<ValueType>& dhpsioverpsi);
 
+  /** Compute the derivatives of the log of the wavefunction with respect to optimizable parameters.
+   *  parameters
+   *  @param P particle set
+   *  @param optvars optimizable parameters
+   *  @param dlogpsi array of derivatives of the log of the wavefunction.
+   *  Note: this function differs from the evaluateDerivatives function in the way that it only computes
+   *        the derivative of the log of the wavefunction.
+  */
   void evaluateDerivativesWF(ParticleSet& P, const opt_variables_type& optvars, Vector<ValueType>& dlogpsi);
+  /// batched version of evaluateDerivativesWF
   static void mw_evaluateParameterDerivativesWF(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                                 const RefVectorWithLeader<ParticleSet>& p_list,
                                                 const opt_variables_type& optvars,


### PR DESCRIPTION
## Proposed changes
SR doesn't need derivatives from KE. so introduce and call `TrialWaveFunction::mw_evaluateParameterDerivativesWF`.
`WFC::mw_evaluateParameterDerivativesWF` exists, I just need to expose it at the TWF level.

## What type(s) of changes does this code introduce?
- New feature
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted