### PR TITLE
Fix short-He_orb_rot_param_grad parameter checking.

### DIFF
--- a/tests/molecules/He_param/CMakeLists.txt
+++ b/tests/molecules/He_param/CMakeLists.txt
@@ -84,8 +84,8 @@ if(NOT QMC_MIXED_PRECISION)
 
     # Two atomic orbitals, no jastrow
 
-    list(APPEND HE_ORB_ROT_PARAM rot-spo-up_orb_rot_0000_0001 -0.218 0.01) # scalar name, value, error
-    list(APPEND HE_ORB_ROT_PARAM rot-spo-down_orb_rot_0000_0001 -0.218 0.01) # scalar name, value, error
+    list(APPEND HE_ORB_ROT_PARAM rot-spo-up_orb_rot_0000_0001_r -0.218 0.01) # scalar name, value, error
+    list(APPEND HE_ORB_ROT_PARAM rot-spo-down_orb_rot_0000_0001_r -0.218 0.01) # scalar name, value, error
 
     qmc_run_and_check_custom_scalar(
       BASE_NAME
@@ -159,7 +159,7 @@ if(NOT QMC_MIXED_PRECISION)
       SCALAR_VALUES
       HE_ORB_ROT_PARAM)
 
-    list(APPEND HE_ORB_ROT_RHF_PARAM rot-spo-up_orb_rot_0000_0001 -0.766 0.01) # scalar name, value, error
+    list(APPEND HE_ORB_ROT_RHF_PARAM rot-spo-up_orb_rot_0000_0001_r -0.766 0.01) # scalar name, value, error
     qmc_run_and_check_custom_scalar(
       BASE_NAME
       short-He_orb_rot_param_grad_rhf
@@ -180,8 +180,8 @@ if(NOT QMC_MIXED_PRECISION)
 
     # Two atomic orbitals, with jastrow
 
-    list(APPEND HE_ORB_ROT_JASTROW_PARAM rot-spo-up_orb_rot_0000_0001 0.078 0.02) # scalar name, value, error
-    list(APPEND HE_ORB_ROT_JASTROW_PARAM rot-spo-down_orb_rot_0000_0001 0.078 0.02)
+    list(APPEND HE_ORB_ROT_JASTROW_PARAM rot-spo-up_orb_rot_0000_0001_r 0.078 0.02) # scalar name, value, error
+    list(APPEND HE_ORB_ROT_JASTROW_PARAM rot-spo-down_orb_rot_0000_0001_r 0.078 0.02)
     list(APPEND HE_ORB_ROT_JASTROW_PARAM jud_b -0.106 0.013)
 
     qmc_run_and_check_custom_scalar(


### PR DESCRIPTION
## Proposed changes
Fix failure found in https://github.com/QMCPACK/qmcpack/pull/5298#issuecomment-2637259140

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
