### PR TITLE
Introduce MultiSplineBase and MultiSplineOffload classes

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -21,7 +21,7 @@
 #include <memory>
 #include "QMCWaveFunctions/BsplineFactory/BsplineSet.h"
 #include "OhmmsSoA/VectorSoaContainer.h"
-#include "spline2/MultiBspline.hpp"
+#include "spline2/MultiBsplineOffload.hpp"
 #include "OMPTarget/OffloadAlignedAllocators.hpp"
 #include "Utilities/FairDivide.h"
 #include "Utilities/TimerManager.h"
@@ -71,7 +71,7 @@ private:
   ///\f$GGt=G^t G \f$, transformation for tensor in LatticeUnit to CartesianUnit, e.g. Hessian
   Tensor<ST, 3> GGt;
   ///multi bspline set
-  std::shared_ptr<MultiBspline<ST, OffloadAllocator<ST>>> SplineInst;
+  std::shared_ptr<MultiBsplineBase<ST>> SplineInst;
 
   std::shared_ptr<OffloadVector<ST>> mKK;
   std::shared_ptr<OffloadPosVector<ST>> myKcart;
@@ -173,7 +173,7 @@ public:
   void create_spline(const Ugrid xyz_g[3], const BCT& xyz_bc)
   {
     resize_kpoints();
-    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator<ST>>>();
+    SplineInst = std::make_shared<MultiBsplineOffload<ST>>();
     SplineInst->create(xyz_g, xyz_bc, myV.size());
 
     app_log() << "MEMORY " << SplineInst->sizeInByte() / (1 << 20) << " MB allocated "

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -183,29 +183,17 @@ public:
   /// this routine can not be called from threaded region
   void finalizeConstruction() override
   {
-    // map the SplineInst->getSplinePtr() structure to GPU
-    auto* MultiSpline    = SplineInst->getSplinePtr();
-    auto* restrict coefs = MultiSpline->coefs;
-    // attach pointers on the device to achieve deep copy
-    PRAGMA_OFFLOAD("omp target map(always, to: MultiSpline[0:1], coefs[0:MultiSpline->coefs_size])")
-    {
-      MultiSpline->coefs = coefs;
-    }
-
+    SplineInst->finalize();
     // transfer static data to GPU
-    auto* mKK_ptr = mKK->data();
-    PRAGMA_OFFLOAD("omp target update to(mKK_ptr[0:mKK->size()])")
-    auto* myKcart_ptr = myKcart->data();
-    PRAGMA_OFFLOAD("omp target update to(myKcart_ptr[0:myKcart->capacity()*3])")
+    mKK->updateTo();
+    myKcart->updateTo();
     for (uint32_t i = 0; i < 9; i++)
     {
       (*GGt_offload)[i]           = GGt[i];
       (*PrimLattice_G_offload)[i] = PrimLattice.G[i];
     }
-    auto* PrimLattice_G_ptr = PrimLattice_G_offload->data();
-    PRAGMA_OFFLOAD("omp target update to(PrimLattice_G_ptr[0:9])")
-    auto* GGt_ptr = GGt_offload->data();
-    PRAGMA_OFFLOAD("omp target update to(GGt_ptr[0:9])")
+    PrimLattice_G_offload->updateTo();
+    GGt_offload->updateTo();
   }
 
   inline void flush_zero() { SplineInst->flush_zero(); }

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -21,7 +21,7 @@
 #include <memory>
 #include "QMCWaveFunctions/BsplineFactory/BsplineSet.h"
 #include "OhmmsSoA/VectorSoaContainer.h"
-#include "spline2/MultiBspline.hpp"
+#include "spline2/MultiBsplineOffload.hpp"
 #include "OMPTarget/OffloadAlignedAllocators.hpp"
 #include "Utilities/FairDivide.h"
 #include "Utilities/TimerManager.h"
@@ -76,7 +76,7 @@ private:
   ///number of complex bands
   int nComplexBands;
   ///multi bspline set
-  std::shared_ptr<MultiBspline<ST, OffloadAllocator<ST>>> SplineInst;
+  std::shared_ptr<MultiBsplineBase<ST>> SplineInst;
 
   std::shared_ptr<OffloadVector<ST>> mKK;
   std::shared_ptr<OffloadPosVector<ST>> myKcart;
@@ -179,7 +179,7 @@ public:
   void create_spline(const Ugrid xyz_g[3], const BCT& xyz_bc)
   {
     resize_kpoints();
-    SplineInst = std::make_shared<MultiBspline<ST, OffloadAllocator<ST>>>();
+    SplineInst = std::make_shared<MultiBsplineOffload<ST>>();
     SplineInst->create(xyz_g, xyz_bc, myV.size());
 
     app_log() << "MEMORY " << SplineInst->sizeInByte() / (1 << 20) << " MB allocated "

--- a/src/spline2/BsplineAllocator.hpp
+++ b/src/spline2/BsplineAllocator.hpp
@@ -80,9 +80,9 @@ public:
   SplineType* allocateMultiBspline(Ugrid x_grid,
                                    Ugrid y_grid,
                                    Ugrid z_grid,
-                                   BCType xBC,
-                                   BCType yBC,
-                                   BCType zBC,
+                                   const BCType& xBC,
+                                   const BCType& yBC,
+                                   const BCType& zBC,
                                    int num_splines);
 
   ///allocate a UBspline_3d_d, it can be made template to support UBspline_3d_s
@@ -103,29 +103,15 @@ public:
      */
   template<typename UBT, typename MBT>
   void copy(UBT* single, MBT* multi, int i, const int* offset, const int* N);
-
-  template<typename Allocator = ALLOC, typename = qmcplusplus::IsDualSpace<Allocator>>
-  void finalize(SplineType* multi_spline)
-  {
-    auto* coefs_host_ptr   = multi_spline->coefs;
-    auto* coefs_device_ptr = coefs_allocator.get_device_ptr();
-    // overwrite coefs pointer for updating device copy
-    multi_spline->coefs = coefs_device_ptr;
-    // transfer multi_spline and its spline coefficients to device
-    qmc_allocator_traits<MultiAlloc>::updateTo(multi_spline_allocator, multi_spline, 1);
-    qmc_allocator_traits<ALLOC>::updateTo(coefs_allocator, coefs_host_ptr, multi_spline->coefs_size);
-    // restore coefs pointer on host
-    multi_spline->coefs = coefs_host_ptr;
-  }
 };
 
 template<typename T, typename ALLOC>
 typename BsplineAllocator<T, ALLOC>::SplineType* BsplineAllocator<T, ALLOC>::allocateMultiBspline(Ugrid x_grid,
                                                                                                   Ugrid y_grid,
                                                                                                   Ugrid z_grid,
-                                                                                                  BCType xBC,
-                                                                                                  BCType yBC,
-                                                                                                  BCType zBC,
+                                                                                                  const BCType& xBC,
+                                                                                                  const BCType& yBC,
+                                                                                                  const BCType& zBC,
                                                                                                   int num_splines)
 {
   // Create new spline

--- a/src/spline2/MultiBspline.hpp
+++ b/src/spline2/MultiBspline.hpp
@@ -102,6 +102,12 @@ public:
   int num_splines() const { return (spline_m == nullptr) ? 0 : spline_m->num_splines; }
 
   size_t sizeInByte() const { return (spline_m == nullptr) ? 0 : spline_m->coefs_size * sizeof(T); }
+
+  template<typename Allocator = ALLOC, typename = qmcplusplus::IsDualSpace<Allocator>>
+  void finalize()
+  {
+    myAllocator.finalize(spline_m);
+  }
 };
 
 

--- a/src/spline2/MultiBspline.hpp
+++ b/src/spline2/MultiBspline.hpp
@@ -19,11 +19,9 @@
 #ifndef QMCPLUSPLUS_MULTIEINSPLINE_HPP
 #define QMCPLUSPLUS_MULTIEINSPLINE_HPP
 
-#include <cstdlib>
-#include <type_traits>
-#include "config.h"
 #include "MultiBsplineBase.hpp"
 #include "spline2/BsplineAllocator.hpp"
+#include "CPU/SIMD/aligned_allocator.hpp"
 
 namespace qmcplusplus
 {

--- a/src/spline2/MultiBsplineBase.hpp
+++ b/src/spline2/MultiBsplineBase.hpp
@@ -19,10 +19,6 @@
 #ifndef QMCPLUSPLUS_MULTIEINSPLINEBASE_HPP
 #define QMCPLUSPLUS_MULTIEINSPLINEBASE_HPP
 
-#include <iostream>
-#include <cstdlib>
-#include <type_traits>
-#include "config.h"
 #include "spline2/bspline_traits.hpp"
 
 namespace qmcplusplus

--- a/src/spline2/MultiBsplineBase.hpp
+++ b/src/spline2/MultiBsplineBase.hpp
@@ -1,0 +1,140 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2024 QMCPACK developers.
+//
+// File developed by: Jeongnim Kim, jeongnim.kim@intel.com, Intel Corp.
+//                    Amrita Mathuriya, amrita.mathuriya@intel.com, Intel Corp.
+//                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+// -*- C++ -*-
+/**@file MultiBsplineBase.hpp
+ *
+ * define classes MultiBsplineBase
+ * The evaluation functions are defined in MultiBsplineBaseEval.hpp
+ */
+#ifndef QMCPLUSPLUS_MULTIEINSPLINEBASE_HPP
+#define QMCPLUSPLUS_MULTIEINSPLINEBASE_HPP
+
+#include <iostream>
+#include <cstdlib>
+#include <type_traits>
+#include "config.h"
+#include "spline2/bspline_traits.hpp"
+
+namespace qmcplusplus
+{
+/** container class to hold a 3D multi spline pointer
+ * @tparam T the precision of splines
+ *
+ * This class contains a pointer to a C object, copy and assign of this class is forbidden.
+ */
+template<typename T>
+class MultiBsplineBase
+{
+protected:
+  ///define the einsplie object type
+  using SplineType = typename bspline_traits<T, 3>::SplineType;
+  ///define the real type
+  using real_type = typename bspline_traits<T, 3>::real_type;
+  ///define the boundary condition type
+  using BoundaryCondition = typename bspline_traits<T, 3>::BCType;
+  ///actual einspline multi-bspline object
+  SplineType* spline_m;
+
+  virtual SplineType* createImpl(const Ugrid grid[3], const BoundaryCondition bc[3], int num_splines) = 0;
+
+public:
+  MultiBsplineBase() : spline_m(nullptr) {}
+  MultiBsplineBase(const MultiBsplineBase& in)            = delete;
+  MultiBsplineBase& operator=(const MultiBsplineBase& in) = delete;
+
+  virtual ~MultiBsplineBase() = default;
+
+  SplineType* getSplinePtr() { return spline_m; }
+
+  /** create the einspline as used in the builder
+   * @tparam BCT boundary type
+   * @param bc num_splines number of splines
+   *
+   * num_splines must be padded to the aligned size. The caller must be aware of padding and pad all result arrays.
+   */
+  template<typename BCT>
+  inline void create(const Ugrid grid[3], const BCT& bc, int num_splines)
+  {
+    if (spline_m == nullptr)
+    {
+      BoundaryCondition xyzBC[3];
+      xyzBC[0].lCode = bc[0].lCode;
+      xyzBC[1].lCode = bc[1].lCode;
+      xyzBC[2].lCode = bc[2].lCode;
+      xyzBC[0].rCode = bc[0].rCode;
+      xyzBC[1].rCode = bc[1].rCode;
+      xyzBC[2].rCode = bc[2].rCode;
+      xyzBC[0].lVal  = static_cast<T>(bc[0].lVal);
+      xyzBC[1].lVal  = static_cast<T>(bc[1].lVal);
+      xyzBC[2].lVal  = static_cast<T>(bc[2].lVal);
+      xyzBC[0].rVal  = static_cast<T>(bc[0].rVal);
+      xyzBC[1].rVal  = static_cast<T>(bc[1].rVal);
+      xyzBC[2].rVal  = static_cast<T>(bc[2].rVal);
+      spline_m       = createImpl(grid, xyzBC, num_splines);
+    }
+    else
+      throw std::runtime_error("MultiBsplineBase::spline_m cannot be created twice!\n");
+  }
+
+  void flush_zero() const
+  {
+    if (spline_m != nullptr)
+      std::fill(spline_m->coefs, spline_m->coefs + spline_m->coefs_size, T(0));
+  }
+
+  int num_splines() const { return (spline_m == nullptr) ? 0 : spline_m->num_splines; }
+
+  size_t sizeInByte() const { return (spline_m == nullptr) ? 0 : spline_m->coefs_size * sizeof(T); }
+
+  virtual void finalize(){};
+};
+
+/** copy a single spline to multi spline
+   * @tparam SSDT single spline coefficient data type
+   * @tparam MSDT multi spline coefficient data type
+   * @param single UBspline_3d_(d,s)
+   * @param multi multi_UBspline_3d_(d,s)
+   * @param int index of single in multi
+   */
+template<typename SSDT, typename MSDT>
+void copy_spline(const typename bspline_traits<SSDT, 3>::SingleSplineType& single,
+                 typename bspline_traits<MSDT, 3>::SplineType& multi,
+                 int i)
+{
+  static_assert(std::is_floating_point<SSDT>::value, "SSDT must be a float point type");
+  static_assert(std::is_floating_point<MSDT>::value, "MSDT must be a float point type");
+
+  if (single.x_grid.num != multi.x_grid.num || single.y_grid.num != multi.y_grid.num ||
+      single.z_grid.num != multi.z_grid.num)
+    throw std::runtime_error("Cannot copy a single spline to MultiSpline with a different grid!\n");
+
+  intptr_t x_stride_in  = single.x_stride;
+  intptr_t y_stride_in  = single.y_stride;
+  intptr_t x_stride_out = multi.x_stride;
+  intptr_t y_stride_out = multi.y_stride;
+  intptr_t z_stride_out = multi.z_stride;
+  const intptr_t istart = static_cast<intptr_t>(i);
+  const intptr_t n0 = multi.x_grid.num + 3, n1 = multi.y_grid.num + 3, n2 = multi.z_grid.num + 3;
+  for (intptr_t ix = 0; ix < n0; ++ix)
+    for (intptr_t iy = 0; iy < n1; ++iy)
+    {
+      auto* __restrict__ out      = multi.coefs + ix * x_stride_out + iy * y_stride_out + istart;
+      const auto* __restrict__ in = single.coefs + ix * x_stride_in + iy * y_stride_in;
+      for (intptr_t iz = 0; iz < n2; ++iz)
+        out[iz * z_stride_out] = in[iz];
+    }
+}
+
+} // namespace qmcplusplus
+
+#endif

--- a/src/spline2/MultiBsplineOffload.hpp
+++ b/src/spline2/MultiBsplineOffload.hpp
@@ -4,26 +4,25 @@
 //
 // Copyright (c) 2024 QMCPACK developers.
 //
-// File developed by: Jeongnim Kim, jeongnim.kim@intel.com, Intel Corp.
-//                    Amrita Mathuriya, amrita.mathuriya@intel.com, Intel Corp.
-//                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //
-// File created by: Jeongnim Kim, jeongnim.kim@intel.com, Intel Corp.
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 // -*- C++ -*-
-/**@file MultiBspline.hpp
+/**@file MultiBsplineOffload.hpp
  *
- * define classes MultiBspline
- * The evaluation functions are defined in MultiBsplineEval.hpp
+ * define classes MultiBsplineOffload
+ * The evaluation functions are defined in MultiBsplineOffloadEval.hpp
  */
-#ifndef QMCPLUSPLUS_MULTIEINSPLINE_HPP
-#define QMCPLUSPLUS_MULTIEINSPLINE_HPP
-
+#ifndef QMCPLUSPLUS_MULTIEINSPLINEOFFLOAD_HPP
+#define QMCPLUSPLUS_MULTIEINSPLINEOFFLOAD_HPP
+#include <iostream>
 #include <cstdlib>
 #include <type_traits>
 #include "config.h"
 #include "MultiBsplineBase.hpp"
 #include "spline2/BsplineAllocator.hpp"
+#include "OMPTarget/OffloadAlignedAllocators.hpp"
 
 namespace qmcplusplus
 {
@@ -31,11 +30,11 @@ namespace qmcplusplus
  * @tparam T the precision of splines
  */
 template<typename T>
-class MultiBspline : public MultiBsplineBase<T>
+class MultiBsplineOffload : public MultiBsplineBase<T>
 {
 private:
   using Base  = MultiBsplineBase<T>;
-  using Alloc = aligned_allocator<T>;
+  using Alloc = OffloadAllocator<T>;
   ///use allocator
   BsplineAllocator<T, Alloc> myAllocator;
 
@@ -43,22 +42,34 @@ private:
                                         const typename Base::BoundaryCondition bc[3],
                                         int num_splines) override
   {
-    static_assert(std::is_same<T, typename Alloc::value_type>::value, "MultiBspline and Alloc data types must agree!");
+    static_assert(std::is_same<T, typename Alloc::value_type>::value,
+                  "MultiBsplineOffload and Alloc data types must agree!");
     if (getAlignedSize<T, Alloc::alignment>(num_splines) != num_splines)
-      throw std::runtime_error("When creating the data space of MultiBspline, num_splines must be padded!\n");
+      throw std::runtime_error("When creating the data space of MultiBsplineOffload, num_splines must be padded!\n");
     return myAllocator.allocateMultiBspline(grid[0], grid[1], grid[2], bc[0], bc[1], bc[2], num_splines);
   }
 
 public:
-  MultiBspline() = default;
+  MultiBsplineOffload() = default;
 
-  ~MultiBspline() override
+  ~MultiBsplineOffload() override
   {
     if (Base::spline_m != nullptr)
       myAllocator.destroy(Base::spline_m);
   }
 
-  void finalize() override {}
+  void finalize() override
+  {
+    if (auto* spline_m = Base::spline_m; spline_m != nullptr)
+    {
+      auto* coefs = spline_m->coefs;
+      // attach pointers on the device to achieve deep copy
+      PRAGMA_OFFLOAD("omp target map(always, to: spline_m[:1], coefs[:spline_m->coefs_size])")
+      {
+        spline_m->coefs = coefs;
+      }
+    }
+  }
 };
 
 } // namespace qmcplusplus

--- a/src/spline2/MultiBsplineOffload.hpp
+++ b/src/spline2/MultiBsplineOffload.hpp
@@ -16,10 +16,7 @@
  */
 #ifndef QMCPLUSPLUS_MULTIEINSPLINEOFFLOAD_HPP
 #define QMCPLUSPLUS_MULTIEINSPLINEOFFLOAD_HPP
-#include <iostream>
-#include <cstdlib>
-#include <type_traits>
-#include "config.h"
+
 #include "MultiBsplineBase.hpp"
 #include "spline2/BsplineAllocator.hpp"
 #include "OMPTarget/OffloadAlignedAllocators.hpp"


### PR DESCRIPTION
Review after #5195
## Proposed changes
Introduce MultiSplineBase as the base class for MultiSpline and MultiSplineOffload.
When implementing R2R offload, I'm trying to prevent creating an offload class by copying the whole R2R class. As a preparation step, I need to make MultiSpline abstracted.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted