### PR TITLE
Fix printing 0 caused by #5078

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilderESHDF.fft.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilderESHDF.fft.cpp
@@ -685,7 +685,7 @@ int EinsplineSetBuilder::OccupyBands_ESHDF(hdf_archive& h5,
       numOrbs_counter++;
     orbIndex++;
   }
-  app_log() << "We will read " << NumDistinctOrbitals << " distinct complex-valued orbitals from h5.\n";
+  app_log() << "We will read " << orbIndex << " distinct complex-valued orbitals from h5." << std::endl;
   return orbIndex;
 }
 


### PR DESCRIPTION
## Proposed changes
#5078 removed setting `NumDistinctOrbitals` inside `EinsplineSetBuilder::OccupyBands_ESHDF` thus, the printing should also be updated.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'