### PR TITLE
Skip deterministic-unit_test_estimators on mac in ci

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -290,8 +290,16 @@ case "$1" in
   test)
     
     # Run only deterministic tests (reasonable for CI) by default
-    TEST_LABEL="-L deterministic"
-    
+    case "${GH_JOBNAME}" in
+      *"macOS-GCC14"*"-Real"*)
+        TEST_LABEL="-L deterministic -E deterministic-unit_test_estimators"
+        # estimator test bus error on mac only
+      ;;
+      *)  
+        TEST_LABEL="-L deterministic"
+      ;;  
+    esac  
+
     cd ${GITHUB_WORKSPACE}/../qmcpack-build
     
     # Enable oversubscription in OpenMPI


### PR DESCRIPTION
## Proposed changes

deterministic-unit_test_estimators has a 100% fail rate on mac ci

As far as I know there is no hint of either a full diagnosis or a solution; the problem is not seen elsewhere including other arm systems.

After such a long time I think the merit of having a passing CI exceeds the merit of having the mac ci fail, which results in a red check mark for every PR. If we merge this PR, I'll add a fresh issue on the mac problem.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None. Check for scripting errors.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
