### PR TITLE
Porting `FakeSPO` to `SPOSetT<T>`

### DIFF
--- a/src/QMCWaveFunctions/tests/FakeSPO.cpp
+++ b/src/QMCWaveFunctions/tests/FakeSPO.cpp
@@ -73,10 +73,10 @@ FakeSPO<T>::FakeSPO() : SPOSet("one_FakeSPO")
   v2(3, 3) = 2.2;
 
   gv.resize(4);
-  gv[0] = TinyVector<ValueType, DIM>(1.0, 0.0, 0.1);
-  gv[1] = TinyVector<ValueType, DIM>(1.0, 2.0, 0.1);
-  gv[2] = TinyVector<ValueType, DIM>(2.0, 1.0, 0.1);
-  gv[3] = TinyVector<ValueType, DIM>(0.4, 0.3, 0.1);
+  gv[0] = TinyVector<Value, DIM>(1.0, 0.0, 0.1);
+  gv[1] = TinyVector<Value, DIM>(1.0, 2.0, 0.1);
+  gv[2] = TinyVector<Value, DIM>(2.0, 1.0, 0.1);
+  gv[3] = TinyVector<Value, DIM>(0.4, 0.3, 0.1);
 }
 
 template<typename T>
@@ -140,7 +140,7 @@ void FakeSPO<T>::evaluate_notranspose(const ParticleSet& P,
       for (int j = 0; j < 3; j++)
       {
         logdet(j, i)  = a(i, j);
-        dlogdet[i][j] = gv[j] + GradType(i);
+        dlogdet[i][j] = gv[j] + Grad(i);
       }
   }
   else if (OrbitalSetSize == 4)
@@ -149,7 +149,7 @@ void FakeSPO<T>::evaluate_notranspose(const ParticleSet& P,
       for (int j = 0; j < 4; j++)
       {
         logdet(j, i)  = a2(i, j);
-        dlogdet[i][j] = gv[j] + GradType(i);
+        dlogdet[i][j] = gv[j] + Grad(i);
       }
   }
 }

--- a/src/QMCWaveFunctions/tests/FakeSPO.cpp
+++ b/src/QMCWaveFunctions/tests/FakeSPO.cpp
@@ -80,10 +80,16 @@ FakeSPO<T>::FakeSPO() : SPOSet("one_FakeSPO")
 }
 
 template<typename T>
-std::unique_ptr<SPOSetT<T>> FakeSPO<T>::makeClone() const { return std::make_unique<FakeSPO<T>>(*this); }
+std::unique_ptr<SPOSetT<T>> FakeSPO<T>::makeClone() const
+{
+  return std::make_unique<FakeSPO<T>>(*this);
+}
 
 template<typename T>
-void FakeSPO<T>::setOrbitalSetSize(int norbs) { OrbitalSetSize = norbs; }
+void FakeSPO<T>::setOrbitalSetSize(int norbs)
+{
+  OrbitalSetSize = norbs;
+}
 
 template<typename T>
 void FakeSPO<T>::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)

--- a/src/QMCWaveFunctions/tests/FakeSPO.cpp
+++ b/src/QMCWaveFunctions/tests/FakeSPO.cpp
@@ -15,7 +15,8 @@
 namespace qmcplusplus
 {
 
-FakeSPO::FakeSPO() : SPOSet("one_FakeSPO")
+template<typename T>
+FakeSPO<T>::FakeSPO() : SPOSet("one_FakeSPO")
 {
   a.resize(3, 3);
 
@@ -78,11 +79,14 @@ FakeSPO::FakeSPO() : SPOSet("one_FakeSPO")
   gv[3] = TinyVector<ValueType, DIM>(0.4, 0.3, 0.1);
 }
 
-std::unique_ptr<SPOSet> FakeSPO::makeClone() const { return std::make_unique<FakeSPO>(*this); }
+template<typename T>
+std::unique_ptr<SPOSetT<T>> FakeSPO<T>::makeClone() const { return std::make_unique<FakeSPO<T>>(*this); }
 
-void FakeSPO::setOrbitalSetSize(int norbs) { OrbitalSetSize = norbs; }
+template<typename T>
+void FakeSPO<T>::setOrbitalSetSize(int norbs) { OrbitalSetSize = norbs; }
 
-void FakeSPO::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
+template<typename T>
+void FakeSPO<T>::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
 {
   if (iat < 0)
     for (int i = 0; i < psi.size(); i++)
@@ -95,7 +99,8 @@ void FakeSPO::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
       psi[i] = a2(iat, i);
 }
 
-void FakeSPO::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)
+template<typename T>
+void FakeSPO<T>::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)
 {
   if (OrbitalSetSize == 3)
   {
@@ -115,12 +120,13 @@ void FakeSPO::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradV
   }
 }
 
-void FakeSPO::evaluate_notranspose(const ParticleSet& P,
-                                   int first,
-                                   int last,
-                                   ValueMatrix& logdet,
-                                   GradMatrix& dlogdet,
-                                   ValueMatrix& d2logdet)
+template<typename T>
+void FakeSPO<T>::evaluate_notranspose(const ParticleSet& P,
+                                      int first,
+                                      int last,
+                                      ValueMatrix& logdet,
+                                      GradMatrix& dlogdet,
+                                      ValueMatrix& d2logdet)
 {
   if (OrbitalSetSize == 3)
   {
@@ -141,5 +147,12 @@ void FakeSPO::evaluate_notranspose(const ParticleSet& P,
       }
   }
 }
+
+#if !defined(MIXED_PRECISION)
+template class FakeSPO<double>;
+template class FakeSPO<std::complex<double>>;
+#endif
+template class FakeSPO<float>;
+template class FakeSPO<std::complex<float>>;
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/FakeSPO.cpp
+++ b/src/QMCWaveFunctions/tests/FakeSPO.cpp
@@ -82,7 +82,7 @@ FakeSPO<T>::FakeSPO() : SPOSet("one_FakeSPO")
 template<typename T>
 std::unique_ptr<SPOSetT<T>> FakeSPO<T>::makeClone() const
 {
-  return std::make_unique<FakeSPO<T>>(*this);
+  return std::make_unique<FakeSPO>(*this);
 }
 
 template<typename T>

--- a/src/QMCWaveFunctions/tests/FakeSPO.h
+++ b/src/QMCWaveFunctions/tests/FakeSPO.h
@@ -18,7 +18,7 @@
 namespace qmcplusplus
 {
 
-template <typename T>
+template<typename T>
 class FakeSPO : public SPOSetT<T>
 {
 public:

--- a/src/QMCWaveFunctions/tests/FakeSPO.h
+++ b/src/QMCWaveFunctions/tests/FakeSPO.h
@@ -24,17 +24,17 @@ class FakeSPO : public SPOSetT<T>
 public:
   using SPOSet = SPOSetT<T>;
   using SPOSet::DIM;
-  using ValueType = typename SPOSet::ValueType;
+  using Value       = typename SPOSet::ValueType;
   using ValueVector = typename SPOSet::ValueVector;
   using ValueMatrix = typename SPOSet::ValueMatrix;
-  using GradType = typename SPOSet::GradType;
-  using GradVector = typename SPOSet::GradVector;
-  using GradMatrix = typename SPOSet::GradMatrix;
+  using Grad        = typename SPOSet::GradType;
+  using GradVector  = typename SPOSet::GradVector;
+  using GradMatrix  = typename SPOSet::GradMatrix;
 
-  Matrix<ValueType> a;
-  Matrix<ValueType> a2;
-  Vector<ValueType> v;
-  Matrix<ValueType> v2;
+  Matrix<Value> a;
+  Matrix<Value> a2;
+  Vector<Value> v;
+  Matrix<Value> v2;
 
   GradVector gv;
 

--- a/src/QMCWaveFunctions/tests/FakeSPO.h
+++ b/src/QMCWaveFunctions/tests/FakeSPO.h
@@ -18,15 +18,25 @@
 namespace qmcplusplus
 {
 
-class FakeSPO : public SPOSet
+template <typename T>
+class FakeSPO : public SPOSetT<T>
 {
 public:
+  using SPOSet = SPOSetT<T>;
+  using SPOSet::DIM;
+  using ValueType = typename SPOSet::ValueType;
+  using ValueVector = typename SPOSet::ValueVector;
+  using ValueMatrix = typename SPOSet::ValueMatrix;
+  using GradType = typename SPOSet::GradType;
+  using GradVector = typename SPOSet::GradVector;
+  using GradMatrix = typename SPOSet::GradMatrix;
+
   Matrix<ValueType> a;
   Matrix<ValueType> a2;
   Vector<ValueType> v;
   Matrix<ValueType> v2;
 
-  SPOSet::GradVector gv;
+  GradVector gv;
 
   FakeSPO();
   ~FakeSPO() override {}
@@ -47,6 +57,8 @@ public:
                             ValueMatrix& logdet,
                             GradMatrix& dlogdet,
                             ValueMatrix& d2logdet) override;
+private:
+  using SPOSet::OrbitalSetSize;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -28,12 +28,12 @@ using std::string;
 
 namespace qmcplusplus
 {
-using RealType    = QMCTraits::RealType;
-using ValueType   = QMCTraits::ValueType;
-using ComplexType = QMCTraits::ComplexType;
-using PosType     = QMCTraits::PosType;
-using LogValue    = std::complex<QMCTraits::QTFull::RealType>;
-using PsiValue    = QMCTraits::QTFull::ValueType;
+using Real     = QMCTraits::RealType;
+using Value    = QMCTraits::ValueType;
+using Complex  = QMCTraits::ComplexType;
+using Pos      = QMCTraits::PosType;
+using LogValue = std::complex<QMCTraits::QTFull::RealType>;
+using PsiValue = QMCTraits::QTFull::ValueType;
 
 template<typename T1, typename T2>
 void check_matrix(Matrix<T1>& a, Matrix<T2>& b)
@@ -51,11 +51,11 @@ void check_matrix(Matrix<T1>& a, Matrix<T2>& b)
 template<typename DET>
 void test_DiracDeterminant_first(const DetMatInvertor inverter_kind)
 {
-  auto spo_init  = std::make_unique<FakeSPO<ValueType>>();
+  auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 3;
   spo_init->setOrbitalSetSize(norb);
   DET ddb(std::move(spo_init), 0, norb, 1, inverter_kind);
-  auto spo = dynamic_cast<FakeSPO<ValueType>*>(ddb.getPhi());
+  auto spo = dynamic_cast<FakeSPO<Value>*>(ddb.getPhi());
 
   // occurs in call to registerData
   ddb.dpsiV.resize(norb);
@@ -67,7 +67,7 @@ void test_DiracDeterminant_first(const DetMatInvertor inverter_kind)
   elec.create({3});
   ddb.recompute(elec);
 
-  Matrix<ValueType> b;
+  Matrix<Value> b;
   b.resize(3, 3);
 
   b(0, 0) = 0.6159749342;
@@ -102,10 +102,10 @@ void test_DiracDeterminant_first(const DetMatInvertor inverter_kind)
   check_matrix(ddb.psiM, b);
 
   // set virtutal particle position
-  PosType newpos(0.3, 0.2, 0.5);
+  Pos newpos(0.3, 0.2, 0.5);
 
   elec.makeVirtualMoves(newpos);
-  std::vector<ValueType> ratios(elec.getTotalNum());
+  std::vector<Value> ratios(elec.getTotalNum());
   ddb.evaluateRatiosAlltoOne(elec, ratios);
 
   CHECK(std::real(ratios[0]) == Approx(1.2070809985));
@@ -119,10 +119,10 @@ void test_DiracDeterminant_first(const DetMatInvertor inverter_kind)
   CHECK(std::real(ratio_0) == Approx(-0.5343861437));
 
   VirtualParticleSet VP(elec, 2);
-  std::vector<PosType> newpos2(2);
-  std::vector<ValueType> ratios2(2);
+  std::vector<Pos> newpos2(2);
+  std::vector<Value> ratios2(2);
   newpos2[0] = newpos - elec.R[1];
-  newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
+  newpos2[1] = Pos(0.2, 0.5, 0.3) - elec.R[1];
   VP.makeMoves(elec, 1, newpos2);
   ddb.evaluateRatios(VP, ratios2);
 
@@ -159,11 +159,11 @@ TEST_CASE("DiracDeterminant_first", "[wavefunction][fermion]")
 template<typename DET>
 void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
 {
-  auto spo_init  = std::make_unique<FakeSPO<ValueType>>();
+  auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);
   DET ddb(std::move(spo_init), 0, norb, 1, inverter_kind);
-  auto spo = dynamic_cast<FakeSPO<ValueType>*>(ddb.getPhi());
+  auto spo = dynamic_cast<FakeSPO<Value>*>(ddb.getPhi());
 
   // occurs in call to registerData
   ddb.dpsiV.resize(norb);
@@ -175,7 +175,7 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
   elec.create({4});
   ddb.recompute(elec);
 
-  Matrix<ValueType> orig_a;
+  Matrix<Value> orig_a;
   orig_a.resize(4, 4);
   orig_a = spo->a2;
 
@@ -188,9 +188,9 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
   }
 
   //check_matrix(ddb.psiM, b);
-  DiracMatrix<ValueType> dm;
+  DiracMatrix<Value> dm;
 
-  Matrix<ValueType> a_update1, scratchT;
+  Matrix<Value> a_update1, scratchT;
   a_update1.resize(4, 4);
   scratchT.resize(4, 4);
   a_update1 = spo->a2;
@@ -199,7 +199,7 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
     a_update1(j, 0) = spo->v2(0, j);
   }
 
-  Matrix<ValueType> a_update2;
+  Matrix<Value> a_update2;
   a_update2.resize(4, 4);
   a_update2 = spo->a2;
   for (int j = 0; j < norb; j++)
@@ -208,7 +208,7 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
     a_update2(j, 1) = spo->v2(1, j);
   }
 
-  Matrix<ValueType> a_update3;
+  Matrix<Value> a_update3;
   a_update3.resize(4, 4);
   a_update3 = spo->a2;
   for (int j = 0; j < norb; j++)
@@ -225,7 +225,7 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
                   scratchT.cols());
   LogValue det_update1;
   dm.invert_transpose(scratchT, a_update1, det_update1);
-  PsiValue det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddb.get_log_value());
+  PsiValue det_ratio1 = LogToValue<Value>::convert(det_update1 - ddb.get_log_value());
 #ifdef DUMP_INFO
   app_log() << "det 0 = " << std::exp(ddb.get_log_value()) << std::endl;
   app_log() << "det 1 = " << std::exp(det_update1) << std::endl;
@@ -242,7 +242,7 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
   simd::transpose(a_update2.data(), a_update2.rows(), a_update2.cols(), scratchT.data(), scratchT.rows(),
                   scratchT.cols());
   dm.invert_transpose(scratchT, a_update2, det_update2);
-  PsiValue det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
+  PsiValue det_ratio2_val = LogToValue<Value>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
   app_log() << "det 1 = " << std::exp(ddb.get_log_value()) << std::endl;
   app_log() << "det 2 = " << std::exp(det_update2) << std::endl;
@@ -258,7 +258,7 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
   simd::transpose(a_update3.data(), a_update3.rows(), a_update3.cols(), scratchT.data(), scratchT.rows(),
                   scratchT.cols());
   dm.invert_transpose(scratchT, a_update3, det_update3);
-  PsiValue det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
+  PsiValue det_ratio3_val = LogToValue<Value>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
   app_log() << "det 2 = " << std::exp(ddb.get_log_value()) << std::endl;
   app_log() << "det 3 = " << std::exp(det_update3) << std::endl;
@@ -300,12 +300,12 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
 template<typename DET>
 void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
 {
-  auto spo_init  = std::make_unique<FakeSPO<ValueType>>();
+  auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);
   // maximum delay 2
   DET ddc(std::move(spo_init), 0, norb, 2, inverter_kind);
-  auto spo = dynamic_cast<FakeSPO<ValueType>*>(ddc.getPhi());
+  auto spo = dynamic_cast<FakeSPO<Value>*>(ddc.getPhi());
 
   // occurs in call to registerData
   ddc.dpsiV.resize(norb);
@@ -317,7 +317,7 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
   elec.create({4});
   ddc.recompute(elec);
 
-  Matrix<ValueType> orig_a;
+  Matrix<Value> orig_a;
   orig_a.resize(4, 4);
   orig_a = spo->a2;
 
@@ -330,9 +330,9 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
   }
 
   //check_matrix(ddc.psiM, b);
-  DiracMatrix<ValueType> dm;
+  DiracMatrix<Value> dm;
 
-  Matrix<ValueType> a_update1, scratchT;
+  Matrix<Value> a_update1, scratchT;
   scratchT.resize(4, 4);
   a_update1.resize(4, 4);
   a_update1 = spo->a2;
@@ -341,7 +341,7 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
     a_update1(j, 0) = spo->v2(0, j);
   }
 
-  Matrix<ValueType> a_update2;
+  Matrix<Value> a_update2;
   a_update2.resize(4, 4);
   a_update2 = spo->a2;
   for (int j = 0; j < norb; j++)
@@ -350,7 +350,7 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
     a_update2(j, 1) = spo->v2(1, j);
   }
 
-  Matrix<ValueType> a_update3;
+  Matrix<Value> a_update3;
   a_update3.resize(4, 4);
   a_update3 = spo->a2;
   for (int j = 0; j < norb; j++)
@@ -368,7 +368,7 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
                   scratchT.cols());
   LogValue det_update1;
   dm.invert_transpose(scratchT, a_update1, det_update1);
-  PsiValue det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddc.get_log_value());
+  PsiValue det_ratio1 = LogToValue<Value>::convert(det_update1 - ddc.get_log_value());
 #ifdef DUMP_INFO
   app_log() << "det 0 = " << std::exp(ddc.get_log_value()) << std::endl;
   app_log() << "det 1 = " << std::exp(det_update1) << std::endl;
@@ -392,7 +392,7 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
                   scratchT.cols());
   LogValue det_update2;
   dm.invert_transpose(scratchT, a_update2, det_update2);
-  PsiValue det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
+  PsiValue det_ratio2_val = LogToValue<Value>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
   app_log() << "det 1 = " << std::exp(ddc.get_log_value()) << std::endl;
   app_log() << "det 2 = " << std::exp(det_update2) << std::endl;
@@ -412,7 +412,7 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
                   scratchT.cols());
   LogValue det_update3;
   dm.invert_transpose(scratchT, a_update3, det_update3);
-  PsiValue det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
+  PsiValue det_ratio3_val = LogToValue<Value>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
   app_log() << "det 2 = " << std::exp(ddc.get_log_value()) << std::endl;
   app_log() << "det 3 = " << std::exp(det_update3) << std::endl;

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -51,11 +51,11 @@ void check_matrix(Matrix<T1>& a, Matrix<T2>& b)
 template<typename DET>
 void test_DiracDeterminant_first(const DetMatInvertor inverter_kind)
 {
-  auto spo_init  = std::make_unique<FakeSPO>();
+  auto spo_init  = std::make_unique<FakeSPO<ValueType>>();
   const int norb = 3;
   spo_init->setOrbitalSetSize(norb);
   DET ddb(std::move(spo_init), 0, norb, 1, inverter_kind);
-  auto spo = dynamic_cast<FakeSPO*>(ddb.getPhi());
+  auto spo = dynamic_cast<FakeSPO<ValueType>*>(ddb.getPhi());
 
   // occurs in call to registerData
   ddb.dpsiV.resize(norb);
@@ -159,11 +159,11 @@ TEST_CASE("DiracDeterminant_first", "[wavefunction][fermion]")
 template<typename DET>
 void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
 {
-  auto spo_init  = std::make_unique<FakeSPO>();
+  auto spo_init  = std::make_unique<FakeSPO<ValueType>>();
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);
   DET ddb(std::move(spo_init), 0, norb, 1, inverter_kind);
-  auto spo = dynamic_cast<FakeSPO*>(ddb.getPhi());
+  auto spo = dynamic_cast<FakeSPO<ValueType>*>(ddb.getPhi());
 
   // occurs in call to registerData
   ddb.dpsiV.resize(norb);
@@ -300,12 +300,12 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
 template<typename DET>
 void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
 {
-  auto spo_init  = std::make_unique<FakeSPO>();
+  auto spo_init  = std::make_unique<FakeSPO<ValueType>>();
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);
   // maximum delay 2
   DET ddc(std::move(spo_init), 0, norb, 2, inverter_kind);
-  auto spo = dynamic_cast<FakeSPO*>(ddc.getPhi());
+  auto spo = dynamic_cast<FakeSPO<ValueType>*>(ddc.getPhi());
 
   // occurs in call to registerData
   ddc.dpsiV.resize(norb);

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -144,12 +144,12 @@ TEST_CASE("DiracDeterminant_first", "[wavefunction][fermion]")
   test_DiracDeterminant_first<DiracDeterminant<>>(DetMatInvertor::HOST);
   test_DiracDeterminant_first<DiracDeterminant<>>(DetMatInvertor::ACCEL);
 #if defined(ENABLE_CUDA)
-  test_DiracDeterminant_first<DiracDeterminant<DelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>>(
+  test_DiracDeterminant_first<DiracDeterminant<DelayedUpdateCUDA<Value, QMCTraits::QTFull::ValueType>>>(
       DetMatInvertor::HOST);
-  test_DiracDeterminant_first<DiracDeterminant<DelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>>(
+  test_DiracDeterminant_first<DiracDeterminant<DelayedUpdateCUDA<Value, QMCTraits::QTFull::ValueType>>>(
       DetMatInvertor::ACCEL);
 #elif defined(ENABLE_SYCL)
-  test_DiracDeterminant_first<DiracDeterminant<DelayedUpdateSYCL<ValueType, QMCTraits::QTFull::ValueType>>>(
+  test_DiracDeterminant_first<DiracDeterminant<DelayedUpdateSYCL<Value, QMCTraits::QTFull::ValueType>>>(
       DetMatInvertor::HOST);
 #endif
 }
@@ -287,12 +287,12 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
   test_DiracDeterminant_second<DiracDeterminant<>>(DetMatInvertor::HOST);
   test_DiracDeterminant_second<DiracDeterminant<>>(DetMatInvertor::ACCEL);
 #if defined(ENABLE_CUDA)
-  test_DiracDeterminant_second<DiracDeterminant<DelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>>(
+  test_DiracDeterminant_second<DiracDeterminant<DelayedUpdateCUDA<Value, QMCTraits::QTFull::ValueType>>>(
       DetMatInvertor::HOST);
-  test_DiracDeterminant_second<DiracDeterminant<DelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>>(
+  test_DiracDeterminant_second<DiracDeterminant<DelayedUpdateCUDA<Value, QMCTraits::QTFull::ValueType>>>(
       DetMatInvertor::ACCEL);
 #elif defined(ENABLE_SYCL)
-  test_DiracDeterminant_second<DiracDeterminant<DelayedUpdateSYCL<ValueType, QMCTraits::QTFull::ValueType>>>(
+  test_DiracDeterminant_second<DiracDeterminant<DelayedUpdateSYCL<Value, QMCTraits::QTFull::ValueType>>>(
       DetMatInvertor::HOST);
 #endif
 }
@@ -446,12 +446,12 @@ TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
   test_DiracDeterminant_delayed_update<DiracDeterminant<>>(DetMatInvertor::HOST);
   test_DiracDeterminant_delayed_update<DiracDeterminant<>>(DetMatInvertor::ACCEL);
 #if defined(ENABLE_CUDA)
-  test_DiracDeterminant_delayed_update<DiracDeterminant<DelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>>(
+  test_DiracDeterminant_delayed_update<DiracDeterminant<DelayedUpdateCUDA<Value, QMCTraits::QTFull::ValueType>>>(
       DetMatInvertor::HOST);
-  test_DiracDeterminant_delayed_update<DiracDeterminant<DelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>>(
+  test_DiracDeterminant_delayed_update<DiracDeterminant<DelayedUpdateCUDA<Value, QMCTraits::QTFull::ValueType>>>(
       DetMatInvertor::ACCEL);
 #elif defined(ENABLE_SYCL)
-  test_DiracDeterminant_delayed_update<DiracDeterminant<DelayedUpdateSYCL<ValueType, QMCTraits::QTFull::ValueType>>>(
+  test_DiracDeterminant_delayed_update<DiracDeterminant<DelayedUpdateSYCL<Value, QMCTraits::QTFull::ValueType>>>(
       DetMatInvertor::HOST);
 #endif
 }
@@ -460,9 +460,9 @@ TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
 template<typename DET>
 void test_DiracDeterminant_spinor_update(const DetMatInvertor inverter_kind)
 {
-  using ValueType         = QMCTraits::ValueType;
-  using PosType           = QMCTraits::PosType;
-  using GradType          = QMCTraits::GradType;
+  using Value             = QMCTraits::ValueType;
+  using Pos               = QMCTraits::PosType;
+  using Grad              = QMCTraits::GradType;
   using LogValue          = WaveFunctionComponent::LogValue;
   using ParticlePos       = ParticleSet::ParticlePos;
   using ParticleGradient  = ParticleSet::ParticleGradient;
@@ -507,19 +507,19 @@ void test_DiracDeterminant_spinor_update(const DetMatInvertor inverter_kind)
   //Our test case is going to be three electron gas orbitals distinguished by 3 different kpoints.
   //Independent SPO's for the up and down channels.
   //
-  std::vector<PosType> kup, kdn;
-  std::vector<RealType> k2up, k2dn;
+  std::vector<Pos> kup, kdn;
+  std::vector<Real> k2up, k2dn;
 
 
   kup.resize(nelec);
-  kup[0] = PosType(0, 0, 0);
-  kup[1] = PosType(0.1, 0.2, 0.3);
-  kup[2] = PosType(0.4, 0.5, 0.6);
+  kup[0] = Pos(0, 0, 0);
+  kup[1] = Pos(0.1, 0.2, 0.3);
+  kup[2] = Pos(0.4, 0.5, 0.6);
 
   kdn.resize(nelec);
-  kdn[0] = PosType(0, 0, 0);
-  kdn[1] = PosType(-0.1, 0.2, -0.3);
-  kdn[2] = PosType(0.4, -0.5, 0.6);
+  kdn[0] = Pos(0, 0, 0);
+  kdn[1] = Pos(-0.1, 0.2, -0.3);
+  kdn[2] = Pos(0.4, -0.5, 0.6);
 
   auto spo_up = std::make_unique<FreeOrbital>("free_orb_up", kup);
   auto spo_dn = std::make_unique<FreeOrbital>("free_orb_up", kdn);
@@ -532,7 +532,7 @@ void test_DiracDeterminant_spinor_update(const DetMatInvertor inverter_kind)
 
   ParticleGradient G;
   ParticleLaplacian L;
-  ParticleAttrib<ComplexType> SG;
+  ParticleAttrib<Complex> SG;
 
   G.resize(nelec);
   L.resize(nelec);
@@ -542,8 +542,8 @@ void test_DiracDeterminant_spinor_update(const DetMatInvertor inverter_kind)
   L  = 0.0;
   SG = 0.0;
 
-  PosType dr(0.1, -0.05, 0.2);
-  RealType ds = 0.3;
+  Pos dr(0.1, -0.05, 0.2);
+  Real ds = 0.3;
 
   app_log() << " BEFORE\n";
   app_log() << " R = " << elec_.R << std::endl;
@@ -554,30 +554,30 @@ void test_DiracDeterminant_spinor_update(const DetMatInvertor inverter_kind)
 
   LogValue logref = dd.evaluateLog(elec_, G, L);
 
-  CHECK(logref == ComplexApprox(ValueType(-1.1619939279564413, 0.8794794652468605)));
-  CHECK(G[0][0] == ComplexApprox(ValueType(0.13416635, 0.2468612)));
-  CHECK(G[0][1] == ComplexApprox(ValueType(-1.1165475, 0.71497753)));
-  CHECK(G[0][2] == ComplexApprox(ValueType(0.0178403, 0.08212244)));
-  CHECK(G[1][0] == ComplexApprox(ValueType(1.00240841, 0.12371593)));
-  CHECK(G[1][1] == ComplexApprox(ValueType(1.62679698, -0.41080777)));
-  CHECK(G[1][2] == ComplexApprox(ValueType(1.81324632, 0.78589013)));
-  CHECK(G[2][0] == ComplexApprox(ValueType(-1.10994555, 0.15525902)));
-  CHECK(G[2][1] == ComplexApprox(ValueType(-0.46335602, -0.50809713)));
-  CHECK(G[2][2] == ComplexApprox(ValueType(-1.751199, 0.10949589)));
-  CHECK(L[0] == ComplexApprox(ValueType(-2.06554158, 1.18145239)));
-  CHECK(L[1] == ComplexApprox(ValueType(-5.06340536, 0.82126749)));
-  CHECK(L[2] == ComplexApprox(ValueType(-4.82375261, -1.97943258)));
+  CHECK(logref == ComplexApprox(Value(-1.1619939279564413, 0.8794794652468605)));
+  CHECK(G[0][0] == ComplexApprox(Value(0.13416635, 0.2468612)));
+  CHECK(G[0][1] == ComplexApprox(Value(-1.1165475, 0.71497753)));
+  CHECK(G[0][2] == ComplexApprox(Value(0.0178403, 0.08212244)));
+  CHECK(G[1][0] == ComplexApprox(Value(1.00240841, 0.12371593)));
+  CHECK(G[1][1] == ComplexApprox(Value(1.62679698, -0.41080777)));
+  CHECK(G[1][2] == ComplexApprox(Value(1.81324632, 0.78589013)));
+  CHECK(G[2][0] == ComplexApprox(Value(-1.10994555, 0.15525902)));
+  CHECK(G[2][1] == ComplexApprox(Value(-0.46335602, -0.50809713)));
+  CHECK(G[2][2] == ComplexApprox(Value(-1.751199, 0.10949589)));
+  CHECK(L[0] == ComplexApprox(Value(-2.06554158, 1.18145239)));
+  CHECK(L[1] == ComplexApprox(Value(-5.06340536, 0.82126749)));
+  CHECK(L[2] == ComplexApprox(Value(-4.82375261, -1.97943258)));
 
   //This is a workaround for the fact that I haven't implemented
   // evaluateLogWithSpin().  Shouldn't be needed unless we do drifted all-electron moves...
   for (int iat = 0; iat < nelec; iat++)
     dd.evalGradWithSpin(elec_, iat, SG[iat]);
 
-  CHECK(SG[0] == ComplexApprox(ValueType(-1.05686704, -2.01802154)));
-  CHECK(SG[1] == ComplexApprox(ValueType(1.18922259, 2.80414598)));
-  CHECK(SG[2] == ComplexApprox(ValueType(-0.62617675, -0.51093984)));
+  CHECK(SG[0] == ComplexApprox(Value(-1.05686704, -2.01802154)));
+  CHECK(SG[1] == ComplexApprox(Value(1.18922259, 2.80414598)));
+  CHECK(SG[2] == ComplexApprox(Value(-0.62617675, -0.51093984)));
 
-  GradType g_singleeval(0.0);
+  Grad g_singleeval(0.0);
   g_singleeval = dd.evalGrad(elec_, 1);
 
   CHECK(g_singleeval[0] == ComplexApprox(G[1][0]));
@@ -590,28 +590,28 @@ void test_DiracDeterminant_spinor_update(const DetMatInvertor inverter_kind)
   //
   elec_.makeMoveAndCheckWithSpin(1, dr, ds);
 
-  ValueType ratio_new;
-  ValueType spingrad_new;
-  GradType grad_new;
+  Value ratio_new;
+  Value spingrad_new;
+  Grad grad_new;
 
   //This tests ratio only evaluation.  Indirectly a call to evaluate(P,iat)
   ratio_new = dd.ratio(elec_, 1);
-  CHECK(ratio_new == ComplexApprox(ValueType(1.7472917722050971, 1.1900872950904169)));
+  CHECK(ratio_new == ComplexApprox(Value(1.7472917722050971, 1.1900872950904169)));
 
   ratio_new = dd.ratioGrad(elec_, 1, grad_new);
-  CHECK(ratio_new == ComplexApprox(ValueType(1.7472917722050971, 1.1900872950904169)));
-  CHECK(grad_new[0] == ComplexApprox(ValueType(0.5496675534224996, -0.07968022499097227)));
-  CHECK(grad_new[1] == ComplexApprox(ValueType(0.4927399293808675, -0.29971549854643653)));
-  CHECK(grad_new[2] == ComplexApprox(ValueType(1.2792642963632226, 0.12110307514989149)));
+  CHECK(ratio_new == ComplexApprox(Value(1.7472917722050971, 1.1900872950904169)));
+  CHECK(grad_new[0] == ComplexApprox(Value(0.5496675534224996, -0.07968022499097227)));
+  CHECK(grad_new[1] == ComplexApprox(Value(0.4927399293808675, -0.29971549854643653)));
+  CHECK(grad_new[2] == ComplexApprox(Value(1.2792642963632226, 0.12110307514989149)));
 
   grad_new     = 0;
   spingrad_new = 0;
   ratio_new    = dd.ratioGradWithSpin(elec_, 1, grad_new, spingrad_new);
-  CHECK(ratio_new == ComplexApprox(ValueType(1.7472917722050971, 1.1900872950904169)));
-  CHECK(grad_new[0] == ComplexApprox(ValueType(0.5496675534224996, -0.07968022499097227)));
-  CHECK(grad_new[1] == ComplexApprox(ValueType(0.4927399293808675, -0.29971549854643653)));
-  CHECK(grad_new[2] == ComplexApprox(ValueType(1.2792642963632226, 0.12110307514989149)));
-  CHECK(spingrad_new == ComplexApprox(ValueType(1.164708841479661, 0.9576425115390172)));
+  CHECK(ratio_new == ComplexApprox(Value(1.7472917722050971, 1.1900872950904169)));
+  CHECK(grad_new[0] == ComplexApprox(Value(0.5496675534224996, -0.07968022499097227)));
+  CHECK(grad_new[1] == ComplexApprox(Value(0.4927399293808675, -0.29971549854643653)));
+  CHECK(grad_new[2] == ComplexApprox(Value(1.2792642963632226, 0.12110307514989149)));
+  CHECK(spingrad_new == ComplexApprox(Value(1.164708841479661, 0.9576425115390172)));
 
 
   //Cool.  Now we test the transition between rejecting a move and accepting a move.
@@ -624,7 +624,7 @@ void test_DiracDeterminant_spinor_update(const DetMatInvertor inverter_kind)
   CHECK(g_singleeval[1] == ComplexApprox(G[1][1]));
   CHECK(g_singleeval[2] == ComplexApprox(G[1][2]));
 
-  ValueType spingrad_old_test;
+  Value spingrad_old_test;
   g_singleeval = dd.evalGradWithSpin(elec_, 1, spingrad_old_test);
 
   CHECK(spingrad_old_test == ComplexApprox(SG[1]));
@@ -647,7 +647,7 @@ void test_DiracDeterminant_spinor_update(const DetMatInvertor inverter_kind)
   //logval for the new configuration has been computed with python.
   //The others reference values are computed earlier in this section.  New values equal the previous
   // "new values" associated with the previous trial moves.
-  CHECK(lognew == ComplexApprox(ValueType(-0.41337396772929913, 1.4774106123071726)));
+  CHECK(lognew == ComplexApprox(Value(-0.41337396772929913, 1.4774106123071726)));
   CHECK(G[1][0] == ComplexApprox(grad_new[0]));
   CHECK(G[1][1] == ComplexApprox(grad_new[1]));
   CHECK(G[1][2] == ComplexApprox(grad_new[2]));
@@ -659,9 +659,9 @@ TEST_CASE("DiracDeterminant_spinor_update", "[wavefunction][fermion]")
   test_DiracDeterminant_spinor_update<DiracDeterminant<>>(DetMatInvertor::HOST);
   test_DiracDeterminant_spinor_update<DiracDeterminant<>>(DetMatInvertor::ACCEL);
 #ifdef ENABLE_CUDA
-  test_DiracDeterminant_spinor_update<DiracDeterminant<DelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>>(
+  test_DiracDeterminant_spinor_update<DiracDeterminant<DelayedUpdateCUDA<Value, QMCTraits::QTFull::ValueType>>>(
       DetMatInvertor::HOST);
-  test_DiracDeterminant_spinor_update<DiracDeterminant<DelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>>(
+  test_DiracDeterminant_spinor_update<DiracDeterminant<DelayedUpdateCUDA<Value, QMCTraits::QTFull::ValueType>>>(
       DetMatInvertor::ACCEL);
 #endif
 }

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -37,11 +37,11 @@ template<PlatformKind PL>
 void test_DiracDeterminantBatched_first()
 {
   using DetType  = DiracDeterminantBatched<PL, ValueType, QMCTraits::QTFull::ValueType>;
-  auto spo_init  = std::make_unique<FakeSPO>();
+  auto spo_init  = std::make_unique<FakeSPO<ValueType>>();
   const int norb = 3;
   spo_init->setOrbitalSetSize(norb);
   DetType ddb(std::move(spo_init), 0, norb);
-  auto spo = dynamic_cast<FakeSPO*>(ddb.getPhi());
+  auto spo = dynamic_cast<FakeSPO<ValueType>*>(ddb.getPhi());
 
   const SimulationCell simulation_cell;
   ParticleSet elec(simulation_cell);
@@ -140,11 +140,11 @@ template<PlatformKind PL>
 void test_DiracDeterminantBatched_second()
 {
   using DetType  = DiracDeterminantBatched<PL, ValueType, QMCTraits::QTFull::ValueType>;
-  auto spo_init  = std::make_unique<FakeSPO>();
+  auto spo_init  = std::make_unique<FakeSPO<ValueType>>();
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);
   DetType ddb(std::move(spo_init), 0, norb);
-  auto spo = dynamic_cast<FakeSPO*>(ddb.getPhi());
+  auto spo = dynamic_cast<FakeSPO<ValueType>*>(ddb.getPhi());
 
   const SimulationCell simulation_cell;
   ParticleSet elec(simulation_cell);
@@ -275,11 +275,11 @@ template<PlatformKind PL>
 void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor matrix_inverter_kind)
 {
   using DetType  = DiracDeterminantBatched<PL, ValueType, QMCTraits::QTFull::ValueType>;
-  auto spo_init  = std::make_unique<FakeSPO>();
+  auto spo_init  = std::make_unique<FakeSPO<ValueType>>();
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);
   DetType ddc(std::move(spo_init), 0, norb, delay_rank, matrix_inverter_kind);
-  auto spo = dynamic_cast<FakeSPO*>(ddc.getPhi());
+  auto spo = dynamic_cast<FakeSPO<ValueType>*>(ddc.getPhi());
 
   const SimulationCell simulation_cell;
   ParticleSet elec(simulation_cell);

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -36,7 +36,7 @@ using PsiValue = QMCTraits::QTFull::ValueType;
 template<PlatformKind PL>
 void test_DiracDeterminantBatched_first()
 {
-  using Det  = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
+  using Det      = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
   auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 3;
   spo_init->setOrbitalSetSize(norb);
@@ -139,7 +139,7 @@ TEST_CASE("DiracDeterminantBatched_first", "[wavefunction][fermion]")
 template<PlatformKind PL>
 void test_DiracDeterminantBatched_second()
 {
-  using Det  = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
+  using Det      = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
   auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);
@@ -274,7 +274,7 @@ TEST_CASE("DiracDeterminantBatched_second", "[wavefunction][fermion]")
 template<PlatformKind PL>
 void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor matrix_inverter_kind)
 {
-  using Det  = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
+  using Det      = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
   auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -25,23 +25,23 @@
 
 namespace qmcplusplus
 {
-using RealType    = QMCTraits::RealType;
-using ValueType   = QMCTraits::ValueType;
-using ComplexType = QMCTraits::ComplexType;
-using PosType     = QMCTraits::PosType;
-using GradType    = QMCTraits::GradType;
-using LogValue    = std::complex<QMCTraits::QTFull::RealType>;
-using PsiValue    = QMCTraits::QTFull::ValueType;
+using Real     = QMCTraits::RealType;
+using Value    = QMCTraits::ValueType;
+using Complex  = QMCTraits::ComplexType;
+using Pos      = QMCTraits::PosType;
+using Grad     = QMCTraits::GradType;
+using LogValue = std::complex<QMCTraits::QTFull::RealType>;
+using PsiValue = QMCTraits::QTFull::ValueType;
 
 template<PlatformKind PL>
 void test_DiracDeterminantBatched_first()
 {
-  using DetType  = DiracDeterminantBatched<PL, ValueType, QMCTraits::QTFull::ValueType>;
-  auto spo_init  = std::make_unique<FakeSPO<ValueType>>();
+  using Det  = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
+  auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 3;
   spo_init->setOrbitalSetSize(norb);
-  DetType ddb(std::move(spo_init), 0, norb);
-  auto spo = dynamic_cast<FakeSPO<ValueType>*>(ddb.getPhi());
+  Det ddb(std::move(spo_init), 0, norb);
+  auto spo = dynamic_cast<FakeSPO<Value>*>(ddb.getPhi());
 
   const SimulationCell simulation_cell;
   ParticleSet elec(simulation_cell);
@@ -49,7 +49,7 @@ void test_DiracDeterminantBatched_first()
   elec.create({3});
   ddb.recompute(elec);
 
-  Matrix<ValueType> b;
+  Matrix<Value> b;
   b.resize(3, 3);
 
   b(0, 0) = 0.6159749342;
@@ -86,10 +86,10 @@ void test_DiracDeterminantBatched_first()
   CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 
   // set virtutal particle position
-  PosType newpos(0.3, 0.2, 0.5);
+  Pos newpos(0.3, 0.2, 0.5);
 
   elec.makeVirtualMoves(newpos);
-  std::vector<ValueType> ratios(elec.getTotalNum());
+  std::vector<Value> ratios(elec.getTotalNum());
   ddb.evaluateRatiosAlltoOne(elec, ratios);
 
   CHECK(std::real(ratios[0]) == Approx(1.2070809985));
@@ -103,10 +103,10 @@ void test_DiracDeterminantBatched_first()
   CHECK(std::real(ratio_0) == Approx(-0.5343861437));
 
   VirtualParticleSet VP(elec, 2);
-  std::vector<PosType> newpos2(2);
-  std::vector<ValueType> ratios2(2);
+  std::vector<Pos> newpos2(2);
+  std::vector<Value> ratios2(2);
   newpos2[0] = newpos - elec.R[1];
-  newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
+  newpos2[1] = Pos(0.2, 0.5, 0.3) - elec.R[1];
   VP.makeMoves(elec, 1, newpos2);
   ddb.evaluateRatios(VP, ratios2);
 
@@ -139,12 +139,12 @@ TEST_CASE("DiracDeterminantBatched_first", "[wavefunction][fermion]")
 template<PlatformKind PL>
 void test_DiracDeterminantBatched_second()
 {
-  using DetType  = DiracDeterminantBatched<PL, ValueType, QMCTraits::QTFull::ValueType>;
-  auto spo_init  = std::make_unique<FakeSPO<ValueType>>();
+  using Det  = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
+  auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);
-  DetType ddb(std::move(spo_init), 0, norb);
-  auto spo = dynamic_cast<FakeSPO<ValueType>*>(ddb.getPhi());
+  Det ddb(std::move(spo_init), 0, norb);
+  auto spo = dynamic_cast<FakeSPO<Value>*>(ddb.getPhi());
 
   const SimulationCell simulation_cell;
   ParticleSet elec(simulation_cell);
@@ -152,7 +152,7 @@ void test_DiracDeterminantBatched_second()
   elec.create({4});
   ddb.recompute(elec);
 
-  Matrix<ValueType> orig_a;
+  Matrix<Value> orig_a;
   orig_a.resize(4, 4);
   orig_a = spo->a2;
 
@@ -165,9 +165,9 @@ void test_DiracDeterminantBatched_second()
   }
 
   //check_matrix(ddb.getPsiMinv(), b);
-  DiracMatrix<ValueType> dm;
+  DiracMatrix<Value> dm;
 
-  Matrix<ValueType> a_update1, scratchT;
+  Matrix<Value> a_update1, scratchT;
   a_update1.resize(4, 4);
   scratchT.resize(4, 4);
   a_update1 = spo->a2;
@@ -176,7 +176,7 @@ void test_DiracDeterminantBatched_second()
     a_update1(j, 0) = spo->v2(0, j);
   }
 
-  Matrix<ValueType> a_update2;
+  Matrix<Value> a_update2;
   a_update2.resize(4, 4);
   a_update2 = spo->a2;
   for (int j = 0; j < norb; j++)
@@ -185,7 +185,7 @@ void test_DiracDeterminantBatched_second()
     a_update2(j, 1) = spo->v2(1, j);
   }
 
-  Matrix<ValueType> a_update3;
+  Matrix<Value> a_update3;
   a_update3.resize(4, 4);
   a_update3 = spo->a2;
   for (int j = 0; j < norb; j++)
@@ -202,7 +202,7 @@ void test_DiracDeterminantBatched_second()
                   scratchT.cols());
   LogValue det_update1;
   dm.invert_transpose(scratchT, a_update1, det_update1);
-  PsiValue det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddb.get_log_value());
+  PsiValue det_ratio1 = LogToValue<Value>::convert(det_update1 - ddb.get_log_value());
 #ifdef DUMP_INFO
   app_log() << "det 0 = " << std::exp(ddb.get_log_value()) << std::endl;
   app_log() << "det 1 = " << std::exp(det_update1) << std::endl;
@@ -219,7 +219,7 @@ void test_DiracDeterminantBatched_second()
   simd::transpose(a_update2.data(), a_update2.rows(), a_update2.cols(), scratchT.data(), scratchT.rows(),
                   scratchT.cols());
   dm.invert_transpose(scratchT, a_update2, det_update2);
-  PsiValue det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
+  PsiValue det_ratio2_val = LogToValue<Value>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
   app_log() << "det 1 = " << std::exp(ddb.get_log_value()) << std::endl;
   app_log() << "det 2 = " << std::exp(det_update2) << std::endl;
@@ -235,7 +235,7 @@ void test_DiracDeterminantBatched_second()
   simd::transpose(a_update3.data(), a_update3.rows(), a_update3.cols(), scratchT.data(), scratchT.rows(),
                   scratchT.cols());
   dm.invert_transpose(scratchT, a_update3, det_update3);
-  PsiValue det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
+  PsiValue det_ratio3_val = LogToValue<Value>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
   app_log() << "det 2 = " << std::exp(ddb.get_log_value()) << std::endl;
   app_log() << "det 3 = " << std::exp(det_update3) << std::endl;
@@ -274,12 +274,12 @@ TEST_CASE("DiracDeterminantBatched_second", "[wavefunction][fermion]")
 template<PlatformKind PL>
 void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor matrix_inverter_kind)
 {
-  using DetType  = DiracDeterminantBatched<PL, ValueType, QMCTraits::QTFull::ValueType>;
-  auto spo_init  = std::make_unique<FakeSPO<ValueType>>();
+  using Det  = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
+  auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);
-  DetType ddc(std::move(spo_init), 0, norb, delay_rank, matrix_inverter_kind);
-  auto spo = dynamic_cast<FakeSPO<ValueType>*>(ddc.getPhi());
+  Det ddc(std::move(spo_init), 0, norb, delay_rank, matrix_inverter_kind);
+  auto spo = dynamic_cast<FakeSPO<Value>*>(ddc.getPhi());
 
   const SimulationCell simulation_cell;
   ParticleSet elec(simulation_cell);
@@ -287,7 +287,7 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   elec.create({4});
   ddc.recompute(elec);
 
-  Matrix<ValueType> orig_a;
+  Matrix<Value> orig_a;
   orig_a.resize(4, 4);
   orig_a = spo->a2;
 
@@ -300,9 +300,9 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   }
 
   //check_matrix(ddc.getPsiMinv(), b);
-  DiracMatrix<ValueType> dm;
+  DiracMatrix<Value> dm;
 
-  Matrix<ValueType> a_update1, scratchT;
+  Matrix<Value> a_update1, scratchT;
   scratchT.resize(4, 4);
   a_update1.resize(4, 4);
   a_update1 = spo->a2;
@@ -311,7 +311,7 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
     a_update1(j, 0) = spo->v2(0, j);
   }
 
-  Matrix<ValueType> a_update2;
+  Matrix<Value> a_update2;
   a_update2.resize(4, 4);
   a_update2 = spo->a2;
   for (int j = 0; j < norb; j++)
@@ -320,7 +320,7 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
     a_update2(j, 1) = spo->v2(1, j);
   }
 
-  Matrix<ValueType> a_update3;
+  Matrix<Value> a_update3;
   a_update3.resize(4, 4);
   a_update3 = spo->a2;
   for (int j = 0; j < norb; j++)
@@ -338,7 +338,7 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
                   scratchT.cols());
   LogValue det_update1;
   dm.invert_transpose(scratchT, a_update1, det_update1);
-  PsiValue det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddc.get_log_value());
+  PsiValue det_ratio1 = LogToValue<Value>::convert(det_update1 - ddc.get_log_value());
 #ifdef DUMP_INFO
   app_log() << "det 0 = " << std::exp(ddc.get_log_value()) << std::endl;
   app_log() << "det 1 = " << std::exp(det_update1) << std::endl;
@@ -363,7 +363,7 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
                   scratchT.cols());
   LogValue det_update2;
   dm.invert_transpose(scratchT, a_update2, det_update2);
-  PsiValue det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
+  PsiValue det_ratio2_val = LogToValue<Value>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
   app_log() << "det 1 = " << std::exp(ddc.get_log_value()) << std::endl;
   app_log() << "det 2 = " << std::exp(det_update2) << std::endl;
@@ -383,7 +383,7 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
                   scratchT.cols());
   LogValue det_update3;
   dm.invert_transpose(scratchT, a_update3, det_update3);
-  PsiValue det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
+  PsiValue det_ratio3_val = LogToValue<Value>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
   app_log() << "det 2 = " << std::exp(ddc.get_log_value()) << std::endl;
   app_log() << "det 3 = " << std::exp(det_update3) << std::endl;
@@ -422,7 +422,7 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   // make a clones
   ParticleSet elec_clone(elec);
   std::unique_ptr<WaveFunctionComponent> ddc_clone(ddc.makeCopy(ddc.getPhi()->makeClone()));
-  auto& ddc_clone_ref = dynamic_cast<DetType&>(*ddc_clone);
+  auto& ddc_clone_ref = dynamic_cast<Det&>(*ddc_clone);
 
   // testing batched interfaces
   RefVectorWithLeader<ParticleSet> p_ref_list(elec, {elec, elec_clone});
@@ -436,7 +436,7 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   ddc.mw_recompute(ddc_ref_list, p_ref_list, isAccepted);
 
   std::vector<PsiValue> ratios(2);
-  std::vector<GradType> grad_new(2);
+  std::vector<Grad> grad_new(2);
   ddc.mw_ratioGrad(ddc_ref_list, p_ref_list, 0, ratios, grad_new);
 
   CHECK(det_ratio1 == ValueApprox(ratios[0]));
@@ -539,19 +539,19 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   //Our test case is going to be three electron gas orbitals distinguished by 3 different kpoints.
   //Independent SPO's for the up and down channels.
   //
-  std::vector<PosType> kup, kdn;
-  std::vector<RealType> k2up, k2dn;
+  std::vector<Pos> kup, kdn;
+  std::vector<Real> k2up, k2dn;
 
 
   kup.resize(nelec);
-  kup[0] = PosType(0, 0, 0);
-  kup[1] = PosType(0.1, 0.2, 0.3);
-  kup[2] = PosType(0.4, 0.5, 0.6);
+  kup[0] = Pos(0, 0, 0);
+  kup[1] = Pos(0.1, 0.2, 0.3);
+  kup[2] = Pos(0.4, 0.5, 0.6);
 
   kdn.resize(nelec);
-  kdn[0] = PosType(0, 0, 0);
-  kdn[1] = PosType(-0.1, 0.2, -0.3);
-  kdn[2] = PosType(0.4, -0.5, 0.6);
+  kdn[0] = Pos(0, 0, 0);
+  kdn[1] = Pos(-0.1, 0.2, -0.3);
+  kdn[2] = Pos(0.4, -0.5, 0.6);
 
   auto spo_up = std::make_unique<FreeOrbital>("free_orb_up", kup);
   auto spo_dn = std::make_unique<FreeOrbital>("free_orb_up", kdn);
@@ -559,13 +559,13 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   auto spinor_set = std::make_unique<SpinorSet>("free_orb_spinor");
   spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
 
-  using DetType = DiracDeterminantBatched<PL, ValueType, QMCTraits::QTFull::ValueType>;
-  DetType dd(std::move(spinor_set), 0, nelec, delay_rank, matrix_inverter_kind);
+  using Det = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
+  Det dd(std::move(spinor_set), 0, nelec, delay_rank, matrix_inverter_kind);
   app_log() << " nelec=" << nelec << std::endl;
 
   ParticleGradient G;
   ParticleLaplacian L;
-  ParticleAttrib<ComplexType> SG;
+  ParticleAttrib<Complex> SG;
 
   G.resize(nelec);
   L.resize(nelec);
@@ -575,8 +575,8 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   L  = 0.0;
   SG = 0.0;
 
-  PosType dr(0.1, -0.05, 0.2);
-  RealType ds = 0.3;
+  Pos dr(0.1, -0.05, 0.2);
+  Real ds = 0.3;
 
   app_log() << " BEFORE\n";
   app_log() << " R = " << elec_.R << std::endl;
@@ -587,30 +587,30 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
 
   LogValue logref = dd.evaluateLog(elec_, G, L);
 
-  CHECK(logref == ComplexApprox(ValueType(-1.1619939279564413, 0.8794794652468605)));
-  CHECK(G[0][0] == ComplexApprox(ValueType(0.13416635, 0.2468612)));
-  CHECK(G[0][1] == ComplexApprox(ValueType(-1.1165475, 0.71497753)));
-  CHECK(G[0][2] == ComplexApprox(ValueType(0.0178403, 0.08212244)));
-  CHECK(G[1][0] == ComplexApprox(ValueType(1.00240841, 0.12371593)));
-  CHECK(G[1][1] == ComplexApprox(ValueType(1.62679698, -0.41080777)));
-  CHECK(G[1][2] == ComplexApprox(ValueType(1.81324632, 0.78589013)));
-  CHECK(G[2][0] == ComplexApprox(ValueType(-1.10994555, 0.15525902)));
-  CHECK(G[2][1] == ComplexApprox(ValueType(-0.46335602, -0.50809713)));
-  CHECK(G[2][2] == ComplexApprox(ValueType(-1.751199, 0.10949589)));
-  CHECK(L[0] == ComplexApprox(ValueType(-2.06554158, 1.18145239)));
-  CHECK(L[1] == ComplexApprox(ValueType(-5.06340536, 0.82126749)));
-  CHECK(L[2] == ComplexApprox(ValueType(-4.82375261, -1.97943258)));
+  CHECK(logref == ComplexApprox(Value(-1.1619939279564413, 0.8794794652468605)));
+  CHECK(G[0][0] == ComplexApprox(Value(0.13416635, 0.2468612)));
+  CHECK(G[0][1] == ComplexApprox(Value(-1.1165475, 0.71497753)));
+  CHECK(G[0][2] == ComplexApprox(Value(0.0178403, 0.08212244)));
+  CHECK(G[1][0] == ComplexApprox(Value(1.00240841, 0.12371593)));
+  CHECK(G[1][1] == ComplexApprox(Value(1.62679698, -0.41080777)));
+  CHECK(G[1][2] == ComplexApprox(Value(1.81324632, 0.78589013)));
+  CHECK(G[2][0] == ComplexApprox(Value(-1.10994555, 0.15525902)));
+  CHECK(G[2][1] == ComplexApprox(Value(-0.46335602, -0.50809713)));
+  CHECK(G[2][2] == ComplexApprox(Value(-1.751199, 0.10949589)));
+  CHECK(L[0] == ComplexApprox(Value(-2.06554158, 1.18145239)));
+  CHECK(L[1] == ComplexApprox(Value(-5.06340536, 0.82126749)));
+  CHECK(L[2] == ComplexApprox(Value(-4.82375261, -1.97943258)));
 
   //This is a workaround for the fact that I haven't implemented
   // evaluateLogWithSpin().  Shouldn't be needed unless we do drifted all-electron moves...
   for (int iat = 0; iat < nelec; iat++)
     dd.evalGradWithSpin(elec_, iat, SG[iat]);
 
-  CHECK(SG[0] == ComplexApprox(ValueType(-1.05686704, -2.01802154)));
-  CHECK(SG[1] == ComplexApprox(ValueType(1.18922259, 2.80414598)));
-  CHECK(SG[2] == ComplexApprox(ValueType(-0.62617675, -0.51093984)));
+  CHECK(SG[0] == ComplexApprox(Value(-1.05686704, -2.01802154)));
+  CHECK(SG[1] == ComplexApprox(Value(1.18922259, 2.80414598)));
+  CHECK(SG[2] == ComplexApprox(Value(-0.62617675, -0.51093984)));
 
-  GradType g_singleeval(0.0);
+  Grad g_singleeval(0.0);
   g_singleeval = dd.evalGrad(elec_, 1);
 
   CHECK(g_singleeval[0] == ComplexApprox(G[1][0]));
@@ -623,28 +623,28 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   //
   elec_.makeMoveAndCheckWithSpin(1, dr, ds);
 
-  ValueType ratio_new;
-  ValueType spingrad_new;
-  GradType grad_new;
+  Value ratio_new;
+  Value spingrad_new;
+  Grad grad_new;
 
   //This tests ratio only evaluation.  Indirectly a call to evaluate(P,iat)
   ratio_new = dd.ratio(elec_, 1);
-  CHECK(ratio_new == ComplexApprox(ValueType(1.7472917722050971, 1.1900872950904169)));
+  CHECK(ratio_new == ComplexApprox(Value(1.7472917722050971, 1.1900872950904169)));
 
   ratio_new = dd.ratioGrad(elec_, 1, grad_new);
-  CHECK(ratio_new == ComplexApprox(ValueType(1.7472917722050971, 1.1900872950904169)));
-  CHECK(grad_new[0] == ComplexApprox(ValueType(0.5496675534224996, -0.07968022499097227)));
-  CHECK(grad_new[1] == ComplexApprox(ValueType(0.4927399293808675, -0.29971549854643653)));
-  CHECK(grad_new[2] == ComplexApprox(ValueType(1.2792642963632226, 0.12110307514989149)));
+  CHECK(ratio_new == ComplexApprox(Value(1.7472917722050971, 1.1900872950904169)));
+  CHECK(grad_new[0] == ComplexApprox(Value(0.5496675534224996, -0.07968022499097227)));
+  CHECK(grad_new[1] == ComplexApprox(Value(0.4927399293808675, -0.29971549854643653)));
+  CHECK(grad_new[2] == ComplexApprox(Value(1.2792642963632226, 0.12110307514989149)));
 
   grad_new     = 0;
   spingrad_new = 0;
   ratio_new    = dd.ratioGradWithSpin(elec_, 1, grad_new, spingrad_new);
-  CHECK(ratio_new == ComplexApprox(ValueType(1.7472917722050971, 1.1900872950904169)));
-  CHECK(grad_new[0] == ComplexApprox(ValueType(0.5496675534224996, -0.07968022499097227)));
-  CHECK(grad_new[1] == ComplexApprox(ValueType(0.4927399293808675, -0.29971549854643653)));
-  CHECK(grad_new[2] == ComplexApprox(ValueType(1.2792642963632226, 0.12110307514989149)));
-  CHECK(spingrad_new == ComplexApprox(ValueType(1.164708841479661, 0.9576425115390172)));
+  CHECK(ratio_new == ComplexApprox(Value(1.7472917722050971, 1.1900872950904169)));
+  CHECK(grad_new[0] == ComplexApprox(Value(0.5496675534224996, -0.07968022499097227)));
+  CHECK(grad_new[1] == ComplexApprox(Value(0.4927399293808675, -0.29971549854643653)));
+  CHECK(grad_new[2] == ComplexApprox(Value(1.2792642963632226, 0.12110307514989149)));
+  CHECK(spingrad_new == ComplexApprox(Value(1.164708841479661, 0.9576425115390172)));
 
 
   //Cool.  Now we test the transition between rejecting a move and accepting a move.
@@ -657,7 +657,7 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   CHECK(g_singleeval[1] == ComplexApprox(G[1][1]));
   CHECK(g_singleeval[2] == ComplexApprox(G[1][2]));
 
-  ValueType spingrad_old_test;
+  Value spingrad_old_test;
   g_singleeval = dd.evalGradWithSpin(elec_, 1, spingrad_old_test);
 
   CHECK(spingrad_old_test == ComplexApprox(SG[1]));
@@ -680,7 +680,7 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   //logval for the new configuration has been computed with python.
   //The others reference values are computed earlier in this section.  New values equal the previous
   // "new values" associated with the previous trial moves.
-  CHECK(lognew == ComplexApprox(ValueType(-0.41337396772929913, 1.4774106123071726)));
+  CHECK(lognew == ComplexApprox(Value(-0.41337396772929913, 1.4774106123071726)));
   CHECK(G[1][0] == ComplexApprox(grad_new[0]));
   CHECK(G[1][1] == ComplexApprox(grad_new[1]));
   CHECK(G[1][2] == ComplexApprox(grad_new[2]));
@@ -700,7 +700,7 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
 
   ParticleSet elec_clone(elec_);
   std::unique_ptr<WaveFunctionComponent> dd_clone(dd.makeCopy(dd.getPhi()->makeClone()));
-  auto& dd_clone_ref = dynamic_cast<DetType&>(*dd_clone);
+  auto& dd_clone_ref = dynamic_cast<Det&>(*dd_clone);
 
   RefVectorWithLeader<ParticleSet> p_ref_list(elec_, {elec_, elec_clone});
   RefVectorWithLeader<WaveFunctionComponent> dd_ref_list(dd, {dd, *dd_clone});
@@ -722,19 +722,19 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   for (int iw = 0; iw < dd_ref_list.size(); iw++)
   {
     PsiValue ref = dd_ref_list[iw].getValue();
-    CHECK(std::log(ref) == ComplexApprox(ValueType(-1.1619939279564413, 0.8794794652468605)));
-    CHECK(G_list[iw].get()[0][0] == ComplexApprox(ValueType(0.13416635, 0.2468612)));
-    CHECK(G_list[iw].get()[0][1] == ComplexApprox(ValueType(-1.1165475, 0.71497753)));
-    CHECK(G_list[iw].get()[0][2] == ComplexApprox(ValueType(0.0178403, 0.08212244)));
-    CHECK(G_list[iw].get()[1][0] == ComplexApprox(ValueType(1.00240841, 0.12371593)));
-    CHECK(G_list[iw].get()[1][1] == ComplexApprox(ValueType(1.62679698, -0.41080777)));
-    CHECK(G_list[iw].get()[1][2] == ComplexApprox(ValueType(1.81324632, 0.78589013)));
-    CHECK(G_list[iw].get()[2][0] == ComplexApprox(ValueType(-1.10994555, 0.15525902)));
-    CHECK(G_list[iw].get()[2][1] == ComplexApprox(ValueType(-0.46335602, -0.50809713)));
-    CHECK(G_list[iw].get()[2][2] == ComplexApprox(ValueType(-1.751199, 0.10949589)));
-    CHECK(L_list[iw].get()[0] == ComplexApprox(ValueType(-2.06554158, 1.18145239)));
-    CHECK(L_list[iw].get()[1] == ComplexApprox(ValueType(-5.06340536, 0.82126749)));
-    CHECK(L_list[iw].get()[2] == ComplexApprox(ValueType(-4.82375261, -1.97943258)));
+    CHECK(std::log(ref) == ComplexApprox(Value(-1.1619939279564413, 0.8794794652468605)));
+    CHECK(G_list[iw].get()[0][0] == ComplexApprox(Value(0.13416635, 0.2468612)));
+    CHECK(G_list[iw].get()[0][1] == ComplexApprox(Value(-1.1165475, 0.71497753)));
+    CHECK(G_list[iw].get()[0][2] == ComplexApprox(Value(0.0178403, 0.08212244)));
+    CHECK(G_list[iw].get()[1][0] == ComplexApprox(Value(1.00240841, 0.12371593)));
+    CHECK(G_list[iw].get()[1][1] == ComplexApprox(Value(1.62679698, -0.41080777)));
+    CHECK(G_list[iw].get()[1][2] == ComplexApprox(Value(1.81324632, 0.78589013)));
+    CHECK(G_list[iw].get()[2][0] == ComplexApprox(Value(-1.10994555, 0.15525902)));
+    CHECK(G_list[iw].get()[2][1] == ComplexApprox(Value(-0.46335602, -0.50809713)));
+    CHECK(G_list[iw].get()[2][2] == ComplexApprox(Value(-1.751199, 0.10949589)));
+    CHECK(L_list[iw].get()[0] == ComplexApprox(Value(-2.06554158, 1.18145239)));
+    CHECK(L_list[iw].get()[1] == ComplexApprox(Value(-5.06340536, 0.82126749)));
+    CHECK(L_list[iw].get()[2] == ComplexApprox(Value(-4.82375261, -1.97943258)));
   }
 
   //Move particle 1 in each walker
@@ -745,15 +745,15 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
 
   //Check ratios and grads for both walkers for proposed move
   std::vector<PsiValue> ratios(2);
-  std::vector<GradType> grads(2);
-  std::vector<ComplexType> spingrads(2);
+  std::vector<Grad> grads(2);
+  std::vector<Complex> spingrads(2);
   dd.mw_ratioGrad(dd_ref_list, p_ref_list, 1, ratios, grads);
   for (int iw = 0; iw < grads.size(); iw++)
   {
-    CHECK(ratios[iw] == ComplexApprox(ValueType(1.7472917722050971, 1.1900872950904169)));
-    CHECK(grads[iw][0] == ComplexApprox(ValueType(0.5496675534224996, -0.07968022499097227)));
-    CHECK(grads[iw][1] == ComplexApprox(ValueType(0.4927399293808675, -0.29971549854643653)));
-    CHECK(grads[iw][2] == ComplexApprox(ValueType(1.2792642963632226, 0.12110307514989149)));
+    CHECK(ratios[iw] == ComplexApprox(Value(1.7472917722050971, 1.1900872950904169)));
+    CHECK(grads[iw][0] == ComplexApprox(Value(0.5496675534224996, -0.07968022499097227)));
+    CHECK(grads[iw][1] == ComplexApprox(Value(0.4927399293808675, -0.29971549854643653)));
+    CHECK(grads[iw][2] == ComplexApprox(Value(1.2792642963632226, 0.12110307514989149)));
   }
 
   std::fill(ratios.begin(), ratios.end(), 0);
@@ -761,11 +761,11 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   dd.mw_ratioGradWithSpin(dd_ref_list, p_ref_list, 1, ratios, grads, spingrads);
   for (int iw = 0; iw < grads.size(); iw++)
   {
-    CHECK(ratios[iw] == ComplexApprox(ValueType(1.7472917722050971, 1.1900872950904169)));
-    CHECK(grads[iw][0] == ComplexApprox(ValueType(0.5496675534224996, -0.07968022499097227)));
-    CHECK(grads[iw][1] == ComplexApprox(ValueType(0.4927399293808675, -0.29971549854643653)));
-    CHECK(grads[iw][2] == ComplexApprox(ValueType(1.2792642963632226, 0.12110307514989149)));
-    CHECK(spingrads[iw] == ComplexApprox(ValueType(1.164708841479661, 0.9576425115390172)));
+    CHECK(ratios[iw] == ComplexApprox(Value(1.7472917722050971, 1.1900872950904169)));
+    CHECK(grads[iw][0] == ComplexApprox(Value(0.5496675534224996, -0.07968022499097227)));
+    CHECK(grads[iw][1] == ComplexApprox(Value(0.4927399293808675, -0.29971549854643653)));
+    CHECK(grads[iw][2] == ComplexApprox(Value(1.2792642963632226, 0.12110307514989149)));
+    CHECK(spingrads[iw] == ComplexApprox(Value(1.164708841479661, 0.9576425115390172)));
   }
 
   //reject move and check for initial values for mw_evalGrad
@@ -787,7 +787,7 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
     CHECK(grads[iw][0] == ComplexApprox(G_list[iw].get()[1][0]));
     CHECK(grads[iw][1] == ComplexApprox(G_list[iw].get()[1][1]));
     CHECK(grads[iw][2] == ComplexApprox(G_list[iw].get()[1][2]));
-    CHECK(spingrads[iw] == ComplexApprox(ValueType(1.18922259, 2.80414598)));
+    CHECK(spingrads[iw] == ComplexApprox(Value(1.18922259, 2.80414598)));
   }
 
   //now make and accept move, checking new values
@@ -802,15 +802,15 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   for (int iw = 0; iw < dd_ref_list.size(); iw++)
   {
     PsiValue ref = dd_ref_list[iw].getValue();
-    CHECK(std::log(ref) == ComplexApprox(ValueType(-0.41337396772929913, 1.4774106123071726)));
-    CHECK(G_list[iw].get()[1][0] == ComplexApprox(ValueType(0.5496675534224996, -0.07968022499097227)));
-    CHECK(G_list[iw].get()[1][1] == ComplexApprox(ValueType(0.4927399293808675, -0.29971549854643653)));
-    CHECK(G_list[iw].get()[1][2] == ComplexApprox(ValueType(1.2792642963632226, 0.12110307514989149)));
+    CHECK(std::log(ref) == ComplexApprox(Value(-0.41337396772929913, 1.4774106123071726)));
+    CHECK(G_list[iw].get()[1][0] == ComplexApprox(Value(0.5496675534224996, -0.07968022499097227)));
+    CHECK(G_list[iw].get()[1][1] == ComplexApprox(Value(0.4927399293808675, -0.29971549854643653)));
+    CHECK(G_list[iw].get()[1][2] == ComplexApprox(Value(1.2792642963632226, 0.12110307514989149)));
   }
 
   dd.mw_evalGradWithSpin(dd_ref_list, p_ref_list, 1, grads, spingrads);
   for (int iw = 0; iw < grads.size(); iw++)
-    CHECK(spingrads[iw] == ComplexApprox(ValueType(1.164708841479661, 0.9576425115390172)));
+    CHECK(spingrads[iw] == ComplexApprox(Value(1.164708841479661, 0.9576425115390172)));
 }
 
 TEST_CASE("DiracDeterminantBatched_spinor_update", "[wavefunction][fermion]")

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -740,7 +740,7 @@ TEST_CASE("RotatedSPOs read and write parameters", "[wavefunction]")
 {
   //There is an issue with the real<->complex parameter parsing to h5 in QMC_COMPLEX.
   //This needs to be fixed in a future PR.
-  auto fake_spo = std::make_unique<FakeSPO>();
+  auto fake_spo = std::make_unique<FakeSPO<QMCTraits::ValueType>>();
   fake_spo->setOrbitalSetSize(4);
   RotatedSPOs rot("fake_rot", std::move(fake_spo));
   int nel = 2;
@@ -762,7 +762,7 @@ TEST_CASE("RotatedSPOs read and write parameters", "[wavefunction]")
     rot.writeVariationalParameters(hout);
   }
 
-  auto fake_spo2 = std::make_unique<FakeSPO>();
+  auto fake_spo2 = std::make_unique<FakeSPO<QMCTraits::ValueType>>();
   fake_spo2->setOrbitalSetSize(4);
 
   RotatedSPOs rot2("fake_rot", std::move(fake_spo2));
@@ -791,7 +791,7 @@ TEST_CASE("RotatedSPOs read and write parameters", "[wavefunction]")
 TEST_CASE("RotatedSPOs read and write parameters history", "[wavefunction]")
 {
   //Problem with h5 parameter parsing for complex build.  To be fixed in future PR.
-  auto fake_spo = std::make_unique<FakeSPO>();
+  auto fake_spo = std::make_unique<FakeSPO<QMCTraits::ValueType>>();
   fake_spo->setOrbitalSetSize(4);
   RotatedSPOs rot("fake_rot", std::move(fake_spo));
   rot.set_use_global_rotation(false);
@@ -814,7 +814,7 @@ TEST_CASE("RotatedSPOs read and write parameters history", "[wavefunction]")
     rot.writeVariationalParameters(hout);
   }
 
-  auto fake_spo2 = std::make_unique<FakeSPO>();
+  auto fake_spo2 = std::make_unique<FakeSPO<QMCTraits::ValueType>>();
   fake_spo2->setOrbitalSetSize(4);
 
   RotatedSPOs rot2("fake_rot", std::move(fake_spo2));


### PR DESCRIPTION
## Proposed changes

This PR ports `FakeSPO` to the templatized version of `SPOSet`, namely `SPOSetT<T>`, which is introduced in #5306. 

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Linux with GCC and Open MPI.

## Checklist

- Yes. This PR is up to date with the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
