### PR TITLE
explicitly instantiate CrystalLattice simplify initialization

### DIFF
--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -29,6 +29,7 @@ set(PARTICLE
     createDistanceTableAA.cpp
     createDistanceTableAB.cpp
     HDFWalkerInputManager.cpp
+    Lattice/CrystalLattice.cpp
     LongRange/KContainer.cpp
     LongRange/StructFact.cpp
     LongRange/LPQHIBasis.cpp

--- a/src/Particle/Lattice/CrystalLattice.cpp
+++ b/src/Particle/Lattice/CrystalLattice.cpp
@@ -38,15 +38,6 @@ CrystalLattice<T, D>::CrystalLattice()
   reset();
 }
 
-template<typename T, unsigned D>
-template<typename TT>
-CrystalLattice<T, D>::CrystalLattice(const Tensor<TT, D>& lat)
-{
-  explicitly_defined = true;
-  R                  = lat;
-  reset();
-}
-
 template<class T, unsigned D>
 bool CrystalLattice<T, D>::outOfBound(const TinyVector<T, D>& u) const
 {
@@ -202,14 +193,10 @@ inline bool operator!=(const CrystalLattice<T, D>& lhs, const CrystalLattice<T, 
 }
 
 template struct CrystalLattice<double, OHMMS_DIM>;
-template CrystalLattice<double, OHMMS_DIM>::CrystalLattice(const Tensor<double, OHMMS_DIM>& tensor);
-template CrystalLattice<double, OHMMS_DIM>::CrystalLattice(const Tensor<float, OHMMS_DIM>& tensor);
 template void CrystalLattice<double, OHMMS_DIM>::set(const Tensor<double, OHMMS_DIM>& tensor);
 template void CrystalLattice<double, OHMMS_DIM>::set(const Tensor<float, OHMMS_DIM>& tensor);
 
 template struct CrystalLattice<float, OHMMS_DIM>;
-template CrystalLattice<float, OHMMS_DIM>::CrystalLattice(const Tensor<double, OHMMS_DIM>& tensor);
-template CrystalLattice<float, OHMMS_DIM>::CrystalLattice(const Tensor<float, OHMMS_DIM>& tensor);
 template void CrystalLattice<float, OHMMS_DIM>::set(const Tensor<double, OHMMS_DIM>& tensor);
 template void CrystalLattice<float, OHMMS_DIM>::set(const Tensor<float, OHMMS_DIM>& tensor);
 

--- a/src/Particle/Lattice/CrystalLattice.cpp
+++ b/src/Particle/Lattice/CrystalLattice.cpp
@@ -38,6 +38,25 @@ CrystalLattice<T, D>::CrystalLattice()
   reset();
 }
 
+template<typename T, unsigned D>
+template<typename TT>
+CrystalLattice<T, D>::CrystalLattice(const Tensor<TT, D>& lat)
+{
+  explicitly_defined = true;
+  R                  = lat;
+  reset();
+}
+
+template<class T, unsigned D>
+bool CrystalLattice<T, D>::outOfBound(const TinyVector<T, D>& u) const
+{
+  for (int i = 0; i < D; ++i)
+    if (std::abs(u[i]) > 0.5)
+      return true;
+  return false;
+}
+
+
 template<class T, unsigned D>
 template<class TT>
 void CrystalLattice<T, D>::set(const Tensor<TT, D>& lat)
@@ -181,5 +200,18 @@ inline bool operator!=(const CrystalLattice<T, D>& lhs, const CrystalLattice<T, 
 {
   return !(lhs == rhs);
 }
+
+template struct CrystalLattice<double, OHMMS_DIM>;
+template CrystalLattice<double, OHMMS_DIM>::CrystalLattice(const Tensor<double, OHMMS_DIM>& tensor);
+template CrystalLattice<double, OHMMS_DIM>::CrystalLattice(const Tensor<float, OHMMS_DIM>& tensor);
+template void CrystalLattice<double, OHMMS_DIM>::set(const Tensor<double, OHMMS_DIM>& tensor);
+template void CrystalLattice<double, OHMMS_DIM>::set(const Tensor<float, OHMMS_DIM>& tensor);
+
+template struct CrystalLattice<float, OHMMS_DIM>;
+template CrystalLattice<float, OHMMS_DIM>::CrystalLattice(const Tensor<double, OHMMS_DIM>& tensor);
+template CrystalLattice<float, OHMMS_DIM>::CrystalLattice(const Tensor<float, OHMMS_DIM>& tensor);
+template void CrystalLattice<float, OHMMS_DIM>::set(const Tensor<double, OHMMS_DIM>& tensor);
+template void CrystalLattice<float, OHMMS_DIM>::set(const Tensor<float, OHMMS_DIM>& tensor);
+
 
 } // namespace qmcplusplus

--- a/src/Particle/Lattice/CrystalLattice.h
+++ b/src/Particle/Lattice/CrystalLattice.h
@@ -23,6 +23,7 @@
 #define OHMMS_CRYSTALLATTICE_H
 #include <limits>
 #include <iostream>
+#include <OhmmsData/Libxml2Doc.h>
 #include "config/stdlib/Constants.h"
 #include "OhmmsPETE/TinyVector.h"
 #include "OhmmsPETE/Tensor.h"
@@ -54,6 +55,8 @@ enum
 template<class T, unsigned D>
 struct CrystalLattice : public LRBreakupParameters<T, D>
 {
+public:
+  using Real = T;
   /// alias to the base class
   using Base = LRBreakupParameters<T, D>;
 
@@ -63,7 +66,7 @@ struct CrystalLattice : public LRBreakupParameters<T, D>
     DIM = D
   };
   //@{
-  ///the type of scalar
+  ///the type of scalar, actually can only be real based on Configuration.h
   using Scalar_t = T;
   ///the type of a D-dimensional position vector
   using SingleParticlePos = TinyVector<T, D>;
@@ -73,14 +76,50 @@ struct CrystalLattice : public LRBreakupParameters<T, D>
   using Tensor_t = Tensor<T, D>;
   //@}
 
+  ///default constructor, assign a huge supercell
+  CrystalLattice();
+
+  template<typename TT>
+  CrystalLattice(const Tensor<TT, D>& tensor);
+
+  /** modern factory function
+   *  friend has to be any possible
+   */
+  friend CrystalLattice<double, OHMMS_DIM> makeFullPrecParticleLayout(xmlNodePtr cur);
+
+  const auto& getBoxBConds() const { return BoxBConds; }
+  const auto& getG() const { return G; }
+  const auto& getGv() const { return Gv; }
+  int getSuperCellEnum() const { return SuperCellEnum; }
+  const auto& getR() const { return R; };
+  const auto& getOneOverLength() const { return OneOverLength; }
+  const auto& getLength() const { return Length; }
+  const auto& getRv() const { return Rv; }
+  const auto& getVacuumScale() const { return VacuumScale; }
+  bool getExplicitlyDefined() const { return explicitly_defined; }
+  // \todo remove this and factor resetLRBox into lattice?
+  auto& getR() { return R; };
+  auto getVolume() const { return Volume; }
+  auto getCenter() const { return Center; }
+  // These are all a result of calling LatticeAnalyzer and not valid until reset is called after any number of changes
+  // to the lattice.
+  auto getCellRadiusSq() const { return CellRadiusSq; }
+  auto getWignerSeitzRadius() const { return WignerSeitzRadius; }
+  auto getWignerSeitzRadius_G() const { return WignerSeitzRadius_G; }
+  auto getSimulationCellRadius() const { return SimulationCellRadius; }
+  bool getDiagonalOnly() const { return DiagonalOnly; }
+
+  void setBoxBConds(TinyVector<int, D> bbc) { BoxBConds = bbc; }
+  void setVacuumScale(Real vscale) { VacuumScale = vscale; }
+
   ///true, if off-diagonal elements are zero so that other classes can take advantage of this
   bool DiagonalOnly;
   ///supercell enumeration
   int SuperCellEnum;
   ///The boundary condition in each direction.
-  TinyVector<int, D> BoxBConds;
+  TinyVector<int, D> BoxBConds{false,false,false};
   ///The scale factor for adding vacuum.
-  T VacuumScale;
+  T VacuumScale = 1.0;
   //@{
   /**@brief Physical properties of a supercell*/
   /// Volume of a supercell
@@ -125,10 +164,7 @@ struct CrystalLattice : public LRBreakupParameters<T, D>
   //angles between the two lattice vectors
   SingleParticlePos ABC;
   ///true, the lattice is defined by the input instead of an artificial default
-  bool explicitly_defined;
-
-  ///default constructor, assign a huge supercell
-  CrystalLattice();
+  bool explicitly_defined = false;
 
   /**@param i the index of the directional vector, \f$i\in [0,D)\f$
    *@return The lattice vector of the ith direction
@@ -183,13 +219,7 @@ struct CrystalLattice : public LRBreakupParameters<T, D>
   }
 
   /// return true if any direction of reduced coordinates u goes larger than 0.5
-  inline bool outOfBound(const TinyVector<T, D>& u) const
-  {
-    for (int i = 0; i < D; ++i)
-      if (std::abs(u[i]) > 0.5)
-        return true;
-    return false;
-  }
+  bool outOfBound(const TinyVector<T, D>& u) const;
 
   inline void applyMinimumImage(TinyVector<T, D>& c) const
   {
@@ -243,6 +273,7 @@ struct CrystalLattice : public LRBreakupParameters<T, D>
 
     explicitly_defined = rhs.explicitly_defined;
     BoxBConds          = rhs.BoxBConds;
+    SuperCellEnum      = rhs.getSuperCellEnum();
     VacuumScale        = rhs.VacuumScale;
     R                  = rhs.R;
     reset();
@@ -280,10 +311,27 @@ struct CrystalLattice : public LRBreakupParameters<T, D>
 
   //! Print out CrystalLattice Data
   void print(std::ostream&, int level = 2) const;
+
+  // Allow assignment operator between say T=double and T=float
+  template<class TT, unsigned DD>
+  friend struct CrystalLattice;
+
+  friend class LatticeParser;
 };
+
+extern template struct CrystalLattice<double, OHMMS_DIM>;
+extern template CrystalLattice<double, OHMMS_DIM>::CrystalLattice(const Tensor<double, OHMMS_DIM>& tensor);
+extern template CrystalLattice<double, OHMMS_DIM>::CrystalLattice(const Tensor<float, OHMMS_DIM>& tensor);
+extern template void CrystalLattice<double, OHMMS_DIM>::set(const Tensor<double, OHMMS_DIM>& tensor);
+extern template void CrystalLattice<double, OHMMS_DIM>::set(const Tensor<float, OHMMS_DIM>& tensor);
+
+extern template struct CrystalLattice<float, OHMMS_DIM>;
+extern template CrystalLattice<float, OHMMS_DIM>::CrystalLattice(const Tensor<double, OHMMS_DIM>& tensor);
+extern template CrystalLattice<float, OHMMS_DIM>::CrystalLattice(const Tensor<float, OHMMS_DIM>& tensor);
+extern template void CrystalLattice<float, OHMMS_DIM>::set(const Tensor<double, OHMMS_DIM>& tensor);
+extern template void CrystalLattice<float, OHMMS_DIM>::set(const Tensor<float, OHMMS_DIM>& tensor);
 
 } // namespace qmcplusplus
 //including the definitions of the member functions
-#include "CrystalLattice.cpp"
 
 #endif

--- a/src/Particle/Lattice/CrystalLattice.h
+++ b/src/Particle/Lattice/CrystalLattice.h
@@ -23,11 +23,16 @@
 #define OHMMS_CRYSTALLATTICE_H
 #include <limits>
 #include <iostream>
-#include <OhmmsData/Libxml2Doc.h>
 #include "config/stdlib/Constants.h"
 #include "OhmmsPETE/TinyVector.h"
 #include "OhmmsPETE/Tensor.h"
 #include "LRBreakupParameters.h"
+
+/** forward declare xmlNodePtr xmlNodePtr
+ *  these are c types so I follow libmxml2's scheme to forward declare
+ */
+typedef struct _xmlNode xmlNode;
+typedef xmlNode *xmlNodePtr;
 
 namespace qmcplusplus
 {

--- a/src/Particle/Lattice/CrystalLattice.h
+++ b/src/Particle/Lattice/CrystalLattice.h
@@ -28,12 +28,6 @@
 #include "OhmmsPETE/Tensor.h"
 #include "LRBreakupParameters.h"
 
-/** forward declare xmlNodePtr xmlNodePtr
- *  these are c types so I follow libmxml2's scheme to forward declare
- */
-typedef struct _xmlNode xmlNode;
-typedef xmlNode *xmlNodePtr;
-
 namespace qmcplusplus
 {
 /** enumeration to classify a CrystalLattice
@@ -83,12 +77,6 @@ public:
 
   ///default constructor, assign a huge supercell
   CrystalLattice();
-
-  /** modern factory function
-   *  friend has to be any possible
-   *  Stepping stone to CrystalLattice(const LatticeInput& input)
-   */
-  friend CrystalLattice<double, OHMMS_DIM> makeFullPrecParticleLayout(xmlNodePtr cur);
 
   const auto& getBoxBConds() const { return BoxBConds; }
   const auto& getG() const { return G; }

--- a/src/Particle/Lattice/CrystalLattice.h
+++ b/src/Particle/Lattice/CrystalLattice.h
@@ -79,11 +79,9 @@ public:
   ///default constructor, assign a huge supercell
   CrystalLattice();
 
-  template<typename TT>
-  CrystalLattice(const Tensor<TT, D>& tensor);
-
   /** modern factory function
    *  friend has to be any possible
+   *  Stepping stone to CrystalLattice(const LatticeInput& input)
    */
   friend CrystalLattice<double, OHMMS_DIM> makeFullPrecParticleLayout(xmlNodePtr cur);
 
@@ -109,15 +107,23 @@ public:
   auto getSimulationCellRadius() const { return SimulationCellRadius; }
   bool getDiagonalOnly() const { return DiagonalOnly; }
 
-  void setBoxBConds(TinyVector<int, D> bbc) { BoxBConds = bbc; }
-  void setVacuumScale(Real vscale) { VacuumScale = vscale; }
+  void setBoxBConds(TinyVector<int, D> bbc)
+  {
+    BoxBConds = bbc;
+    reset();
+  }
+  void setVacuumScale(Real vscale)
+  {
+    VacuumScale = vscale;
+    reset();
+  }
 
   ///true, if off-diagonal elements are zero so that other classes can take advantage of this
   bool DiagonalOnly;
   ///supercell enumeration
   int SuperCellEnum;
   ///The boundary condition in each direction.
-  TinyVector<int, D> BoxBConds{false,false,false};
+  TinyVector<int, D> BoxBConds{false, false, false};
   ///The scale factor for adding vacuum.
   T VacuumScale = 1.0;
   //@{
@@ -320,14 +326,10 @@ public:
 };
 
 extern template struct CrystalLattice<double, OHMMS_DIM>;
-extern template CrystalLattice<double, OHMMS_DIM>::CrystalLattice(const Tensor<double, OHMMS_DIM>& tensor);
-extern template CrystalLattice<double, OHMMS_DIM>::CrystalLattice(const Tensor<float, OHMMS_DIM>& tensor);
 extern template void CrystalLattice<double, OHMMS_DIM>::set(const Tensor<double, OHMMS_DIM>& tensor);
 extern template void CrystalLattice<double, OHMMS_DIM>::set(const Tensor<float, OHMMS_DIM>& tensor);
 
 extern template struct CrystalLattice<float, OHMMS_DIM>;
-extern template CrystalLattice<float, OHMMS_DIM>::CrystalLattice(const Tensor<double, OHMMS_DIM>& tensor);
-extern template CrystalLattice<float, OHMMS_DIM>::CrystalLattice(const Tensor<float, OHMMS_DIM>& tensor);
 extern template void CrystalLattice<float, OHMMS_DIM>::set(const Tensor<double, OHMMS_DIM>& tensor);
 extern template void CrystalLattice<float, OHMMS_DIM>::set(const Tensor<float, OHMMS_DIM>& tensor);
 

--- a/src/Particle/Lattice/LatticeAnalyzer.h
+++ b/src/Particle/Lattice/LatticeAnalyzer.h
@@ -16,6 +16,8 @@
 #ifndef QMCPLUSPLUS_LATTICE_ANALYZER_H
 #define QMCPLUSPLUS_LATTICE_ANALYZER_H
 #include "OhmmsPETE/TinyVector.h"
+#include "CrystalLattice.h"
+
 namespace qmcplusplus
 {
 /** enumeration for DTD_BConds specialization
@@ -38,7 +40,10 @@ enum
 };
 
 
-///generic class to analyze a Lattice
+/** generic class to analyze a Lattice
+ *  NOTE: There is no constructor but operator() should be considered one in most
+ *        cases as the "class" is invalid until it is called since mySC is not intialized.
+ */
 template<typename T, unsigned D>
 struct LatticeAnalyzer
 {};

--- a/src/Particle/Lattice/ParticleBConds3D.h
+++ b/src/Particle/Lattice/ParticleBConds3D.h
@@ -17,6 +17,7 @@
 
 #include <config.h>
 #include "Lattice/CrystalLattice.h"
+#include "LatticeAnalyzer.h"
 
 namespace qmcplusplus
 {
@@ -27,7 +28,8 @@ struct DTD_BConds<T, 3, PPPO>
 {
   T Linv0, L0, Linv1, L1, Linv2, L2, r2max, dummy;
 
-  inline DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename TT>
+  inline DTD_BConds(const CrystalLattice<TT, 3>& lat)
       : Linv0(lat.OneOverLength[0]),
         L0(lat.Length[0]),
         Linv1(lat.OneOverLength[1]),
@@ -163,7 +165,8 @@ struct DTD_BConds<T, 3, PPPG>
   TinyVector<TinyVector<T, 3>, 3> rb;
   std::vector<TinyVector<T, 3>> corners;
 
-  DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename TT>
+  DTD_BConds(const CrystalLattice<TT, 3>& lat)
   {
     rb[0] = lat.a(0);
     rb[1] = lat.a(1);

--- a/src/Particle/Lattice/tests/CMakeLists.txt
+++ b/src/Particle/Lattice/tests/CMakeLists.txt
@@ -15,6 +15,10 @@ set(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 
 add_executable(${UTEST_EXE} test_ParticleBConds.cpp test_CrystalLattice.cpp test_LRBreakupParameters.cpp)
 target_include_directories(${UTEST_EXE} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../..")
-target_link_libraries(${UTEST_EXE} catch_main qmcutil platform_runtime)
+target_link_libraries(${UTEST_EXE} catch_main qmcutil platform_runtime qmcparticle)
+
+if(USE_OBJECT_TARGET)
+  target_link_libraries(${UTEST_EXE} qmcparticle_omptarget)
+endif()
 
 add_unit_test(${UTEST_NAME} 1 1 $<TARGET_FILE:${UTEST_EXE}>)

--- a/src/Particle/Lattice/tests/test_CrystalLattice.cpp
+++ b/src/Particle/Lattice/tests/test_CrystalLattice.cpp
@@ -27,7 +27,7 @@ using vec_t = TinyVector<double, 3>;
  */
 TEST_CASE("Crystal_lattice_periodic_bulk", "[lattice]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  CrystalLattice<OHMMS_PRECISION_FULL, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = false; // Open BC
   Lattice.R.diagonal(0.4);
   Lattice.reset();


### PR DESCRIPTION
@ye-luo suggestion this works as a separate PR.

Build and link CrystalLattice once as opposed to repeatedly due to including implementation into header.
Add accessors to facilitate encapsulation and full precision lattices.

this supports #5327 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation or build script changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
sdgx server

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
