### PR TITLE
Set full precision batched recomputation default

### DIFF
--- a/src/QMCDrivers/QMCDriverInput.h
+++ b/src/QMCDrivers/QMCDriverInput.h
@@ -77,7 +77,7 @@ protected:
   RealType tau_              = 0.1;
   RealType spin_mass_        = 1.0;
   // call recompute at the end of each block in the full/mixed precision case.
-  IndexType blocks_between_recompute_ = std::is_same<RealType, FullPrecisionRealType>::value ? 0 : 1;
+  IndexType blocks_between_recompute_ = std::is_same<RealType, FullPrecisionRealType>::value ? 10 : 1;
   bool append_run_                    = false;
 
   // from QMCDriverFactory


### PR DESCRIPTION
## Proposed changes

Missed in #4109 . Set batched full precision recomputation frequency consistent with documentation. Credit to Ye for noticing.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Sulfur, GCC14 nightly config, via grep.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
-No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
