### PR TITLE
Improve the xsf format data precision

### DIFF
--- a/nexus/lib/fileio.py
+++ b/nexus/lib/fileio.py
@@ -680,7 +680,7 @@ class XsfFile(StandardFile):
                         if n%ncols==0:
                             c += '\n    '
                         #end if
-                        c += ' {0:12.6E}'.format(v)
+                        c += ' {0:14.8E}'.format(v)
                         n+=1
                     #end for
                     c += '\n   END_DATAGRID_{0}D_{1}\n'.format(d,dgk)

--- a/nexus/lib/fileio.py
+++ b/nexus/lib/fileio.py
@@ -680,7 +680,7 @@ class XsfFile(StandardFile):
                         if n%ncols==0:
                             c += '\n    '
                         #end if
-                        c += ' {0:12.8f}'.format(v)
+                        c += ' {0:12.6E}'.format(v)
                         n+=1
                     #end for
                     c += '\n   END_DATAGRID_{0}D_{1}\n'.format(d,dgk)


### PR DESCRIPTION
## Proposed changes

A common way to analyze charge/spin densities in qmcpack is to generate the `*.xsf` data files via `qdens` that reads the data from the native `stat.h5` files. The xsf files can then be further analyzed via `qdens-radial` or other tools. Currently, the data (such as charge density) in the xsf files are written as floats with 8 significant digits (`12.8f`). I think scientific notation is better for this type of data. For example, QE (v7.0) uses scientific notation with 6 significant digits (`12.6E`). In a simple test I did, the integrated charge (norm) has improved significantly using the `12.6E` style for CH4 molecules in a 16^3 Ang box. Here the correct norm is 5.

Old code:
```
Max Density: 0.00069445
Norm: 4.999454429999994
File Size: 111 MB
```

New code:
```
Max Density: 0.0006944463
Norm: 5.000000002221036
File Size: 111 MB
```

The accuracy can be further improved at the expense of a larger file size.

## What type(s) of changes does this code introduce?
- enhancement

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
- NERSC
- Local Machine

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
