### PR TITLE
disable norm check for hybridrep on spinor WFs

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
@@ -140,6 +140,7 @@ std::unique_ptr<SPOSet> HybridRepSetReader<SA>::create_spline_set(const std::str
                                                                   int spin,
                                                                   const BandInfoGroup& bandgroup)
 {
+  spline_reader_.setCheckNorm(checkNorm);
   auto bspline = std::make_unique<SA>(my_name);
   app_log() << "  ClassName = " << bspline->getClassName() << std::endl;
   // set info for Hybrid


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Hybridrep spinor wave functions wasn't working because the orbital norm check was still being used in the hybridrep splines. This needs to be disabled since individual up/down components aren't normalized, only the total spinor is. This is now fixed, and enables hybridrep with spinors. 


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
mac 

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
