### PR TITLE
Set batched defaults in QMCPACK and NEXUS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to QMCPACK are documented in this file.
 
 ## [Unreleased]
 
+* IMPORTANT: the default drivers are now the batched versions in both QMCPACK and NEXUS. To recover legacy v3 behavior in QMCPACK,
+  set the driver_version parameter to legacy https://qmcpack.readthedocs.io/en/develop/input_overview.html#driver-version-parameter
+  . For NEXUS put driver = 'legacy' within generate_qmcpack sections. 
+
 * Support for backflow optimization has been removed as part of refactoring and cleaning the codebase. QMC runs using backflow
   wavefunctions are still supported. This feature is expected to eventually be reimplemented in v4. Users needing
   backflow optimization can use previously released versions of QMCPACK or work towards its reimplementation in the modern code.
@@ -25,6 +29,7 @@ This minor release is recommended for all users and includes a couple of build f
 ### NEXUS
 
 * NEXUS: Support for spinor inputs. [#4707](https://github.com/QMCPACK/qmcpack/pull/4707)
+
 ## [3.17.0] - 2023-08-18
 
 This is a recommended release for all users. Thanks to everyone who contributed directly, reported an issue, or suggested an

--- a/nexus/lib/qmcpack_input.py
+++ b/nexus/lib/qmcpack_input.py
@@ -7364,7 +7364,7 @@ gen_basic_input_defaults = obj(
     J3_rcut        = 5.0,              
     J1_rcut_open   = 5.0,              
     J2_rcut_open   = 10.0,
-    driver         = 'legacy', # legacy,batched
+    driver         = 'batched', # legacy,batched
     # batched driver inputs
     orbitals_cpu   = None,     # place/evaluate orbitals on cpu if on gpu
     matrix_inv_cpu = None,     # evaluate matrix inverse on cpu if on gpu

--- a/nexus/tests/unit/test_qmcpack_input.py
+++ b/nexus/tests/unit/test_qmcpack_input.py
@@ -1279,6 +1279,7 @@ def test_generate():
     # legacy drivers
     qi = generate_qmcpack_input(
         input_type      = 'basic',
+        driver          = 'legacy',
         system          = system,
         randomsrc       = False,
         pseudos         = ['V.opt.xml','O.opt.xml'],
@@ -1826,6 +1827,7 @@ def test_incorporate_system():
 
     qi = generate_qmcpack_input(
         input_type      = 'basic',
+        driver          = 'legacy',
         system          = system,
         pseudos         = ['V.opt.xml','O.opt.xml'],
         spin_polarized  = True,

--- a/src/QMCDrivers/tests/test_QMCDriverFactory.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverFactory.cpp
@@ -71,7 +71,8 @@ TEST_CASE("QMCDriverFactory create VMC Driver", "[qmcapp]")
   Communicate* comm;
   comm = OHMMS::Controller;
 
-  ProjectData test_project;
+  using DV = ProjectData::DriverVersion;
+  ProjectData test_project("testing",DV::LEGACY);
   QMCDriverFactory driver_factory(test_project);
 
   Libxml2Document doc;
@@ -141,7 +142,8 @@ TEST_CASE("QMCDriverFactory create DMC driver", "[qmcapp]")
   Communicate* comm;
   comm = OHMMS::Controller;
 
-  ProjectData test_project;
+  using DV = ProjectData::DriverVersion;
+  ProjectData test_project("testing",DV::LEGACY);
   QMCDriverFactory driver_factory(test_project);
 
   Libxml2Document doc;

--- a/src/Utilities/ProjectData.h
+++ b/src/Utilities/ProjectData.h
@@ -58,7 +58,7 @@ private:
 
 public:
   /// constructor
-  ProjectData(const std::string& atitle = "", DriverVersion de = DriverVersion::LEGACY);
+  ProjectData(const std::string& atitle = "", DriverVersion de = DriverVersion::BATCH);
 
   bool get(std::ostream& os) const;
   bool put(std::istream& is);

--- a/src/Utilities/tests/test_project_data.cpp
+++ b/src/Utilities/tests/test_project_data.cpp
@@ -88,6 +88,7 @@ TEST_CASE("ProjectData::TestDriverVersion", "[ohmmsapp]")
   SECTION("driver version batch")
   {
     ProjectData proj;
+    REQUIRE(proj.getDriverVersion() == DV::BATCH);
 
     const char* xml_input = R"(
       <project id="test1" series="1">
@@ -109,7 +110,6 @@ TEST_CASE("ProjectData::TestDriverVersion", "[ohmmsapp]")
   SECTION("driver version legacy")
   {
     ProjectData proj;
-    REQUIRE(proj.getDriverVersion() == DV::LEGACY);
 
     const char* xml_input = R"(
       <project id="test1" series="1">


### PR DESCRIPTION
## Proposed changes

Switch QMCPACK and NEXUS to use the batched drivers as default. Minimal updates to tests to ensure that they now pass. Potentially additional tests could be added.

Updated CHANGELOG.md since this is a breaking change.

Closes #5149
Closes #5273

## What type(s) of changes does this code introduce?

- New feature
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation or build script changes

### Does this introduce a breaking change?

- Yes

## What systems has this change been tested on?

nitrogen2, gcc14 nightly configuration

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
