### PR TITLE
Hamiltonian updates for batched estimators

### DIFF
--- a/src/QMCHamiltonians/CMakeLists.txt
+++ b/src/QMCHamiltonians/CMakeLists.txt
@@ -23,6 +23,7 @@ set(HAMSRCS
     QMCHamiltonian.cpp
     Hdispatcher.cpp
     BareKineticEnergy.cpp
+    CoulombPotential.cpp
     CoulombPBCAA.cpp
     CoulombPBCAB.cpp
     EwaldRef.cpp

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -124,6 +124,7 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces, bo
     {
       app_log() << "  Check passed." << std::endl;
     }
+
   }
   prefix_ = "F_AA";
   app_log() << "  Maximum K shell " << AA->MaxKshell << std::endl;
@@ -331,14 +332,14 @@ void CoulombPBCAA::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase
       app_log() << "accumtest: CoulombPBCAA::evaluate()" << std::endl;
       app_log() << "accumtest:   tot:" << Vnow << std::endl;
       app_log() << "accumtest:   sum:" << Vsum << std::endl;
-      APP_ABORT("Trace check failed");
+      throw std::runtime_error("Trace check failed");
     }
     if (std::abs(Vcsum - Vcnow) > TraceManager::trace_tol)
     {
       app_log() << "accumtest: CoulombPBCAA::evalConsts()" << std::endl;
       app_log() << "accumtest:   tot:" << Vcnow << std::endl;
       app_log() << "accumtest:   sum:" << Vcsum << std::endl;
-      APP_ABORT("Trace check failed");
+      throw std::runtime_error("Trace check failed");
     }
 #endif
 

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -320,7 +320,7 @@ void CoulombPBCAA::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase
     for (const ListenerVector<RealType>& listener : listeners)
       listener.report(walker_index, name, v_sample);
 
-#if defined TRACE_CHECK && defined NDEBUG
+#ifndef NDEBUG
     RealType Vlrnow = cpbcaa.evalLR(pset);
     RealType Vsrnow = cpbcaa.evalSR(pset);
     RealType Vcnow  = cpbcaa.myConst;

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -23,6 +23,7 @@
 #include <ResourceCollection.h>
 #include <Message/UniformCommunicateError.h>
 #include "Numerics/OneDimCubicSplineLinearGrid.h"
+#include <numeric>
 
 namespace qmcplusplus
 {
@@ -317,6 +318,30 @@ void CoulombPBCAA::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase
 
     for (const ListenerVector<RealType>& listener : listeners)
       listener.report(walker_index, name, v_sample);
+
+#if defined TRACE_CHECK && defined NDEBUG
+    RealType Vlrnow = cpbcaa.evalLR(pset);
+    RealType Vsrnow = cpbcaa.evalSR(pset);
+    RealType Vcnow  = cpbcaa.myConst;
+    RealType Vcsum = std::accumulate(pp_consts.begin(), pp_consts.end(), 0.0);
+    RealType Vnow   = Vlrnow + Vsrnow + Vcnow;
+    RealType Vsum   = std::accumulate(v_sample.begin(), v_sample.end(), 0.0);
+    if (std::abs(Vsum - Vnow) > TraceManager::trace_tol)
+    {
+      app_log() << "accumtest: CoulombPBCAA::evaluate()" << std::endl;
+      app_log() << "accumtest:   tot:" << Vnow << std::endl;
+      app_log() << "accumtest:   sum:" << Vsum << std::endl;
+      APP_ABORT("Trace check failed");
+    }
+    if (std::abs(Vcsum - Vcnow) > TraceManager::trace_tol)
+    {
+      app_log() << "accumtest: CoulombPBCAA::evalConsts()" << std::endl;
+      app_log() << "accumtest:   tot:" << Vcnow << std::endl;
+      app_log() << "accumtest:   sum:" << Vcsum << std::endl;
+      APP_ABORT("Trace check failed");
+    }
+#endif
+
     return value;
   };
 
@@ -326,6 +351,17 @@ void CoulombPBCAA::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase
     coulomb_aa.value_ = evaluate_walker(iw, coulomb_aa, p_list[iw], listeners);
   }
 }
+
+void CoulombPBCAA::mw_evaluatePerParticleWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                                       const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                                       const RefVectorWithLeader<ParticleSet>& p_list,
+                                                       const std::vector<ListenerVector<RealType>>& listeners,
+                                                       const std::vector<ListenerVector<RealType>>& ion_listeners) const
+
+{
+  mw_evaluatePerParticle(o_list, wf_list, p_list, listeners, ion_listeners);
+}
+
 
 void CoulombPBCAA::evaluateIonDerivs(ParticleSet& P,
                                      ParticleSet& ions,
@@ -631,7 +667,7 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalConsts(bool report)
 }
 
 
-CoulombPBCAA::Return_t CoulombPBCAA::evalSR(ParticleSet& P)
+CoulombPBCAA::Return_t CoulombPBCAA::evalSR(const ParticleSet& P) const
 {
   ScopedTimer local_timer(evalSR_timer_);
   const auto& d_aa(P.getDistTableAA(d_aa_ID));
@@ -738,7 +774,7 @@ std::vector<CoulombPBCAA::Return_t> CoulombPBCAA::mw_evalSR_offload(const RefVec
   return values;
 }
 
-CoulombPBCAA::Return_t CoulombPBCAA::evalLR(ParticleSet& P)
+CoulombPBCAA::Return_t CoulombPBCAA::evalLR(const ParticleSet& P) const
 {
   ScopedTimer local_timer(evalLR_timer_);
   mRealType res = 0.0;

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -113,6 +113,11 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
                               const std::vector<ListenerVector<RealType>>& listeners,
                               const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
+  void mw_evaluatePerParticleWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                           const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                           const RefVectorWithLeader<ParticleSet>& p_list,
+                                           const std::vector<ListenerVector<RealType>>& listeners,
+                                           const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
   void evaluateIonDerivs(ParticleSet& P,
                          ParticleSet& ions,
@@ -144,12 +149,12 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
   void deleteParticleQuantities() override;
 #endif
 
-  Return_t evalSR(ParticleSet& P);
+  Return_t evalSR(const ParticleSet& P) const;
 
   static std::vector<Return_t> mw_evalSR_offload(const RefVectorWithLeader<OperatorBase>& o_list,
                                                  const RefVectorWithLeader<ParticleSet>& p_list);
 
-  Return_t evalLR(ParticleSet& P);
+  Return_t evalLR(const ParticleSet& P) const;
   Return_t evalSRwithForces(ParticleSet& P);
   Return_t evalLRwithForces(ParticleSet& P);
   Return_t evalConsts(bool report = true);

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -379,6 +379,16 @@ void CoulombPBCAB::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase
   }
 }
 
+void CoulombPBCAB::mw_evaluatePerParticleWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                                       const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                                       const RefVectorWithLeader<ParticleSet>& p_list,
+                                                       const std::vector<ListenerVector<RealType>>& listeners,
+                                                       const std::vector<ListenerVector<RealType>>& ion_listeners) const
+
+{
+  mw_evaluatePerParticle(o_list, wf_list, p_list, listeners, ion_listeners);
+}
+
 /** Evaluate the background term. Other constants are handled by AA potentials.
  *
  * \f$V_{bg}^{AB}=-\sum_{\alpha}\sum_{\beta} N^{\alpha} N^{\beta} q^{\alpha} q^{\beta} v_s(k=0) \f$

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -153,6 +153,12 @@ public:
                               const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
 
+  void mw_evaluatePerParticleWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                           const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                           const RefVectorWithLeader<ParticleSet>& p_list,
+                                           const std::vector<ListenerVector<RealType>>& listeners,
+                                           const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
+
   void evaluateIonDerivs(ParticleSet& P,
                          ParticleSet& ions,
                          TrialWaveFunction& psi,

--- a/src/QMCHamiltonians/CoulombPotential.cpp
+++ b/src/QMCHamiltonians/CoulombPotential.cpp
@@ -1,0 +1,506 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2025 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
+//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//                    Peter W. Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "CoulombPotential.h"
+#include <numeric>
+#include <Resource.h>
+
+namespace qmcplusplus
+{
+using WP       = WalkerProperties::Indexes;
+using Return_t = CoulombPotential::Return_t;
+
+struct CoulombPotential::CoulombPotentialMultiWalkerResource : public Resource
+{
+  CoulombPotentialMultiWalkerResource() : Resource("CoulombPotential") {}
+
+  std::unique_ptr<Resource> makeClone() const override
+  {
+    return std::make_unique<CoulombPotentialMultiWalkerResource>(*this);
+  }
+
+  /// a crowds worth of per particle local ecp potential values
+  Vector<RealType> va_samples;
+  Vector<RealType> vb_samples;
+};
+
+/** Hamiltonian operator for simple particle particle coulomb interaction.
+ *
+ *  This is more of a problem than you might thing because A can be either electron or ion for AA.
+ *  A is ion and B is elec for AB interactions
+ *
+ *  Because ion (static particles) and elec (dynamic or target particles) aren't on equal footing.
+ *  ion's are almost entirely state, elec are passed as arguements.
+ *
+ *  So this class tries to generically support any particle particle coulomb interaction but consistency isn't
+ *  really possible.
+ */
+CoulombPotential::CoulombPotential(ParticleSet& s, bool active, bool computeForces, bool copy)
+    : ForceBase(s, s),
+      Pa(s),
+      Pb(s),
+      myTableIndex(s.addTable(s, DTModes::NEED_FULL_TABLE_ON_HOST_AFTER_DONEPBYP)),
+      is_AA(true),
+      is_active(active),
+      ComputeForces(computeForces)
+{
+  setEnergyDomain(POTENTIAL);
+  twoBodyQuantumDomain(s, s);
+  nCenters = s.getTotalNum();
+  prefix_  = "F_AA";
+
+  if (!is_active) //precompute the value
+  {
+    if (!copy)
+      s.update();
+    value_ = evaluateAA(s.getDistTableAA(myTableIndex), s.Z.first_address());
+    if (ComputeForces)
+      evaluateAAForces(s.getDistTableAA(myTableIndex), s.Z.first_address());
+  }
+}
+
+/** constructor for AB
+   * @param s source particleset
+   * @param t target particleset
+   * @param active if true, new Value is computed whenver evaluate is used.
+   * @param ComputeForces is not implemented for AB
+   */
+CoulombPotential::CoulombPotential(ParticleSet& s, ParticleSet& t, bool active, bool copy)
+    : ForceBase(s, t), Pa(s), Pb(t), myTableIndex(t.addTable(s)), is_AA(false), is_active(active), ComputeForces(false)
+{
+  setEnergyDomain(POTENTIAL);
+  twoBodyQuantumDomain(s, t);
+  nCenters = s.getTotalNum();
+}
+
+std::string CoulombPotential::getClassName() const { return "CoulombPotential"; }
+
+#if !defined(REMOVE_TRACEMANAGER)
+void CoulombPotential::contributeParticleQuantities() { request_.contribute_array(name_); }
+
+void CoulombPotential::checkoutParticleQuantities(TraceManager& tm)
+{
+  streaming_particles_ = request_.streaming_array(name_);
+  if (streaming_particles_)
+  {
+    Va_sample = tm.checkout_real<1>(name_, Pa);
+    if (!is_AA)
+    {
+      Vb_sample = tm.checkout_real<1>(name_, Pb);
+    }
+    else if (!is_active)
+      evaluate_spAA(Pa.getDistTableAA(myTableIndex), Pa.Z.first_address());
+  }
+}
+
+void CoulombPotential::deleteParticleQuantities()
+{
+  if (streaming_particles_)
+  {
+    delete Va_sample;
+    if (!is_AA)
+      delete Vb_sample;
+  }
+}
+#endif
+
+void CoulombPotential::addObservables(PropertySetType& plist, BufferType& collectables)
+{
+  addValue(plist);
+  if (ComputeForces)
+    addObservablesF(plist);
+}
+
+/** evaluate AA-type interactions */
+Return_t CoulombPotential::evaluateAA(const DistanceTableAA& d, const ParticleScalar* restrict Z)
+{
+  Return_t res = 0.0;
+#if !defined(REMOVE_TRACEMANAGER)
+  if (streaming_particles_)
+    res = evaluate_spAA(d, Z);
+  else
+#endif
+    for (size_t iat = 1; iat < nCenters; ++iat)
+    {
+      const auto& dist = d.getDistRow(iat);
+      Return_t q       = Z[iat];
+      for (size_t j = 0; j < iat; ++j)
+        res += q * Z[j] / dist[j];
+    }
+  return res;
+}
+
+
+/** evaluate AA-type forces */
+void CoulombPotential::evaluateAAForces(const DistanceTableAA& d, const ParticleScalar* restrict Z)
+{
+  forces_ = 0.0;
+  for (size_t iat = 1; iat < nCenters; ++iat)
+  {
+    const auto& dist  = d.getDistRow(iat);
+    const auto& displ = d.getDisplRow(iat);
+    Return_t q        = Z[iat];
+    for (size_t j = 0; j < iat; ++j)
+    {
+      forces_[iat] += -q * Z[j] * displ[j] / (dist[j] * dist[j] * dist[j]);
+      forces_[j] -= -q * Z[j] * displ[j] / (dist[j] * dist[j] * dist[j]);
+    }
+  }
+}
+
+
+/** JNKIM: Need to check the precision */
+Return_t CoulombPotential::evaluateAB(const DistanceTableAB& d,
+                                      const ParticleScalar* restrict Za,
+                                      const ParticleScalar* restrict Zb)
+{
+  constexpr Return_t czero(0);
+  Return_t res = czero;
+#if !defined(REMOVE_TRACEMANAGER)
+  if (streaming_particles_)
+    res = evaluate_spAB(d, Za, Zb);
+  else
+#endif
+  {
+    const size_t nTargets = d.targets();
+    for (size_t b = 0; b < nTargets; ++b)
+    {
+      const auto& dist = d.getDistRow(b);
+      Return_t e       = czero;
+      for (size_t a = 0; a < nCenters; ++a)
+        e += Za[a] / dist[a];
+      res += e * Zb[b];
+    }
+  }
+  return res;
+}
+
+Return_t CoulombPotential::evaluate_spAA(const DistanceTableAA& d,
+                                         const ParticleScalar* restrict Z,
+                                         Vector<RealType>& va_sample,
+                                         const std::vector<ListenerVector<RealType>>& listeners)
+{
+  Return_t res = 0.0;
+  Return_t pairpot;
+  int num_centers = d.centers();
+  std::fill(va_sample.begin(), va_sample.end(), 0.0);
+
+  for (size_t iat = 1; iat < num_centers; ++iat)
+  {
+    const auto& dist = d.getDistRow(iat);
+    Return_t q       = Z[iat];
+    for (size_t j = 0; j < iat; ++j)
+    {
+      pairpot = 0.5 * q * Z[j] / dist[j];
+      va_sample[iat] += pairpot;
+      va_sample[j] += pairpot;
+      res += pairpot;
+    }
+  }
+  res *= 2.0;
+  return res;
+}
+
+Return_t CoulombPotential::evaluate_spAB(const DistanceTableAB& d,
+                                         const ParticleScalar* restrict Za,
+                                         const ParticleScalar* restrict Zb,
+                                         Vector<RealType>& va_sample,
+                                         Vector<RealType>& vb_sample,
+                                         const std::vector<ListenerVector<RealType>>& listeners,
+                                         const std::vector<ListenerVector<RealType>>& ion_listeners)
+{
+  Return_t res = 0.0;
+  Return_t pairpot;
+  std::fill(va_sample.begin(), va_sample.end(), 0.0);
+  std::fill(vb_sample.begin(), vb_sample.end(), 0.0);
+  const size_t num_targets = d.targets();
+  const int num_sources    = d.sources();
+  for (size_t b = 0; b < num_targets; ++b)
+  {
+    const auto& dist = d.getDistRow(b);
+    Return_t z       = 0.5 * Zb[b];
+    for (size_t a = 0; a < num_sources; ++a)
+    {
+      pairpot = z * Za[a] / dist[a];
+      vb_sample[b] += pairpot;
+      va_sample[a] += pairpot;
+      res += pairpot;
+    }
+  }
+  res *= 2.0;
+  return res;
+}
+
+#if !defined(REMOVE_TRACEMANAGER)
+/** evaluate AA-type interactions */
+Return_t CoulombPotential::evaluate_spAA(const DistanceTableAA& d, const ParticleScalar* restrict Z)
+{
+  Return_t res = 0.0;
+  Return_t pairpot;
+  Array<RealType, 1>& Va_samp = *Va_sample;
+  Va_samp                     = 0.0;
+  for (size_t iat = 1; iat < nCenters; ++iat)
+  {
+    const auto& dist = d.getDistRow(iat);
+    Return_t q       = Z[iat];
+    for (size_t j = 0; j < iat; ++j)
+    {
+      pairpot = 0.5 * q * Z[j] / dist[j];
+      Va_samp(iat) += pairpot;
+      Va_samp(j) += pairpot;
+      res += pairpot;
+    }
+  }
+  res *= 2.0;
+#if defined(TRACE_CHECK)
+  auto sptmp           = streaming_particles_;
+  streaming_particles_ = false;
+  Return_t Vnow        = res;
+  Return_t Vsum        = Va_samp.sum();
+  Return_t Vorig       = evaluateAA(d, Z);
+  if (std::abs(Vorig - Vnow) > TraceManager::trace_tol)
+  {
+    app_log() << "versiontest: CoulombPotential::evaluateAA()" << std::endl;
+    app_log() << "versiontest:   orig:" << Vorig << std::endl;
+    app_log() << "versiontest:    mod:" << Vnow << std::endl;
+    APP_ABORT("Trace check failed");
+  }
+  if (std::abs(Vsum - Vnow) > TraceManager::trace_tol)
+  {
+    app_log() << "accumtest: CoulombPotential::evaluateAA()" << std::endl;
+    app_log() << "accumtest:   tot:" << Vnow << std::endl;
+    app_log() << "accumtest:   sum:" << Vsum << std::endl;
+    APP_ABORT("Trace check failed");
+  }
+  streaming_particles_ = sptmp;
+#endif
+  return res;
+}
+
+
+Return_t CoulombPotential::evaluate_spAB(const DistanceTableAB& d,
+                                         const ParticleScalar* restrict Za,
+                                         const ParticleScalar* restrict Zb)
+{
+  Return_t res = 0.0;
+  Return_t pairpot;
+  Array<RealType, 1>& Va_samp = *Va_sample;
+  Array<RealType, 1>& Vb_samp = *Vb_sample;
+  Va_samp                     = 0.0;
+  Vb_samp                     = 0.0;
+  const size_t nTargets       = d.targets();
+  for (size_t b = 0; b < nTargets; ++b)
+  {
+    const auto& dist = d.getDistRow(b);
+    Return_t z       = 0.5 * Zb[b];
+    for (size_t a = 0; a < nCenters; ++a)
+    {
+      pairpot = z * Za[a] / dist[a];
+      Va_samp(a) += pairpot;
+      Vb_samp(b) += pairpot;
+      res += pairpot;
+    }
+  }
+  res *= 2.0;
+
+#if defined(TRACE_CHECK)
+  auto sptmp           = streaming_particles_;
+  streaming_particles_ = false;
+  Return_t Vnow        = res;
+  Return_t Vasum       = Va_samp.sum();
+  Return_t Vbsum       = Vb_samp.sum();
+  Return_t Vsum        = Vasum + Vbsum;
+  Return_t Vorig       = evaluateAB(d, Za, Zb);
+  if (std::abs(Vorig - Vnow) > TraceManager::trace_tol)
+  {
+    app_log() << "versiontest: CoulombPotential::evaluateAB()" << std::endl;
+    app_log() << "versiontest:   orig:" << Vorig << std::endl;
+    app_log() << "versiontest:    mod:" << Vnow << std::endl;
+    APP_ABORT("Trace check failed");
+  }
+  if (std::abs(Vsum - Vnow) > TraceManager::trace_tol)
+  {
+    app_log() << "accumtest: CoulombPotential::evaluateAB()" << std::endl;
+    app_log() << "accumtest:   tot:" << Vnow << std::endl;
+    app_log() << "accumtest:   sum:" << Vsum << std::endl;
+    APP_ABORT("Trace check failed");
+  }
+  if (std::abs(Vasum - Vbsum) > TraceManager::trace_tol)
+  {
+    app_log() << "sharetest: CoulombPotential::evaluateAB()" << std::endl;
+    app_log() << "sharetest:   a share:" << Vasum << std::endl;
+    app_log() << "sharetest:   b share:" << Vbsum << std::endl;
+    APP_ABORT("Trace check failed");
+  }
+  streaming_particles_ = sptmp;
+#endif
+  return res;
+}
+#endif
+
+
+void CoulombPotential::resetTargetParticleSet(ParticleSet& P)
+{
+  //myTableIndex is the same
+}
+
+void CoulombPotential::updateSource(ParticleSet& s)
+{
+  if (is_AA)
+  {
+    value_ = evaluateAA(s.getDistTableAA(myTableIndex), s.Z.first_address());
+  }
+}
+
+Return_t CoulombPotential::evaluate(ParticleSet& P)
+{
+  if (is_active)
+  {
+    if (is_AA)
+      value_ = evaluateAA(P.getDistTableAA(myTableIndex), P.Z.first_address());
+    else
+      value_ = evaluateAB(P.getDistTableAB(myTableIndex), Pa.Z.first_address(), P.Z.first_address());
+  }
+  return value_;
+}
+
+void CoulombPotential::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
+                                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                              const RefVectorWithLeader<ParticleSet>& p_list,
+                                              const std::vector<ListenerVector<RealType>>& listeners,
+                                              const std::vector<ListenerVector<RealType>>& ion_listeners) const
+{
+  auto& o_leader = o_list.getCastedLeader<CoulombPotential>();
+  auto& p_leader = p_list.getLeader();
+  assert(this == &o_list.getLeader());
+  auto& mw_res                = o_leader.mw_res_handle_.getResource();
+  Vector<RealType>& va_sample = mw_res.va_samples;
+  Vector<RealType>& vb_sample = mw_res.vb_samples;
+  auto is_AA                  = o_leader.is_AA;
+  auto is_active              = o_leader.is_active;
+  auto myTableIndex           = o_leader.myTableIndex;
+  auto nCenters               = o_leader.nCenters;
+
+  auto evaluate_walker = [&va_sample, &vb_sample, myTableIndex,
+                          is_AA, is_active](int walker_index, const ParticleSet& pset, const ParticleSet& pset_ions,
+                                 const std::vector<ListenerVector<RealType>>& listeners,
+                                 const std::vector<ListenerVector<RealType>>& ion_listeners) -> Return_t {
+    Return_t value = 0;
+    if (is_AA)
+      if (is_active)
+	value =
+          evaluate_spAA(pset.getDistTableAA(myTableIndex), pset.Z.first_address(), va_sample, listeners);
+      else
+	value =
+          evaluate_spAA(pset.getDistTableAA(myTableIndex), pset.Z.first_address(), va_sample, ion_listeners);
+    else
+      value = evaluate_spAB(pset.getDistTableAB(myTableIndex), pset_ions.Z.first_address(), pset.Z.first_address(), va_sample, vb_sample, listeners, ion_listeners);
+    return value;
+  };
+
+  auto name                   = o_leader.name_;
+  for (int iw = 0; iw < o_list.size(); ++iw)
+  {
+    auto& coulomb_pot = o_list.getCastedElement<CoulombPotential>(iw);
+    if (coulomb_pot.is_active)
+    {
+      if (is_AA)
+        evaluate_walker(iw, p_list[iw], coulomb_pot.Pa, listeners, ion_listeners);
+      else
+        evaluate_walker(iw, p_list[iw], coulomb_pot.Pa, listeners, ion_listeners);
+    }
+    if (coulomb_pot.is_active)
+    {
+      if (is_AA)
+        for (const ListenerVector<RealType>& listener : listeners)
+          listener.report(iw, name, va_sample);
+      else
+        for (const ListenerVector<RealType>& listener : listeners)
+          listener.report(iw, name, vb_sample);
+      if (!is_AA)
+        for (const ListenerVector<RealType>& ion_listener : ion_listeners)
+          ion_listener.report(iw, name, va_sample);
+    }
+    else // its my belief that the only case here is ion AA.
+      for (const ListenerVector<RealType>& ion_listener : ion_listeners)
+        ion_listener.report(iw, name, va_sample);
+  }
+}
+
+void CoulombPotential::mw_evaluatePerParticleWithToperator(
+    const RefVectorWithLeader<OperatorBase>& o_list,
+    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+    const RefVectorWithLeader<ParticleSet>& p_list,
+    const std::vector<ListenerVector<RealType>>& listeners,
+    const std::vector<ListenerVector<RealType>>& ion_listeners) const
+{
+  mw_evaluatePerParticle(o_list, wf_list, p_list, listeners, ion_listeners);
+}
+
+void CoulombPotential::evaluateIonDerivs(ParticleSet& P,
+                                         ParticleSet& ions,
+                                         TrialWaveFunction& psi,
+                                         ParticleSet::ParticlePos& hf_terms,
+                                         ParticleSet::ParticlePos& pulay_terms)
+{
+  if (!is_active)
+    hf_terms -= forces_;
+  // No Pulay here
+}
+
+bool CoulombPotential::put(xmlNodePtr cur) { return true; }
+
+bool CoulombPotential::get(std::ostream& os) const
+{
+  if (myTableIndex)
+    os << "CoulombAB source=" << Pa.getName() << std::endl;
+  else
+    os << "CoulombAA source/target " << Pa.getName() << std::endl;
+  return true;
+}
+
+void CoulombPotential::setObservables(PropertySetType& plist)
+{
+  OperatorBase::setObservables(plist);
+  if (ComputeForces)
+    setObservablesF(plist);
+}
+
+void CoulombPotential::setParticlePropertyList(PropertySetType& plist, int offset)
+{
+  OperatorBase::setParticlePropertyList(plist, offset);
+  if (ComputeForces)
+    setParticleSetF(plist, offset);
+}
+
+
+std::unique_ptr<OperatorBase> CoulombPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+{
+  if (is_AA)
+  {
+    if (is_active)
+      return std::make_unique<CoulombPotential>(qp, true, ComputeForces);
+    else
+      // Ye Luo April 16th, 2015
+      // avoid recomputing ion-ion DistanceTable when reusing ParticleSet
+      return std::make_unique<CoulombPotential>(Pa, false, ComputeForces, true);
+  }
+  else
+    return std::make_unique<CoulombPotential>(Pa, qp, true);
+}
+
+} // namespace qmcplusplus

--- a/src/QMCHamiltonians/CoulombPotential.cpp
+++ b/src/QMCHamiltonians/CoulombPotential.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2025 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2025 QMCPACK developers.
 //
 // File developed by: Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -2,13 +2,14 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2025 QMCPACK developers.
 //
 // File developed by: Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
 //                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//                    Peter W. Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -16,12 +17,11 @@
 
 #ifndef QMCPLUSPLUS_COULOMBPOTENTIAL_H
 #define QMCPLUSPLUS_COULOMBPOTENTIAL_H
-#include "ParticleSet.h"
-#include "DistanceTable.h"
-#include "MCWalkerConfiguration.h"
-#include "QMCHamiltonians/ForceBase.h"
-#include "QMCHamiltonians/OperatorBase.h"
-#include "QMCHamiltonians/OperatorBase.h"
+#include <ParticleSet.h>
+#include <DistanceTable.h>
+#include <MCWalkerConfiguration.h>
+#include "ForceBase.h"
+#include "OperatorBase.h"
 #include <numeric>
 
 namespace qmcplusplus
@@ -33,9 +33,13 @@ using WP = WalkerProperties::Indexes;
  *
  * Hamiltonian operator for the Coulomb interaction for both AA and AB type for open systems.
  */
-template<typename T>
-struct CoulombPotential : public OperatorBase, public ForceBase
+
+class CoulombPotential : public OperatorBase, public ForceBase
 {
+public:
+  struct CoulombPotentialMultiWalkerResource;
+
+private:
   ///source particle set
   ParticleSet& Pa;
   ///target particle set
@@ -57,34 +61,17 @@ struct CoulombPotential : public OperatorBase, public ForceBase
   /// Flag for whether to compute forces or not
   bool ComputeForces;
 
+public:
   /** constructor for AA
    * @param s source particleset
    * @param active if true, new Value is computed whenver evaluate is used.
    * @param computeForces if true, computes forces between inactive species
+   *
+   * in practice active is true for electrons and false for ions.
+   * we have no choice but to use this later to determine which listeners AA Coulomb potentials should
+   * publish to.
    */
-  inline CoulombPotential(ParticleSet& s, bool active, bool computeForces, bool copy = false)
-      : ForceBase(s, s),
-        Pa(s),
-        Pb(s),
-        myTableIndex(s.addTable(s, DTModes::NEED_FULL_TABLE_ON_HOST_AFTER_DONEPBYP)),
-        is_AA(true),
-        is_active(active),
-        ComputeForces(computeForces)
-  {
-    setEnergyDomain(POTENTIAL);
-    twoBodyQuantumDomain(s, s);
-    nCenters = s.getTotalNum();
-    prefix_  = "F_AA";
-
-    if (!is_active) //precompute the value
-    {
-      if (!copy)
-        s.update();
-      value_ = evaluateAA(s.getDistTableAA(myTableIndex), s.Z.first_address());
-      if (ComputeForces)
-        evaluateAAForces(s.getDistTableAA(myTableIndex), s.Z.first_address());
-    }
-  }
+  CoulombPotential(ParticleSet& s, bool active, bool computeForces, bool copy = false);
 
   /** constructor for AB
    * @param s source particleset
@@ -92,305 +79,80 @@ struct CoulombPotential : public OperatorBase, public ForceBase
    * @param active if true, new Value is computed whenver evaluate is used.
    * @param ComputeForces is not implemented for AB
    */
-  inline CoulombPotential(ParticleSet& s, ParticleSet& t, bool active, bool copy = false)
-      : ForceBase(s, t),
-        Pa(s),
-        Pb(t),
-        myTableIndex(t.addTable(s)),
-        is_AA(false),
-        is_active(active),
-        ComputeForces(false)
-  {
-    setEnergyDomain(POTENTIAL);
-    twoBodyQuantumDomain(s, t);
-    nCenters = s.getTotalNum();
-  }
+  CoulombPotential(ParticleSet& s, ParticleSet& t, bool active, bool copy = false);
 
-  std::string getClassName() const override { return "CoulombPotential"; }
+  std::string getClassName() const override;
 
 #if !defined(REMOVE_TRACEMANAGER)
-  void contributeParticleQuantities() override { request_.contribute_array(name_); }
-
-  void checkoutParticleQuantities(TraceManager& tm) override
-  {
-    streaming_particles_ = request_.streaming_array(name_);
-    if (streaming_particles_)
-    {
-      Va_sample = tm.checkout_real<1>(name_, Pa);
-      if (!is_AA)
-      {
-        Vb_sample = tm.checkout_real<1>(name_, Pb);
-      }
-      else if (!is_active)
-        evaluate_spAA(Pa.getDistTableAA(myTableIndex), Pa.Z.first_address());
-    }
-  }
-
-  void deleteParticleQuantities() override
-  {
-    if (streaming_particles_)
-    {
-      delete Va_sample;
-      if (!is_AA)
-        delete Vb_sample;
-    }
-  }
+  void contributeParticleQuantities() override;
+  void checkoutParticleQuantities(TraceManager& tm) override;
+  void deleteParticleQuantities() override;
 #endif
 
-  inline void addObservables(PropertySetType& plist, BufferType& collectables) override
-  {
-    addValue(plist);
-    if (ComputeForces)
-      addObservablesF(plist);
-  }
+  void addObservables(PropertySetType& plist, BufferType& collectables) override;
 
   /** evaluate AA-type interactions */
-  inline T evaluateAA(const DistanceTableAA& d, const ParticleScalar* restrict Z)
-  {
-    T res = 0.0;
-#if !defined(REMOVE_TRACEMANAGER)
-    if (streaming_particles_)
-      res = evaluate_spAA(d, Z);
-    else
-#endif
-      for (size_t iat = 1; iat < nCenters; ++iat)
-      {
-        const auto& dist = d.getDistRow(iat);
-        T q              = Z[iat];
-        for (size_t j = 0; j < iat; ++j)
-          res += q * Z[j] / dist[j];
-      }
-    return res;
-  }
-
+  Return_t evaluateAA(const DistanceTableAA& d, const ParticleScalar* restrict Z);
 
   /** evaluate AA-type forces */
-  inline void evaluateAAForces(const DistanceTableAA& d, const ParticleScalar* restrict Z)
-  {
-    forces_ = 0.0;
-    for (size_t iat = 1; iat < nCenters; ++iat)
-    {
-      const auto& dist  = d.getDistRow(iat);
-      const auto& displ = d.getDisplRow(iat);
-      T q               = Z[iat];
-      for (size_t j = 0; j < iat; ++j)
-      {
-        forces_[iat] += -q * Z[j] * displ[j] / (dist[j] * dist[j] * dist[j]);
-        forces_[j] -= -q * Z[j] * displ[j] / (dist[j] * dist[j] * dist[j]);
-      }
-    }
-  }
-
+  void evaluateAAForces(const DistanceTableAA& d, const ParticleScalar* restrict Z);
 
   /** JNKIM: Need to check the precision */
-  inline T evaluateAB(const DistanceTableAB& d, const ParticleScalar* restrict Za, const ParticleScalar* restrict Zb)
-  {
-    constexpr T czero(0);
-    T res = czero;
-#if !defined(REMOVE_TRACEMANAGER)
-    if (streaming_particles_)
-      res = evaluate_spAB(d, Za, Zb);
-    else
-#endif
-    {
-      const size_t nTargets = d.targets();
-      for (size_t b = 0; b < nTargets; ++b)
-      {
-        const auto& dist = d.getDistRow(b);
-        T e              = czero;
-        for (size_t a = 0; a < nCenters; ++a)
-          e += Za[a] / dist[a];
-        res += e * Zb[b];
-      }
-    }
-    return res;
-  }
+  Return_t evaluateAB(const DistanceTableAB& d, const ParticleScalar* restrict Za, const ParticleScalar* restrict Zb);
 
+  static Return_t evaluate_spAA(const DistanceTableAA& d,
+                                const ParticleScalar* restrict Z, Vector<RealType>& ve_samples,
+                                const std::vector<ListenerVector<RealType>>& listeners);
+  static Return_t evaluate_spAB(const DistanceTableAB& d,
+                                const ParticleScalar* restrict Za,
+                                const ParticleScalar* restrict Zb,
+				Vector<RealType>& ve_samples,
+				Vector<RealType>& vi_samples,
+				const std::vector<ListenerVector<RealType>>& listeners,
+				const std::vector<ListenerVector<RealType>>& ion_listeners);
 
 #if !defined(REMOVE_TRACEMANAGER)
   /** evaluate AA-type interactions */
-  inline T evaluate_spAA(const DistanceTableAA& d, const ParticleScalar* restrict Z)
-  {
-    T res = 0.0;
-    T pairpot;
-    Array<RealType, 1>& Va_samp = *Va_sample;
-    Va_samp                     = 0.0;
-    for (size_t iat = 1; iat < nCenters; ++iat)
-    {
-      const auto& dist = d.getDistRow(iat);
-      T q              = Z[iat];
-      for (size_t j = 0; j < iat; ++j)
-      {
-        pairpot = 0.5 * q * Z[j] / dist[j];
-        Va_samp(iat) += pairpot;
-        Va_samp(j) += pairpot;
-        res += pairpot;
-      }
-    }
-    res *= 2.0;
-#if defined(TRACE_CHECK)
-    auto sptmp           = streaming_particles_;
-    streaming_particles_ = false;
-    T Vnow               = res;
-    T Vsum               = Va_samp.sum();
-    T Vorig              = evaluateAA(d, Z);
-    if (std::abs(Vorig - Vnow) > TraceManager::trace_tol)
-    {
-      app_log() << "versiontest: CoulombPotential::evaluateAA()" << std::endl;
-      app_log() << "versiontest:   orig:" << Vorig << std::endl;
-      app_log() << "versiontest:    mod:" << Vnow << std::endl;
-      APP_ABORT("Trace check failed");
-    }
-    if (std::abs(Vsum - Vnow) > TraceManager::trace_tol)
-    {
-      app_log() << "accumtest: CoulombPotential::evaluateAA()" << std::endl;
-      app_log() << "accumtest:   tot:" << Vnow << std::endl;
-      app_log() << "accumtest:   sum:" << Vsum << std::endl;
-      APP_ABORT("Trace check failed");
-    }
-    streaming_particles_ = sptmp;
+  Return_t evaluate_spAA(const DistanceTableAA& d, const ParticleScalar* restrict Z);
+  Return_t evaluate_spAB(const DistanceTableAB& d,
+                         const ParticleScalar* restrict Za,
+                         const ParticleScalar* restrict Zb);
 #endif
-    return res;
-  }
+  void resetTargetParticleSet(ParticleSet& P) override;
+  ~CoulombPotential() override {};
 
+  void updateSource(ParticleSet& s) override;
+  Return_t evaluate(ParticleSet& P) override;
 
-  inline T evaluate_spAB(const DistanceTableAB& d, const ParticleScalar* restrict Za, const ParticleScalar* restrict Zb)
-  {
-    T res = 0.0;
-    T pairpot;
-    Array<RealType, 1>& Va_samp = *Va_sample;
-    Array<RealType, 1>& Vb_samp = *Vb_sample;
-    Va_samp                     = 0.0;
-    Vb_samp                     = 0.0;
-    const size_t nTargets       = d.targets();
-    for (size_t b = 0; b < nTargets; ++b)
-    {
-      const auto& dist = d.getDistRow(b);
-      T z              = 0.5 * Zb[b];
-      for (size_t a = 0; a < nCenters; ++a)
-      {
-        pairpot = z * Za[a] / dist[a];
-        Va_samp(a) += pairpot;
-        Vb_samp(b) += pairpot;
-        res += pairpot;
-      }
-    }
-    res *= 2.0;
+  void mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
+                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                              const RefVectorWithLeader<ParticleSet>& p_list,
+                              const std::vector<ListenerVector<RealType>>& listeners,
+                              const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
-#if defined(TRACE_CHECK)
-    auto sptmp           = streaming_particles_;
-    streaming_particles_ = false;
-    T Vnow               = res;
-    T Vasum              = Va_samp.sum();
-    T Vbsum              = Vb_samp.sum();
-    T Vsum               = Vasum + Vbsum;
-    T Vorig              = evaluateAB(d, Za, Zb);
-    if (std::abs(Vorig - Vnow) > TraceManager::trace_tol)
-    {
-      app_log() << "versiontest: CoulombPotential::evaluateAB()" << std::endl;
-      app_log() << "versiontest:   orig:" << Vorig << std::endl;
-      app_log() << "versiontest:    mod:" << Vnow << std::endl;
-      APP_ABORT("Trace check failed");
-    }
-    if (std::abs(Vsum - Vnow) > TraceManager::trace_tol)
-    {
-      app_log() << "accumtest: CoulombPotential::evaluateAB()" << std::endl;
-      app_log() << "accumtest:   tot:" << Vnow << std::endl;
-      app_log() << "accumtest:   sum:" << Vsum << std::endl;
-      APP_ABORT("Trace check failed");
-    }
-    if (std::abs(Vasum - Vbsum) > TraceManager::trace_tol)
-    {
-      app_log() << "sharetest: CoulombPotential::evaluateAB()" << std::endl;
-      app_log() << "sharetest:   a share:" << Vasum << std::endl;
-      app_log() << "sharetest:   b share:" << Vbsum << std::endl;
-      APP_ABORT("Trace check failed");
-    }
-    streaming_particles_ = sptmp;
-#endif
-    return res;
-  }
-#endif
+  void mw_evaluatePerParticleWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                           const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                           const RefVectorWithLeader<ParticleSet>& p_list,
+                                           const std::vector<ListenerVector<RealType>>& listeners,
+                                           const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
+  void evaluateIonDerivs(ParticleSet& P,
+                         ParticleSet& ions,
+                         TrialWaveFunction& psi,
+                         ParticleSet::ParticlePos& hf_terms,
+                         ParticleSet::ParticlePos& pulay_terms) override;
 
-  void resetTargetParticleSet(ParticleSet& P) override
-  {
-    //myTableIndex is the same
-  }
+  bool put(xmlNodePtr cur) override;
 
-  ~CoulombPotential() override {}
+  bool get(std::ostream& os) const override;
 
-  void updateSource(ParticleSet& s) override
-  {
-    if (is_AA)
-    {
-      value_ = evaluateAA(s.getDistTableAA(myTableIndex), s.Z.first_address());
-    }
-  }
+  void setObservables(PropertySetType& plist) override;
 
-  inline Return_t evaluate(ParticleSet& P) override
-  {
-    if (is_active)
-    {
-      if (is_AA)
-        value_ = evaluateAA(P.getDistTableAA(myTableIndex), P.Z.first_address());
-      else
-        value_ = evaluateAB(P.getDistTableAB(myTableIndex), Pa.Z.first_address(), P.Z.first_address());
-    }
-    return value_;
-  }
+  void setParticlePropertyList(PropertySetType& plist, int offset) override;
 
-  inline void evaluateIonDerivs(ParticleSet& P,
-                                ParticleSet& ions,
-                                TrialWaveFunction& psi,
-                                ParticleSet::ParticlePos& hf_terms,
-                                ParticleSet::ParticlePos& pulay_terms) override
-  {
-    if (!is_active)
-      hf_terms -= forces_;
-    // No Pulay here
-  }
-
-  bool put(xmlNodePtr cur) override { return true; }
-
-  bool get(std::ostream& os) const override
-  {
-    if (myTableIndex)
-      os << "CoulombAB source=" << Pa.getName() << std::endl;
-    else
-      os << "CoulombAA source/target " << Pa.getName() << std::endl;
-    return true;
-  }
-
-  void setObservables(PropertySetType& plist) override
-  {
-    OperatorBase::setObservables(plist);
-    if (ComputeForces)
-      setObservablesF(plist);
-  }
-
-  void setParticlePropertyList(PropertySetType& plist, int offset) override
-  {
-    OperatorBase::setParticlePropertyList(plist, offset);
-    if (ComputeForces)
-      setParticleSetF(plist, offset);
-  }
-
-
-  std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) override
-  {
-    if (is_AA)
-    {
-      if (is_active)
-        return std::make_unique<CoulombPotential>(qp, true, ComputeForces);
-      else
-        // Ye Luo April 16th, 2015
-        // avoid recomputing ion-ion DistanceTable when reusing ParticleSet
-        return std::make_unique<CoulombPotential>(Pa, false, ComputeForces, true);
-    }
-    else
-      return std::make_unique<CoulombPotential>(Pa, qp, true);
-  }
+  std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
+private:
+  ResourceHandle<CoulombPotentialMultiWalkerResource> mw_res_handle_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -22,7 +22,6 @@
 #include <MCWalkerConfiguration.h>
 #include "ForceBase.h"
 #include "OperatorBase.h"
-#include <numeric>
 
 namespace qmcplusplus
 {

--- a/src/QMCHamiltonians/CoulombPotentialFactory.cpp
+++ b/src/QMCHamiltonians/CoulombPotentialFactory.cpp
@@ -142,7 +142,7 @@ void HamiltonianFactory::addCoulombPotential(xmlNodePtr cur)
     }
     else
     {
-      targetH->addOperator(std::make_unique<CoulombPotential<Return_t>>(*ptclA, quantum, doForces), title, physical);
+      targetH->addOperator(std::make_unique<CoulombPotential>(*ptclA, quantum, doForces), title, physical);
     }
   }
   else //X-e type, for X=some other source
@@ -150,7 +150,7 @@ void HamiltonianFactory::addCoulombPotential(xmlNodePtr cur)
     if (applyPBC)
       targetH->addOperator(std::make_unique<CoulombPBCAB>(*ptclA, targetPtcl), title);
     else
-      targetH->addOperator(std::make_unique<CoulombPotential<Return_t>>(*ptclA, targetPtcl, true), title);
+      targetH->addOperator(std::make_unique<CoulombPotential>(*ptclA, targetPtcl, true), title);
   }
 }
 

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -2,25 +2,42 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2024 QMCPACK developers.
 //
 // File developed by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
 //                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//                    Peter W. Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#include "Particle/ParticleSet.h"
-#include "Particle/DistanceTable.h"
-#include "QMCHamiltonians/OperatorBase.h"
+#include "Listener.hpp"
+#include <ParticleSet.h>
+#include <DistanceTable.h>
+#include <ResourceCollection.h>
 #include "LocalECPotential.h"
 #include "Utilities/IteratorUtility.h"
 
 namespace qmcplusplus
 {
+
+struct LocalECPotential::LocalECPotentialMultiWalkerResource : public Resource
+{
+  LocalECPotentialMultiWalkerResource() : Resource("LocalECPotential") {}
+
+  std::unique_ptr<Resource> makeClone() const override
+  {
+    return std::make_unique<LocalECPotentialMultiWalkerResource>(*this);
+  }
+
+  /// a crowds worth of per particle local ecp potential values
+  Vector<RealType> ve_samples;
+  Vector<RealType> vi_samples;
+};
+
 LocalECPotential::LocalECPotential(const ParticleSet& ions, ParticleSet& els) : IonConfig(ions), Peln(els), Pion(ions)
 {
   setEnergyDomain(POTENTIAL);
@@ -32,6 +49,26 @@ LocalECPotential::LocalECPotential(const ParticleSet& ions, ParticleSet& els) : 
   PP.resize(NumIons, nullptr);
   Zeff.resize(NumIons, 0.0);
   gZeff.resize(ions.getSpeciesSet().getTotalNum(), 0);
+}
+
+void LocalECPotential::createResource(ResourceCollection& collection) const
+{
+  auto new_res        = std::make_unique<LocalECPotentialMultiWalkerResource>();
+  auto resource_index = collection.addResource(std::move(new_res));
+}
+
+void LocalECPotential::acquireResource(ResourceCollection& collection,
+                                       const RefVectorWithLeader<OperatorBase>& o_list) const
+{
+  auto& O_leader          = o_list.getCastedLeader<LocalECPotential>();
+  O_leader.mw_res_handle_ = collection.lendResource<LocalECPotentialMultiWalkerResource>();
+}
+
+void LocalECPotential::releaseResource(ResourceCollection& collection,
+                                       const RefVectorWithLeader<OperatorBase>& o_list) const
+{
+  auto& O_leader = o_list.getCastedLeader<LocalECPotential>();
+  collection.takebackResource(O_leader.mw_res_handle_);
 }
 
 void LocalECPotential::resetTargetParticleSet(ParticleSet& P)
@@ -103,6 +140,75 @@ LocalECPotential::Return_t LocalECPotential::evaluate(ParticleSet& P)
     }
   }
   return value_;
+}
+
+void LocalECPotential::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
+                                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                              const RefVectorWithLeader<ParticleSet>& p_list,
+                                              const std::vector<ListenerVector<RealType>>& listeners,
+                                              const std::vector<ListenerVector<RealType>>& ion_listeners) const
+{
+  auto& o_leader = o_list.getCastedLeader<LocalECPotential>();
+  auto& p_leader = p_list.getLeader();
+  assert(this == &o_list.getLeader());
+
+  auto num_electrons          = p_leader.getTotalNum();
+  auto& name                  = o_leader.name_;
+  auto& mw_res                = o_leader.mw_res_handle_.getResource();
+  Vector<RealType>& ve_sample = mw_res.ve_samples;
+  Vector<RealType>& vi_sample = mw_res.vi_samples;
+  ve_sample.resize(num_electrons);
+  vi_sample.resize(NumIons);
+  auto myTableIndex    = o_leader.myTableIndex;
+  auto NumIons         = o_leader.NumIons;
+  auto& Zeff           = o_leader.Zeff;
+  auto evaluate_walker = [name, &ve_sample, &vi_sample, myTableIndex, NumIons,
+                          Zeff](int walker_index, const ParticleSet& pset, const auto& PP,
+                                const std::vector<ListenerVector<RealType>>& listeners,
+                                const std::vector<ListenerVector<RealType>>& ion_listeners) -> Return_t {
+    const auto& d_table(pset.getDistTableAB(myTableIndex));
+    Return_t value = 0.0;
+    std::fill(ve_sample.begin(), ve_sample.end(), 0.0);
+    std::fill(vi_sample.begin(), vi_sample.end(), 0.0);
+
+    for (int iel = 0; iel < pset.getTotalNum(); ++iel)
+    {
+      const auto& dist = d_table.getDistRow(iel);
+      Return_t esum(0), pairpot;
+      for (int iat = 0; iat < NumIons; ++iat)
+        if (PP[iat] != nullptr)
+        {
+          pairpot = -0.5 * PP[iat]->splint(dist[iat]) * Zeff[iat] / dist[iat];
+          vi_sample[iat] += pairpot;
+          ve_sample[iel] += pairpot;
+          esum += pairpot;
+        }
+      value += esum;
+    }
+    value *= 2.0;
+
+    for (const ListenerVector<RealType>& listener : listeners)
+      listener.report(walker_index, name, ve_sample);
+    for (const ListenerVector<RealType>& ion_listener : ion_listeners)
+      ion_listener.report(walker_index, name, vi_sample);
+
+    return value;
+  };
+  for (int iw = 0; iw < o_list.size(); ++iw)
+  {
+    auto& local_ecp  = o_list.getCastedElement<LocalECPotential>(iw);
+    local_ecp.value_ = evaluate_walker(iw, p_list[iw], PP, listeners, ion_listeners);
+  }
+}
+
+void LocalECPotential::mw_evaluatePerParticleWithToperator(
+    const RefVectorWithLeader<OperatorBase>& o_list,
+    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+    const RefVectorWithLeader<ParticleSet>& p_list,
+    const std::vector<ListenerVector<RealType>>& listeners,
+    const std::vector<ListenerVector<RealType>>& ion_listeners) const
+{
+  mw_evaluatePerParticle(o_list, wf_list, p_list, listeners, ion_listeners);
 }
 
 void LocalECPotential::evaluateIonDerivs(ParticleSet& P,

--- a/src/QMCHamiltonians/LocalECPotential.h
+++ b/src/QMCHamiltonians/LocalECPotential.h
@@ -2,13 +2,14 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2024 QMCPACK developers.
 //
 // File developed by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //                    Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
 //                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//                    Peter W. Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -16,13 +17,13 @@
 
 #ifndef QMCPLUSPLUS_LOCALECPPOTENTIAL_H
 #define QMCPLUSPLUS_LOCALECPPOTENTIAL_H
-#include "Particle/ParticleSet.h"
-#include "QMCHamiltonians/OperatorBase.h"
+#include <ParticleSet.h>
+#include "OperatorBase.h"
 #include "Numerics/OneDimGridBase.h"
 #include "Numerics/OneDimGridFunctor.h"
 #include "Numerics/OneDimLinearSpline.h"
 #include "Numerics/OneDimCubicSpline.h"
-#include "Particle/DistanceTable.h"
+#include <DistanceTable.h>
 
 namespace qmcplusplus
 {
@@ -34,6 +35,8 @@ struct LocalECPotential : public OperatorBase
 {
   using GridType            = OneDimGridBase<RealType>;
   using RadialPotentialType = OneDimCubicSpline<RealType>;
+
+  struct LocalECPotentialMultiWalkerResource;
 
   ///reference to the ionic configuration
   const ParticleSet& IonConfig;
@@ -63,6 +66,18 @@ struct LocalECPotential : public OperatorBase
 
   LocalECPotential(const ParticleSet& ions, ParticleSet& els);
 
+  /** initialize a shared resource and hand it to a collection
+   */
+  void createResource(ResourceCollection& collection) const override;
+
+  /** acquire a shared resource from a collection
+   */
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const override;
+
+  /** return a shared resource to a collection
+   */
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const override;
+
   std::string getClassName() const override { return "LocalECPotential"; }
   void resetTargetParticleSet(ParticleSet& P) override;
 
@@ -74,6 +89,17 @@ struct LocalECPotential : public OperatorBase
 #endif
 
   Return_t evaluate(ParticleSet& P) override;
+  void mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
+                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                              const RefVectorWithLeader<ParticleSet>& p_list,
+                              const std::vector<ListenerVector<RealType>>& listeners,
+                              const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
+
+  void mw_evaluatePerParticleWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                           const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                           const RefVectorWithLeader<ParticleSet>& p_list,
+                                           const std::vector<ListenerVector<RealType>>& listeners,
+                                           const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
   void evaluateIonDerivs(ParticleSet& P,
                          ParticleSet& ions,
@@ -100,6 +126,8 @@ struct LocalECPotential : public OperatorBase
    * @param z effective charge of groupID particle
    */
   void add(int groupID, std::unique_ptr<RadialPotentialType>&& ppot, RealType z);
+private:
+  ResourceHandle<LocalECPotentialMultiWalkerResource> mw_res_handle_;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -409,12 +409,14 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
     auto& ve_samples  = O_leader.mw_res_handle_.getResource().ve_samples;
     auto& vi_samples  = O_leader.mw_res_handle_.getResource().vi_samples;
     int num_electrons = pset_leader.getTotalNum();
+    const std::string ion_listener_operator_name{O_leader.getName() + "Ion"};
     for (int iw = 0; iw < nw; ++iw)
     {
       Vector<Real> ve_sample(ve_samples.begin(iw), num_electrons);
       Vector<Real> vi_sample(vi_samples.begin(iw), O_leader.NumIons);
       for (const ListenerVector<Real>& listener : listeners->electron_values)
         listener.report(iw, O_leader.getName(), ve_sample);
+
       for (const ListenerVector<Real>& listener : listeners->ion_values)
         listener.report(iw, O_leader.getName(), vi_sample);
     }

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -352,9 +352,9 @@ TEST_CASE("Ion-ion Force", "[hamiltonian]")
   elecSpecies(massIdx, upIdx)    = 1.0;
   elec.resetGroups();
 
-  CoulombPotential<OperatorBase::Return_t> ionForce(ions, false, true);
-  CoulombPotential<OperatorBase::Return_t> elecIonForce(elec, ions, true); // Should be zero
-  CoulombPotential<OperatorBase::Return_t> elecForce(elec, true, true);    // Should be zero
+  CoulombPotential ionForce(ions, false, true);
+  CoulombPotential elecIonForce(elec, ions, true); // Should be zero
+  CoulombPotential elecForce(elec, true, true);    // Should be zero
 
   double coeff0[3] = {-0.60355339059, -0.35355339059, 0.0};
   double coeff1[3] = {0.60355339059, -0.35355339059, 0.0};


### PR DESCRIPTION
## Proposed changes

The default decay behavior for `::mw_evaluatePerParticleWithToperator` breaks any estimator needing per particle Hamiltonian values reported when tmoves were turned on.  See #5245. Here we explicity declare and define  `::mw_evaluatePerParticleWithToperator` to `::mw_evaluatePerParticle` instead of `::mw_evaluateWithToperator` for  
`CoulombPotential`, `CoulombPBCAA`, and `CoulombPBCAB` so that these energies are not omitted from the Batched EnergyDensityEstimator port.

We remove the unnecessary templating on real type from CoulombPotential and split its header into implementation and header to reduce unnecessary recompilation.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- New feature
- Code style update (formatting, renaming)
- Build related changes
- Testing changes, in this PR no significant changed. 
   Indirect testing of all new code is added with EnergyDensityEstimator unit tests in a coming PR.
- Documentation or build script changes
- Other (please describe):

### Does this introduce a breaking change?

- Yes

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
