### PR TITLE
Reduce OhmmsData/Libxml2Doc.h propagation via TimerManager.h

### DIFF
--- a/src/Estimators/tests/test_EnergyDensityInput.cpp
+++ b/src/Estimators/tests/test_EnergyDensityInput.cpp
@@ -12,10 +12,11 @@
 
 #include "catch.hpp"
 
+#include <iostream>
 #include "EnergyDensityInput.h"
 #include "EstimatorTesting.h"
 #include "ValidEnergyDensityInput.h"
-#include <iostream>
+#include "OhmmsData/Libxml2Doc.h"
 
 namespace qmcplusplus
 {

--- a/src/Estimators/tests/test_PerParticleHamiltonianLogger.cpp
+++ b/src/Estimators/tests/test_PerParticleHamiltonianLogger.cpp
@@ -11,11 +11,10 @@
 
 #include "catch.hpp"
 
-#include "PerParticleHamiltonianLogger.h"
-
 #include <filesystem>
-
+#include "PerParticleHamiltonianLogger.h"
 #include "Utilities/StdRandom.h"
+#include "OhmmsData/Libxml2Doc.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -23,7 +23,7 @@
 #include "OhmmsData/XMLParsingString.h"
 #include "Message/CommOperators.h"
 #include "Message/UniformCommunicateError.h"
-
+#include "OhmmsData/Libxml2Doc.h"
 #include <array>
 
 //#define QMCCOSTFUNCTION_DEBUG

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -22,6 +22,7 @@
 #include "QMCHamiltonians/QMCHamiltonian.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "Message/MPIObjectBase.h"
+#include "libxml/xpath.h"
 
 #ifdef HAVE_LMY_ENGINE
 #include "formic/utils/matrix.h"

--- a/src/QMCDrivers/tests/test_QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/tests/test_QMCCostFunctionBase.cpp
@@ -10,6 +10,8 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 #include "catch.hpp"
+
+#include "OhmmsData/Libxml2Doc.h"
 #include "QMCDrivers/WFOpt/QMCCostFunctionBase.h"
 #include "Utilities/RuntimeOptions.h"
 

--- a/src/QMCHamiltonians/tests/test_SOECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_SOECPotential.cpp
@@ -23,6 +23,7 @@
 #include "QMCHamiltonians/NonLocalECPComponent.h"
 #include "TestListenerFunction.h"
 #include "Utilities/RuntimeOptions.h"
+#include "OhmmsData/Libxml2Doc.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/LCAO/CuspCorrectionConstruction.cpp
+++ b/src/QMCWaveFunctions/LCAO/CuspCorrectionConstruction.cpp
@@ -23,7 +23,7 @@
 #include "MultiQuinticSpline1D.h"
 #include "Numerics/MinimizeOneDim.h"
 #include "OhmmsData/AttributeSet.h"
-
+#include "OhmmsData/Libxml2Doc.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/tests/test_J1OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1OrbitalSoA.cpp
@@ -16,6 +16,7 @@
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
 #include "Utilities/RuntimeOptions.h"
+#include "OhmmsData/Libxml2Doc.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/tests/test_J1Spin.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1Spin.cpp
@@ -17,6 +17,7 @@
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
 #include "Utilities/RuntimeOptions.h"
+#include "OhmmsData/Libxml2Doc.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/tests/test_LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/tests/test_LCAOrbitalBuilder.cpp
@@ -23,6 +23,7 @@
 #include "LCAO/SoaLocalizedBasisSet.h"
 #include "LCAO/AOBasisBuilder.h"
 #include "LCAO/MultiFunctorAdapter.h"
+#include "OhmmsData/Libxml2Doc.h"
 
 
 namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -20,6 +20,7 @@
 #include "QMCWaveFunctions/LCAO/LCAOrbitalBuilder.h"
 #include "QMCWaveFunctions/SPOSetBuilderFactory.h"
 #include <ResourceCollection.h>
+#include "OhmmsData/Libxml2Doc.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
@@ -20,6 +20,7 @@
 #include "QMCWaveFunctions/SPOSetBuilderFactory.h"
 #include "Utilities/ResourceCollection.h"
 #include "QMCWaveFunctions/SpinorSet.h"
+#include "OhmmsData/Libxml2Doc.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/tests/test_cartesian_ao.cpp
+++ b/src/QMCWaveFunctions/tests/test_cartesian_ao.cpp
@@ -19,6 +19,7 @@
 #include "Numerics/GaussianBasisSet.h"
 #include "QMCWaveFunctions/LCAO/LCAOrbitalBuilder.h"
 #include "QMCWaveFunctions/SPOSetBuilderFactory.h"
+#include "OhmmsData/Libxml2Doc.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
@@ -26,6 +26,7 @@
 #include "Numerics/GaussianBasisSet.h"
 #include "QMCWaveFunctions/LCAO/LCAOrbitalBuilder.h"
 #include "QMCWaveFunctions/SPOSetBuilderFactory.h"
+#include "OhmmsData/Libxml2Doc.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
+++ b/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
@@ -14,16 +14,14 @@
 #include "catch.hpp"
 
 #include "Configuration.h"
-
 #include "Message/Communicate.h"
 #include "Numerics/OneDimGridBase.h"
 #include "ParticleIO/XMLParticleIO.h"
 #include "Numerics/GaussianBasisSet.h"
-
 #include "QMCWaveFunctions/LCAO/LCAOrbitalSet.h"
 #include "QMCWaveFunctions/LCAO/CuspCorrectionConstruction.h"
-
 #include "QMCWaveFunctions/SPOSetBuilderFactory.h"
+#include "OhmmsData/Libxml2Doc.h"
 
 namespace qmcplusplus
 {

--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -29,6 +29,7 @@
 #include "mpi/collectives.h"
 #include "ParticleBase/ParticleAttribOps.h"
 #include "Concurrency/OpenMP.h"
+#include "OhmmsData/Libxml2Doc.h"
 
 using namespace std;
 using namespace qmcplusplus;

--- a/src/Utilities/TimerManager.cpp
+++ b/src/Utilities/TimerManager.cpp
@@ -26,6 +26,7 @@
 #include "Concurrency/OpenMP.h"
 #include "Message/Communicate.h"
 #include "Message/CommOperators.h"
+#include "OhmmsData/Libxml2Doc.h"
 
 #include <array>
 #include <string_view>

--- a/src/Utilities/TimerManager.h
+++ b/src/Utilities/TimerManager.h
@@ -22,17 +22,19 @@
 #include <string>
 #include <mutex>
 #include <map>
+#include <stdexcept>
 #include <memory>
 #include <type_traits>
 #include "NewTimer.h"
 #include "config.h"
-#include "OhmmsData/Libxml2Doc.h"
+#include "libxml/tree.h"
 
 #ifdef USE_VTUNE_TASKS
 #include <ittnotify.h>
 #endif
 
 class Communicate;
+struct Libxml2Document;
 
 namespace qmcplusplus
 {

--- a/src/Utilities/tests/test_timer.cpp
+++ b/src/Utilities/tests/test_timer.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <vector>
 #include "Utilities/TimerManager.h"
+#include "OhmmsData/Libxml2Doc.h"
 
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
## Proposed changes
Less entanglement and allow easy use of timers.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
frontier

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted