### PR TITLE
Remove erroneous gradient check

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -136,7 +136,6 @@ typename DiracDeterminant<DU_TYPE>::GradType DiracDeterminant<DU_TYPE>::evalGrad
   invRow_id = WorkingIndex;
   updateEng.getInvRow(psiM, WorkingIndex, invRow);
   GradType g = simd::dot(invRow.data(), dpsiM[WorkingIndex], invRow.size());
-  assert(checkG(g));
   return g;
 }
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -189,24 +189,6 @@ protected:
   ValueMatrix dummy_vmt;
 #endif
 
-  static bool checkG(const GradType& g)
-  {
-#if !defined(NDEBUG)
-    auto g_mag = std::abs(dot(g, g));
-    if (qmcplusplus::isnan(g_mag))
-      throw std::runtime_error("gradient of NaN");
-    if (qmcplusplus::isinf(g_mag))
-      throw std::runtime_error("gradient of Inf");
-    if (std::abs(g[0]) < std::abs(std::numeric_limits<RealType>::epsilon()) &&
-        std::abs(g[1]) < std::abs(std::numeric_limits<RealType>::epsilon()) &&
-        std::abs(g[2]) < std::abs(std::numeric_limits<RealType>::epsilon()))
-    {
-      std::cerr << "evalGrad gradient is " << g[0] << ' ' << g[1] << ' ' << g[2] << '\n';
-      throw std::runtime_error("gradient of zero");
-    }
-#endif
-    return true;
-  }
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -196,8 +196,10 @@ protected:
     if (qmcplusplus::isnan(g_mag))
       throw std::runtime_error("gradient of NaN");
     if (qmcplusplus::isinf(g_mag))
-      throw std::runtime_error("gradient of inf");
-    if (g_mag < std::abs(std::numeric_limits<RealType>::epsilon()))
+      throw std::runtime_error("gradient of Inf");
+    if (std::abs(g[0]) < std::abs(std::numeric_limits<RealType>::epsilon()) &&
+        std::abs(g[1]) < std::abs(std::numeric_limits<RealType>::epsilon()) &&
+        std::abs(g[2]) < std::abs(std::numeric_limits<RealType>::epsilon()))
     {
       std::cerr << "evalGrad gradient is " << g[0] << ' ' << g[1] << ' ' << g[2] << '\n';
       throw std::runtime_error("gradient of zero");

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -177,7 +177,6 @@ typename DiracDeterminantBatched<PL, VT, FPVT>::Grad DiracDeterminantBatched<PL,
   ScopedTimer local_timer(RatioTimer);
   const int WorkingIndex = iat - FirstIndex;
   Grad g                 = simd::dot(psiMinv_[WorkingIndex], dpsiM[WorkingIndex], NumOrbitals);
-  assert(checkG(g));
   return g;
 }
 
@@ -209,11 +208,6 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_evalGrad(const RefVectorWithLeade
 
   UpdateEngine::mw_evalGrad(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs,
                             dpsiM_row_list, WorkingIndex, grad_now);
-
-#ifndef NDEBUG
-  for (int iw = 0; iw < nw; iw++)
-    checkG(grad_now[iw]);
-#endif
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>
@@ -227,7 +221,6 @@ typename DiracDeterminantBatched<PL, VT, FPVT>::Grad DiracDeterminantBatched<PL,
   const int WorkingIndex = iat - FirstIndex;
   Grad g                 = simd::dot(psiMinv_[WorkingIndex], dpsiM[WorkingIndex], NumOrbitals);
   ComplexType spin_g     = simd::dot(psiMinv_[WorkingIndex], dspin_psiV.data(), NumOrbitals);
-  assert(checkG(g));
   spingrad += spin_g;
   return g;
 }
@@ -286,11 +279,6 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_evalGradWithSpin(
   UpdateEngine::mw_evalGradWithSpin(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc,
                                     mw_res.psiMinv_refs, dpsiM_row_list, mw_dspin, WorkingIndex, grad_now,
                                     spingrad_now);
-
-#ifndef NDEBUG
-  for (int iw = 0; iw < nw; iw++)
-    checkG(grad_now[iw]);
-#endif
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>


### PR DESCRIPTION
## Proposed changes

Check gradient element by element instead of using the norm.

Fixes failing gradient asserts in e.g. short-Be_STO-vmc-1-16 runs built with debug, where the gradient is wrongly asserted as zero. https://cdash.qmcpack.org/tests/4052499 . 

```
evalGrad gradient is -8.62777e-06 4.98444e-06 -4.77582e-06
gradient of zeroUnexpected exception thrown in threaded section
Fatal Error. Aborting at Unhandled Exception
```

## What type(s) of changes does this code introduce?

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

sulfur, gcc14 debug builds

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
