### PR TITLE
Move timers after no-op early return in WalkerLog classes

### DIFF
--- a/src/QMCDrivers/WalkerLogCollector.cpp
+++ b/src/QMCDrivers/WalkerLogCollector.cpp
@@ -47,9 +47,11 @@ void WalkerLogCollector::init()
 
 void WalkerLogCollector::startBlock()
 {
-  ScopedTimer timer(walker_log_collector_timers_[Timer::START]);
   if (!state_.logs_active)
     return; // no-op for driver if logs are inactive
+
+  ScopedTimer timer(walker_log_collector_timers_[Timer::START]);
+
   if (state_.verbose)
     app_log() << "WalkerLogCollector::startBlock " << std::endl;
   resetBuffers(); // resize buffers to zero rows
@@ -62,10 +64,10 @@ void WalkerLogCollector::collect(const MCPWalker& walker,
                                  const QMCHamiltonian& ham,
                                  int step)
 {
-  ScopedTimer timer(walker_log_collector_timers_[Timer::COLLECT]);
-
   if (!state_.logs_active)
     return; // no-op for driver if logs are inactive
+
+  ScopedTimer timer(walker_log_collector_timers_[Timer::COLLECT]);
 
   // only collect walker data at steps matching the period (default 1)
   int current_step = (step == -1) ? pset.current_step : step;

--- a/src/QMCDrivers/WalkerLogManager.cpp
+++ b/src/QMCDrivers/WalkerLogManager.cpp
@@ -88,10 +88,12 @@ std::unique_ptr<WalkerLogCollector> WalkerLogManager::makeCollector() const
 
 void WalkerLogManager::startRun(RefVector<WalkerLogCollector>&& collectors)
 {
-  ScopedTimer timer(walker_log_timers_[Timer::START]);
-  collectors_in_run_ = std::move(collectors);
   if (!state.logs_active)
     return; // no-op for driver if logs are inactive
+
+  ScopedTimer timer(walker_log_timers_[Timer::START]);
+
+  collectors_in_run_ = std::move(collectors);
   if (collectors_in_run_.empty())
     throw std::runtime_error("BUG collectors are empty but walker logs are active");
   if (state.verbose)
@@ -105,9 +107,11 @@ void WalkerLogManager::startRun(RefVector<WalkerLogCollector>&& collectors)
 
 void WalkerLogManager::stopRun()
 {
-  ScopedTimer timer(walker_log_timers_[Timer::STOP]);
   if (!state.logs_active)
     return; // no-op for driver if logs are inactive
+
+  ScopedTimer timer(walker_log_timers_[Timer::STOP]);
+
   if (state.verbose)
     app_log() << "WalkerLogManager::stopRun " << std::endl;
   collectors_in_run_.clear();
@@ -118,10 +122,11 @@ void WalkerLogManager::stopRun()
 
 void WalkerLogManager::writeBuffers()
 {
-  ScopedTimer timer(walker_log_timers_[Timer::WRITE]);
-  const RefVector<WalkerLogCollector>& collectors = collectors_in_run_;
   if (!state.logs_active)
     return; // no-op for driver if logs are inactive
+
+  ScopedTimer timer(walker_log_timers_[Timer::WRITE]);
+
   if (state.verbose)
     app_log() << "WalkerLogManager::writeBuffers " << std::endl;
 
@@ -144,6 +149,7 @@ void WalkerLogManager::writeBuffers()
     wmed_particle_real_buffer.resetBuffer();
   }
 
+  const RefVector<WalkerLogCollector>& collectors = collectors_in_run_;
   // collect energy information and extract info from min/max/median energy walkers
   if (write_min_data || write_max_data || write_med_data)
   {


### PR DESCRIPTION
## Proposed changes
Don't activate timer when features are inactive.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'