### PR TITLE
Nexus: Add dependency versions file + update docs

### DIFF
--- a/nexus/requirements.txt
+++ b/nexus/requirements.txt
@@ -1,0 +1,13 @@
+# While Nexus does not have strict version requirements, this requirements file
+# corresponds to versions that have been tested and are known to work.
+# Last updated: 2024/12/16
+
+numpy==2.2.0
+scipy==1.14.1
+matplotlib==3.10.0
+h5py==3.12.1
+pydot==3.0.3
+spglib==2.4.0 # Some functionality is broken in 2.5.0
+pycifrw==4.4.6
+cif2cell==2.1.0
+seekpath==2.1.0

--- a/nexus/requirements_minimal.txt
+++ b/nexus/requirements_minimal.txt
@@ -1,0 +1,5 @@
+# While Nexus does not have strict version requirements, this requirements file
+# corresponds to versions that have been tested and are known to work.
+# Last updated: 2024/12/16
+
+numpy==2.2.0

--- a/nexus/sphinx_docs/installation.rst
+++ b/nexus/sphinx_docs/installation.rst
@@ -84,6 +84,9 @@ These specific library versions can be installed using the following command:
 
   pip3 install --user -r requirements.txt
 
+``qmcpack/nexus/requirements_minimal.txt`` can be used similarly but only contains
+a recently tested version of numpy.
+
 The purpose of each library is described below:
 
 **numpy** Needed throughout Nexus for array computation. Nexus will not

--- a/nexus/sphinx_docs/installation.rst
+++ b/nexus/sphinx_docs/installation.rst
@@ -12,7 +12,7 @@ working python environment exists.
 Setting environment variables
 -----------------------------
 
-To make your Python installation (must be Python 2.x as 3.x is not supported)
+To make your Python installation (must be Python 3.x, 2.x is no longer supported)
 aware of Nexus, simply set the PYTHONPATH environment variable.  For example, in bash this would look like:
 
 .. code-block:: rest
@@ -75,6 +75,14 @@ listed with ``apt`` above on Debian systems), try ‘pip3‘:
   pip3 install --user PyCifRW
   pip3 install --user cif2cell
   pip3 install --user seekpath
+
+While Nexus does not have strict version requirements, most recent
+dependency versions that have been tested and are known to work can be
+found at ``qmcpack/nexus/requirements.txt``.
+These specific library versions can be installed using the following command:
+::
+
+  pip3 install --user -r requirements.txt
 
 The purpose of each library is described below:
 
@@ -192,7 +200,7 @@ in your ``PATH``. Installation is successful if all tests pass:
 Only portions of Nexus consistent with your Python installed Python
 libraries will be tested.
 
-To run the tests with ``pytest`` (``pip install –user pytest``), enter
+To run the tests with ``pytest`` (``pip install --user pytest``), enter
 the unit test directory and simply invoke the ``pytest`` command:
 
 ::
@@ -268,7 +276,7 @@ Assessing Test Coverage (Developer Topic)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Code coverage can be assessed by using the ``coverage`` tool
-(``pip install –user coverage``):
+(``pip install --user coverage``):
 
 ::
 


### PR DESCRIPTION
## Proposed changes
This PR should close #5253. A `requirements.txt` file was added in `qmcpack/nexus/`. I did not add `requirements_minimal.txt` as only numpy is needed for core functionality and adding a file for just a single package seems redundant to me.

Appropriate description has been added to the Nexus documentation. Other smaller issues were also fixed in the docs: python3 support, and `--user` instead of `-user`.

## What type(s) of changes does this code introduce?
- Documentation or build script changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Local Linux Machine

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Documentation has been added (if appropriate)
