### PR TITLE
Update nightly test configurations

### DIFF
--- a/tests/test_automation/nightly_test_scripts/ornl_setup.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_setup.sh
@@ -79,11 +79,6 @@ packages:
         - spec: openssl@1.1.1k
           prefix: /usr
           buildable: False
-    libffi:
-        externals:
-        - spec: libffi@3.4.2
-          prefix: /
-          buildable: False
 EOF
 ;;
     nitrogen )
@@ -110,11 +105,6 @@ packages:
         - spec: openssl@1.1.1k
           prefix: /usr
           buildable: False
-    libffi:
-        externals:
-        - spec: libffi@3.4.2
-          prefix: /
-          buildable: False
 EOF
 ;;
     sulfur )
@@ -140,11 +130,6 @@ packages:
         externals:
         - spec: openssl@1.1.1k
           prefix: /usr
-          buildable: False
-    libffi:
-        externals:
-        - spec: libffi@3.4.2
-          prefix: /
           buildable: False
 EOF
 	;;
@@ -197,12 +182,22 @@ cd $HOME/apps/spack
 
 # For reproducibility, use a specific version of Spack
 # Prefer to use tagged releases https://github.com/spack/spack/releases
-git checkout eb9ff5d7a7d47f112ece5a4c70ef603a047a2fbc
-#commit eb9ff5d7a7d47f112ece5a4c70ef603a047a2fbc (HEAD -> develop, origin/develop, origin/HEAD)
-#Author: Harmen Stoppels <me@harmenstoppels.nl>
-#Date:   Tue Nov 5 13:25:19 2024 +0100
+
+git checkout 75b03bc12ffbabdfac0775ead5442c3f102f94c7
+#commit 75b03bc12ffbabdfac0775ead5442c3f102f94c7 (HEAD -> develop, origin/develop, origin/HEAD)
+#Author: Adam J. Stewart <ajstewart426@gmail.com>
+#Date:   Sun Nov 24 20:55:18 2024 +0100
 #
-#    paraview: add forward compat bound with cuda (#47430)
+#    glib: add v2.82.2 (#47766)
+
+#git checkout dfab174f3100840c889e8bb939260b64d93d8dbd
+#commit dfab174f3100840c889e8bb939260b64d93d8dbd (HEAD -> develop, origin/develop, origin/HEAD)
+#Author: Stephen Nicholas Swatman <stephen@v25.nl>
+#Date:   Mon Nov 18 14:04:52 2024 +0100
+#
+#    benchmark: add version 1.9.0 (#47658)
+#    
+#    This commit adds Google Benchmark v1.9.0.
 
 echo --- Git version and last log entry
 git log -1

--- a/tests/test_automation/nightly_test_scripts/ornl_setup_environments.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_setup_environments.sh
@@ -103,13 +103,16 @@ spack add py-numpy@${numpy_vnew}
 spack add py-scipy
 spack add py-h5py ^hdf5@${hdf5_vnew}%gcc@${gcc_vnew} +fortran +hl +mpi
 spack add quantum-espresso@7.4 +mpi +qmcpack
+export CMAKE_BUILD_PARALLEL_LEVEL=8 # For PySCF
 spack add py-pyscf
 #spack add rmgdft #Fails to compile with GCC14 due to bug in vendored SCALAPACK 
 
 #Luxury options for actual science use:
 spack add py-requests # for pseudo helper
 spack add py-ase      # full Atomic Simulation Environment
-#spack add graphviz +ghostscript +libgd +pangocairo +poppler # NEXUS requires optional PNG support
+#spack add graphviz +libgd # NEXUS requires optional PNG support in dot
+spack add libffi
+spack add graphviz +pangocairo # NEXUS requires optional PNG support in dot
 spack add py-pydot    # NEXUS optional
 spack add py-spglib   # NEXUS optional 
 spack add py-seekpath # NEXUS optional
@@ -211,13 +214,16 @@ spack add py-numpy@${numpy_vold}
 spack add py-scipy
 spack add py-h5py ^hdf5@${hdf5_vnew}%gcc@${gcc_vold} +fortran +hl +mpi
 #spack add quantum-espresso@7.4 +mpi +qmcpack
+#export CMAKE_BUILD_PARALLEL_LEVEL=8 # For PySCF
 #spack add py-pyscf
 spack add rmgdft
 
 #Luxury options for actual science use:
 spack add py-requests # for pseudo helper
 spack add py-ase      # full Atomic Simulation Environment
-#spack add graphviz +ghostscript +libgd +pangocairo +poppler # NEXUS requires optional PNG support
+#spack add graphviz +libgd # NEXUS requires optional PNG support in dot
+spack add libffi
+spack add graphviz +pangocairo # NEXUS requires optional PNG support in dot
 spack add py-pydot    # NEXUS optional
 spack add py-spglib   # NEXUS optional 
 spack add py-seekpath # NEXUS optional

--- a/tests/test_automation/nightly_test_scripts/ornl_versions.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_versions.sh
@@ -18,7 +18,7 @@ gcc_vllvmoffload=${gcc_vold}
 
 # LLVM 
 # Dates at https://releases.llvm.org/
-llvm_vnew=19.1.3 # Released 2024-10-30
+llvm_vnew=19.1.4 # Released 2024-11-19
 llvm_voffload=${llvm_vnew}
 cuda_voffload=12.4.0 # CUDA version for offload builds
 


### PR DESCRIPTION
## Proposed changes

Update nightly test configurations. Key changes:

1. Set CMAKE_BUILD_PARALLEL_LEVEL=8 when PySCF involved. Reduces install time from e.g. 37 minutes to 7 minutes. By default PySCF will build its substantial C-based components sequentially.
2. Working graphviz "dot" that can produce png files. Enables nexus simulation test to pass.
3. Latest LLVM

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

sulfur, nitrogen, nitrogen2

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
