### PR TITLE
Increase  short-bccH_1x1x1_ae-vmc-all-nodrift_sdj-1-16-totenergy error

### DIFF
--- a/tests/solids/bccH_1x1x1_ae/CMakeLists.txt
+++ b/tests/solids/bccH_1x1x1_ae/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Short tests, about 2-3 seconds on 16 cores
 #
-list(APPEND BCC_H_SCALARS "totenergy" "-1.834032 0.0003")
+list(APPEND BCC_H_SCALARS "totenergy" "-1.834032 0.0005")
 list(APPEND BCC_H_SCALARS "kinetic" "0.186673807952 0.003")
 list(APPEND BCC_H_SCALARS "potential" "-2.02070672998 0.003")
 list(APPEND BCC_H_SCALARS "eeenergy" "-0.775870180954 0.003")


### PR DESCRIPTION
## Proposed changes

https://cdash.qmcpack.org/tests/4363516

Address rare statistical failure in short-bccH_1x1x1_ae-vmc-all-nodrift_sdj-1-16-totenergy with increased error bar

e.g. Clang18 build gave:

```
Tests for series 0
  Testing quantity: LocalEnergy
    reference mean value     :  -1.83403200
    reference error bar      :   0.00030000
    computed  mean value     :  -1.83527856
    computed  error bar      :   0.00052208
    pass tolerance           :   0.00090000  (  3.00000000 sigma)
    deviation from reference :  -0.00124656  ( -4.15519995 sigma)
    error bar of deviation   :   0.00060214
    significance probability :   0.99996748  (gaussian statistics)
    status of this test      :   fail

Test status: fail
```


## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None

## Checklist


- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
