### PR TITLE
Improve input file argument handling

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -5,7 +5,7 @@ Running QMCPACK
 
 QMCPACK requires at least one xml input file, and is invoked via:
 
-``qmcpack [command line options] <XML input file(s)>``
+``qmcpack [command line options] <XML input file(s) and/or text file(s)>``
 
 .. _commandline:
 
@@ -33,14 +33,20 @@ option is disabled:
 
 - ``--verbosity=low|high|debug`` Control the output verbosity. The default low verbosity is concise and, for example, does not include all electron or atomic positions for large systems to reduce output size. Use "high" to see this information and more details of initialization, allocations, QMC method settings, etc.
 
-- ``version`` Print version information and optional arguments. Same as ``help``.
+- ``--version`` Print version information and optional arguments. Same as ``help``.
 
 .. _inputs:
 
 Input files
 -----------
 
-The input is one or more XML file(s), documented in :ref:`input-overview`.
+The input is one or more XML file(s), documented in :ref:`input-overview`. Input XML files must end in the suffice ``.xml``.
+
+An ensemble of calculations can be run by specifying multiple input XML files or text files containing a list of valid XML input
+files. In the latter case, a single filename of an XML input should be specified on each line. Ensemble runs split available MPI
+tasks evenly between all the specified inputs. Because QMCPACK will only exit when all calculations are completed, it is recommended
+for computational efficiency that either all calculations have similar costs and runtimes, or the ``max_seconds`` input parameter
+should be used to enforce similar runtimes.
 
 Output files
 ------------

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -40,7 +40,7 @@ option is disabled:
 Input files
 -----------
 
-The input is one or more XML file(s), documented in :ref:`input-overview`. Input XML files must end in the suffice ``.xml``.
+The input is one or more XML file(s), documented in :ref:`input-overview`. Input XML files must end in the suffix ``.xml``.
 
 An ensemble of calculations can be run by specifying multiple input XML files or text files containing a list of valid XML input
 files. In the latter case, a single filename of an XML input should be specified on each line. Ensemble runs split available MPI

--- a/src/QMCApp/qmcapp.cpp
+++ b/src/QMCApp/qmcapp.cpp
@@ -53,7 +53,6 @@ int main(int argc, char** argv)
   {
     //qmc_common  and MPI is initialized
     qmcplusplus::qmc_common.initialize(argc, argv);
-    int clones = 1;
     std::vector<std::string> fgroup1, fgroup2;
     int i = 1;
     while (i < argc)
@@ -61,8 +60,6 @@ int main(int argc, char** argv)
       std::string c(argv[i]);
       if (c[0] == '-')
       {
-        if (c.find("clones") < c.size())
-          clones = atoi(argv[++i]);
         if (c == "-debug")
           ReportEngine::enableOutput();
 
@@ -109,7 +106,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        if (c.find("xml") < c.size())
+        if (c.find(".xml") == c.size() - 4)
           fgroup1.push_back(argv[i]);
         else
         {
@@ -121,7 +118,7 @@ int main(int argc, char** argv)
             getwords(words, fin);
             if (words.size())
             {
-              if (words[0].find("xml") < words[0].size())
+              if (words[0].find(".xml") == words[0].size() - 4)
               {
                 int nc = 1;
                 if (words.size() > 1)
@@ -141,18 +138,20 @@ int main(int argc, char** argv)
       ++i;
     }
     int in_files = fgroup1.size();
-    std::vector<std::string> inputs(in_files * clones + fgroup2.size());
+    std::vector<std::string> inputs(in_files + fgroup2.size());
     copy(fgroup2.begin(), fgroup2.end(), inputs.begin());
     i = fgroup2.size();
     for (int k = 0; k < in_files; ++k)
-      for (int c = 0; c < clones; ++c)
-        inputs[i++] = fgroup1[k];
+      inputs[i++] = fgroup1[k];
     if (inputs.empty())
     {
       if (OHMMS::Controller->rank() == 0)
       {
-        std::cerr << "No input file is given." << std::endl;
-        std::cerr << "Usage: qmcpack <input-files> " << std::endl;
+        std::cerr << "No valid input file is given." << std::endl;
+        std::cerr << "Usage: qmcpack [options] <input-files.xml> " << std::endl;
+        std::cerr << "Ensemble runs may be initialized by specifying either multiple .xml files or text files "
+                     "containing lists of .xml input files."
+                  << std::endl;
       }
       OHMMS::Controller->finalize();
       return 1;

--- a/src/QMCApp/qmcapp.cpp
+++ b/src/QMCApp/qmcapp.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
   {
     //qmc_common  and MPI is initialized
     qmcplusplus::qmc_common.initialize(argc, argv);
-    std::vector<std::string> fgroup1, fgroup2;
+    std::vector<std::string> fgroup_names_cmd, fgroup_names_txt;
     int i = 1;
     while (i < argc)
     {
@@ -107,7 +107,7 @@ int main(int argc, char** argv)
       else
       {
         if (c.find(".xml") == c.size() - 4)
-          fgroup1.push_back(argv[i]);
+          fgroup_names_cmd.push_back(argv[i]);
         else
         {
           std::ifstream fin(argv[i], std::ifstream::in);
@@ -119,16 +119,7 @@ int main(int argc, char** argv)
             if (words.size())
             {
               if (words[0].find(".xml") == words[0].size() - 4)
-              {
-                int nc = 1;
-                if (words.size() > 1)
-                  nc = atoi(words[1].c_str());
-                while (nc)
-                {
-                  fgroup2.push_back(words[0]);
-                  --nc;
-                }
-              }
+                  fgroup_names_txt.push_back(words[0]);
             }
             else
               valid = false;
@@ -137,12 +128,11 @@ int main(int argc, char** argv)
       }
       ++i;
     }
-    int in_files = fgroup1.size();
-    std::vector<std::string> inputs(in_files + fgroup2.size());
-    copy(fgroup2.begin(), fgroup2.end(), inputs.begin());
-    i = fgroup2.size();
-    for (int k = 0; k < in_files; ++k)
-      inputs[i++] = fgroup1[k];
+    std::vector<std::string> inputs(fgroup_names_cmd.size() + fgroup_names_txt.size());
+    copy(fgroup_names_txt.begin(), fgroup_names_txt.end(), inputs.begin());
+    i = fgroup_names_txt.size();
+    for (int k = 0; k < fgroup_names_cmd.size(); ++k)
+      inputs[i++] = fgroup_names_cmd[k];
     if (inputs.empty())
     {
       if (OHMMS::Controller->rank() == 0)

--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -2192,3 +2192,14 @@ qmc_run_and_check(
   1
   1
   FALSE)
+
+# Input file does not exist and does not have XML suffix
+  qmc_run_and_check(
+  deterministic-input_check_not_present_not_xml_suffix
+  "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+  det_qmc_input_check_not_present_not_xml_suffix
+  det_qmc_input_check_not_present_not_xml_suffix.in.notxml
+  1
+  1
+  FALSE)
+


### PR DESCRIPTION
## Proposed changes

Closes #3124 

Enforce QMCPACK input files end in .xml vs have xml string in them

Accurate more verbose message when no valid input specified 

(Could still be nicer for new users, e.g. print list of valid options,  print QMCPACK title and version)

Also: Remove long hidden/untested/undocumented clone feature. There are other ways to do what it does, so simplify by removing.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

All deterministic tests including ensemble tests, gcc14 mpi,

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
