### PR TITLE
Increase short-LiH_solid_1x1x1_pp-x-dmc-hf_noj-1-16-totenergy error

### DIFF
--- a/tests/solids/LiH_solid_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/LiH_solid_1x1x1_pp/CMakeLists.txt
@@ -153,7 +153,7 @@ qmc_run_and_check(
   LIH_GAMMA_DMC_SCALARS # DMC
 )
 
-list(APPEND LIH_X_DMC_SCALARS "totenergy" "-8.31413 0.004")
+list(APPEND LIH_X_DMC_SCALARS "totenergy" "-8.31413 0.005")
 qmc_run_and_check(
   short-LiH_solid_1x1x1_pp-x-dmc-hf_noj
   "${qmcpack_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp"


### PR DESCRIPTION
## Proposed changes

https://cdash.qmcpack.org/tests/4363490

Address rare failure in short-LiH_solid_1x1x1_pp-x-dmc-hf_noj-1-16-totenergy

```
Tests for series 1
  Testing quantity: LocalEnergy
    reference mean value     :  -8.31413000
    reference error bar      :   0.00400000
    computed  mean value     :  -8.30212434
    computed  error bar      :   0.00462636
    pass tolerance           :   0.01200000  (  3.00000000 sigma)
    deviation from reference :   0.01200566  (  3.00141515 sigma)
    error bar of deviation   :   0.00611581
    significance probability :   0.99731258  (gaussian statistics)
    status of this test      :   fail

Test status: fail
```

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
