### PR TITLE
Nexus: Bugfix for SOC J3 terms

### DIFF
--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -932,7 +932,10 @@ class Qmcpack(Simulation):
                     if J3 is not None:
                         corr = J3.get('correlation')
                         if hasattr(corr, 'coefficients'):
-                            pass
+                            # For single-species systems, the data structure changes.
+                            # In this case, the only J3 term should be 'uu'.
+                            # Otherwise, the user might be trying to do something strange.
+                            assert 'uu' in corr.coefficients.id, 'Only uu J3 terms are allowed in SOC calculations.'
                         else:
                             j3_ids = []
                             for j3_term in corr:

--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -931,16 +931,19 @@ class Qmcpack(Simulation):
                     J3 = optwf.get('J3')
                     if J3 is not None:
                         corr = J3.get('correlation')
-                        j3_ids = []
-                        for j3_term in corr:
-                            j3_id = j3_term.coefficients.id
-                            j3_ids.append(j3_id)
-                        #end for
-                        for j3_id in j3_ids:
-                            if 'ud' in j3_id:
-                                delattr(corr, j3_id)
-                            #end if
-                        #end for
+                        if hasattr(corr, 'coefficients'):
+                            pass
+                        else:
+                            j3_ids = []
+                            for j3_term in corr:
+                                j3_id = j3_term.coefficients.id
+                                j3_ids.append(j3_id)
+                            #end for
+                            for j3_id in j3_ids:
+                                if 'ud' in j3_id:
+                                    delattr(corr, j3_id)
+                                #end if
+                            #end for
                     #end if
                 #end if
                 def process_jastrow(wf):                


### PR DESCRIPTION
## Proposed changes

In #5184, I introduced the handling of J3 terms in Nexus for SOC calculations. At the time I tested it in CrI3, which has two species. For single-element systems such as Ir, the data structure of J3 terms changes (reported by @rcclay). In this edge case, nothing needs to be done when incorporating the previous Jastrow, since there will be only a single 'uu' term in J3.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
NERSC. Nexus tests are passing.

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
