### PR TITLE
Put some legacy energy density variables back into the correct hdf5 group.

### DIFF
--- a/src/QMCHamiltonians/EnergyDensityEstimator.cpp
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.cpp
@@ -492,7 +492,7 @@ void EnergyDensityEstimator::registerCollectables(std::vector<ObservableHelper>&
     oh.addProperty(const_cast<Matrix<RealType>&>(Rion), "ion_positions", file);
   }
 
-  ref.save(h5desc, file);
+  ref.save(h5desc, hdf_name, file);
   h5desc.emplace_back(hdf_name / "outside");
   auto& ohOutside = h5desc.back();
   std::vector<int> ng(1);
@@ -501,7 +501,7 @@ void EnergyDensityEstimator::registerCollectables(std::vector<ObservableHelper>&
   for (int i = 0; i < spacegrids.size(); i++)
   {
     SpaceGrid& sg = *spacegrids[i];
-    sg.registerCollectables(h5desc, file, i);
+    sg.registerCollectables(h5desc, file, hdf_name, i);
   }
   if (ion_points)
   {

--- a/src/QMCHamiltonians/ReferencePoints.cpp
+++ b/src/QMCHamiltonians/ReferencePoints.cpp
@@ -130,9 +130,9 @@ void ReferencePoints::write_description(std::ostream& os, std::string& indent)
   return;
 }
 
-void ReferencePoints::save(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
+void ReferencePoints::save(std::vector<ObservableHelper>& h5desc, hdf_path& enclosing_path, hdf_archive& file) const
 {
-  h5desc.emplace_back(hdf_path{"reference_points"});
+  h5desc.emplace_back(enclosing_path / "reference_points");
   auto& oh = h5desc.back();
   for (auto it = points.cbegin(); it != points.cend(); ++it)
   {

--- a/src/QMCHamiltonians/ReferencePoints.cpp
+++ b/src/QMCHamiltonians/ReferencePoints.cpp
@@ -130,7 +130,9 @@ void ReferencePoints::write_description(std::ostream& os, std::string& indent)
   return;
 }
 
-void ReferencePoints::save(std::vector<ObservableHelper>& h5desc, hdf_path& enclosing_path, hdf_archive& file) const
+void ReferencePoints::save(std::vector<ObservableHelper>& h5desc,
+                           const hdf_path& enclosing_path,
+                           hdf_archive& file) const
 {
   h5desc.emplace_back(enclosing_path / "reference_points");
   auto& oh = h5desc.back();

--- a/src/QMCHamiltonians/ReferencePoints.h
+++ b/src/QMCHamiltonians/ReferencePoints.h
@@ -34,7 +34,7 @@ public:
   bool put(xmlNodePtr cur, ParticleSet& P, std::vector<ParticleSet*>& Pref);
   bool put(ParticleSet& P, std::vector<ParticleSet*>& Pref);
   void write_description(std::ostream& os, std::string& indent);
-  void save(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const;
+  void save(std::vector<ObservableHelper>& h5desc, hdf_path& enclosing_path, hdf_archive& file) const;
 
 private:
   enum Coordinate

--- a/src/QMCHamiltonians/ReferencePoints.h
+++ b/src/QMCHamiltonians/ReferencePoints.h
@@ -34,7 +34,7 @@ public:
   bool put(xmlNodePtr cur, ParticleSet& P, std::vector<ParticleSet*>& Pref);
   bool put(ParticleSet& P, std::vector<ParticleSet*>& Pref);
   void write_description(std::ostream& os, std::string& indent);
-  void save(std::vector<ObservableHelper>& h5desc, hdf_path& enclosing_path, hdf_archive& file) const;
+  void save(std::vector<ObservableHelper>& h5desc, const hdf_path& enclosing_path, hdf_archive& file) const;
 
 private:
   enum Coordinate

--- a/src/QMCHamiltonians/SpaceGrid.cpp
+++ b/src/QMCHamiltonians/SpaceGrid.cpp
@@ -701,7 +701,7 @@ int SpaceGrid::allocate_buffer_space(BufferType& buf)
 }
 
 
-void SpaceGrid::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file, int grid_index) const
+void SpaceGrid::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file, hdf_path& enclosing_path, int grid_index) const
 {
   using iMatrix = Matrix<int>;
   iMatrix imat;
@@ -710,7 +710,8 @@ void SpaceGrid::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_
   std::stringstream ss;
   ss << grid_index + cshift;
   std::string name = "spacegrid" + ss.str();
-  h5desc.push_back({{name}});
+  hdf_path full_hdf5_path = enclosing_path / name;
+  h5desc.push_back(full_hdf5_path);
   auto& oh = h5desc.back();
   if (!chempot)
     ng[0] = nvalues_per_domain * ndomains;

--- a/src/QMCHamiltonians/SpaceGrid.cpp
+++ b/src/QMCHamiltonians/SpaceGrid.cpp
@@ -701,7 +701,7 @@ int SpaceGrid::allocate_buffer_space(BufferType& buf)
 }
 
 
-void SpaceGrid::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file, hdf_path& enclosing_path, int grid_index) const
+void SpaceGrid::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file, const hdf_path& enclosing_path, int grid_index) const
 {
   using iMatrix = Matrix<int>;
   iMatrix imat;
@@ -710,8 +710,7 @@ void SpaceGrid::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_
   std::stringstream ss;
   ss << grid_index + cshift;
   std::string name = "spacegrid" + ss.str();
-  hdf_path full_hdf5_path = enclosing_path / name;
-  h5desc.push_back(full_hdf5_path);
+  h5desc.push_back(enclosing_path / name);
   auto& oh = h5desc.back();
   if (!chempot)
     ng[0] = nvalues_per_domain * ndomains;

--- a/src/QMCHamiltonians/SpaceGrid.h
+++ b/src/QMCHamiltonians/SpaceGrid.h
@@ -49,7 +49,7 @@ public:
   bool initialize_voronoi(std::map<std::string, Point>& points);
   void write_description(std::ostream& os, std::string& indent);
   int allocate_buffer_space(BufferType& buf);
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file, hdf_path& enclosing_path, int grid_index) const;
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file, const hdf_path& enclosing_path, int grid_index) const;
   void evaluate(const ParticlePos& R,
                 const Matrix<RealType>& values,
                 BufferType& buf,

--- a/src/QMCHamiltonians/SpaceGrid.h
+++ b/src/QMCHamiltonians/SpaceGrid.h
@@ -49,7 +49,7 @@ public:
   bool initialize_voronoi(std::map<std::string, Point>& points);
   void write_description(std::ostream& os, std::string& indent);
   int allocate_buffer_space(BufferType& buf);
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file, int grid_index) const;
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file, hdf_path& enclosing_path, int grid_index) const;
   void evaluate(const ParticlePos& R,
                 const Matrix<RealType>& values,
                 BufferType& buf,


### PR DESCRIPTION
## Proposed changes

- Bugfix
At least on my system check_stat.py cannot successfully read the output of the legacy energy density estimator anymore.  This fixes that.
Consequently the
short-diamondC_1x1x1_pp-vmc-estimator-energydensity-cell-4-4-check
short-diamondC_1x1x1_pp-dmc-estimator-energydensity-cell-4-4-check 
tests pass

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
dgx workstation.

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
