### PR TITLE
Remove 16 rank driver unit tests

### DIFF
--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -120,7 +120,7 @@ if(HAVE_MPI)
       qmcutil
       platform_omptarget_LA)
   endif()
-  foreach(NUM_RANKS 1 2 3 4 16)
+  foreach(NUM_RANKS 1 2 3 4)
     set(UTEST_NAME deterministic-unit_${UTEST_EXE}-r${NUM_RANKS})
     add_unit_test(${UTEST_NAME} ${NUM_RANKS} 1 $<TARGET_FILE:${UTEST_EXE}>)
     set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${UTEST_DIR})


### PR DESCRIPTION
## Proposed changes

Remove the 16 task driver unit tests, leaving the 1,2,3, and 4 way versions.

The 16 task tests are occasionally unreliable when run on single GPUs (e.g. via sulfur CI, and in bora nightlies) and do not add needed coverage in my opinion.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None. CI should run and we should check the coverage.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
