### PR TITLE
Fix two small typos

### DIFF
--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -18,7 +18,7 @@
 #define QMCPACK_VERSION_PATCH  @qmcpack_VERSION_PATCH@
 
 /* define the release version */
-#cmakedefine QMCPACK_RELEASE  @QMCAPCK_RELEASE@
+#cmakedefine QMCPACK_RELEASE  @QMCPACK_RELEASE@
 
 /* define the git last commit date */
 // #cmakedefine QMCPLUSPLUS_LAST_CHANGED_DATE  "@QMCPLUSPLUS_LAST_CHANGED_DATE@"

--- a/src/io/hdf/hdf_archive.cpp
+++ b/src/io/hdf/hdf_archive.cpp
@@ -148,7 +148,7 @@ bool hdf_archive::create(const std::filesystem::path& fname, unsigned flags)
   if (!(Mode[IS_PARALLEL] || Mode[IS_MASTER]))
     throw std::runtime_error("Only create file in parallel or by master but not every rank!");
   close();
-  file_id = H5Fcreate(fname.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, access_id);
+  file_id = H5Fcreate(fname.c_str(), flags, H5P_DEFAULT, access_id);
   return file_id != is_closed;
 }
 


### PR DESCRIPTION
## Proposed changes

I've encountered two small typos:
- The CMake release variable was spelled `QMCAPCK` instead of `QMCPACK`  
    - This doesn't seem to be set anywhere though
- The hdf5 `create` ignores `flags` input
    - any created archive would be done with `H5F_ACC_TRUNC` mode only
    - There are only a few instances of the alternative `H5F_ACC_EXCL` being used 
    ```
    AFQMC/Wavefunctions/WavefunctionFactory.cpp
    1191:        if (!restart.create(restart_file, H5F_ACC_EXCL))
    
    AFQMC/Walkers/tests/test_sharedwset.cpp
    252:  if (!dump.create("dummy_walkers.h5", H5F_ACC_EXCL))
    317:  if (!dump.create("dummy_walkers.h5", H5F_ACC_EXCL))
    458:    if (!dump.create("dummy_walkers.h5", H5F_ACC_EXCL))
    ```

## What type(s) of changes does this code introduce?
- Bugfix
- Code style update (formatting, renaming)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
