### PR TITLE
Simplify template parameters of BsplineAllocator and remove an unused variable in a unit test

### DIFF
--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -274,7 +274,6 @@ TEST_CASE("OneBodyDensityMatrices::OneBodyDensityMatrices", "[estimators]")
 TEST_CASE("OneBodyDensityMatrices::generateSamples", "[estimators]")
 {
   using Input = testing::ValidOneBodyDensityMatricesInput;
-  Input input;
   using MCPWalker = OperatorEstBase::MCPWalker;
 
   ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
@@ -287,7 +286,7 @@ TEST_CASE("OneBodyDensityMatrices::generateSamples", "[estimators]")
   auto& species_set = pset_target.getSpeciesSet();
   auto& spo_map     = wavefunction_pool.getWaveFunction("wavefunction")->getSPOMap();
 
-  auto samplingCaseRunner = [&input, &pset_target, &species_set, &spo_map](Input::valid test_case) {
+  auto samplingCaseRunner = [&pset_target, &species_set, &spo_map](Input::valid test_case) {
     Libxml2Document doc;
     bool okay = doc.parseFromString(Input::getXml(test_case));
     if (!okay)

--- a/src/Platforms/CUDA/CUDAallocator.hpp
+++ b/src/Platforms/CUDA/CUDAallocator.hpp
@@ -251,10 +251,10 @@ struct CUDALockedPageAllocator : public ULPHA
   CUDALockedPageAllocator(const CUDALockedPageAllocator<U, V>&)
   {}
 
-  template<class U, class V>
+  template<class U>
   struct rebind
   {
-    using other = CUDALockedPageAllocator<U, V>;
+    using other = CUDALockedPageAllocator<U, typename std::allocator_traits<ULPHA>::template rebind_alloc<U>>;
   };
 
   value_type* allocate(std::size_t n)

--- a/src/Platforms/OMPTarget/OMPallocator.hpp
+++ b/src/Platforms/OMPTarget/OMPallocator.hpp
@@ -75,10 +75,10 @@ struct OMPallocator : public HostAllocator
   OMPallocator(const OMPallocator<U, V>&) : device_ptr_(nullptr)
   {}
 
-  template<class U, class V>
+  template<class U>
   struct rebind
   {
-    using other = OMPallocator<U, V>;
+    using other = OMPallocator<U, typename std::allocator_traits<HostAllocator>::template rebind_alloc<U>>;
   };
 
   value_type* allocate(std::size_t n)

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -71,7 +71,7 @@ private:
   ///\f$GGt=G^t G \f$, transformation for tensor in LatticeUnit to CartesianUnit, e.g. Hessian
   Tensor<ST, 3> GGt;
   ///multi bspline set
-  std::shared_ptr<MultiBspline<ST, OffloadAllocator<ST>, OffloadAllocator<SplineType>>> SplineInst;
+  std::shared_ptr<MultiBspline<ST, OffloadAllocator<ST>>> SplineInst;
 
   std::shared_ptr<OffloadVector<ST>> mKK;
   std::shared_ptr<OffloadPosVector<ST>> myKcart;
@@ -173,7 +173,7 @@ public:
   void create_spline(GT& xyz_g, BCT& xyz_bc)
   {
     resize_kpoints();
-    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator<ST>, OffloadAllocator<SplineType>>>();
+    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator<ST>>>();
     SplineInst->create(xyz_g, xyz_bc, myV.size());
 
     app_log() << "MEMORY " << SplineInst->sizeInByte() / (1 << 20) << " MB allocated "

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -71,7 +71,7 @@ private:
   ///\f$GGt=G^t G \f$, transformation for tensor in LatticeUnit to CartesianUnit, e.g. Hessian
   Tensor<ST, 3> GGt;
   ///multi bspline set
-  std::shared_ptr<MultiBspline<ST, OffloadAllocator>> SplineInst;
+  std::shared_ptr<MultiBspline<ST, OffloadAllocator<ST>, OffloadAllocator<SplineType>>> SplineInst;
 
   std::shared_ptr<OffloadVector<ST>> mKK;
   std::shared_ptr<OffloadPosVector<ST>> myKcart;
@@ -173,7 +173,7 @@ public:
   void create_spline(GT& xyz_g, BCT& xyz_bc)
   {
     resize_kpoints();
-    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator>>();
+    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator<ST>, OffloadAllocator<SplineType>>>();
     SplineInst->create(xyz_g, xyz_bc, myV.size());
 
     app_log() << "MEMORY " << SplineInst->sizeInByte() / (1 << 20) << " MB allocated "

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -71,7 +71,7 @@ private:
   ///\f$GGt=G^t G \f$, transformation for tensor in LatticeUnit to CartesianUnit, e.g. Hessian
   Tensor<ST, 3> GGt;
   ///multi bspline set
-  std::shared_ptr<MultiBspline<ST, OffloadAllocator<ST>, OffloadAllocator<SplineType>>> SplineInst;
+  std::shared_ptr<MultiBspline<ST, OffloadAllocator>> SplineInst;
 
   std::shared_ptr<OffloadVector<ST>> mKK;
   std::shared_ptr<OffloadPosVector<ST>> myKcart;
@@ -173,7 +173,7 @@ public:
   void create_spline(GT& xyz_g, BCT& xyz_bc)
   {
     resize_kpoints();
-    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator<ST>, OffloadAllocator<SplineType>>>();
+    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator>>();
     SplineInst->create(xyz_g, xyz_bc, myV.size());
 
     app_log() << "MEMORY " << SplineInst->sizeInByte() / (1 << 20) << " MB allocated "

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -76,7 +76,7 @@ private:
   ///number of complex bands
   int nComplexBands;
   ///multi bspline set
-  std::shared_ptr<MultiBspline<ST, OffloadAllocator<ST>, OffloadAllocator<SplineType>>> SplineInst;
+  std::shared_ptr<MultiBspline<ST, OffloadAllocator>> SplineInst;
 
   std::shared_ptr<OffloadVector<ST>> mKK;
   std::shared_ptr<OffloadPosVector<ST>> myKcart;
@@ -179,7 +179,7 @@ public:
   void create_spline(GT& xyz_g, BCT& xyz_bc)
   {
     resize_kpoints();
-    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator<ST>, OffloadAllocator<SplineType>>>();
+    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator>>();
     SplineInst->create(xyz_g, xyz_bc, myV.size());
 
     app_log() << "MEMORY " << SplineInst->sizeInByte() / (1 << 20) << " MB allocated "

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -76,7 +76,7 @@ private:
   ///number of complex bands
   int nComplexBands;
   ///multi bspline set
-  std::shared_ptr<MultiBspline<ST, OffloadAllocator<ST>, OffloadAllocator<SplineType>>> SplineInst;
+  std::shared_ptr<MultiBspline<ST, OffloadAllocator<ST>>> SplineInst;
 
   std::shared_ptr<OffloadVector<ST>> mKK;
   std::shared_ptr<OffloadPosVector<ST>> myKcart;
@@ -179,7 +179,7 @@ public:
   void create_spline(GT& xyz_g, BCT& xyz_bc)
   {
     resize_kpoints();
-    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator<ST>, OffloadAllocator<SplineType>>>();
+    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator<ST>>>();
     SplineInst->create(xyz_g, xyz_bc, myV.size());
 
     app_log() << "MEMORY " << SplineInst->sizeInByte() / (1 << 20) << " MB allocated "

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -76,7 +76,7 @@ private:
   ///number of complex bands
   int nComplexBands;
   ///multi bspline set
-  std::shared_ptr<MultiBspline<ST, OffloadAllocator>> SplineInst;
+  std::shared_ptr<MultiBspline<ST, OffloadAllocator<ST>, OffloadAllocator<SplineType>>> SplineInst;
 
   std::shared_ptr<OffloadVector<ST>> mKK;
   std::shared_ptr<OffloadPosVector<ST>> myKcart;
@@ -179,7 +179,7 @@ public:
   void create_spline(GT& xyz_g, BCT& xyz_bc)
   {
     resize_kpoints();
-    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator>>();
+    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator<ST>, OffloadAllocator<SplineType>>>();
     SplineInst->create(xyz_g, xyz_bc, myV.size());
 
     app_log() << "MEMORY " << SplineInst->sizeInByte() / (1 << 20) << " MB allocated "

--- a/src/spline2/BsplineAllocator.hpp
+++ b/src/spline2/BsplineAllocator.hpp
@@ -41,9 +41,7 @@ inline void find_coefs_1d(Ugrid grid, BCtype_s bc, float* data, intptr_t dstride
 }
 } // namespace einspline
 
-template<typename T,
-         typename COEFS_ALLOC        = aligned_allocator<T>,
-         typename MULTI_SPLINE_ALLOC = aligned_allocator<typename bspline_traits<T, 3>::SplineType>>
+template<typename T, template<typename> class ALLOC = aligned_allocator>
 class BsplineAllocator
 {
   using SplineType       = typename bspline_traits<T, 3>::SplineType;
@@ -52,8 +50,8 @@ class BsplineAllocator
   using real_type        = typename bspline_traits<T, 3>::real_type;
 
   /// allocators
-  COEFS_ALLOC coefs_allocator;
-  MULTI_SPLINE_ALLOC multi_spline_allocator;
+  ALLOC<T> coefs_allocator;
+  ALLOC<typename bspline_traits<T, 3>::SplineType> multi_spline_allocator;
 
 public:
   ///default constructor
@@ -84,7 +82,60 @@ public:
                                    BCType xBC,
                                    BCType yBC,
                                    BCType zBC,
-                                   int num_splines);
+                                   int num_splines)
+  {
+    // Create new spline
+    SplineType* spline = multi_spline_allocator.allocate(1);
+
+    spline->spcode      = bspline_traits<T, 3>::spcode;
+    spline->tcode       = bspline_traits<T, 3>::tcode;
+    spline->xBC         = xBC;
+    spline->yBC         = yBC;
+    spline->zBC         = zBC;
+    spline->num_splines = num_splines;
+
+    // Setup internal variables
+    int Mx = x_grid.num;
+    int My = y_grid.num;
+    int Mz = z_grid.num;
+    int Nx, Ny, Nz;
+
+    if (xBC.lCode == PERIODIC || xBC.lCode == ANTIPERIODIC)
+      Nx = Mx + 3;
+    else
+      Nx = Mx + 2;
+    x_grid.delta     = (x_grid.end - x_grid.start) / (double)(Nx - 3);
+    x_grid.delta_inv = 1.0 / x_grid.delta;
+    spline->x_grid   = x_grid;
+
+    if (yBC.lCode == PERIODIC || yBC.lCode == ANTIPERIODIC)
+      Ny = My + 3;
+    else
+      Ny = My + 2;
+    y_grid.delta     = (y_grid.end - y_grid.start) / (double)(Ny - 3);
+    y_grid.delta_inv = 1.0 / y_grid.delta;
+    spline->y_grid   = y_grid;
+
+    if (zBC.lCode == PERIODIC || zBC.lCode == ANTIPERIODIC)
+      Nz = Mz + 3;
+    else
+      Nz = Mz + 2;
+    z_grid.delta     = (z_grid.end - z_grid.start) / (double)(Nz - 3);
+    z_grid.delta_inv = 1.0 / z_grid.delta;
+    spline->z_grid   = z_grid;
+
+    const int N = getAlignedSize<real_type, ALLOC<T>::alignment>(num_splines);
+
+    spline->x_stride = (size_t)Ny * (size_t)Nz * (size_t)N;
+    spline->y_stride = Nz * N;
+    spline->z_stride = N;
+
+    spline->coefs_size = (size_t)Nx * spline->x_stride;
+    spline->coefs      = coefs_allocator.allocate(spline->coefs_size);
+
+    return spline;
+  }
+
 
   ///allocate a UBspline_3d_d, it can be made template to support UBspline_3d_s
   SingleSplineType* allocateUBspline(Ugrid x_grid,
@@ -93,7 +144,88 @@ public:
                                      BCType xBC,
                                      BCType yBC,
                                      BCType zBC,
-                                     T* data = nullptr);
+                                     T* data = nullptr)
+  {
+    // Create new spline
+    auto* spline = new SingleSplineType;
+
+    spline->spcode = bspline_traits<T, 3>::single_spcode;
+    spline->tcode  = bspline_traits<T, 3>::tcode;
+    spline->xBC    = xBC;
+    spline->yBC    = yBC;
+    spline->zBC    = zBC;
+
+    // Setup internal variables
+    int Mx = x_grid.num;
+    int My = y_grid.num;
+    int Mz = z_grid.num;
+    int Nx, Ny, Nz;
+
+    if (xBC.lCode == PERIODIC || xBC.lCode == ANTIPERIODIC)
+      Nx = Mx + 3;
+    else
+      Nx = Mx + 2;
+    x_grid.delta     = (x_grid.end - x_grid.start) / (double)(Nx - 3);
+    x_grid.delta_inv = 1.0 / x_grid.delta;
+    spline->x_grid   = x_grid;
+
+    if (yBC.lCode == PERIODIC || yBC.lCode == ANTIPERIODIC)
+      Ny = My + 3;
+    else
+      Ny = My + 2;
+    y_grid.delta     = (y_grid.end - y_grid.start) / (double)(Ny - 3);
+    y_grid.delta_inv = 1.0 / y_grid.delta;
+    spline->y_grid   = y_grid;
+
+    if (zBC.lCode == PERIODIC || zBC.lCode == ANTIPERIODIC)
+      Nz = Mz + 3;
+    else
+      Nz = Mz + 2;
+    z_grid.delta     = (z_grid.end - z_grid.start) / (double)(Nz - 3);
+    z_grid.delta_inv = 1.0 / z_grid.delta;
+    spline->z_grid   = z_grid;
+
+    spline->x_stride = Ny * Nz;
+    spline->y_stride = Nz;
+
+    spline->coefs_size = (size_t)Nx * (size_t)Ny * (size_t)Nz;
+
+    spline->coefs = coefs_allocator.allocate(spline->coefs_size);
+
+    if (data != NULL) // only data is provided
+    {
+// First, solve in the X-direction
+#pragma omp parallel for
+      for (int iy = 0; iy < My; iy++)
+        for (int iz = 0; iz < Mz; iz++)
+        {
+          intptr_t doffset = iy * Mz + iz;
+          intptr_t coffset = iy * Nz + iz;
+          einspline::find_coefs_1d(spline->x_grid, xBC, data + doffset, My * Mz, spline->coefs + coffset, Ny * Nz);
+        }
+
+// Now, solve in the Y-direction
+#pragma omp parallel for
+      for (intptr_t ix = 0; ix < Nx; ix++)
+        for (intptr_t iz = 0; iz < Nz; iz++)
+        {
+          intptr_t doffset = ix * Ny * Nz + iz;
+          intptr_t coffset = ix * Ny * Nz + iz;
+          einspline::find_coefs_1d(spline->y_grid, yBC, spline->coefs + doffset, Nz, spline->coefs + coffset, Nz);
+        }
+
+// Now, solve in the Z-direction
+#pragma omp parallel for
+      for (intptr_t ix = 0; ix < Nx; ix++)
+        for (intptr_t iy = 0; iy < Ny; iy++)
+        {
+          intptr_t doffset = (ix * Ny + iy) * Nz;
+          intptr_t coffset = (ix * Ny + iy) * Nz;
+          einspline::find_coefs_1d(spline->z_grid, zBC, spline->coefs + doffset, 1, spline->coefs + coffset, 1);
+        }
+    }
+    return spline;
+  }
 
   /** copy a UBSpline_3d_X to multi_UBspline_3d_X at i-th band
      * @param single  UBspline_3d_X
@@ -103,186 +235,33 @@ public:
      * @param N shape of AoSoA
      */
   template<typename UBT, typename MBT>
-  void copy(UBT* single, MBT* multi, int i, const int* offset, const int* N);
-};
-
-template<typename T, typename COEFS_ALLOC, typename MULTI_SPLINE_ALLOC>
-typename BsplineAllocator<T, COEFS_ALLOC, MULTI_SPLINE_ALLOC>::SplineType* BsplineAllocator<T,
-                                                                                            COEFS_ALLOC,
-                                                                                            MULTI_SPLINE_ALLOC>::
-    allocateMultiBspline(Ugrid x_grid, Ugrid y_grid, Ugrid z_grid, BCType xBC, BCType yBC, BCType zBC, int num_splines)
-{
-  // Create new spline
-  SplineType* spline = multi_spline_allocator.allocate(1);
-
-  spline->spcode      = bspline_traits<T, 3>::spcode;
-  spline->tcode       = bspline_traits<T, 3>::tcode;
-  spline->xBC         = xBC;
-  spline->yBC         = yBC;
-  spline->zBC         = zBC;
-  spline->num_splines = num_splines;
-
-  // Setup internal variables
-  int Mx = x_grid.num;
-  int My = y_grid.num;
-  int Mz = z_grid.num;
-  int Nx, Ny, Nz;
-
-  if (xBC.lCode == PERIODIC || xBC.lCode == ANTIPERIODIC)
-    Nx = Mx + 3;
-  else
-    Nx = Mx + 2;
-  x_grid.delta     = (x_grid.end - x_grid.start) / (double)(Nx - 3);
-  x_grid.delta_inv = 1.0 / x_grid.delta;
-  spline->x_grid   = x_grid;
-
-  if (yBC.lCode == PERIODIC || yBC.lCode == ANTIPERIODIC)
-    Ny = My + 3;
-  else
-    Ny = My + 2;
-  y_grid.delta     = (y_grid.end - y_grid.start) / (double)(Ny - 3);
-  y_grid.delta_inv = 1.0 / y_grid.delta;
-  spline->y_grid   = y_grid;
-
-  if (zBC.lCode == PERIODIC || zBC.lCode == ANTIPERIODIC)
-    Nz = Mz + 3;
-  else
-    Nz = Mz + 2;
-  z_grid.delta     = (z_grid.end - z_grid.start) / (double)(Nz - 3);
-  z_grid.delta_inv = 1.0 / z_grid.delta;
-  spline->z_grid   = z_grid;
-
-  const int N = getAlignedSize<real_type, COEFS_ALLOC::alignment>(num_splines);
-
-  spline->x_stride = (size_t)Ny * (size_t)Nz * (size_t)N;
-  spline->y_stride = Nz * N;
-  spline->z_stride = N;
-
-  spline->coefs_size = (size_t)Nx * spline->x_stride;
-  spline->coefs      = coefs_allocator.allocate(spline->coefs_size);
-
-  return spline;
-}
-
-template<typename T, typename COEFS_ALLOC, typename MULTI_SPLINE_ALLOC>
-typename BsplineAllocator<T, COEFS_ALLOC, MULTI_SPLINE_ALLOC>::SingleSplineType* BsplineAllocator<T,
-                                                                                                  COEFS_ALLOC,
-                                                                                                  MULTI_SPLINE_ALLOC>::
-    allocateUBspline(Ugrid x_grid, Ugrid y_grid, Ugrid z_grid, BCType xBC, BCType yBC, BCType zBC, T* data)
-{
-  // Create new spline
-  auto* spline = new SingleSplineType;
-
-  spline->spcode = bspline_traits<T, 3>::single_spcode;
-  spline->tcode  = bspline_traits<T, 3>::tcode;
-  spline->xBC    = xBC;
-  spline->yBC    = yBC;
-  spline->zBC    = zBC;
-
-  // Setup internal variables
-  int Mx = x_grid.num;
-  int My = y_grid.num;
-  int Mz = z_grid.num;
-  int Nx, Ny, Nz;
-
-  if (xBC.lCode == PERIODIC || xBC.lCode == ANTIPERIODIC)
-    Nx = Mx + 3;
-  else
-    Nx = Mx + 2;
-  x_grid.delta     = (x_grid.end - x_grid.start) / (double)(Nx - 3);
-  x_grid.delta_inv = 1.0 / x_grid.delta;
-  spline->x_grid   = x_grid;
-
-  if (yBC.lCode == PERIODIC || yBC.lCode == ANTIPERIODIC)
-    Ny = My + 3;
-  else
-    Ny = My + 2;
-  y_grid.delta     = (y_grid.end - y_grid.start) / (double)(Ny - 3);
-  y_grid.delta_inv = 1.0 / y_grid.delta;
-  spline->y_grid   = y_grid;
-
-  if (zBC.lCode == PERIODIC || zBC.lCode == ANTIPERIODIC)
-    Nz = Mz + 3;
-  else
-    Nz = Mz + 2;
-  z_grid.delta     = (z_grid.end - z_grid.start) / (double)(Nz - 3);
-  z_grid.delta_inv = 1.0 / z_grid.delta;
-  spline->z_grid   = z_grid;
-
-  spline->x_stride = Ny * Nz;
-  spline->y_stride = Nz;
-
-  spline->coefs_size = (size_t)Nx * (size_t)Ny * (size_t)Nz;
-
-  spline->coefs = coefs_allocator.allocate(spline->coefs_size);
-
-  if (data != NULL) // only data is provided
+  void copy(UBT* single, MBT* multi, int i, const int* offset, const int* N)
   {
-// First, solve in the X-direction
-#pragma omp parallel for
-    for (int iy = 0; iy < My; iy++)
-      for (int iz = 0; iz < Mz; iz++)
+    using out_type        = typename bspline_type<MBT>::value_type;
+    using in_type         = typename bspline_type<UBT>::value_type;
+    intptr_t x_stride_in  = single->x_stride;
+    intptr_t y_stride_in  = single->y_stride;
+    intptr_t x_stride_out = multi->x_stride;
+    intptr_t y_stride_out = multi->y_stride;
+    intptr_t z_stride_out = multi->z_stride;
+    intptr_t offset0      = static_cast<intptr_t>(offset[0]);
+    intptr_t offset1      = static_cast<intptr_t>(offset[1]);
+    intptr_t offset2      = static_cast<intptr_t>(offset[2]);
+    const intptr_t istart = static_cast<intptr_t>(i);
+    const intptr_t n0 = N[0], n1 = N[1], n2 = N[2];
+    for (intptr_t ix = 0; ix < n0; ++ix)
+      for (intptr_t iy = 0; iy < n1; ++iy)
       {
-        intptr_t doffset = iy * Mz + iz;
-        intptr_t coffset = iy * Nz + iz;
-        einspline::find_coefs_1d(spline->x_grid, xBC, data + doffset, My * Mz, spline->coefs + coffset, Ny * Nz);
-      }
-
-// Now, solve in the Y-direction
-#pragma omp parallel for
-    for (intptr_t ix = 0; ix < Nx; ix++)
-      for (intptr_t iz = 0; iz < Nz; iz++)
-      {
-        intptr_t doffset = ix * Ny * Nz + iz;
-        intptr_t coffset = ix * Ny * Nz + iz;
-        einspline::find_coefs_1d(spline->y_grid, yBC, spline->coefs + doffset, Nz, spline->coefs + coffset, Nz);
-      }
-
-// Now, solve in the Z-direction
-#pragma omp parallel for
-    for (intptr_t ix = 0; ix < Nx; ix++)
-      for (intptr_t iy = 0; iy < Ny; iy++)
-      {
-        intptr_t doffset = (ix * Ny + iy) * Nz;
-        intptr_t coffset = (ix * Ny + iy) * Nz;
-        einspline::find_coefs_1d(spline->z_grid, zBC, spline->coefs + doffset, 1, spline->coefs + coffset, 1);
+        out_type* restrict out = multi->coefs + ix * x_stride_out + iy * y_stride_out + istart;
+        const in_type* restrict in =
+            single->coefs + (ix + offset0) * x_stride_in + (iy + offset1) * y_stride_in + offset2;
+        for (intptr_t iz = 0; iz < n2; ++iz)
+        {
+          out[iz * z_stride_out] = static_cast<out_type>(in[iz]);
+        }
       }
   }
-  return spline;
-}
-
-template<typename T, typename COEFS_ALLOC, typename MULTI_SPLINE_ALLOC>
-template<typename UBT, typename MBT>
-void BsplineAllocator<T, COEFS_ALLOC, MULTI_SPLINE_ALLOC>::copy(UBT* single,
-                                                                MBT* multi,
-                                                                int i,
-                                                                const int* offset,
-                                                                const int* N)
-{
-  using out_type        = typename bspline_type<MBT>::value_type;
-  using in_type         = typename bspline_type<UBT>::value_type;
-  intptr_t x_stride_in  = single->x_stride;
-  intptr_t y_stride_in  = single->y_stride;
-  intptr_t x_stride_out = multi->x_stride;
-  intptr_t y_stride_out = multi->y_stride;
-  intptr_t z_stride_out = multi->z_stride;
-  intptr_t offset0      = static_cast<intptr_t>(offset[0]);
-  intptr_t offset1      = static_cast<intptr_t>(offset[1]);
-  intptr_t offset2      = static_cast<intptr_t>(offset[2]);
-  const intptr_t istart = static_cast<intptr_t>(i);
-  const intptr_t n0 = N[0], n1 = N[1], n2 = N[2];
-  for (intptr_t ix = 0; ix < n0; ++ix)
-    for (intptr_t iy = 0; iy < n1; ++iy)
-    {
-      out_type* restrict out = multi->coefs + ix * x_stride_out + iy * y_stride_out + istart;
-      const in_type* restrict in =
-          single->coefs + (ix + offset0) * x_stride_in + (iy + offset1) * y_stride_in + offset2;
-      for (intptr_t iz = 0; iz < n2; ++iz)
-      {
-        out[iz * z_stride_out] = static_cast<out_type>(in[iz]);
-      }
-    }
-}
+};
 
 } // namespace qmcplusplus
 #endif

--- a/src/spline2/BsplineAllocator.hpp
+++ b/src/spline2/BsplineAllocator.hpp
@@ -41,7 +41,9 @@ inline void find_coefs_1d(Ugrid grid, BCtype_s bc, float* data, intptr_t dstride
 }
 } // namespace einspline
 
-template<typename T, template<typename> class ALLOC = aligned_allocator>
+template<typename T,
+         typename COEFS_ALLOC        = aligned_allocator<T>,
+         typename MULTI_SPLINE_ALLOC = aligned_allocator<typename bspline_traits<T, 3>::SplineType>>
 class BsplineAllocator
 {
   using SplineType       = typename bspline_traits<T, 3>::SplineType;
@@ -50,8 +52,8 @@ class BsplineAllocator
   using real_type        = typename bspline_traits<T, 3>::real_type;
 
   /// allocators
-  ALLOC<T> coefs_allocator;
-  ALLOC<typename bspline_traits<T, 3>::SplineType> multi_spline_allocator;
+  COEFS_ALLOC coefs_allocator;
+  MULTI_SPLINE_ALLOC multi_spline_allocator;
 
 public:
   ///default constructor
@@ -82,60 +84,7 @@ public:
                                    BCType xBC,
                                    BCType yBC,
                                    BCType zBC,
-                                   int num_splines)
-  {
-    // Create new spline
-    SplineType* spline = multi_spline_allocator.allocate(1);
-
-    spline->spcode      = bspline_traits<T, 3>::spcode;
-    spline->tcode       = bspline_traits<T, 3>::tcode;
-    spline->xBC         = xBC;
-    spline->yBC         = yBC;
-    spline->zBC         = zBC;
-    spline->num_splines = num_splines;
-
-    // Setup internal variables
-    int Mx = x_grid.num;
-    int My = y_grid.num;
-    int Mz = z_grid.num;
-    int Nx, Ny, Nz;
-
-    if (xBC.lCode == PERIODIC || xBC.lCode == ANTIPERIODIC)
-      Nx = Mx + 3;
-    else
-      Nx = Mx + 2;
-    x_grid.delta     = (x_grid.end - x_grid.start) / (double)(Nx - 3);
-    x_grid.delta_inv = 1.0 / x_grid.delta;
-    spline->x_grid   = x_grid;
-
-    if (yBC.lCode == PERIODIC || yBC.lCode == ANTIPERIODIC)
-      Ny = My + 3;
-    else
-      Ny = My + 2;
-    y_grid.delta     = (y_grid.end - y_grid.start) / (double)(Ny - 3);
-    y_grid.delta_inv = 1.0 / y_grid.delta;
-    spline->y_grid   = y_grid;
-
-    if (zBC.lCode == PERIODIC || zBC.lCode == ANTIPERIODIC)
-      Nz = Mz + 3;
-    else
-      Nz = Mz + 2;
-    z_grid.delta     = (z_grid.end - z_grid.start) / (double)(Nz - 3);
-    z_grid.delta_inv = 1.0 / z_grid.delta;
-    spline->z_grid   = z_grid;
-
-    const int N = getAlignedSize<real_type, ALLOC<T>::alignment>(num_splines);
-
-    spline->x_stride = (size_t)Ny * (size_t)Nz * (size_t)N;
-    spline->y_stride = Nz * N;
-    spline->z_stride = N;
-
-    spline->coefs_size = (size_t)Nx * spline->x_stride;
-    spline->coefs      = coefs_allocator.allocate(spline->coefs_size);
-
-    return spline;
-  }
-
+                                   int num_splines);
 
   ///allocate a UBspline_3d_d, it can be made template to support UBspline_3d_s
   SingleSplineType* allocateUBspline(Ugrid x_grid,
@@ -144,88 +93,7 @@ public:
                                      BCType xBC,
                                      BCType yBC,
                                      BCType zBC,
-                                     T* data = nullptr)
-  {
-    // Create new spline
-    auto* spline = new SingleSplineType;
-
-    spline->spcode = bspline_traits<T, 3>::single_spcode;
-    spline->tcode  = bspline_traits<T, 3>::tcode;
-    spline->xBC    = xBC;
-    spline->yBC    = yBC;
-    spline->zBC    = zBC;
-
-    // Setup internal variables
-    int Mx = x_grid.num;
-    int My = y_grid.num;
-    int Mz = z_grid.num;
-    int Nx, Ny, Nz;
-
-    if (xBC.lCode == PERIODIC || xBC.lCode == ANTIPERIODIC)
-      Nx = Mx + 3;
-    else
-      Nx = Mx + 2;
-    x_grid.delta     = (x_grid.end - x_grid.start) / (double)(Nx - 3);
-    x_grid.delta_inv = 1.0 / x_grid.delta;
-    spline->x_grid   = x_grid;
-
-    if (yBC.lCode == PERIODIC || yBC.lCode == ANTIPERIODIC)
-      Ny = My + 3;
-    else
-      Ny = My + 2;
-    y_grid.delta     = (y_grid.end - y_grid.start) / (double)(Ny - 3);
-    y_grid.delta_inv = 1.0 / y_grid.delta;
-    spline->y_grid   = y_grid;
-
-    if (zBC.lCode == PERIODIC || zBC.lCode == ANTIPERIODIC)
-      Nz = Mz + 3;
-    else
-      Nz = Mz + 2;
-    z_grid.delta     = (z_grid.end - z_grid.start) / (double)(Nz - 3);
-    z_grid.delta_inv = 1.0 / z_grid.delta;
-    spline->z_grid   = z_grid;
-
-    spline->x_stride = Ny * Nz;
-    spline->y_stride = Nz;
-
-    spline->coefs_size = (size_t)Nx * (size_t)Ny * (size_t)Nz;
-
-    spline->coefs = coefs_allocator.allocate(spline->coefs_size);
-
-    if (data != NULL) // only data is provided
-    {
-// First, solve in the X-direction
-#pragma omp parallel for
-      for (int iy = 0; iy < My; iy++)
-        for (int iz = 0; iz < Mz; iz++)
-        {
-          intptr_t doffset = iy * Mz + iz;
-          intptr_t coffset = iy * Nz + iz;
-          einspline::find_coefs_1d(spline->x_grid, xBC, data + doffset, My * Mz, spline->coefs + coffset, Ny * Nz);
-        }
-
-// Now, solve in the Y-direction
-#pragma omp parallel for
-      for (intptr_t ix = 0; ix < Nx; ix++)
-        for (intptr_t iz = 0; iz < Nz; iz++)
-        {
-          intptr_t doffset = ix * Ny * Nz + iz;
-          intptr_t coffset = ix * Ny * Nz + iz;
-          einspline::find_coefs_1d(spline->y_grid, yBC, spline->coefs + doffset, Nz, spline->coefs + coffset, Nz);
-        }
-
-// Now, solve in the Z-direction
-#pragma omp parallel for
-      for (intptr_t ix = 0; ix < Nx; ix++)
-        for (intptr_t iy = 0; iy < Ny; iy++)
-        {
-          intptr_t doffset = (ix * Ny + iy) * Nz;
-          intptr_t coffset = (ix * Ny + iy) * Nz;
-          einspline::find_coefs_1d(spline->z_grid, zBC, spline->coefs + doffset, 1, spline->coefs + coffset, 1);
-        }
-    }
-    return spline;
-  }
+                                     T* data = nullptr);
 
   /** copy a UBSpline_3d_X to multi_UBspline_3d_X at i-th band
      * @param single  UBspline_3d_X
@@ -235,33 +103,186 @@ public:
      * @param N shape of AoSoA
      */
   template<typename UBT, typename MBT>
-  void copy(UBT* single, MBT* multi, int i, const int* offset, const int* N)
+  void copy(UBT* single, MBT* multi, int i, const int* offset, const int* N);
+};
+
+template<typename T, typename COEFS_ALLOC, typename MULTI_SPLINE_ALLOC>
+typename BsplineAllocator<T, COEFS_ALLOC, MULTI_SPLINE_ALLOC>::SplineType* BsplineAllocator<T,
+                                                                                            COEFS_ALLOC,
+                                                                                            MULTI_SPLINE_ALLOC>::
+    allocateMultiBspline(Ugrid x_grid, Ugrid y_grid, Ugrid z_grid, BCType xBC, BCType yBC, BCType zBC, int num_splines)
+{
+  // Create new spline
+  SplineType* spline = multi_spline_allocator.allocate(1);
+
+  spline->spcode      = bspline_traits<T, 3>::spcode;
+  spline->tcode       = bspline_traits<T, 3>::tcode;
+  spline->xBC         = xBC;
+  spline->yBC         = yBC;
+  spline->zBC         = zBC;
+  spline->num_splines = num_splines;
+
+  // Setup internal variables
+  int Mx = x_grid.num;
+  int My = y_grid.num;
+  int Mz = z_grid.num;
+  int Nx, Ny, Nz;
+
+  if (xBC.lCode == PERIODIC || xBC.lCode == ANTIPERIODIC)
+    Nx = Mx + 3;
+  else
+    Nx = Mx + 2;
+  x_grid.delta     = (x_grid.end - x_grid.start) / (double)(Nx - 3);
+  x_grid.delta_inv = 1.0 / x_grid.delta;
+  spline->x_grid   = x_grid;
+
+  if (yBC.lCode == PERIODIC || yBC.lCode == ANTIPERIODIC)
+    Ny = My + 3;
+  else
+    Ny = My + 2;
+  y_grid.delta     = (y_grid.end - y_grid.start) / (double)(Ny - 3);
+  y_grid.delta_inv = 1.0 / y_grid.delta;
+  spline->y_grid   = y_grid;
+
+  if (zBC.lCode == PERIODIC || zBC.lCode == ANTIPERIODIC)
+    Nz = Mz + 3;
+  else
+    Nz = Mz + 2;
+  z_grid.delta     = (z_grid.end - z_grid.start) / (double)(Nz - 3);
+  z_grid.delta_inv = 1.0 / z_grid.delta;
+  spline->z_grid   = z_grid;
+
+  const int N = getAlignedSize<real_type, COEFS_ALLOC::alignment>(num_splines);
+
+  spline->x_stride = (size_t)Ny * (size_t)Nz * (size_t)N;
+  spline->y_stride = Nz * N;
+  spline->z_stride = N;
+
+  spline->coefs_size = (size_t)Nx * spline->x_stride;
+  spline->coefs      = coefs_allocator.allocate(spline->coefs_size);
+
+  return spline;
+}
+
+template<typename T, typename COEFS_ALLOC, typename MULTI_SPLINE_ALLOC>
+typename BsplineAllocator<T, COEFS_ALLOC, MULTI_SPLINE_ALLOC>::SingleSplineType* BsplineAllocator<T,
+                                                                                                  COEFS_ALLOC,
+                                                                                                  MULTI_SPLINE_ALLOC>::
+    allocateUBspline(Ugrid x_grid, Ugrid y_grid, Ugrid z_grid, BCType xBC, BCType yBC, BCType zBC, T* data)
+{
+  // Create new spline
+  auto* spline = new SingleSplineType;
+
+  spline->spcode = bspline_traits<T, 3>::single_spcode;
+  spline->tcode  = bspline_traits<T, 3>::tcode;
+  spline->xBC    = xBC;
+  spline->yBC    = yBC;
+  spline->zBC    = zBC;
+
+  // Setup internal variables
+  int Mx = x_grid.num;
+  int My = y_grid.num;
+  int Mz = z_grid.num;
+  int Nx, Ny, Nz;
+
+  if (xBC.lCode == PERIODIC || xBC.lCode == ANTIPERIODIC)
+    Nx = Mx + 3;
+  else
+    Nx = Mx + 2;
+  x_grid.delta     = (x_grid.end - x_grid.start) / (double)(Nx - 3);
+  x_grid.delta_inv = 1.0 / x_grid.delta;
+  spline->x_grid   = x_grid;
+
+  if (yBC.lCode == PERIODIC || yBC.lCode == ANTIPERIODIC)
+    Ny = My + 3;
+  else
+    Ny = My + 2;
+  y_grid.delta     = (y_grid.end - y_grid.start) / (double)(Ny - 3);
+  y_grid.delta_inv = 1.0 / y_grid.delta;
+  spline->y_grid   = y_grid;
+
+  if (zBC.lCode == PERIODIC || zBC.lCode == ANTIPERIODIC)
+    Nz = Mz + 3;
+  else
+    Nz = Mz + 2;
+  z_grid.delta     = (z_grid.end - z_grid.start) / (double)(Nz - 3);
+  z_grid.delta_inv = 1.0 / z_grid.delta;
+  spline->z_grid   = z_grid;
+
+  spline->x_stride = Ny * Nz;
+  spline->y_stride = Nz;
+
+  spline->coefs_size = (size_t)Nx * (size_t)Ny * (size_t)Nz;
+
+  spline->coefs = coefs_allocator.allocate(spline->coefs_size);
+
+  if (data != NULL) // only data is provided
   {
-    using out_type        = typename bspline_type<MBT>::value_type;
-    using in_type         = typename bspline_type<UBT>::value_type;
-    intptr_t x_stride_in  = single->x_stride;
-    intptr_t y_stride_in  = single->y_stride;
-    intptr_t x_stride_out = multi->x_stride;
-    intptr_t y_stride_out = multi->y_stride;
-    intptr_t z_stride_out = multi->z_stride;
-    intptr_t offset0      = static_cast<intptr_t>(offset[0]);
-    intptr_t offset1      = static_cast<intptr_t>(offset[1]);
-    intptr_t offset2      = static_cast<intptr_t>(offset[2]);
-    const intptr_t istart = static_cast<intptr_t>(i);
-    const intptr_t n0 = N[0], n1 = N[1], n2 = N[2];
-    for (intptr_t ix = 0; ix < n0; ++ix)
-      for (intptr_t iy = 0; iy < n1; ++iy)
+// First, solve in the X-direction
+#pragma omp parallel for
+    for (int iy = 0; iy < My; iy++)
+      for (int iz = 0; iz < Mz; iz++)
       {
-        out_type* restrict out = multi->coefs + ix * x_stride_out + iy * y_stride_out + istart;
-        const in_type* restrict in =
-            single->coefs + (ix + offset0) * x_stride_in + (iy + offset1) * y_stride_in + offset2;
-        for (intptr_t iz = 0; iz < n2; ++iz)
-        {
-          out[iz * z_stride_out] = static_cast<out_type>(in[iz]);
-        }
+        intptr_t doffset = iy * Mz + iz;
+        intptr_t coffset = iy * Nz + iz;
+        einspline::find_coefs_1d(spline->x_grid, xBC, data + doffset, My * Mz, spline->coefs + coffset, Ny * Nz);
+      }
+
+// Now, solve in the Y-direction
+#pragma omp parallel for
+    for (intptr_t ix = 0; ix < Nx; ix++)
+      for (intptr_t iz = 0; iz < Nz; iz++)
+      {
+        intptr_t doffset = ix * Ny * Nz + iz;
+        intptr_t coffset = ix * Ny * Nz + iz;
+        einspline::find_coefs_1d(spline->y_grid, yBC, spline->coefs + doffset, Nz, spline->coefs + coffset, Nz);
+      }
+
+// Now, solve in the Z-direction
+#pragma omp parallel for
+    for (intptr_t ix = 0; ix < Nx; ix++)
+      for (intptr_t iy = 0; iy < Ny; iy++)
+      {
+        intptr_t doffset = (ix * Ny + iy) * Nz;
+        intptr_t coffset = (ix * Ny + iy) * Nz;
+        einspline::find_coefs_1d(spline->z_grid, zBC, spline->coefs + doffset, 1, spline->coefs + coffset, 1);
       }
   }
-};
+  return spline;
+}
+
+template<typename T, typename COEFS_ALLOC, typename MULTI_SPLINE_ALLOC>
+template<typename UBT, typename MBT>
+void BsplineAllocator<T, COEFS_ALLOC, MULTI_SPLINE_ALLOC>::copy(UBT* single,
+                                                                MBT* multi,
+                                                                int i,
+                                                                const int* offset,
+                                                                const int* N)
+{
+  using out_type        = typename bspline_type<MBT>::value_type;
+  using in_type         = typename bspline_type<UBT>::value_type;
+  intptr_t x_stride_in  = single->x_stride;
+  intptr_t y_stride_in  = single->y_stride;
+  intptr_t x_stride_out = multi->x_stride;
+  intptr_t y_stride_out = multi->y_stride;
+  intptr_t z_stride_out = multi->z_stride;
+  intptr_t offset0      = static_cast<intptr_t>(offset[0]);
+  intptr_t offset1      = static_cast<intptr_t>(offset[1]);
+  intptr_t offset2      = static_cast<intptr_t>(offset[2]);
+  const intptr_t istart = static_cast<intptr_t>(i);
+  const intptr_t n0 = N[0], n1 = N[1], n2 = N[2];
+  for (intptr_t ix = 0; ix < n0; ++ix)
+    for (intptr_t iy = 0; iy < n1; ++iy)
+    {
+      out_type* restrict out = multi->coefs + ix * x_stride_out + iy * y_stride_out + istart;
+      const in_type* restrict in =
+          single->coefs + (ix + offset0) * x_stride_in + (iy + offset1) * y_stride_in + offset2;
+      for (intptr_t iz = 0; iz < n2; ++iz)
+      {
+        out[iz * z_stride_out] = static_cast<out_type>(in[iz]);
+      }
+    }
+}
 
 } // namespace qmcplusplus
 #endif

--- a/src/spline2/MultiBspline.hpp
+++ b/src/spline2/MultiBspline.hpp
@@ -33,9 +33,8 @@ namespace qmcplusplus
  * This class contains a pointer to a C object, copy and assign of this class is forbidden.
  */
 template<typename T,
-         typename COEFS_ALLOC         = aligned_allocator<T>,
-         typename MULTI_SPLINE_ALLOC  = aligned_allocator<typename bspline_traits<T, 3>::SplineType>,
-         typename SINGLE_SPLINE_ALLOC = aligned_allocator<typename bspline_traits<T, 3>::SingleSplineType>>
+         typename COEFS_ALLOC        = aligned_allocator<T>,
+         typename MULTI_SPLINE_ALLOC = aligned_allocator<typename bspline_traits<T, 3>::SplineType>>
 class MultiBspline
 {
 private:
@@ -46,11 +45,11 @@ private:
   ///actual einspline multi-bspline object
   SplineType* spline_m;
   ///use allocator
-  BsplineAllocator<T, COEFS_ALLOC, MULTI_SPLINE_ALLOC, SINGLE_SPLINE_ALLOC> myAllocator;
+  BsplineAllocator<T, COEFS_ALLOC, MULTI_SPLINE_ALLOC> myAllocator;
 
 public:
   MultiBspline() : spline_m(nullptr) {}
-  MultiBspline(const MultiBspline& in) = delete;
+  MultiBspline(const MultiBspline& in)            = delete;
   MultiBspline& operator=(const MultiBspline& in) = delete;
 
   ~MultiBspline()
@@ -71,7 +70,8 @@ public:
   template<typename GT, typename BCT>
   void create(GT& grid, BCT& bc, int num_splines)
   {
-    static_assert(std::is_same<T, typename COEFS_ALLOC::value_type>::value, "MultiBspline and ALLOC data types must agree!");
+    static_assert(std::is_same<T, typename COEFS_ALLOC::value_type>::value,
+                  "MultiBspline and ALLOC data types must agree!");
     if (getAlignedSize<T, COEFS_ALLOC::alignment>(num_splines) != num_splines)
       throw std::runtime_error("When creating the data space of MultiBspline, num_splines must be padded!\n");
     if (spline_m == nullptr)

--- a/src/spline2/MultiBspline.hpp
+++ b/src/spline2/MultiBspline.hpp
@@ -32,7 +32,9 @@ namespace qmcplusplus
  *
  * This class contains a pointer to a C object, copy and assign of this class is forbidden.
  */
-template<typename T, template<typename> class ALLOC = aligned_allocator>
+template<typename T,
+         typename COEFS_ALLOC        = aligned_allocator<T>,
+         typename MULTI_SPLINE_ALLOC = aligned_allocator<typename bspline_traits<T, 3>::SplineType>>
 class MultiBspline
 {
 private:
@@ -43,7 +45,7 @@ private:
   ///actual einspline multi-bspline object
   SplineType* spline_m;
   ///use allocator
-  BsplineAllocator<T, ALLOC> myAllocator;
+  BsplineAllocator<T, COEFS_ALLOC, MULTI_SPLINE_ALLOC> myAllocator;
 
 public:
   MultiBspline() : spline_m(nullptr) {}
@@ -68,9 +70,9 @@ public:
   template<typename GT, typename BCT>
   void create(GT& grid, BCT& bc, int num_splines)
   {
-    static_assert(std::is_same<T, typename ALLOC<T>::value_type>::value,
+    static_assert(std::is_same<T, typename COEFS_ALLOC::value_type>::value,
                   "MultiBspline and ALLOC data types must agree!");
-    if (getAlignedSize<T, ALLOC<T>::alignment>(num_splines) != num_splines)
+    if (getAlignedSize<T, COEFS_ALLOC::alignment>(num_splines) != num_splines)
       throw std::runtime_error("When creating the data space of MultiBspline, num_splines must be padded!\n");
     if (spline_m == nullptr)
     {

--- a/src/spline2/MultiBspline.hpp
+++ b/src/spline2/MultiBspline.hpp
@@ -32,9 +32,7 @@ namespace qmcplusplus
  *
  * This class contains a pointer to a C object, copy and assign of this class is forbidden.
  */
-template<typename T,
-         typename COEFS_ALLOC        = aligned_allocator<T>,
-         typename MULTI_SPLINE_ALLOC = aligned_allocator<typename bspline_traits<T, 3>::SplineType>>
+template<typename T, typename ALLOC = aligned_allocator<T>>
 class MultiBspline
 {
 private:
@@ -45,7 +43,7 @@ private:
   ///actual einspline multi-bspline object
   SplineType* spline_m;
   ///use allocator
-  BsplineAllocator<T, COEFS_ALLOC, MULTI_SPLINE_ALLOC> myAllocator;
+  BsplineAllocator<T, ALLOC> myAllocator;
 
 public:
   MultiBspline() : spline_m(nullptr) {}
@@ -70,9 +68,8 @@ public:
   template<typename GT, typename BCT>
   void create(GT& grid, BCT& bc, int num_splines)
   {
-    static_assert(std::is_same<T, typename COEFS_ALLOC::value_type>::value,
-                  "MultiBspline and ALLOC data types must agree!");
-    if (getAlignedSize<T, COEFS_ALLOC::alignment>(num_splines) != num_splines)
+    static_assert(std::is_same<T, typename ALLOC::value_type>::value, "MultiBspline and ALLOC data types must agree!");
+    if (getAlignedSize<T, ALLOC::alignment>(num_splines) != num_splines)
       throw std::runtime_error("When creating the data space of MultiBspline, num_splines must be padded!\n");
     if (spline_m == nullptr)
     {

--- a/src/spline2/MultiBspline.hpp
+++ b/src/spline2/MultiBspline.hpp
@@ -32,9 +32,7 @@ namespace qmcplusplus
  *
  * This class contains a pointer to a C object, copy and assign of this class is forbidden.
  */
-template<typename T,
-         typename COEFS_ALLOC        = aligned_allocator<T>,
-         typename MULTI_SPLINE_ALLOC = aligned_allocator<typename bspline_traits<T, 3>::SplineType>>
+template<typename T, template<typename> class ALLOC = aligned_allocator>
 class MultiBspline
 {
 private:
@@ -45,7 +43,7 @@ private:
   ///actual einspline multi-bspline object
   SplineType* spline_m;
   ///use allocator
-  BsplineAllocator<T, COEFS_ALLOC, MULTI_SPLINE_ALLOC> myAllocator;
+  BsplineAllocator<T, ALLOC> myAllocator;
 
 public:
   MultiBspline() : spline_m(nullptr) {}
@@ -70,9 +68,9 @@ public:
   template<typename GT, typename BCT>
   void create(GT& grid, BCT& bc, int num_splines)
   {
-    static_assert(std::is_same<T, typename COEFS_ALLOC::value_type>::value,
+    static_assert(std::is_same<T, typename ALLOC<T>::value_type>::value,
                   "MultiBspline and ALLOC data types must agree!");
-    if (getAlignedSize<T, COEFS_ALLOC::alignment>(num_splines) != num_splines)
+    if (getAlignedSize<T, ALLOC<T>::alignment>(num_splines) != num_splines)
       throw std::runtime_error("When creating the data space of MultiBspline, num_splines must be padded!\n");
     if (spline_m == nullptr)
     {


### PR DESCRIPTION
## Proposed changes
1. Simplify template parameters of BsplineAllocator
2. Resolve the last warning about "&input"
https://cdash.qmcpack.org/viewBuildError.php?type=1&buildid=12897

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted