### PR TITLE
Set recompute period in performance tests to once every QMC section

### DIFF
--- a/tests/performance/C-graphite/sample/dmc-a16-e64-cpu/C-graphite-S4-dmc.xml
+++ b/tests/performance/C-graphite/sample/dmc-a16-e64-cpu/C-graphite-S4-dmc.xml
@@ -98,6 +98,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -108,6 +109,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -120,6 +122,7 @@
     <parameter name="steps">                  80 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 
 </simulation>

--- a/tests/performance/C-graphite/sample/dmc-a16-e64-cpu/C-graphite-S4-dmc.xml
+++ b/tests/performance/C-graphite/sample/dmc-a16-e64-cpu/C-graphite-S4-dmc.xml
@@ -98,7 +98,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -109,7 +109,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -122,7 +122,7 @@
     <parameter name="steps">                  80 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 
 </simulation>

--- a/tests/performance/C-graphite/sample/dmc-a36-e144-cpu/C-graphite-S9-dmc.xml
+++ b/tests/performance/C-graphite/sample/dmc-a36-e144-cpu/C-graphite-S9-dmc.xml
@@ -121,6 +121,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -131,6 +132,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -143,6 +145,7 @@
     <parameter name="steps">                  80 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 
 </simulation>

--- a/tests/performance/C-graphite/sample/dmc-a36-e144-cpu/C-graphite-S9-dmc.xml
+++ b/tests/performance/C-graphite/sample/dmc-a36-e144-cpu/C-graphite-S9-dmc.xml
@@ -121,7 +121,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -132,7 +132,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -145,7 +145,7 @@
     <parameter name="steps">                  80 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 
 </simulation>

--- a/tests/performance/C-graphite/sample/dmc-a4-e16-cpu/C-graphite-S1-dmc.xml
+++ b/tests/performance/C-graphite/sample/dmc-a4-e16-cpu/C-graphite-S1-dmc.xml
@@ -85,6 +85,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -95,6 +96,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -107,6 +109,7 @@
     <parameter name="steps">                  80 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 
 </simulation>

--- a/tests/performance/C-graphite/sample/dmc-a4-e16-cpu/C-graphite-S1-dmc.xml
+++ b/tests/performance/C-graphite/sample/dmc-a4-e16-cpu/C-graphite-S1-dmc.xml
@@ -85,7 +85,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -96,7 +96,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -109,7 +109,7 @@
     <parameter name="steps">                  80 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 
 </simulation>

--- a/tests/performance/C-graphite/sample/dmc-a64-e256-cpu/C-graphite-S16-dmc.xml
+++ b/tests/performance/C-graphite/sample/dmc-a64-e256-cpu/C-graphite-S16-dmc.xml
@@ -150,7 +150,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -161,7 +161,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -174,6 +174,6 @@
     <parameter name="steps">                  80 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-graphite/sample/dmc-a64-e256-cpu/C-graphite-S16-dmc.xml
+++ b/tests/performance/C-graphite/sample/dmc-a64-e256-cpu/C-graphite-S16-dmc.xml
@@ -150,6 +150,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -160,6 +161,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -172,5 +174,6 @@
     <parameter name="steps">                  80 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C12-e48-pp/C12-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C12-e48-pp/C12-dmc.xml
@@ -78,6 +78,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -88,6 +89,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -100,5 +102,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C12-e48-pp/C12-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C12-e48-pp/C12-dmc.xml
@@ -78,7 +78,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -89,7 +89,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -102,6 +102,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C12-e72-ae/C12-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C12-e72-ae/C12-dmc.xml
@@ -76,7 +76,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -87,7 +87,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -100,6 +100,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C12-e72-ae/C12-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C12-e72-ae/C12-dmc.xml
@@ -76,6 +76,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -86,6 +87,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -98,5 +100,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C18-e108-ae/C18-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C18-e108-ae/C18-dmc.xml
@@ -82,6 +82,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -92,6 +93,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -104,5 +106,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C18-e108-ae/C18-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C18-e108-ae/C18-dmc.xml
@@ -82,7 +82,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -93,7 +93,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -106,6 +106,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C18-e72-pp/C18-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C18-e72-pp/C18-dmc.xml
@@ -84,7 +84,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -95,7 +95,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -108,6 +108,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C18-e72-pp/C18-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C18-e72-pp/C18-dmc.xml
@@ -84,6 +84,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -94,6 +95,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -106,5 +108,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C24-e144-ae/C24-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C24-e144-ae/C24-dmc.xml
@@ -88,7 +88,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -99,7 +99,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -112,6 +112,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C24-e144-ae/C24-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C24-e144-ae/C24-dmc.xml
@@ -88,6 +88,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -98,6 +99,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -110,5 +112,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C24-e96-pp/C24-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C24-e96-pp/C24-dmc.xml
@@ -90,7 +90,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -101,7 +101,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -114,6 +114,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C24-e96-pp/C24-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C24-e96-pp/C24-dmc.xml
@@ -90,6 +90,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -100,6 +101,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -112,5 +114,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C30-e120-pp/C30-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C30-e120-pp/C30-dmc.xml
@@ -96,7 +96,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -107,7 +107,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -120,6 +120,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C30-e120-pp/C30-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C30-e120-pp/C30-dmc.xml
@@ -96,6 +96,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -106,6 +107,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -118,5 +120,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C30-e180-ae/C30-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C30-e180-ae/C30-dmc.xml
@@ -94,6 +94,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -104,6 +105,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -116,5 +118,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C30-e180-ae/C30-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C30-e180-ae/C30-dmc.xml
@@ -94,7 +94,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -105,7 +105,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -118,6 +118,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C60-e240-pp/C60-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C60-e240-pp/C60-dmc.xml
@@ -126,7 +126,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -137,7 +137,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -150,6 +150,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/C-molecule/sample/dmc-C60-e240-pp/C60-dmc.xml
+++ b/tests/performance/C-molecule/sample/dmc-C60-e240-pp/C60-dmc.xml
@@ -126,6 +126,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -136,6 +137,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -148,5 +150,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/README
+++ b/tests/performance/NiO/README
@@ -216,18 +216,10 @@ their speed.
 
 7. Additional considerations
 
-When testing the mixed precision build, note that it performs more
-computation than the full precision build to ensure numerical
-accuracy.  One significant overhead is the recomputation of the
-inverse of the Slater determinants at every block.  It can be diluted
-by setting larger steps or substeps in the driver (VMC/DMC) block of
-the XML input file or completely disabled by adding the following line
-in each block.
-<parameter name="blocks_between_recompute">0</parameter>
-
-These settings will be revisited once performance data is obtained and
-analyzed for a wide variety of platforms, with the goal of short but
-representative runs.
-
-Please ask in QMCPACK's Google group if you have any questions.
-https://groups.google.com/forum/#!forum/qmcpack
+The performance runs have settings to recompute the inverse of the Slater determinants at a different frequency to the defaults. The
+recomputation is controlled by the blocks_between_recompute parameter and is set so that this occurs once per QMC section. This
+ensures that the relevant code paths are utilized in these short runs and is included in any performance analysis based on them. The
+defaults, which depend on whether the build is mixed or full precision, are described in
+https://qmcpack.readthedocs.io/en/develop/methods.html . To maintain numerical accuracy in production QMC calculations this
+recomputation must be performed at a minimum frequency determined by the electron count, precision, and details of the simulated
+system.

--- a/tests/performance/NiO/sample/dmc-a1024-e12288-cpu-J3/NiO-fcc-S256-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a1024-e12288-cpu-J3/NiO-fcc-S256-dmc.xml.in
@@ -1256,7 +1256,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -1267,7 +1267,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -1280,6 +1280,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a1024-e12288-cpu-J3/NiO-fcc-S256-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a1024-e12288-cpu-J3/NiO-fcc-S256-dmc.xml.in
@@ -1256,6 +1256,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -1266,6 +1267,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -1278,5 +1280,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a1024-e12288-cpu/NiO-fcc-S256-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a1024-e12288-cpu/NiO-fcc-S256-dmc.xml.in
@@ -1243,7 +1243,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -1254,7 +1254,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -1267,6 +1267,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a1024-e12288-cpu/NiO-fcc-S256-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a1024-e12288-cpu/NiO-fcc-S256-dmc.xml.in
@@ -1243,6 +1243,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -1253,6 +1254,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -1265,5 +1267,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a128-e1536-cpu-J3/NiO-fcc-S32-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a128-e1536-cpu-J3/NiO-fcc-S32-dmc.xml.in
@@ -248,6 +248,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -258,6 +259,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -270,5 +272,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a128-e1536-cpu-J3/NiO-fcc-S32-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a128-e1536-cpu-J3/NiO-fcc-S32-dmc.xml.in
@@ -248,7 +248,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -259,7 +259,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -272,6 +272,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a128-e1536-cpu/NiO-fcc-S32-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a128-e1536-cpu/NiO-fcc-S32-dmc.xml.in
@@ -235,7 +235,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -246,7 +246,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -259,6 +259,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a128-e1536-cpu/NiO-fcc-S32-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a128-e1536-cpu/NiO-fcc-S32-dmc.xml.in
@@ -235,6 +235,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -245,6 +246,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -257,5 +259,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a16-e192-cpu-J3/NiO-fcc-S4-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a16-e192-cpu-J3/NiO-fcc-S4-dmc.xml.in
@@ -122,7 +122,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -133,7 +133,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -146,6 +146,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a16-e192-cpu-J3/NiO-fcc-S4-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a16-e192-cpu-J3/NiO-fcc-S4-dmc.xml.in
@@ -122,6 +122,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -132,6 +133,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -144,5 +146,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a16-e192-cpu/NiO-fcc-S4-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a16-e192-cpu/NiO-fcc-S4-dmc.xml.in
@@ -109,7 +109,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -120,7 +120,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -133,6 +133,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a16-e192-cpu/NiO-fcc-S4-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a16-e192-cpu/NiO-fcc-S4-dmc.xml.in
@@ -109,6 +109,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -119,6 +120,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -131,5 +133,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a192-e2304-cpu-J3/NiO-fcc-S48-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a192-e2304-cpu-J3/NiO-fcc-S48-dmc.xml.in
@@ -320,6 +320,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -330,6 +331,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -342,5 +344,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a192-e2304-cpu-J3/NiO-fcc-S48-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a192-e2304-cpu-J3/NiO-fcc-S48-dmc.xml.in
@@ -320,7 +320,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -331,7 +331,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -344,6 +344,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a192-e2304-cpu/NiO-fcc-S48-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a192-e2304-cpu/NiO-fcc-S48-dmc.xml.in
@@ -307,6 +307,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -317,6 +318,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -329,5 +331,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a192-e2304-cpu/NiO-fcc-S48-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a192-e2304-cpu/NiO-fcc-S48-dmc.xml.in
@@ -307,7 +307,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -318,7 +318,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -331,6 +331,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a256-e3072-cpu-J3/NiO-fcc-S64-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a256-e3072-cpu-J3/NiO-fcc-S64-dmc.xml.in
@@ -392,7 +392,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -403,7 +403,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -416,6 +416,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a256-e3072-cpu-J3/NiO-fcc-S64-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a256-e3072-cpu-J3/NiO-fcc-S64-dmc.xml.in
@@ -392,6 +392,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -402,6 +403,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -414,5 +416,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a256-e3072-cpu/NiO-fcc-S64-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a256-e3072-cpu/NiO-fcc-S64-dmc.xml.in
@@ -379,6 +379,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -389,6 +390,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -401,5 +403,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a256-e3072-cpu/NiO-fcc-S64-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a256-e3072-cpu/NiO-fcc-S64-dmc.xml.in
@@ -379,7 +379,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -390,7 +390,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -403,6 +403,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a32-e384-cpu-J3/NiO-fcc-S8-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a32-e384-cpu-J3/NiO-fcc-S8-dmc.xml.in
@@ -140,6 +140,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -150,6 +151,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -162,5 +164,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a32-e384-cpu-J3/NiO-fcc-S8-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a32-e384-cpu-J3/NiO-fcc-S8-dmc.xml.in
@@ -140,7 +140,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -151,7 +151,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -164,6 +164,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a32-e384-cpu/NiO-fcc-S8-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a32-e384-cpu/NiO-fcc-S8-dmc.xml.in
@@ -127,6 +127,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -137,6 +138,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -149,5 +151,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a32-e384-cpu/NiO-fcc-S8-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a32-e384-cpu/NiO-fcc-S8-dmc.xml.in
@@ -127,7 +127,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -138,7 +138,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -151,6 +151,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a4-e48-cpu-J3/NiO-fcc-S1-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a4-e48-cpu-J3/NiO-fcc-S1-dmc.xml.in
@@ -109,7 +109,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -120,7 +120,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -133,6 +133,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a4-e48-cpu-J3/NiO-fcc-S1-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a4-e48-cpu-J3/NiO-fcc-S1-dmc.xml.in
@@ -109,6 +109,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -119,6 +120,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -131,5 +133,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a4-e48-cpu/NiO-fcc-S1-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a4-e48-cpu/NiO-fcc-S1-dmc.xml.in
@@ -96,7 +96,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -107,7 +107,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -120,6 +120,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a4-e48-cpu/NiO-fcc-S1-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a4-e48-cpu/NiO-fcc-S1-dmc.xml.in
@@ -96,6 +96,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -106,6 +107,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -118,5 +120,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a512-e6144-cpu-J3/NiO-fcc-S128-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a512-e6144-cpu-J3/NiO-fcc-S128-dmc.xml.in
@@ -680,6 +680,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -690,6 +691,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -702,5 +704,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a512-e6144-cpu-J3/NiO-fcc-S128-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a512-e6144-cpu-J3/NiO-fcc-S128-dmc.xml.in
@@ -680,7 +680,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -691,7 +691,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -704,6 +704,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a512-e6144-cpu/NiO-fcc-S128-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a512-e6144-cpu/NiO-fcc-S128-dmc.xml.in
@@ -667,7 +667,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -678,7 +678,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -691,6 +691,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a512-e6144-cpu/NiO-fcc-S128-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a512-e6144-cpu/NiO-fcc-S128-dmc.xml.in
@@ -667,6 +667,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -677,6 +678,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -689,5 +691,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a64-e768-cpu-J3/NiO-fcc-S16-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a64-e768-cpu-J3/NiO-fcc-S16-dmc.xml.in
@@ -176,6 +176,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -186,6 +187,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -198,5 +200,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a64-e768-cpu-J3/NiO-fcc-S16-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a64-e768-cpu-J3/NiO-fcc-S16-dmc.xml.in
@@ -176,7 +176,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -187,7 +187,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -200,6 +200,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a64-e768-cpu/NiO-fcc-S16-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a64-e768-cpu/NiO-fcc-S16-dmc.xml.in
@@ -163,6 +163,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -173,6 +174,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -185,5 +187,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a64-e768-cpu/NiO-fcc-S16-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a64-e768-cpu/NiO-fcc-S16-dmc.xml.in
@@ -163,7 +163,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -174,7 +174,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -187,6 +187,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a8-e96-cpu-J3/NiO-fcc-S2-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a8-e96-cpu-J3/NiO-fcc-S2-dmc.xml.in
@@ -113,7 +113,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -124,7 +124,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -137,6 +137,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a8-e96-cpu-J3/NiO-fcc-S2-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a8-e96-cpu-J3/NiO-fcc-S2-dmc.xml.in
@@ -113,6 +113,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -123,6 +124,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -135,5 +137,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a8-e96-cpu/NiO-fcc-S2-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a8-e96-cpu/NiO-fcc-S2-dmc.xml.in
@@ -100,7 +100,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -111,7 +111,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -124,6 +124,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a8-e96-cpu/NiO-fcc-S2-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a8-e96-cpu/NiO-fcc-S2-dmc.xml.in
@@ -100,6 +100,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -110,6 +111,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -122,5 +124,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a96-e1152-cpu-J3/NiO-fcc-S24-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a96-e1152-cpu-J3/NiO-fcc-S24-dmc.xml.in
@@ -212,7 +212,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -223,7 +223,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -236,6 +236,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a96-e1152-cpu-J3/NiO-fcc-S24-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a96-e1152-cpu-J3/NiO-fcc-S24-dmc.xml.in
@@ -212,6 +212,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc gpu="yes" method="vmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -222,6 +223,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc checkpoint="-1" gpu="yes" method="dmc" move="pbyp">
     <estimator hdf5="no" name="LocalEnergy" />
@@ -234,5 +236,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a96-e1152-cpu/NiO-fcc-S24-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a96-e1152-cpu/NiO-fcc-S24-dmc.xml.in
@@ -199,6 +199,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -209,6 +210,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -221,5 +223,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
+    <parameter name="blocks_between_recompute">      10 </parameter>
   </qmc>
 </simulation>

--- a/tests/performance/NiO/sample/dmc-a96-e1152-cpu/NiO-fcc-S24-dmc.xml.in
+++ b/tests/performance/NiO/sample/dmc-a96-e1152-cpu/NiO-fcc-S24-dmc.xml.in
@@ -199,7 +199,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">              no </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="vmc" move="pbyp" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -210,7 +210,7 @@
     <parameter name="blocks">                 2 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      2 </parameter>
   </qmc>
   <qmc method="dmc" move="pbyp" checkpoint="-1" gpu="yes">
     <estimator name="LocalEnergy" hdf5="no" />
@@ -223,6 +223,6 @@
     <parameter name="steps">                  5 </parameter>
     <parameter name="blocks">                 5 </parameter>
     <parameter name="nonlocalmoves">        yes </parameter>
-    <parameter name="blocks_between_recompute">      10 </parameter>
+    <parameter name="blocks_between_recompute">      5 </parameter>
   </qmc>
 </simulation>


### PR DESCRIPTION
## Proposed changes

Set the recompute periodic explicitly in the performance tests so that full & mixed precision builds do the same number of matrix inversions. (Mixed precision default is every block vs every 10 for full precision builds.) This changes addresses a couple of recent queries where the code has been profiled by users using the default settings.

Due to the few steps per block in the performance tests the existing settings result in a skew towards matrix inversion in profiles, performance analysis etc. In real/performance focused runs the number of steps per block would be larger than the e.g. 5 used for the DMC sections. A side effect is that some of the mixed precision performance tests will now show closer to real-world speedup.

Also added end of lines to a couple of the files for consistency.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- Yes

New mixed precision results should not be compared to old mixed precision results in terms of overall runtime.

## What systems has this change been tested on?

gcc14 mpi nightly configuration, sulfur.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
