### PR TITLE
[CMake] Rename ENABLE_HIP to BUILD_AFQMC_HIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,11 +57,11 @@ option(QMC_OMP "Enable/disable OpenMP" ON)
 option(QMC_COMPLEX "Build for complex binary" OFF)
 option(ENABLE_CUDA "Build with GPU support through CUDA" OFF)
 option(QMC_CUDA2HIP "Map all CUDA kernels and library calls to HIP" OFF)
-if(QMC_CUDA2HIP OR ENABLE_HIP)
+if(QMC_CUDA2HIP OR BUILD_AFQMC_HIP)
   set(ENABLE_ROCM ON) # option(ENABLE_ROCM) will be no-op
 endif()
 # explicit HIP source codes only exist in AFQMC.
-option(ENABLE_HIP "Build with with GPU support through explicit HIP source code" OFF)
+option(BUILD_AFQMC_HIP "Build with with GPU support in AFQMC through explicit HIP source code" OFF)
 option(ENABLE_ROCM "Build with with GPU support through ROCM libraries" OFF)
 option(ENABLE_OFFLOAD "Enable OpenMP offload" OFF)
 option(ENABLE_SYCL "Enable SYCL offload" OFF)
@@ -849,9 +849,9 @@ if(USE_NVTX_API AND QMC_CUDA2HIP)
 endif(USE_NVTX_API AND QMC_CUDA2HIP)
 
 #-------------------------------------------------------------------
-#  set up HIP compiler options
+#  set up AFQMC-specific HIP compiler options
 #-------------------------------------------------------------------
-if(ENABLE_HIP)
+if(BUILD_AFQMC_HIP)
   if(NOT ENABLE_ROCM)
     message(FATAL_ERROR "ROCM is required to use HIP. Please set ENABLE_ROCM=ON.")
   endif()
@@ -860,7 +860,7 @@ if(ENABLE_HIP)
   add_library(HIP::HIP INTERFACE IMPORTED)
   # temporarily put hipsparse hipblas here for convenience, should be moved to Platforms.
   target_link_libraries(HIP::HIP INTERFACE roc::hipsparse roc::hipblas)
-  target_compile_definitions(HIP::HIP INTERFACE "ENABLE_HIP")
+  target_compile_definitions(HIP::HIP INTERFACE "BUILD_AFQMC_HIP")
 
   # FindHIP sets HIP_PLATFORM to amd or nvcc
   message(STATUS "FindHIP determined HIP_PLATFORM is ${HIP_PLATFORM}.")
@@ -871,7 +871,7 @@ if(ENABLE_HIP)
   else()
     message(FATAL_ERROR "Unknown HIP platform ${HIP_PLATFORM} only support 'amd' or 'nvcc'")
   endif()
-endif(ENABLE_HIP)
+endif(BUILD_AFQMC_HIP)
 
 #-------------------------------------------------------------------
 #  set up SYCL compiler options and libraries

--- a/README.md
+++ b/README.md
@@ -207,19 +207,23 @@ before doing significant production. i.e. Check the details below.
  * Additional QMCPACK options
 
 ```
-     QE_BIN              Location of Quantum Espresso binaries including pw2qmcpack.x
-     RMG_BIN             Location of RMG binary
-     QMC_DATA            Specify data directory for QMCPACK performance and integration tests
-     QMC_INCLUDE         Add extra include paths
-     QMC_EXTRA_LIBS      Add extra link libraries
-     QMC_BUILD_STATIC    ON/OFF(default). Add -static flags to build
+     BUILD_AFQMC            ON/OFF(default). Build the Auxiliary-Field Quantum Monte Carlo (AFQMC) feature
+     BUILD_AFQMC_WITH_NCCL  ON/OFF(default). Enable the optimized code path using NVIDIA Collective Communications Library (NCCL) in AFQMC.
+                            AFQMC and CUDA features required to enable this feature.
+     BUILD_AFQMC_HIP        ON/OFF(default). Enable HIP accelerated code paths in AFQMC. AFQMC feature required to enable this feature.
+     QE_BIN                 Location of Quantum Espresso binaries including pw2qmcpack.x
+     RMG_BIN                Location of RMG binary
+     QMC_DATA               Specify data directory for QMCPACK performance and integration tests
+     QMC_INCLUDE            Add extra include paths
+     QMC_EXTRA_LIBS         Add extra link libraries
+     QMC_BUILD_STATIC       ON/OFF(default). Add -static flags to build
      QMC_SYMLINK_TEST_FILES Set to zero to require test files to be copied. Avoids space
                             saving default use of symbolic links for test files. Useful
                             if the build is on a separate filesystem from the source, as
                             required on some HPC systems.
-     ENABLE_TIMERS       ON(default)/OFF. Enable fine-grained timers. Timers are on by default but at level coarse
-                         to avoid potential slowdown in tiny systems.
-                         For systems beyond tiny sizes (100+ electrons) there is no risk.
+     ENABLE_TIMERS          ON(default)/OFF. Enable fine-grained timers. Timers are on by default but at level coarse
+                            to avoid potential slowdown in tiny systems.
+                            For systems beyond tiny sizes (100+ electrons) there is no risk.
 ```
 
   * libxml2 related

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -329,6 +329,10 @@ the path to the source directory.
 
   ::
 
+    BUILD_AFQMC            ON/OFF(default). Build the Auxiliary-Field Quantum Monte Carlo (AFQMC) feature
+    BUILD_AFQMC_WITH_NCCL  ON/OFF(default). Enable the optimized code path using NVIDIA Collective Communications Library (NCCL) in AFQMC.
+                           AFQMC and CUDA features required to enable this feature.
+    BUILD_AFQMC_HIP        ON/OFF(default). Enable HIP accelerated code paths in AFQMC. AFQMC feature required to enable this feature.
     ENABLE_TIMERS          ON(default)/OFF. Enable fine-grained timers. Timers are on by default but at level coarse
                            to avoid potential slowdown in tiny systems.
                            For systems beyond tiny sizes (100+ electrons) there is no risk.

--- a/src/AFQMC/AFQMCFactory.cpp
+++ b/src/AFQMC/AFQMCFactory.cpp
@@ -72,7 +72,7 @@ AFQMCFactory::AFQMCFactory(boost::mpi3::communicator& comm_)
       PropFac(InfoMap),
       DriverFac(gTG, TGHandler, InfoMap, WSetFac, PropFac, WfnFac, HamFac)
 {
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   // taken from src/OhmmsApp/RandomNumberControl.cpp
   int rank   = gTG.Global().rank();
   int nprocs = gTG.Global().size();

--- a/src/AFQMC/CMakeLists.txt
+++ b/src/AFQMC/CMakeLists.txt
@@ -61,7 +61,7 @@ if(ENABLE_CUDA)
       Numerics/detail/CUDA/Kernels/Auwn_Bun_Cuw.cu
       Numerics/detail/CUDA/Kernels/inplace_product.cu
       Numerics/detail/CUDA/Kernels/get_diagonal.cu)
-elseif(ENABLE_HIP)
+elseif(BUILD_AFQMC_HIP)
   set(AFQMC_HIP_SRCS
       Numerics/detail/HIP/hip_kernel_utils.cpp
       Numerics/detail/HIP/Kernels/determinant.hip.cpp
@@ -102,7 +102,7 @@ endif()
 if(ENABLE_CUDA)
   add_library(afqmc ${AFQMC_SRCS})
   target_link_libraries(afqmc PRIVATE CUDA::curand CUDA::cusparse CUDA::cusolver CUDA::cublas)
-elseif(ENABLE_HIP)
+elseif(BUILD_AFQMC_HIP)
   set_source_files_properties(${AFQMC_HIP_SRCS} PROPERTIES LANGUAGE HIP)
   add_library(afqmc_hip_lib ${AFQMC_HIP_SRCS})
   target_link_libraries(afqmc_hip_lib PUBLIC HIP::HIP ROCM::libraries Boost::boost qmc_external_thrust)
@@ -137,13 +137,13 @@ if(BUILD_UNIT_TESTS)
   set(AFQMC_UNIT_TEST_INPUT_REAL_DENSE ${qmcpack_SOURCE_DIR}/tests/afqmc/Ne_cc-pvdz/ham_chol_dense.h5
                                        ${qmcpack_SOURCE_DIR}/tests/afqmc/Ne_cc-pvdz/wfn_rhf.dat)
   if(QMC_COMPLEX)
-    if(ENABLE_CUDA OR ENABLE_HIP)
+    if(ENABLE_CUDA OR BUILD_AFQMC_HIP)
       set(AFQMC_UNIT_TEST_INPUTS ${AFQMC_UNIT_TEST_INPUT_SYM})
     else()
       set(AFQMC_UNIT_TEST_INPUTS ${AFQMC_UNIT_TEST_INPUT_SYM} ${AFQMC_UNIT_TEST_INPUT_NOSYM})
     endif()
   else()
-    if(ENABLE_CUDA OR ENABLE_HIP)
+    if(ENABLE_CUDA OR BUILD_AFQMC_HIP)
       set(AFQMC_UNIT_TEST_INPUTS ${AFQMC_UNIT_TEST_INPUT_REAL_DENSE})
     else()
       set(AFQMC_UNIT_TEST_INPUTS ${AFQMC_UNIT_TEST_INPUT_REAL})

--- a/src/AFQMC/Estimators/FullObsHandler.hpp
+++ b/src/AFQMC/Estimators/FullObsHandler.hpp
@@ -125,7 +125,7 @@ public:
       }
       else if (cname == "n2r" || cname == "ontop2rdm")
       {
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
         std::string str("false");
         ParameterSet m_param;
         m_param.add(str, "use_host_memory");

--- a/src/AFQMC/Estimators/Observables/Observable.hpp
+++ b/src/AFQMC/Estimators/Observables/Observable.hpp
@@ -71,7 +71,7 @@ class Observable : public boost::variant<dummy::dummy_obs,
                                          atomcentered_correlators,
                                          generalizedFockMatrix,
                                          n2r<shared_allocator<ComplexType>>
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
                                          ,
                                          n2r<device_allocator<ComplexType>>
 #endif
@@ -101,7 +101,7 @@ public:
   explicit Observable(n2r<shared_allocator<ComplexType>>&& other) : variant(std::move(other)) {}
   explicit Observable(n2r<shared_allocator<ComplexType>> const& other) = delete;
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   explicit Observable(n2r<device_allocator<ComplexType>>&& other) : variant(std::move(other)) {}
   explicit Observable(n2r<device_allocator<ComplexType>> const& other) = delete;
 #endif

--- a/src/AFQMC/Estimators/Observables/full2rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full2rdm.hpp
@@ -327,7 +327,7 @@ private:
     // put this in shared memory!!!
     StaticMatrix Gt({NMO, NMO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     CMatrix_ref GtC(Gt.origin(), {NMO * NMO, 1});
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     if (Grot.size() < R.num_elements())
       Grot = stdCVector(iextensions<1u>(R.num_elements()));
 #endif
@@ -349,7 +349,7 @@ private:
 
         //  (a,a,a,a)
         ma::product(Gup.sliced(i0, iN), ma::T(Gup), R);
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
         using std::copy_n;
         copy_n(R.origin(), R.num_elements(), Grot.origin());
         ma::axpy(Xw[iw], Grot, DMWork[iw].sliced(size_t(i0) * M2, size_t(iN) * M2));
@@ -363,7 +363,7 @@ private:
         for (int i = 0; i < NMO; ++i)
         {
           ma::product(ComplexType(-1.0), GtC, G[iw][0].sliced(i, i + 1), ComplexType(0.0), Q);
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
           using std::copy_n;
           copy_n(Q.origin(), Q.num_elements(), Grot.origin());
           ma::axpy(Xw[iw], Grot.sliced(0, Q.num_elements()),
@@ -375,7 +375,7 @@ private:
 
         //  (a,a,b,b)
         ma::product(Gup.sliced(i0, iN), ma::T(Gdn), R);
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
         using std::copy_n;
         copy_n(R.origin(), R.num_elements(), Grot.origin());
         ma::axpy(Xw[iw], Grot, DMWork[iw].sliced(M4 + size_t(i0) * M2, M4 + size_t(iN) * M2));
@@ -385,7 +385,7 @@ private:
 
         //  (b,b,b,b)
         ma::product(Gdn.sliced(i0, iN), ma::T(Gdn), R);
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
         using std::copy_n;
         copy_n(R.origin(), R.num_elements(), Grot.origin());
         ma::axpy(Xw[iw], Grot, DMWork[iw].sliced(2 * M4 + size_t(i0) * M2, 2 * M4 + size_t(iN) * M2));
@@ -399,7 +399,7 @@ private:
         for (int i = 0; i < NMO; ++i)
         {
           ma::product(ComplexType(-1.0), GtC, G[iw][1].sliced(i, i + 1), ComplexType(0.0), Q);
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
           using std::copy_n;
           copy_n(Q.origin(), Q.num_elements(), Grot.origin());
           ma::axpy(Xw[iw], Grot.sliced(0, Q.num_elements()),

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -249,7 +249,7 @@ TEST_CASE("reduced_density_matrix", "[estimators]")
     infoLog.pause();
   auto node = world.split_shared(world.rank());
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   arch::INIT(node);
   using Alloc = device::device_allocator<ComplexType>;
 #else

--- a/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
+++ b/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
@@ -165,7 +165,7 @@ void ham_ops_basic_serial(boost::mpi3::communicator& world)
 
     // Calculates Overlap, G
 // NOTE: Make small factory routine!
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     auto SDet(SlaterDetOperations_serial<ComplexType, DeviceBufferManager>(NPOL * NMO, NAEA, DeviceBufferManager{}));
 #else
     auto SDet(SlaterDetOperations_shared<ComplexType>(NPOL * NMO, NAEA));
@@ -381,7 +381,7 @@ TEST_CASE("ham_ops_basic_serial", "[hamiltonian_operations]")
   auto world = boost::mpi3::environment::get_world_instance();
   auto node  = world.split_shared(world.rank());
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 
   arch::INIT(node);
   using Alloc = device::device_allocator<ComplexType>;

--- a/src/AFQMC/Hamiltonians/HamiltonianFactory.cpp
+++ b/src/AFQMC/Hamiltonians/HamiltonianFactory.cpp
@@ -308,7 +308,7 @@ Hamiltonian HamiltonianFactory::fromHDF5(GlobalTaskGroup& gTG, xmlNodePtr cur)
     TG.global_barrier();
     // KPFactorizedHamiltonian matrices are read by THCHamiltonian object when needed,
     // since their ownership is passed to the HamOps object.
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     //      if(alt == "yes" || alt == "true")
     //        return Hamiltonian(RealDenseHamiltonian(AFinfo,cur,std::move(H1),TG,
     //                                        NuclearCoulombEnergy,FrozenCoreEnergy));

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
@@ -75,7 +75,7 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
 
   // distribute work over equivalent nodes in TGprop.TG() across TG.Global()
   auto Qcomm(TG.Global().split(TGprop.getLocalGroupNumber(), TG.Global().rank()));
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   auto distNode(TG.Node().split(TGprop.getLocalGroupNumber(), TG.Node().rank()));
 #else
   auto distNode(TG.Node().split(0, TG.Node().rank()));

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian_v2.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian_v2.cpp
@@ -71,7 +71,7 @@ HamiltonianOperations RealDenseHamiltonian_v2::getHamiltonianOperations(bool pur
 
   // distribute work over equivalent nodes in TGprop.TG() across TG.Global()
   auto Qcomm(TG.Global().split(TGprop.getLocalGroupNumber(), TG.Global().rank()));
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   auto distNode(TG.Node().split(TGprop.getLocalGroupNumber(), TG.Node().rank()));
 #else
   auto distNode(TG.Node().split(0, TG.Node().rank()));

--- a/src/AFQMC/Hamiltonians/tests/test_hamiltonian_factory.cpp
+++ b/src/AFQMC/Hamiltonians/tests/test_hamiltonian_factory.cpp
@@ -140,7 +140,7 @@ TEST_CASE("ham_factory", "[hamiltonian_factory]")
   if (not world.root())
     infoLog.pause();
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   auto node = world.split_shared(world.rank());
 
   arch::INIT(node);
@@ -159,7 +159,7 @@ TEST_CASE("ham_generation_timing_hdf", "[hamiltonian_factory]")
   if (not world.root())
     infoLog.pause();
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   auto node = world.split_shared(world.rank());
 
   arch::INIT(node);

--- a/src/AFQMC/Matrix/tests/test_csr_matrix.cpp
+++ b/src/AFQMC/Matrix/tests/test_csr_matrix.cpp
@@ -23,7 +23,7 @@
 #include "AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp"
 
 #include "AFQMC/Matrix/csr_matrix.hpp"
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 #include "AFQMC/Memory/custom_pointers.hpp"
 #endif
 
@@ -300,7 +300,7 @@ void test_csr_matrix_shm_allocator(Alloc A, bool serial)
       }
     }
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     {
       using dev_csr_matrix = ma::sparse::csr_matrix<Type, IndxType, IntType, device::device_allocator<Type>>;
       dev_csr_matrix small11(small4);

--- a/src/AFQMC/Memory/arch.hpp
+++ b/src/AFQMC/Memory/arch.hpp
@@ -17,7 +17,7 @@
 
 #if defined(ENABLE_CUDA)
 #include "AFQMC/Memory/CUDA/cuda_arch.h"
-#elif defined(ENABLE_HIP)
+#elif defined(BUILD_AFQMC_HIP)
 #include "AFQMC/Memory/HIP/hip_arch.h"
 #endif
 

--- a/src/AFQMC/Memory/buffer_managers.cpp
+++ b/src/AFQMC/Memory/buffer_managers.cpp
@@ -20,7 +20,7 @@ namespace qmcplusplus
 namespace afqmc
 {
 std::unique_ptr<HostBufferManager::generator_t> HostBufferManager::generator(nullptr);
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 std::unique_ptr<DeviceBufferManager::generator_t> DeviceBufferManager::generator(nullptr);
 bool DeviceBufferManager::initialized_by_derived_class(false);
 #else
@@ -40,7 +40,7 @@ void setup_memory_managers(mpi3::shared_communicator& local, size_t size)
 
 void setup_memory_managers(mpi3::shared_communicator& node, size_t size, int nc)
 {
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   setup_memory_managers(node, size);
 #else
   mpi3::shared_communicator local(
@@ -53,7 +53,7 @@ void update_memory_managers()
 {
   HostBufferManager host_buffer;
   host_buffer.get_generator().update();
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   DeviceBufferManager dev_buffer;
   dev_buffer.get_generator().update();
 #else

--- a/src/AFQMC/Memory/custom_pointers.hpp
+++ b/src/AFQMC/Memory/custom_pointers.hpp
@@ -16,7 +16,7 @@
 #define AFQMC_CUSTOM_POINTERS_HPP
 
 #include "AFQMC/Memory/raw_pointers.hpp"
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 #include "AFQMC/Memory/device_pointers.hpp"
 //#include "AFQMC/Memory/CUDA/cuda_utilities.h"
 //#include "AFQMC/Memory/CUDA/cuda_init.h"

--- a/src/AFQMC/Memory/device_buffer_manager.hpp
+++ b/src/AFQMC/Memory/device_buffer_manager.hpp
@@ -28,7 +28,7 @@ namespace afqmc
 // Class that manages the memory resource that generates allcators for device memory.
 // Follows a monostate-type pattern. All variables are static and refer to a global instance
 // of the resource.
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 class DeviceBufferManager
 {
 public:

--- a/src/AFQMC/Memory/localTG_buffer_manager.hpp
+++ b/src/AFQMC/Memory/localTG_buffer_manager.hpp
@@ -29,7 +29,7 @@ namespace afqmc
 // Reserved for buffers with the localTG communicator.
 // Follows a monostate-type pattern. All variables are static and refer to a global instance
 // of the resource.
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 //  using DeviceBufferManager = LocalTGBufferManager;
 class LocalTGBufferManager : public DeviceBufferManager
 {

--- a/src/AFQMC/Memory/utilities.hpp
+++ b/src/AFQMC/Memory/utilities.hpp
@@ -18,7 +18,7 @@
 #if defined(ENABLE_CUDA)
 #include <cuda_runtime.h>
 #include "AFQMC/Memory/CUDA/cuda_utilities.h"
-#elif defined(ENABLE_HIP)
+#elif defined(BUILD_AFQMC_HIP)
 #include <hip/hip_runtime.h>
 #include "AFQMC/Memory/HIP/hip_utilities.h"
 #endif
@@ -29,7 +29,7 @@ namespace qmc_cuda
 {
 extern bool afqmc_cuda_handles_init;
 }
-#elif defined(ENABLE_HIP)
+#elif defined(BUILD_AFQMC_HIP)
 namespace qmc_hip
 {
 extern bool afqmc_hip_handles_init;
@@ -43,7 +43,7 @@ inline int number_of_devices()
   if (not qmc_cuda::afqmc_cuda_handles_init)
     throw std::runtime_error(" Error: Uninitialized CUDA environment.");
   cudaGetDeviceCount(&num_devices);
-#elif defined(ENABLE_HIP)
+#elif defined(BUILD_AFQMC_HIP)
   if (not qmc_hip::afqmc_hip_handles_init)
     throw std::runtime_error(" Error: Uninitialized HIP environment.");
   hipGetDeviceCount(&num_devices);

--- a/src/AFQMC/Numerics/batched_operations.hpp
+++ b/src/AFQMC/Numerics/batched_operations.hpp
@@ -16,7 +16,7 @@
 #define AFQMC_NUMERICS_HELPERS_BATCHED_OPERATIONS_HPP
 
 #include <cassert>
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 #include "AFQMC/Memory/custom_pointers.hpp"
 #include "AFQMC/Numerics/device_kernels.hpp"
 #endif
@@ -675,7 +675,7 @@ void inplace_product(int nbatch, int n, int m, T1 const* B, int ldb, std::comple
 
 } // namespace ma
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 namespace device
 {
 template<typename T, typename Q>

--- a/src/AFQMC/Numerics/detail/blas.hpp
+++ b/src/AFQMC/Numerics/detail/blas.hpp
@@ -21,7 +21,7 @@
 #if defined(ENABLE_CUDA)
 #include "AFQMC/Numerics/detail/CUDA/blas_cuda_gpu_ptr.hpp"
 #include "AFQMC/Numerics/detail/CUDA/blas_cuda_catch_all.hpp"
-#elif defined(ENABLE_HIP)
+#elif defined(BUILD_AFQMC_HIP)
 #include "AFQMC/Numerics/detail/HIP/blas_hip_gpu_ptr.hpp"
 #include "AFQMC/Numerics/detail/HIP/blas_hip_catch_all.hpp"
 #endif

--- a/src/AFQMC/Numerics/detail/lapack.hpp
+++ b/src/AFQMC/Numerics/detail/lapack.hpp
@@ -20,7 +20,7 @@
 #if defined(ENABLE_CUDA)
 #include "AFQMC/Numerics/detail/CUDA/lapack_cuda_gpu_ptr.hpp"
 //#include "AFQMC/Numerics/detail/CUDA/lapack_cuda_catch_all.hpp"
-#elif defined(ENABLE_HIP)
+#elif defined(BUILD_AFQMC_HIP)
 #include "AFQMC/Numerics/detail/HIP/lapack_hip_gpu_ptr.hpp"
 #endif
 #endif

--- a/src/AFQMC/Numerics/detail/sparse.hpp
+++ b/src/AFQMC/Numerics/detail/sparse.hpp
@@ -21,7 +21,7 @@
 #if defined(ENABLE_CUDA)
 #include "AFQMC/Numerics/detail/CUDA/sparse_cuda_gpu_ptr.hpp"
 #include "AFQMC/Numerics/detail/CUDA/sparse_cuda_catch_all.hpp"
-#elif defined(ENABLE_HIP)
+#elif defined(BUILD_AFQMC_HIP)
 #include "AFQMC/Numerics/detail/HIP/sparse_hip_gpu_ptr.hpp"
 #include "AFQMC/Numerics/detail/HIP/sparse_hip_catch_all.hpp"
 #endif

--- a/src/AFQMC/Numerics/determinant.hpp
+++ b/src/AFQMC/Numerics/determinant.hpp
@@ -16,7 +16,7 @@
 #define AFQMC_NUMERICS_HELPERS_HPP
 
 #include <cassert>
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 #include "AFQMC/Memory/custom_pointers.hpp"
 #include "AFQMC/Numerics/device_kernels.hpp"
 #endif
@@ -175,7 +175,7 @@ inline void scale_columns(int n, int m, T* A, int lda, T* scl)
 
 } // namespace ma
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 namespace device
 {
 // using thrust for now to avoid kernels!!!

--- a/src/AFQMC/Numerics/device_kernels.hpp
+++ b/src/AFQMC/Numerics/device_kernels.hpp
@@ -51,7 +51,7 @@
 #include "AFQMC/Numerics/detail/CUDA/Kernels/inplace_product.cuh"
 #include "AFQMC/Numerics/detail/CUDA/Kernels/get_diagonal.cuh"
 
-#elif defined(ENABLE_HIP)
+#elif defined(BUILD_AFQMC_HIP)
 
 #include "AFQMC/Numerics/detail/HIP/Kernels/determinant.hip.h"
 #include "AFQMC/Numerics/detail/HIP/Kernels/adotpby.hip.h"

--- a/src/AFQMC/Numerics/performance/performance.cpp
+++ b/src/AFQMC/Numerics/performance/performance.cpp
@@ -34,7 +34,7 @@ using namespace afqmc;
 
 using std::copy_n;
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 template<typename T>
 using Alloc = device::device_allocator<T>;
 #else
@@ -278,10 +278,10 @@ int main(int argc, char* argv[])
   boost::mpi3::environment env(argc, argv);
   auto world = boost::mpi3::environment::get_world_instance();
   auto node  = world.split_shared(world.rank());
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   arch::INIT(node);
 #endif
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 /*
   {
     std::ofstream out;
@@ -371,7 +371,7 @@ int main(int argc, char* argv[])
       timeExchangeKernel(out, alloc, buffer, b, nwalk, nocc, nchol);
     }
   }
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   {
     std::ofstream out;
     out.open("time_batched_matrix_inverse.dat");

--- a/src/AFQMC/Numerics/tensor_operations.hpp
+++ b/src/AFQMC/Numerics/tensor_operations.hpp
@@ -17,7 +17,7 @@
 
 #include <cassert>
 #include "AFQMC/Numerics/detail/utilities.hpp"
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 #include "AFQMC/Memory/custom_pointers.hpp"
 #include "AFQMC/Numerics/device_kernels.hpp"
 #endif
@@ -277,7 +277,7 @@ void transpose_wabn_to_wban(int nwalk, int na, int nb, int nchol, T const* Tab, 
 
 } //namespace ma
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 namespace device
 {
 template<typename T, typename Q>

--- a/src/AFQMC/Numerics/tests/test_batched_operations.cpp
+++ b/src/AFQMC/Numerics/tests/test_batched_operations.cpp
@@ -43,7 +43,7 @@ namespace qmcplusplus
 {
 using namespace afqmc;
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 template<typename T>
 using Alloc = device::device_allocator<T>;
 #else

--- a/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
@@ -44,7 +44,7 @@
 #include "multi/array.hpp"
 #include "multi/array_ref.hpp"
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 #include "mpi3/communicator.hpp"
 #include "mpi3/shared_communicator.hpp"
 #include "AFQMC/Memory/custom_pointers.hpp"
@@ -336,7 +336,7 @@ void test_dense_matrix_mult()
 
 TEST_CASE("dense_ma_operations", "[matrix_operations]") { test_dense_matrix_mult(); }
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 template<class Allocator>
 void test_dense_mat_vec_device(Allocator& alloc)
 {

--- a/src/AFQMC/Numerics/tests/test_determinant.cpp
+++ b/src/AFQMC/Numerics/tests/test_determinant.cpp
@@ -45,7 +45,7 @@ namespace qmcplusplus
 {
 using namespace afqmc;
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 template<typename T>
 using Alloc = device::device_allocator<T>;
 #else

--- a/src/AFQMC/Numerics/tests/test_ma_blas_extensions.cpp
+++ b/src/AFQMC/Numerics/tests/test_ma_blas_extensions.cpp
@@ -43,7 +43,7 @@ namespace qmcplusplus
 {
 using namespace afqmc;
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 template<typename T>
 using Alloc = device::device_allocator<T>;
 #else

--- a/src/AFQMC/Numerics/tests/test_misc_kernels.cpp
+++ b/src/AFQMC/Numerics/tests/test_misc_kernels.cpp
@@ -32,7 +32,7 @@
 #if defined(ENABLE_CUDA)
 #include "AFQMC/Numerics/detail/CUDA/blas_cuda_gpu_ptr.hpp"
 #include "AFQMC/Numerics/device_kernels.hpp"
-#elif defined(ENABLE_HIP)
+#elif defined(BUILD_AFQMC_HIP)
 #include "AFQMC/Numerics/detail/HIP/blas_hip_gpu_ptr.hpp"
 #include "AFQMC/Numerics/device_kernels.hpp"
 #endif
@@ -50,7 +50,7 @@ namespace qmcplusplus
 {
 using namespace afqmc;
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 template<typename T>
 using Alloc = device::device_allocator<T>;
 #else
@@ -89,7 +89,7 @@ TEST_CASE("axpyBatched", "[Numerics][misc_kernels]")
   verify_approx(y, ref);
 }
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 // Not in dispatching routine yet, called directly from AFQMCBasePropagator.
 TEST_CASE("construct_X", "[Numerics][misc_kernels]")
 {

--- a/src/AFQMC/Numerics/tests/test_sparse_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_sparse_numerics.cpp
@@ -63,7 +63,7 @@ void test_sparse_matrix_mult(Allocator const& alloc = {})
   A_[2][1] = 3.;
   A_[0][1] = 9.;
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   A_.remove_empty_spaces();
   ma::sparse::csr_matrix<double, int, int, Allocator> A(A_);
 #else
@@ -124,7 +124,7 @@ void test_sparse_matrix_mult(Allocator const& alloc = {})
     verify_approx(C, D2);
   }
 
-#if !defined(ENABLE_CUDA) && !defined(ENABLE_HIP)
+#if !defined(ENABLE_CUDA) && !defined(BUILD_AFQMC_HIP)
   // test that everything is fine after this
   A.remove_empty_spaces();
   // matrix-matrix
@@ -187,7 +187,7 @@ TEST_CASE("sparse_ma_operations", "[matrix_operations]")
   auto world = boost::mpi3::environment::get_world_instance();
   auto node  = world.split_shared(world.rank());
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   arch::INIT(node);
   using Alloc = device::device_allocator<double>;
   afqmc::setup_memory_managers(node, 10uL * 1024uL * 1024uL);

--- a/src/AFQMC/Numerics/tests/test_tensor_operations.cpp
+++ b/src/AFQMC/Numerics/tests/test_tensor_operations.cpp
@@ -43,7 +43,7 @@ namespace qmcplusplus
 {
 using namespace afqmc;
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 template<typename T>
 using Alloc = device::device_allocator<T>;
 #else

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.icc
@@ -734,7 +734,7 @@ void AFQMCBasePropagator::assemble_X(size_t nsteps,
 // leaving compiler switch until I decide how to do this better
 // basically hide this decision somewhere based on the value of pointer!!!
 // TODO: Move this
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   kernels::construct_X(nCV, nsteps, nwalk, free_projection, sqrtdt, vbias_bound, to_address(vMF.origin()),
                        to_address(vbias.origin()), to_address(HWs.origin()), to_address(MF.origin()),
                        to_address(X.origin()));

--- a/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
+++ b/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
@@ -422,7 +422,7 @@ TEST_CASE("propg_fac_shared", "[propagator_factory]")
     infoLog.pause();
   auto node = world.split_shared(world.rank());
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   arch::INIT(node);
 #endif
   setup_memory_managers(node, 10uL * 1024uL * 1024uL);
@@ -438,7 +438,7 @@ TEST_CASE("propg_fac_distributed", "[propagator_factory]")
     infoLog.pause();
   auto node = world.split_shared(world.rank());
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   int ngrp(world.size());
   arch::INIT(node);
 #else

--- a/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_base.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_base.hpp
@@ -294,7 +294,7 @@ public:
   T Orthogonalize(Mat&& A, T LogOverlapFactor)
   {
     using std::get;
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     // QR on the transpose
     int NMO  = get<0>(A.sizes());
     int NAEA = get<1>(A.sizes());

--- a/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_serial.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_serial.hpp
@@ -80,7 +80,7 @@ public:
                        bool compact = false,
                        bool herm    = true)
   {
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     APP_ABORT(" Error: SlaterDetOperations_serial should not be here. \n");
 #endif
     return Base::MixedDensityMatrix(hermA, B, C, LogOverlapFactor, compact);
@@ -96,7 +96,7 @@ public:
                                   communicator& comm,
                                   bool compact = false)
   {
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     APP_ABORT(" Error: SlaterDetOperations_serial should not be here. \n");
 #endif
     return Base::MixedDensityMatrixForWoodbury(hermA, B, std::forward<MatC>(C), LogOverlapFactor, ref,
@@ -106,7 +106,7 @@ public:
   template<class MatA, class MatB>
   T Overlap(const MatA& hermA, const MatB& B, T LogOverlapFactor, communicator& comm, bool herm = true)
   {
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     APP_ABORT(" Error: SlaterDetOperations_serial should not be here. \n");
 #endif
     return Base::Overlap(hermA, B, LogOverlapFactor);
@@ -120,7 +120,7 @@ public:
                        MatC&& QQ0,
                        communicator& comm)
   {
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     APP_ABORT(" Error: SlaterDetOperations_serial should not be here. \n");
 #endif
     return Base::OverlapForWoodbury(hermA, B, LogOverlapFactor, ref, std::forward<MatC>(QQ0));
@@ -135,7 +135,7 @@ public:
                  char TA           = 'N',
                  bool noncollinear = false)
   {
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     APP_ABORT(" Error: SlaterDetOperations_serial should not be here. \n");
 #endif
     Base::Propagate(std::forward<Mat>(A), P1, V, order, TA, noncollinear);
@@ -327,7 +327,7 @@ public:
     static_assert(pointedType<MatA>::dimensionality == 2, "Wrong dimensionality");
 
     using std::get;
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     // QR on the transpose
     if (Ai.size() == 0)
       return;
@@ -366,7 +366,7 @@ public:
   void BatchedOrthogonalize(std::vector<MatA>& Ai, T LogOverlapFactor)
   {
     using std::get;
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     // QR on the transpose
     if (Ai.size() == 0)
       return;

--- a/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
+++ b/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
@@ -542,7 +542,7 @@ void SDetOps_complex_serial(Allocator alloc, BufferManager b)
 
   // Batched
   // TODO fix CPU.
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   //SECTION("batched_density_matrix")
   {
     boost::multi::array<Type, 3, Allocator> Gw({3, NMO, NMO}, alloc);
@@ -978,7 +978,7 @@ TEST_CASE("SDetOps_complex_serial", "[sdet_ops]")
   auto world = boost::mpi3::environment::get_world_instance();
   auto node  = world.split_shared(world.rank());
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   arch::INIT(node);
   using Alloc = device::device_allocator<ComplexType>;
 #else

--- a/src/AFQMC/Utilities/Utils.hpp
+++ b/src/AFQMC/Utilities/Utils.hpp
@@ -32,7 +32,7 @@
 #include "AFQMC/Memory/CUDA/cuda_arch.h"
 #include "AFQMC/Numerics/device_kernels.hpp"
 #include "cuda_runtime.h"
-#elif ENABLE_HIP
+#elif BUILD_AFQMC_HIP
 #include "AFQMC/Memory/device_pointers.hpp"
 #include "AFQMC/Memory/HIP/hip_arch.h"
 #include "AFQMC/Numerics/device_kernels.hpp"
@@ -351,7 +351,7 @@ inline void memory_report()
   qmcplusplus::app_log() << " --> GPU Memory Available,  Total in MB: " << (free_ >> 20) << " "
                          << (tot_ >> 20) << "\n"
                          << std::endl;
-#elif ENABLE_HIP
+#elif BUILD_AFQMC_HIP
   size_t free_, tot_;
   hipMemGetInfo(&free_, &tot_);
   qmcplusplus::app_log() << " --> GPU Memory Available,  Total in MB: " << (free_ >> 20) << " "
@@ -367,7 +367,7 @@ void sampleGaussianFields_n(device::device_pointer<T> V, int n, Dummy& r)
 {
   kernels::sampleGaussianRNG(to_address(V), n, arch::afqmc_curand_generator);
 }
-#elif defined(ENABLE_HIP)
+#elif defined(BUILD_AFQMC_HIP)
 template<class T, class Dummy>
 void sampleGaussianFields_n(device::device_pointer<T> V, int n, Dummy& r)
 {

--- a/src/AFQMC/Utilities/taskgroup.h
+++ b/src/AFQMC/Utilities/taskgroup.h
@@ -119,7 +119,7 @@ public:
         global_(gTG.Global()),
         node_(gTG.Node()),
         core_(gTG.Cores()),
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
         local_tg_(node_.split(node_.rank(), node_.rank())),
         tgrp_(),
         tgrp_cores_(),
@@ -131,11 +131,11 @@ public:
         tg_heads_(global_.split(node_.rank() % ((nc < 1) ? (1) : (std::min(nc, node_.size()))), global_.rank()))
 #endif
   {
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     if (nc != 1)
     {
       nc = 1;
-      app_log() << " WARNING: Code was compiled with ENABLE_CUDA or ENABLE_HIP, setting ncores=1. \n";
+      app_log() << " WARNING: Code was compiled with ENABLE_CUDA or BUILD_AFQMC_HIP, setting ncores=1. \n";
     }
 #endif
     setup(nn, nc);
@@ -146,7 +146,7 @@ public:
         global_(other.Global()),
         node_(other.Node()),
         core_(other.Cores()),
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
         local_tg_(node_.split(node_.rank(), node_.rank())),
         tgrp_(),
         tgrp_cores_(),
@@ -158,11 +158,11 @@ public:
         tg_heads_(global_.split(node_.rank() % ((nc < 1) ? (1) : (std::min(nc, node_.size()))), global_.rank()))
 #endif
   {
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     if (nc != 1)
     {
       nc = 1;
-      app_log() << " WARNING: Code was compiled with ENABLE_CUDA or ENABLE_HIP, setting ncores=1. \n";
+      app_log() << " WARNING: Code was compiled with ENABLE_CUDA or BUILD_AFQMC_HIP, setting ncores=1. \n";
     }
 #endif
     setup(nn, nc);
@@ -227,7 +227,7 @@ public:
   int getNGroupsPerTG() const { return nnodes_per_TG; }
 
 // THIS NEEDS TO CHANGE IN GPU CODE!
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   int getLocalGroupNumber() const { return getTGRank(); }
 #else
   int getLocalGroupNumber() const { return core_.rank() % nnodes_per_TG; }

--- a/src/AFQMC/Walkers/WalkerSet.hpp
+++ b/src/AFQMC/Walkers/WalkerSet.hpp
@@ -19,7 +19,7 @@ namespace qmcplusplus
 {
 namespace afqmc
 {
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 using WalkerSet = SerialWalkerSet;
 #else
 using WalkerSet = SharedWalkerSet;

--- a/src/AFQMC/Walkers/tests/test_sharedwset.cpp
+++ b/src/AFQMC/Walkers/tests/test_sharedwset.cpp
@@ -83,7 +83,7 @@ void test_basic_walker_features(bool serial, std::string wtype)
   auto world = boost::mpi3::environment::get_world_instance();
   auto node  = world.split_shared(world.rank());
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   arch::INIT(node);
 #endif
 
@@ -228,7 +228,7 @@ void test_hyperslab()
   auto world = boost::mpi3::environment::get_world_instance();
   auto node  = world.split_shared(world.rank());
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   arch::INIT(node);
 #endif
 
@@ -388,7 +388,7 @@ void test_walker_io(std::string wtype)
 
   using Type = std::complex<double>;
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   arch::INIT(node);
 #endif
 

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -309,7 +309,7 @@ TEST_CASE("test_read_phmsd", "[test_read_phmsd]")
     infoLog.pause();
   auto node = world.split_shared(world.rank());
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   arch::INIT(node);
   using Alloc = device::device_allocator<ComplexType>;
 #else
@@ -329,7 +329,7 @@ TEST_CASE("test_phmsd", "[read_phmsd]")
     infoLog.pause();
   auto node = world.split_shared(world.rank());
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   arch::INIT(node);
   using Alloc = device::device_allocator<ComplexType>;
 #else

--- a/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
@@ -1111,7 +1111,7 @@ TEST_CASE("wfn_fac_sdet", "[wavefunction_factory]")
     infoLog.pause();
   auto node = world.split_shared(world.rank());
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 
   arch::INIT(node);
   using Alloc = device::device_allocator<ComplexType>;
@@ -1130,7 +1130,7 @@ TEST_CASE("wfn_fac_distributed", "[wavefunction_factory]")
   if (not world.root())
     infoLog.pause();
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   auto node = world.split_shared(world.rank());
   int ngrp(world.size());
 

--- a/src/AFQMC/config.h
+++ b/src/AFQMC/config.h
@@ -117,7 +117,7 @@ using shared_allocator = shm::allocator_shm_ptr_with_raw_ptr_dispatch<T>;
 template<class T>
 using shm_pointer = typename shared_allocator<T>::pointer;
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 template<class T>
 using device_allocator = device::device_allocator<T>;
 template<class T>
@@ -232,7 +232,7 @@ using VType_shm_csr_matrix =
 template<typename T>
 using PsiT_Matrix_t = ma::sparse::csr_matrix<T, int, int, shared_allocator<T>, ma::sparse::is_root>;
 using PsiT_Matrix   = PsiT_Matrix_t<ComplexType>;
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 using devcsr_Matrix = ma::sparse::csr_matrix<ComplexType, int, int, device_allocator<ComplexType>>;
 #else
 using devcsr_Matrix = ma::sparse::csr_matrix<ComplexType, int, int, shared_allocator<ComplexType>, ma::sparse::is_root>;
@@ -243,7 +243,7 @@ using devcsr_Matrix = ma::sparse::csr_matrix<ComplexType, int, int, shared_alloc
 //#endif
 
 
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 using P1Type = ma::sparse::csr_matrix<ComplexType, int, int, localTG_allocator<ComplexType>>;
 #else
 using P1Type        = ma::sparse::csr_matrix<ComplexType, int, int, localTG_allocator<ComplexType>, ma::sparse::is_root>;

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -98,7 +98,7 @@ QMCMain::QMCMain(Communicate* c)
       << "\n  MPI group ID              = " << myComm->getGroupID()
       << "\n  Number of ranks in group  = " << myComm->size()
       << "\n  MPI ranks per node        = " << node_comm.size()
-#if defined(ENABLE_OFFLOAD) || defined(ENABLE_CUDA) || defined(ENABLE_HIP) || defined(ENABLE_SYCL)
+#if defined(ENABLE_OFFLOAD) || defined(ENABLE_CUDA) || defined(ENABLE_ROCM) || defined(ENABLE_SYCL)
       << "\n  Accelerators per node     = " << DeviceManager::getGlobal().getNumDevices()
 #endif
       << std::endl;
@@ -128,16 +128,15 @@ QMCMain::QMCMain(Communicate* c)
 
   // Record features configured in cmake or selected via command-line arguments to the printout
   app_summary() << std::endl;
-#if !defined(ENABLE_OFFLOAD) && !defined(ENABLE_CUDA) && !defined(ENABLE_HIP) && !defined(ENABLE_SYCL)
+#if !defined(ENABLE_OFFLOAD) && !defined(ENABLE_CUDA) && !defined(ENABLE_ROCM) && !defined(ENABLE_SYCL)
   app_summary() << "  CPU only build" << std::endl;
 #else // GPU case
 #if defined(ENABLE_OFFLOAD)
   app_summary() << "  OpenMP target offload to accelerators build option is enabled" << std::endl;
 #endif
-#if defined(ENABLE_HIP)
-  app_summary() << "  HIP acceleration with direct HIP source code build option is enabled" << std::endl;
+#if defined(BUILD_AFQMC_HIP)
+  app_summary() << "  HIP acceleration with direct HIP source code in AFQMC build option is enabled" << std::endl;
 #endif
-
 #if defined(QMC_CUDA2HIP) && defined(ENABLE_CUDA)
   app_summary() << "  HIP acceleration with CUDA source code build option is enabled" << std::endl;
 #elif defined(ENABLE_CUDA)

--- a/src/io/hdf/hdf_multi.h
+++ b/src/io/hdf/hdf_multi.h
@@ -18,7 +18,7 @@
 #include "hdf_hyperslab.h"
 
 #ifdef BUILD_AFQMC
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 #include "AFQMC/Memory/device_pointers.hpp"
 #endif
 #endif
@@ -151,7 +151,7 @@ struct h5data_proxy<boost::multi::array_ref<T, 2, Ptr>> : public h5_space_type<T
 
 
 #ifdef BUILD_AFQMC
-#if defined(ENABLE_CUDA) || defined(ENABLE_HIP)
+#if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
 // Specializations for cuda_gpu_allocator
 // Need buffered I/O and copies to gpu
 template<typename T>


### PR DESCRIPTION
## Proposed changes
`ENABLE_HIP` was introduced by AFQMC for non-CUDA HIP-explicit source code.
In the current setting, ENABLE_ROCM is the switch to enable hip compilers and rocm libraries.
Thus, rename `ENABLE_HIP` to `BUILD_AFQMC_HIP` to reduce confusion.
Note that unfortunately, the current code cannot compile with this option on.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'