### PR TITLE
Nexus: Set workstation thread binding to none

### DIFF
--- a/nexus/lib/machines.py
+++ b/nexus/lib/machines.py
@@ -978,7 +978,7 @@ class Workstation(Machine):
 
 
     def process_job_options(self,job):
-        job.run_options.add(np='-np '+str(job.processes))
+        job.run_options.add(np='--bind-to none -np '+str(job.processes))
     #end def process_job_options
 
 

--- a/nexus/tests/unit/test_machines.py
+++ b/nexus/tests/unit/test_machines.py
@@ -533,10 +533,10 @@ def test_workstation_scheduling():
     assert(j.threads==2)
     assert(j.local)
     assert(j.processes==2)
-    assert(j.run_options.np=='-np 2')
+    assert(j.run_options.np=='--bind-to none -np 2')
     assert(j.batch_mode==False)
     init_job(j,dir=tpath) # imitate interaction w/ simulation object
-    assert(ws.write_job(j)=='export OMP_NUM_THREADS=2\nmpirun -np 2 echo run')
+    assert(ws.write_job(j)=='export OMP_NUM_THREADS=2\nmpirun --bind-to none -np 2 echo run')
 
     j = job(machine=ws.name,serial=True)
     assert(j.machine==ws.name)
@@ -544,7 +544,7 @@ def test_workstation_scheduling():
     assert(j.threads==1)
     assert(j.serial)
     assert(j.processes==1)
-    assert(j.run_options.np=='-np 1')
+    assert(j.run_options.np=='--bind-to none -np 1')
     assert(j.batch_mode==False)
     init_job(j,dir=tpath) # imitate interaction w/ simulation object
     assert(ws.write_job(j)=='export OMP_NUM_THREADS=1\necho run')


### PR DESCRIPTION
## Proposed changes

The Nexus workstation configuration, e.g. ws16, implicitly assumes codes are built with OpenMPI for MPI runs. When also used with threading, the threads will be wrongly bound for our uses, giving poor performance. The binding is the default behavior of all recent OpenMPI releases and is easily verified in a system with hyperthreading enabled where the per process CPU% will show as 50% instead of the expected 100%, or in a 16 "core" run, 16 cores will not be used. Performance is consequently halved. Added --bind-to none, similar to what has already been done in some of the Supercomputer job definitions.

Open to changing to more optimal settings or moving the location of the setting, but for everyday workstation runs I think this is close enough and simple.

Noticed while testing #5214.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

nitrogen2, GCC14 + OpenMPI, standard nightly configuration.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
