### PR TITLE
[WIP] Make SimulationCell lattice in full precision.

### DIFF
--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -72,6 +72,8 @@ struct QMCTraits
   using PtclGrpIndexes = std::vector<std::pair<int, int>>;
 };
 
+using Lattice = CrystalLattice<OHMMS_PRECISION, OHMMS_DIM>;
+
 /** Particle traits to use UniformGridLayout for the ParticleLayout.
  */
 struct PtclOnLatticeTraits
@@ -96,7 +98,6 @@ struct PtclOnLatticeTraits
   using ParticleLaplacian   = ParticleAttrib<QTFull::ValueType>;
   using SingleParticleValue = QTFull::ValueType;
 };
-
 
 // For unit tests
 //  Check if we are compiling with Catch defined.  Could use other symbols if needed.

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -78,16 +78,14 @@ using Lattice = CrystalLattice<OHMMS_PRECISION, OHMMS_DIM>;
  */
 struct PtclOnLatticeTraits
 {
-  using ParticleLayout = CrystalLattice<OHMMS_PRECISION, OHMMS_DIM>;
   using QTFull         = QMCTraits::QTFull;
 
   using Index_t   = int;
   using Scalar_t  = QTFull::RealType;
   using Complex_t = QTFull::ComplexType;
 
-  using SingleParticleIndex = ParticleLayout::SingleParticleIndex;
-  using SingleParticlePos   = ParticleLayout::SingleParticlePos;
-  using Tensor_t            = ParticleLayout::Tensor_t;
+  using SingleParticlePos   = QMCTraits::QTBase::PosType;
+  using Tensor_t            = QMCTraits::QTBase::TensorType;
 
   using ParticleIndex  = ParticleAttrib<Index_t>;
   using ParticleScalar = ParticleAttrib<Scalar_t>;

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -72,7 +72,7 @@ struct QMCTraits
   using PtclGrpIndexes = std::vector<std::pair<int, int>>;
 };
 
-using Lattice = CrystalLattice<OHMMS_PRECISION, OHMMS_DIM>;
+using Lattice = CrystalLattice<OHMMS_PRECISION_FULL, OHMMS_DIM>;
 
 /** Particle traits to use UniformGridLayout for the ParticleLayout.
  */

--- a/src/Estimators/MagnetizationDensity.h
+++ b/src/Estimators/MagnetizationDensity.h
@@ -47,7 +47,6 @@ public:
   using Real               = RealAlias<Value>;
   using FullPrecReal       = RealAlias<FullPrecValue>;
   using Grad               = TinyVector<Value, OHMMS_DIM>;
-  using Lattice            = PtclOnLatticeTraits::ParticleLayout;
   using Position           = QMCTraits::PosType;
   using Integrator         = MagnetizationDensityInput::Integrator;
   static constexpr int DIM = QMCTraits::DIM;

--- a/src/Estimators/MagnetizationDensityInput.h
+++ b/src/Estimators/MagnetizationDensityInput.h
@@ -36,8 +36,6 @@ public:
                               {"integrator-montecarlo", Integrator::MONTECARLO}};
   // clang-format on
   using Real               = QMCTraits::FullPrecRealType;
-  using POLT               = PtclOnLatticeTraits;
-  using Lattice            = POLT::ParticleLayout;
   using PosType            = TinyVector<Real, OHMMS_DIM>;
   using Consumer           = MagnetizationDensity;
   static constexpr int DIM = QMCTraits::DIM;

--- a/src/Estimators/MomentumDistribution.cpp
+++ b/src/Estimators/MomentumDistribution.cpp
@@ -22,7 +22,7 @@ namespace qmcplusplus
 MomentumDistribution::MomentumDistribution(MomentumDistributionInput&& mdi,
                                            size_t np,
                                            const PosType& twist_in,
-                                           const LatticeType& lattice,
+                                           const Lattice& lattice,
                                            DataLocality dl)
     : OperatorEstBase(dl),
       input_(std::move(mdi)),

--- a/src/Estimators/MomentumDistribution.cpp
+++ b/src/Estimators/MomentumDistribution.cpp
@@ -22,12 +22,12 @@ namespace qmcplusplus
 MomentumDistribution::MomentumDistribution(MomentumDistributionInput&& mdi,
                                            size_t np,
                                            const PosType& twist_in,
-                                           const Lattice& lattice,
+                                           const Lattice& lattice_in,
                                            DataLocality dl)
     : OperatorEstBase(dl),
       input_(std::move(mdi)),
       twist(twist_in),
-      Lattice(lattice),
+      lattice(lattice_in),
       norm_nofK(1.0 / RealType(mdi.get_samples()))
 {
   psi_ratios.resize(np);
@@ -37,11 +37,11 @@ MomentumDistribution::MomentumDistribution(MomentumDistributionInput&& mdi,
   //dims of a grid for generating k points (obtained below)
   int kgrid = 0;
   // minimal length as 2 x WS radius.
-  RealType min_Length = Lattice.WignerSeitzRadius_G * 4.0 * M_PI;
+  RealType min_Length = lattice.WignerSeitzRadius_G * 4.0 * M_PI;
   PosType vec_length;
   //length of reciprocal lattice vector
   for (int i = 0; i < OHMMS_DIM; i++)
-    vec_length[i] = 2.0 * M_PI * std::sqrt(dot(Lattice.Gv[i], Lattice.Gv[i]));
+    vec_length[i] = 2.0 * M_PI * std::sqrt(dot(lattice.Gv[i], lattice.Gv[i]));
   RealType kmax      = input_.get_kmax();
   auto realCast      = [](auto& real) { return static_cast<RealType>(real); };
   PosType kmaxs      = {realCast(input_.get_kmax0()), realCast(input_.get_kmax1()), realCast(input_.get_kmax2())};
@@ -52,7 +52,7 @@ MomentumDistribution::MomentumDistribution(MomentumDistributionInput&& mdi,
   if (!sphere && !directional)
   {
     // default: kmax = 2 x k_F of polarized non-interacting electron system
-    kmax   = 2.0 * std::pow(6.0 * M_PI * M_PI * np / Lattice.Volume, 1.0 / 3);
+    kmax   = 2.0 * std::pow(6.0 * M_PI * M_PI * np / lattice.Volume, 1.0 / 3);
     sphere = true;
   }
   sphere_kmax = kmax;
@@ -83,7 +83,7 @@ MomentumDistribution::MomentumDistribution(MomentumDistributionInput&& mdi,
         ikpt[1] = j + twist[1];
         ikpt[2] = k + twist[2];
         //convert to Cartesian: note that 2Pi is multiplied
-        kpt               = Lattice.k_cart(ikpt);
+        kpt               = lattice.k_cart(ikpt);
         bool not_recorded = true;
         // This collects the k-points within the parallelepiped (if enabled)
         if (directional && ikpt[0] * ikpt[0] <= kgrid_squared[0] && ikpt[1] * ikpt[1] <= kgrid_squared[1] &&
@@ -260,7 +260,7 @@ void MomentumDistribution::accumulate(const RefVector<MCPWalker>& walkers,
       for (int i = 0; i < OHMMS_DIM; ++i)
         newpos[i] = rng();
       //make it cartesian
-      vPos[s] = Lattice.toCart(newpos);
+      vPos[s] = lattice.toCart(newpos);
       pset.makeVirtualMoves(vPos[s]);
       psi.evaluateRatiosAlltoOne(pset, psi_ratios);
       for (int i = 0; i < np; ++i)

--- a/src/Estimators/MomentumDistribution.h
+++ b/src/Estimators/MomentumDistribution.h
@@ -33,7 +33,6 @@ class MomentumDistributionTests;
 class MomentumDistribution : public OperatorEstBase
 {
 public:
-  using LatticeType = PtclOnLatticeTraits::ParticleLayout;
   using RealType    = QMCTraits::RealType;
   using ComplexType = QMCTraits::ComplexType;
   using ValueType   = QMCTraits::ValueType;
@@ -45,7 +44,7 @@ public:
   ///twist angle
   const PosType twist;
   ///lattice vector
-  const LatticeType Lattice;
+  const Lattice Lattice;
   ///normalization factor for n(k)
   const RealType norm_nofK;
   ///list of k-points in Cartesian Coordinates
@@ -76,7 +75,7 @@ public:
   MomentumDistribution(MomentumDistributionInput&& mdi,
                        size_t np,
                        const PosType& twist,
-                       const LatticeType& lattice,
+                       const Lattice& lattice,
                        DataLocality dl = DataLocality::crowd);
 
   /** Constructor used when spawing crowd clones

--- a/src/Estimators/MomentumDistribution.h
+++ b/src/Estimators/MomentumDistribution.h
@@ -44,7 +44,7 @@ public:
   ///twist angle
   const PosType twist;
   ///lattice vector
-  const Lattice Lattice;
+  const Lattice lattice;
   ///normalization factor for n(k)
   const RealType norm_nofK;
   ///list of k-points in Cartesian Coordinates

--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -50,7 +50,6 @@ public:
   using Real          = RealAlias<Value>;
   using FullPrecReal  = RealAlias<FullPrecValue>;
   using Grad          = TinyVector<Value, OHMMS_DIM>;
-  using Lattice       = PtclOnLatticeTraits::ParticleLayout;
   using Position      = QMCTraits::PosType;
 
   using Evaluator  = OneBodyDensityMatricesInput::Evaluator;

--- a/src/Estimators/SelfHealingOverlap.h
+++ b/src/Estimators/SelfHealingOverlap.h
@@ -27,7 +27,6 @@ namespace qmcplusplus
 class SelfHealingOverlap : public OperatorEstBase
 {
 public:
-  using LatticeType = PtclOnLatticeTraits::ParticleLayout;
   using RealType    = QMCTraits::RealType;
   using ComplexType = QMCTraits::ComplexType;
   using ValueType   = QMCTraits::ValueType;

--- a/src/Estimators/SpinDensityInput.h
+++ b/src/Estimators/SpinDensityInput.h
@@ -33,8 +33,6 @@ class SpinDensityInput
 {
 public:
   using Real               = QMCTraits::RealType;
-  using POLT               = PtclOnLatticeTraits;
-  using Lattice            = POLT::ParticleLayout;
   using PosType            = QMCTraits::PosType;
   using Consumer           = SpinDensityNew;
   static constexpr int DIM = QMCTraits::DIM;

--- a/src/Estimators/SpinDensityNew.h
+++ b/src/Estimators/SpinDensityNew.h
@@ -35,8 +35,6 @@ class SpinDensityNewTests;
 class SpinDensityNew : public OperatorEstBase
 {
 public:
-  using POLT    = PtclOnLatticeTraits;
-  using Lattice = POLT::ParticleLayout;
   using QMCT    = QMCTraits;
   using FullPrecRealType = QMCT::FullPrecRealType;
 

--- a/src/Estimators/tests/EstimatorTesting.h
+++ b/src/Estimators/tests/EstimatorTesting.h
@@ -22,8 +22,6 @@ class SpeciesSet;
 
 namespace testing
 {
-using POLT    = PtclOnLatticeTraits;
-using Lattice = POLT::ParticleLayout;
 
 enum class SpeciesCases
 {

--- a/src/Estimators/tests/test_MagnetizationDensity.cpp
+++ b/src/Estimators/tests/test_MagnetizationDensity.cpp
@@ -183,7 +183,7 @@ TEST_CASE("MagnetizationDensity::gridAssignment", "[estimators]")
                                     {6.03341616, 0, 1.77067004},           //bin 6
                                     {2.78496304, 0, 5.31201011}};          //bin 7
 
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R(0, 0) = 5.10509515;
   lattice.R(0, 1) = -3.23993545;
   lattice.R(0, 2) = 0.00000000;
@@ -295,7 +295,7 @@ TEST_CASE("MagnetizationDensity::IntegrationTest", "[estimators]")
   using namespace testing;
 
   // O2 test example from pwscf non-collinear calculation.
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R(0, 0) = 5.10509515;
   lattice.R(0, 1) = -3.23993545;
   lattice.R(0, 2) = 0.00000000;

--- a/src/Estimators/tests/test_MagnetizationDensityInput.cpp
+++ b/src/Estimators/tests/test_MagnetizationDensityInput.cpp
@@ -27,8 +27,6 @@ namespace qmcplusplus
 {
 TEST_CASE("MagnetizationDensityInput::from_xml", "[estimators]")
 {
-  using POLT    = PtclOnLatticeTraits;
-  using Lattice = POLT::ParticleLayout;
   using PosType = QMCTraits::PosType;
   using namespace testing::magdensity;
 

--- a/src/Estimators/tests/test_OneBodyDensityMatricesInput.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatricesInput.cpp
@@ -26,8 +26,6 @@ namespace qmcplusplus
 {
 TEST_CASE("OneBodyDensityMatricesInput::from_xml", "[estimators]")
 {
-  using POLT        = PtclOnLatticeTraits;
-  using Lattice     = POLT::ParticleLayout;
   using Input = testing::ValidOneBodyDensityMatricesInput;
   Input valid_input;
   for (auto input_xml : valid_input)

--- a/src/Estimators/tests/test_SpinDensityInput.cpp
+++ b/src/Estimators/tests/test_SpinDensityInput.cpp
@@ -25,8 +25,6 @@ namespace qmcplusplus
 {
 TEST_CASE("SpinDensityInput::readXML", "[estimators]")
 {
-  using POLT    = PtclOnLatticeTraits;
-  using Lattice = POLT::ParticleLayout;
   using input = testing::ValidSpinDensityInput;
   for (auto input_xml : input::xml)
   {

--- a/src/Estimators/tests/test_SpinDensityNew.cpp
+++ b/src/Estimators/tests/test_SpinDensityNew.cpp
@@ -139,7 +139,7 @@ TEST_CASE("SpinDensityNew::SpinDensityNew(SPInput, SpeciesSet)", "[estimators]")
   species_set(iattribute, ispecies) = 2;
   SpinDensityInput sdi_copy         = sdi;
   SpinDensityNew(std::move(sdi), species_set);
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
 }
 
 TEST_CASE("SpinDensityNew::SpinDensityNew(SPInput, Lattice, SpeciesSet)", "[estimators]")

--- a/src/Particle/InitMolecularSystem.cpp
+++ b/src/Particle/InitMolecularSystem.cpp
@@ -253,7 +253,7 @@ void InitMolecularSystem::initWithVolume(ParticleSet* ions, ParticleSet* els)
     }
   }
 
-  ParticleSet::ParticleLayout slattice(ions->getLattice());
+  Lattice slattice(ions->getLattice());
   slattice.set(newbox);
 
   app_log() << "  InitMolecularSystem::initWithVolume " << std::endl;

--- a/src/Particle/Lattice/CrystalLattice.h
+++ b/src/Particle/Lattice/CrystalLattice.h
@@ -218,7 +218,8 @@ public:
   /// return true if any direction of reduced coordinates u goes larger than 0.5
   bool outOfBound(const TinyVector<T, D>& u) const;
 
-  inline void applyMinimumImage(TinyVector<T, D>& c) const
+  template <typename PT>
+  inline void applyMinimumImage(TinyVector<PT, D>& c) const
   {
     if (SuperCellEnum)
     {

--- a/src/Particle/Lattice/CrystalLattice.h
+++ b/src/Particle/Lattice/CrystalLattice.h
@@ -69,8 +69,6 @@ public:
   using Scalar_t = T;
   ///the type of a D-dimensional position vector
   using SingleParticlePos = TinyVector<T, D>;
-  ///the type of a D-dimensional index vector
-  using SingleParticleIndex = TinyVector<int, D>;
   ///the type of a D-dimensional Tensor
   using Tensor_t = Tensor<T, D>;
   //@}

--- a/src/Particle/Lattice/ParticleBConds.h
+++ b/src/Particle/Lattice/ParticleBConds.h
@@ -69,7 +69,8 @@ template<class T, unsigned D, int SC>
 struct DTD_BConds
 {
   /** constructor: doing nothing */
-  inline DTD_BConds(const CrystalLattice<T, D>& lat) {}
+  template<typename TT>
+  inline DTD_BConds(const CrystalLattice<TT, D>& lat) {}
 
   /** apply BC on displ and return |displ|^2
    * @param displ a displacement vector in the Cartesian coordinate

--- a/src/Particle/Lattice/ParticleBConds3DSoa.h
+++ b/src/Particle/Lattice/ParticleBConds3DSoa.h
@@ -26,7 +26,9 @@ template<class T>
 struct DTD_BConds<T, 3, SUPERCELL_OPEN + SOA_OFFSET>
 {
   /** constructor: doing nothing */
-  inline DTD_BConds(const CrystalLattice<T, 3>& lat) {}
+  template<typename LT>
+  inline DTD_BConds(const CrystalLattice<LT, 3>& lat)
+  {}
 
   template<typename PT, typename RSOA, typename DISPLSOA>
   void computeDistances(const PT& pos,
@@ -46,7 +48,7 @@ struct DTD_BConds<T, 3, SUPERCELL_OPEN + SOA_OFFSET>
     T* restrict dx       = temp_dr.data(0);
     T* restrict dy       = temp_dr.data(1);
     T* restrict dz       = temp_dr.data(2);
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       dx[iat]     = px[iat] - x0;
@@ -83,10 +85,7 @@ struct DTD_BConds<T, 3, SUPERCELL_OPEN + SOA_OFFSET>
     temp_r[iat] = std::sqrt(dx[iat] * dx[iat] + dy[iat] * dy[iat] + dz[iat] * dz[iat]);
   }
 
-  T computeDist(T dx, T dy, T dz) const
-  {
-    return std::sqrt(dx * dx + dy * dy + dz * dz);
-  }
+  T computeDist(T dx, T dy, T dz) const { return std::sqrt(dx * dx + dy * dy + dz * dz); }
 };
 
 /** specialization for a periodic 3D, orthorombic cell
@@ -96,7 +95,8 @@ struct DTD_BConds<T, 3, PPPO + SOA_OFFSET>
 {
   T Linv0, L0, Linv1, L1, Linv2, L2, r2max, dummy;
 
-  inline DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename LT>
+  inline DTD_BConds(const CrystalLattice<LT, 3>& lat)
       : Linv0(lat.OneOverLength[0]),
         L0(lat.Length[0]),
         Linv1(lat.OneOverLength[1]),
@@ -125,7 +125,7 @@ struct DTD_BConds<T, 3, PPPO + SOA_OFFSET>
     T* restrict dx       = temp_dr.data(0);
     T* restrict dy       = temp_dr.data(1);
     T* restrict dz       = temp_dr.data(2);
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       const T x   = (px[iat] - x0) * Linv0;
@@ -173,9 +173,9 @@ struct DTD_BConds<T, 3, PPPO + SOA_OFFSET>
     T x = dx * Linv0;
     T y = dy * Linv1;
     T z = dz * Linv2;
-    dx = L0 * (x - round(x));
-    dy = L1 * (y - round(y));
-    dz = L2 * (z - round(z));
+    dx  = L0 * (x - round(x));
+    dy  = L1 * (y - round(y));
+    dz  = L2 * (z - round(z));
     return std::sqrt(dx * dx + dy * dy + dz * dz);
   }
 };
@@ -189,7 +189,9 @@ struct DTD_BConds<T, 3, PPPS + SOA_OFFSET>
 {
   T r00, r10, r20, r01, r11, r21, r02, r12, r22;
   T g00, g10, g20, g01, g11, g21, g02, g12, g22;
-  DTD_BConds(const CrystalLattice<T, 3>& lat)
+
+  template<typename LT>
+  DTD_BConds(const CrystalLattice<LT, 3>& lat)
       : r00(lat.R(0)),
         r10(lat.R(3)),
         r20(lat.R(6)),
@@ -231,7 +233,7 @@ struct DTD_BConds<T, 3, PPPS + SOA_OFFSET>
     T* restrict dy = temp_dr.data(1);
     T* restrict dz = temp_dr.data(2);
 
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       T displ_0 = px[iat] - x0;
@@ -331,7 +333,8 @@ struct DTD_BConds<T, 3, PPPG + SOA_OFFSET>
   T r00, r10, r20, r01, r11, r21, r02, r12, r22;
   TinyVector<TinyVector<T, 8>, 3> corners;
 
-  DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename LT>
+  DTD_BConds(const CrystalLattice<LT, 3>& lat)
   {
     TinyVector<TinyVector<T, 3>, 3> rb;
     rb[0] = lat.a(0);
@@ -410,7 +413,7 @@ struct DTD_BConds<T, 3, PPPG + SOA_OFFSET>
 
     constexpr T minusone(-1);
     constexpr T one(1);
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       const T flip    = iat < flip_ind ? one : minusone;
@@ -546,7 +549,8 @@ struct DTD_BConds<T, 3, PPNG + SOA_OFFSET>
   TinyVector<TinyVector<T, 3>, 3> rb;
   TinyVector<TinyVector<T, 4>, 2> corners;
 
-  DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename LT>
+  DTD_BConds(const CrystalLattice<LT, 3>& lat)
   {
     rb[0] = lat.a(0);
     rb[1] = lat.a(1);
@@ -598,7 +602,7 @@ struct DTD_BConds<T, 3, PPNG + SOA_OFFSET>
 
     constexpr T minusone(-1);
     constexpr T one(1);
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       const T flip    = iat < flip_ind ? one : minusone;
@@ -719,7 +723,8 @@ struct DTD_BConds<T, 3, PPNO + SOA_OFFSET>
 {
   T Linv0, L0, Linv1, L1;
 
-  inline DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename LT>
+  inline DTD_BConds(const CrystalLattice<LT, 3>& lat)
       : Linv0(lat.OneOverLength[0]), L0(lat.Length[0]), Linv1(lat.OneOverLength[1]), L1(lat.Length[1])
   {}
 
@@ -742,7 +747,7 @@ struct DTD_BConds<T, 3, PPNO + SOA_OFFSET>
     T* restrict dy       = temp_dr.data(1);
     T* restrict dz       = temp_dr.data(2);
 
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       T x         = (px[iat] - x0) * Linv0;
@@ -787,8 +792,8 @@ struct DTD_BConds<T, 3, PPNO + SOA_OFFSET>
   {
     T x = dx * Linv0;
     T y = dy * Linv1;
-    dx = L0 * (x - round(x));
-    dy = L1 * (y - round(y));
+    dx  = L0 * (x - round(x));
+    dy  = L1 * (y - round(y));
     return std::sqrt(dx * dx + dy * dy + dz * dz);
   }
 };
@@ -800,7 +805,9 @@ struct DTD_BConds<T, 3, PPNS + SOA_OFFSET>
 {
   T r00, r10, r01, r11;
   T g00, g10, g01, g11;
-  DTD_BConds(const CrystalLattice<T, 3>& lat)
+
+  template<typename LT>
+  DTD_BConds(const CrystalLattice<LT, 3>& lat)
       : r00(lat.R(0)),
         r10(lat.R(3)),
         r01(lat.R(1)),
@@ -832,7 +839,7 @@ struct DTD_BConds<T, 3, PPNS + SOA_OFFSET>
     T* restrict dy = temp_dr.data(1);
     T* restrict dz = temp_dr.data(2);
 
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       T displ_0 = px[iat] - x0;
@@ -918,7 +925,9 @@ struct DTD_BConds<T, 3, SUPERCELL_WIRE + SOA_OFFSET>
 {
   T Linv0, L0;
 
-  inline DTD_BConds(const CrystalLattice<T, 3>& lat) : Linv0(lat.OneOverLength[0]), L0(lat.Length[0]) {}
+  template<typename LT>
+  inline DTD_BConds(const CrystalLattice<LT, 3>& lat) : Linv0(lat.OneOverLength[0]), L0(lat.Length[0])
+  {}
   template<typename PT, typename RSOA, typename DISPLSOA>
   void computeDistances(const PT& pos,
                         const RSOA& R0,
@@ -940,7 +949,7 @@ struct DTD_BConds<T, 3, SUPERCELL_WIRE + SOA_OFFSET>
     T* restrict dy = temp_dr.data(1);
     T* restrict dz = temp_dr.data(2);
 
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       T x         = (px[iat] - x0) * Linv0;
@@ -981,8 +990,8 @@ struct DTD_BConds<T, 3, SUPERCELL_WIRE + SOA_OFFSET>
 
   T computeDist(T dx, T dy, T dz) const
   {
-    T x         = dx * Linv0;
-    dx     = L0 * (x - round(x));
+    T x = dx * Linv0;
+    dx  = L0 * (x - round(x));
     return std::sqrt(dx * dx + dy * dy + dz * dz);
   }
 };
@@ -999,7 +1008,8 @@ struct DTD_BConds<T, 3, PPPX + SOA_OFFSET>
   T r2max;
   TinyVector<TinyVector<T, 26>, 3> nextcells;
 
-  DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename LT>
+  DTD_BConds(const CrystalLattice<LT, 3>& lat)
       : r00(lat.R(0)),
         r10(lat.R(3)),
         r20(lat.R(6)),
@@ -1078,7 +1088,8 @@ struct DTD_BConds<T, 3, PPNX + SOA_OFFSET>
   T r2max;
   TinyVector<TinyVector<T, 8>, 3> nextcells;
 
-  DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename LT>
+  DTD_BConds(const CrystalLattice<LT, 3>& lat)
       : r00(lat.R(0)),
         r10(lat.R(3)),
         r01(lat.R(1)),

--- a/src/Particle/Lattice/tests/test_ParticleBConds.cpp
+++ b/src/Particle/Lattice/tests/test_ParticleBConds.cpp
@@ -29,8 +29,8 @@ using vec_t = TinyVector<OHMMS_PRECISION, 3>;
 
 TEST_CASE("open_bconds", "[lattice]")
 {
-  Lattice Lattice;
-  DTD_BConds<OHMMS_PRECISION, 3, SUPERCELL_OPEN> bcond(Lattice);
+  Lattice lattice;
+  DTD_BConds<OHMMS_PRECISION, 3, SUPERCELL_OPEN> bcond(lattice);
 
   vec_t v(3.0, 4.0, 5.0);
 
@@ -55,18 +55,18 @@ TEST_CASE("open_bconds", "[lattice]")
   CHECK(Approx(rr[0]) == 50.0);
 }
 
-/** Lattice is defined but Open BC is also used.
+/** lattice is defined but Open BC is also used.
  */
 TEST_CASE("periodic_bulk_bconds", "[lattice]")
 {
-  Lattice Lattice;
-  Lattice.BoxBConds = false; // Open BC
-  Lattice.R.diagonal(0.4);
-  Lattice.reset();
+  Lattice lattice;
+  lattice.BoxBConds = false; // Open BC
+  lattice.R.diagonal(0.4);
+  lattice.reset();
 
-  CHECK(Lattice.Volume == Approx(0.4 * 0.4 * 0.4));
+  CHECK(lattice.Volume == Approx(0.4 * 0.4 * 0.4));
 
-  DTD_BConds<OHMMS_PRECISION, 3, SUPERCELL_BULK> bcond(Lattice);
+  DTD_BConds<OHMMS_PRECISION, 3, SUPERCELL_BULK> bcond(lattice);
 
   vec_t v1(0.0, 0.0, 0.0);
 
@@ -78,23 +78,23 @@ TEST_CASE("periodic_bulk_bconds", "[lattice]")
   CHECK(r2 == Approx(0.01));
 }
 
-TEST_CASE("uniform 3D Lattice layout", "[lattice]")
+TEST_CASE("uniform 3D lattice layout", "[lattice]")
 {
-  Lattice Lattice;
-  Lattice.BoxBConds = true; // periodic
+  Lattice lattice;
+  lattice.BoxBConds = true; // periodic
 
-  Lattice.R.diagonal(1.0);
-  Lattice.reset();
+  lattice.R.diagonal(1.0);
+  lattice.reset();
 
-  REQUIRE(Lattice.R(0, 0) == 1.0);
-  REQUIRE(Lattice.R(0, 1) == 0.0);
-  REQUIRE(Lattice.R(0, 2) == 0.0);
-  REQUIRE(Lattice.R(1, 0) == 0.0);
-  REQUIRE(Lattice.R(1, 1) == 1.0);
-  REQUIRE(Lattice.R(1, 2) == 0.0);
-  REQUIRE(Lattice.R(2, 0) == 0.0);
-  REQUIRE(Lattice.R(2, 1) == 0.0);
-  REQUIRE(Lattice.R(2, 2) == 1.0);
+  REQUIRE(lattice.R(0, 0) == 1.0);
+  REQUIRE(lattice.R(0, 1) == 0.0);
+  REQUIRE(lattice.R(0, 2) == 0.0);
+  REQUIRE(lattice.R(1, 0) == 0.0);
+  REQUIRE(lattice.R(1, 1) == 1.0);
+  REQUIRE(lattice.R(1, 2) == 0.0);
+  REQUIRE(lattice.R(2, 0) == 0.0);
+  REQUIRE(lattice.R(2, 1) == 0.0);
+  REQUIRE(lattice.R(2, 2) == 1.0);
 }
 
 } // namespace qmcplusplus

--- a/src/Particle/Lattice/tests/test_ParticleBConds.cpp
+++ b/src/Particle/Lattice/tests/test_ParticleBConds.cpp
@@ -29,7 +29,7 @@ using vec_t = TinyVector<OHMMS_PRECISION, 3>;
 
 TEST_CASE("open_bconds", "[lattice]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice Lattice;
   DTD_BConds<OHMMS_PRECISION, 3, SUPERCELL_OPEN> bcond(Lattice);
 
   vec_t v(3.0, 4.0, 5.0);
@@ -59,7 +59,7 @@ TEST_CASE("open_bconds", "[lattice]")
  */
 TEST_CASE("periodic_bulk_bconds", "[lattice]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice Lattice;
   Lattice.BoxBConds = false; // Open BC
   Lattice.R.diagonal(0.4);
   Lattice.reset();
@@ -80,7 +80,7 @@ TEST_CASE("periodic_bulk_bconds", "[lattice]")
 
 TEST_CASE("uniform 3D Lattice layout", "[lattice]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice Lattice;
   Lattice.BoxBConds = true; // periodic
 
   Lattice.R.diagonal(1.0);

--- a/src/Particle/LongRange/KContainer.h
+++ b/src/Particle/LongRange/KContainer.h
@@ -34,7 +34,7 @@ private:
 
 public:
   //Typedef for the lattice-type
-  using ParticleLayout = PtclOnLatticeTraits::ParticleLayout;
+  using ParticleLayout = Lattice;
 
   ///number of k-points
   int numk;

--- a/src/Particle/LongRange/LRBasis.h
+++ b/src/Particle/LongRange/LRBasis.h
@@ -40,7 +40,7 @@ struct LRBasis
   mRealType m_rc;
 
   ///Typedef for the lattice-type. We don't need the full particle-set.
-  using ParticleLayout = ParticleSet::ParticleLayout;
+  using ParticleLayout = qmcplusplus::Lattice;
 
   //A copy of the lattice, so that we have the cell-vectors + volume.
   ParticleLayout Lattice;

--- a/src/Particle/LongRange/LRBreakup.h
+++ b/src/Particle/LongRange/LRBreakup.h
@@ -31,7 +31,7 @@ struct LRBreakup
   DECLARE_COULOMB_TYPES
 
   //Typedef for the lattice-type. We don't need the full particle-set.
-  using ParticleLayout = ParticleSet::ParticleLayout;
+  using ParticleLayout = Lattice;
 
   //We use an internal k-list with degeneracies to do the breakup.
   //We do this because the number of vectors is much larger than we'd

--- a/src/Particle/LongRange/LRHandlerSRCoulomb.h
+++ b/src/Particle/LongRange/LRHandlerSRCoulomb.h
@@ -44,7 +44,7 @@ class LRHandlerSRCoulomb : public LRHandlerBase
 {
 public:
   //Typedef for the lattice-type.
-  using ParticleLayout   = ParticleSet::ParticleLayout;
+  using ParticleLayout   = Lattice;
   using BreakupBasisType = BreakupBasis;
   using GridType         = LinearGrid<mRealType>;
 

--- a/src/Particle/LongRange/LRHandlerTemp.h
+++ b/src/Particle/LongRange/LRHandlerTemp.h
@@ -41,7 +41,7 @@ class LRHandlerTemp : public LRHandlerBase
 {
 public:
   //Typedef for the lattice-type.
-  using ParticleLayout   = ParticleSet::ParticleLayout;
+  using ParticleLayout   = Lattice;
   using BreakupBasisType = BreakupBasis;
 
   bool FirstTime;

--- a/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
@@ -38,7 +38,7 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
   DECLARE_COULOMB_TYPES
 
   //Typedef for the lattice-type.
-  using ParticleLayout   = ParticleSet::ParticleLayout;
+  using ParticleLayout   = Lattice;
   using BreakupBasisType = BreakupBasis;
 
   bool FirstTime;

--- a/src/Particle/LongRange/LRRPAHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPAHandlerTemp.h
@@ -38,7 +38,7 @@ struct LRRPAHandlerTemp : public LRHandlerBase
   DECLARE_COULOMB_TYPES
 
   //Typedef for the lattice-type.
-  using ParticleLayout   = ParticleSet::ParticleLayout;
+  using ParticleLayout   = Lattice;
   using BreakupBasisType = BreakupBasis;
 
   bool FirstTime;

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -40,7 +40,7 @@ class StructFact : public QMCTraits
 {
 public:
   //Typedef for the lattice-type
-  using ParticleLayout = PtclOnLatticeTraits::ParticleLayout;
+  using ParticleLayout = Lattice;
 
   /** enumeration for the methods to handle mixed bconds
    *

--- a/src/Particle/LongRange/tests/test_StructFact.cpp
+++ b/src/Particle/LongRange/tests/test_StructFact.cpp
@@ -23,7 +23,7 @@ namespace qmcplusplus
  */
 TEST_CASE("StructFact", "[lrhandler]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice Lattice;
   Lattice.BoxBConds     = true;
   Lattice.LR_dim_cutoff = 30.;
   Lattice.R.diagonal(5.0);

--- a/src/Particle/LongRange/tests/test_StructFact.cpp
+++ b/src/Particle/LongRange/tests/test_StructFact.cpp
@@ -23,19 +23,19 @@ namespace qmcplusplus
  */
 TEST_CASE("StructFact", "[lrhandler]")
 {
-  Lattice Lattice;
-  Lattice.BoxBConds     = true;
-  Lattice.LR_dim_cutoff = 30.;
-  Lattice.R.diagonal(5.0);
-  Lattice.reset();
-  CHECK(Approx(Lattice.Volume) == 125);
-  Lattice.SetLRCutoffs(Lattice.Rv);
-  Lattice.printCutoffs(app_log());
-  CHECK(Approx(Lattice.LR_rc) == 2.5);
-  CHECK(Approx(Lattice.LR_kc) == 12);
+  Lattice lattice;
+  lattice.BoxBConds     = true;
+  lattice.LR_dim_cutoff = 30.;
+  lattice.R.diagonal(5.0);
+  lattice.reset();
+  CHECK(Approx(lattice.Volume) == 125);
+  lattice.SetLRCutoffs(lattice.Rv);
+  lattice.printCutoffs(app_log());
+  CHECK(Approx(lattice.LR_rc) == 2.5);
+  CHECK(Approx(lattice.LR_kc) == 12);
 
-  Lattice.LR_dim_cutoff = 125;
-  const SimulationCell simulation_cell(Lattice);
+  lattice.LR_dim_cutoff = 125;
+  const SimulationCell simulation_cell(lattice);
   ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
 
   SpeciesSet& tspecies = ref.getSpeciesSet();

--- a/src/Particle/LongRange/tests/test_ewald3d.cpp
+++ b/src/Particle/LongRange/tests/test_ewald3d.cpp
@@ -24,26 +24,26 @@ using mRealType = EwaldHandler3D::mRealType;
  */
 TEST_CASE("ewald3d", "[lrhandler]")
 {
-  Lattice Lattice;
-  Lattice.BoxBConds     = true;
-  Lattice.LR_dim_cutoff = 30.;
-  Lattice.R.diagonal(5.0);
-  Lattice.reset();
-  CHECK(Lattice.Volume == Approx(125));
-  Lattice.SetLRCutoffs(Lattice.Rv);
-  //Lattice.printCutoffs(app_log());
-  CHECK(Lattice.LR_rc == Approx(2.5));
-  CHECK(Lattice.LR_kc == Approx(12));
+  Lattice lattice;
+  lattice.BoxBConds     = true;
+  lattice.LR_dim_cutoff = 30.;
+  lattice.R.diagonal(5.0);
+  lattice.reset();
+  CHECK(lattice.Volume == Approx(125));
+  lattice.SetLRCutoffs(lattice.Rv);
+  //lattice.printCutoffs(app_log());
+  CHECK(lattice.LR_rc == Approx(2.5));
+  CHECK(lattice.LR_kc == Approx(12));
 
-  const SimulationCell simulation_cell(Lattice);
+  const SimulationCell simulation_cell(lattice);
   ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
   ref.createSK();
-  EwaldHandler3D handler(ref, Lattice.LR_kc);
+  EwaldHandler3D handler(ref, lattice.LR_kc);
 
   // make sure initBreakup changes the default sigma
-  CHECK(handler.Sigma == Approx(Lattice.LR_kc));
+  CHECK(handler.Sigma == Approx(lattice.LR_kc));
   handler.initBreakup(ref);
-  CHECK(handler.Sigma == Approx(std::sqrt(Lattice.LR_kc / (2.0 * Lattice.LR_rc))));
+  CHECK(handler.Sigma == Approx(std::sqrt(lattice.LR_kc / (2.0 * lattice.LR_rc))));
 
   std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
   CHECK( (std::is_same<OHMMS_PRECISION, OHMMS_PRECISION_FULL>::value ?
@@ -73,26 +73,26 @@ TEST_CASE("ewald3d", "[lrhandler]")
  */
 TEST_CASE("ewald3d df", "[lrhandler]")
 {
-  Lattice Lattice;
-  Lattice.BoxBConds     = true;
-  Lattice.LR_dim_cutoff = 30.;
-  Lattice.R.diagonal(5.0);
-  Lattice.reset();
-  CHECK(Lattice.Volume == Approx(125));
-  Lattice.SetLRCutoffs(Lattice.Rv);
-  //Lattice.printCutoffs(app_log());
-  CHECK(Lattice.LR_rc == Approx(2.5));
-  CHECK(Lattice.LR_kc == Approx(12));
+  Lattice lattice;
+  lattice.BoxBConds     = true;
+  lattice.LR_dim_cutoff = 30.;
+  lattice.R.diagonal(5.0);
+  lattice.reset();
+  CHECK(lattice.Volume == Approx(125));
+  lattice.SetLRCutoffs(lattice.Rv);
+  //lattice.printCutoffs(app_log());
+  CHECK(lattice.LR_rc == Approx(2.5));
+  CHECK(lattice.LR_kc == Approx(12));
 
-  const SimulationCell simulation_cell(Lattice);
+  const SimulationCell simulation_cell(lattice);
   ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
   ref.createSK();
-  EwaldHandler3D handler(ref, Lattice.LR_kc);
+  EwaldHandler3D handler(ref, lattice.LR_kc);
 
   // make sure initBreakup changes the default sigma
-  CHECK(handler.Sigma == Approx(Lattice.LR_kc));
+  CHECK(handler.Sigma == Approx(lattice.LR_kc));
   handler.initBreakup(ref);
-  CHECK(handler.Sigma == Approx(std::sqrt(Lattice.LR_kc / (2.0 * Lattice.LR_rc))));
+  CHECK(handler.Sigma == Approx(std::sqrt(lattice.LR_kc / (2.0 * lattice.LR_rc))));
 
   std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
   CHECK( (std::is_same<OHMMS_PRECISION, OHMMS_PRECISION_FULL>::value ?

--- a/src/Particle/LongRange/tests/test_ewald3d.cpp
+++ b/src/Particle/LongRange/tests/test_ewald3d.cpp
@@ -24,7 +24,7 @@ using mRealType = EwaldHandler3D::mRealType;
  */
 TEST_CASE("ewald3d", "[lrhandler]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice Lattice;
   Lattice.BoxBConds     = true;
   Lattice.LR_dim_cutoff = 30.;
   Lattice.R.diagonal(5.0);
@@ -73,7 +73,7 @@ TEST_CASE("ewald3d", "[lrhandler]")
  */
 TEST_CASE("ewald3d df", "[lrhandler]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice Lattice;
   Lattice.BoxBConds     = true;
   Lattice.LR_dim_cutoff = 30.;
   Lattice.R.diagonal(5.0);

--- a/src/Particle/LongRange/tests/test_kcontainer.cpp
+++ b/src/Particle/LongRange/tests/test_kcontainer.cpp
@@ -27,7 +27,7 @@ TEST_CASE("kcontainer at gamma in 3D", "[longrange]")
   const std::vector<double> kcs = {blat, std::sqrt(2) * blat, std::sqrt(3) * blat};
   const std::vector<int> nks    = {6, 18, 26};
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.R.diagonal(1.0);
   lattice.set(lattice.R); // compute Rv and Gv from R
 
@@ -63,7 +63,7 @@ TEST_CASE("kcontainer at twist in 3D", "[longrange]")
   // twist one shell of kvectors
   const double kc = blat + 1e-6;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.R.diagonal(1.0);
   lattice.set(lattice.R); // compute Rv and Gv from R
 
@@ -94,7 +94,7 @@ TEST_CASE("kcontainer at gamma in 2D", "[longrange]")
   const std::vector<double> kcs = {blat, std::sqrt(2) * blat, 2 * blat};
   const std::vector<int> nks    = {4, 8, 12};
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.R.diagonal(1.0);
   lattice.set(lattice.R); // compute Rv and Gv from R
 
@@ -130,7 +130,7 @@ TEST_CASE("kcontainer at twist in 2D", "[longrange]")
   // twist one shell of kvectors
   const double kc = blat + 1e-6;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.R.diagonal(1.0);
   lattice.set(lattice.R); // compute Rv and Gv from R
 

--- a/src/Particle/LongRange/tests/test_lrhandler.cpp
+++ b/src/Particle/LongRange/tests/test_lrhandler.cpp
@@ -29,7 +29,7 @@ struct CoulombF2
  */
 TEST_CASE("dummy", "[lrhandler]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice Lattice;
   Lattice.BoxBConds     = true;
   Lattice.LR_dim_cutoff = 30.;
   Lattice.R.diagonal(5.0);

--- a/src/Particle/LongRange/tests/test_lrhandler.cpp
+++ b/src/Particle/LongRange/tests/test_lrhandler.cpp
@@ -29,21 +29,21 @@ struct CoulombF2
  */
 TEST_CASE("dummy", "[lrhandler]")
 {
-  Lattice Lattice;
-  Lattice.BoxBConds     = true;
-  Lattice.LR_dim_cutoff = 30.;
-  Lattice.R.diagonal(5.0);
-  Lattice.reset();
-  CHECK(Lattice.Volume == Approx(125));
-  Lattice.SetLRCutoffs(Lattice.Rv);
-  //Lattice.printCutoffs(app_log());
-  CHECK(Lattice.LR_rc == Approx(2.5));
-  CHECK(Lattice.LR_kc == Approx(12));
+  Lattice lattice;
+  lattice.BoxBConds     = true;
+  lattice.LR_dim_cutoff = 30.;
+  lattice.R.diagonal(5.0);
+  lattice.reset();
+  CHECK(lattice.Volume == Approx(125));
+  lattice.SetLRCutoffs(lattice.Rv);
+  //lattice.printCutoffs(app_log());
+  CHECK(lattice.LR_rc == Approx(2.5));
+  CHECK(lattice.LR_kc == Approx(12));
 
-  const SimulationCell simulation_cell(Lattice);
+  const SimulationCell simulation_cell(lattice);
   ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
   ref.createSK();
-  DummyLRHandler<CoulombF2> handler(Lattice.LR_kc);
+  DummyLRHandler<CoulombF2> handler(lattice.LR_kc);
 
   handler.initBreakup(ref);
 
@@ -56,7 +56,7 @@ TEST_CASE("dummy", "[lrhandler]")
   std::vector<pRealType> rhok1(handler.MaxKshell);
   std::vector<pRealType> rhok2(handler.MaxKshell);
   CoulombF2 fk;
-  double norm = 4 * M_PI / Lattice.Volume;
+  double norm = 4 * M_PI / lattice.Volume;
   // no actual LR breakup happened in DummyLRHandler,
   //  the full Coulomb potential should be retained in kspace
   for (int ish = 0; ish < handler.MaxKshell; ish++)

--- a/src/Particle/LongRange/tests/test_srcoul.cpp
+++ b/src/Particle/LongRange/tests/test_srcoul.cpp
@@ -35,7 +35,7 @@ struct EslerCoulomb3D_ForSRCOUL
  */
 TEST_CASE("srcoul", "[lrhandler]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice Lattice;
   Lattice.BoxBConds     = true;
   Lattice.LR_dim_cutoff = 30.;
   Lattice.R.diagonal(5.0);
@@ -80,7 +80,7 @@ TEST_CASE("srcoul", "[lrhandler]")
  */
 TEST_CASE("srcoul df", "[lrhandler]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice Lattice;
   Lattice.BoxBConds     = true;
   Lattice.LR_dim_cutoff = 30.;
   Lattice.R.diagonal(5.0);

--- a/src/Particle/LongRange/tests/test_srcoul.cpp
+++ b/src/Particle/LongRange/tests/test_srcoul.cpp
@@ -35,18 +35,18 @@ struct EslerCoulomb3D_ForSRCOUL
  */
 TEST_CASE("srcoul", "[lrhandler]")
 {
-  Lattice Lattice;
-  Lattice.BoxBConds     = true;
-  Lattice.LR_dim_cutoff = 30.;
-  Lattice.R.diagonal(5.0);
-  Lattice.reset();
-  CHECK(Lattice.Volume == Approx(125));
-  Lattice.SetLRCutoffs(Lattice.Rv);
-  //Lattice.printCutoffs(app_log());
-  CHECK(Approx(Lattice.LR_rc) == 2.5);
-  CHECK(Approx(Lattice.LR_kc) == 12);
+  Lattice lattice;
+  lattice.BoxBConds     = true;
+  lattice.LR_dim_cutoff = 30.;
+  lattice.R.diagonal(5.0);
+  lattice.reset();
+  CHECK(lattice.Volume == Approx(125));
+  lattice.SetLRCutoffs(lattice.Rv);
+  //lattice.printCutoffs(app_log());
+  CHECK(Approx(lattice.LR_rc) == 2.5);
+  CHECK(Approx(lattice.LR_kc) == 12);
 
-  const SimulationCell simulation_cell(Lattice);
+  const SimulationCell simulation_cell(lattice);
   ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
   ref.createSK();
   LRHandlerSRCoulomb<EslerCoulomb3D_ForSRCOUL, LPQHISRCoulombBasis> handler(ref);
@@ -80,18 +80,18 @@ TEST_CASE("srcoul", "[lrhandler]")
  */
 TEST_CASE("srcoul df", "[lrhandler]")
 {
-  Lattice Lattice;
-  Lattice.BoxBConds     = true;
-  Lattice.LR_dim_cutoff = 30.;
-  Lattice.R.diagonal(5.0);
-  Lattice.reset();
-  CHECK(Lattice.Volume == Approx(125));
-  Lattice.SetLRCutoffs(Lattice.Rv);
-  //Lattice.printCutoffs(app_log());
-  CHECK(Approx(Lattice.LR_rc) == 2.5);
-  CHECK(Approx(Lattice.LR_kc) == 12);
+  Lattice lattice;
+  lattice.BoxBConds     = true;
+  lattice.LR_dim_cutoff = 30.;
+  lattice.R.diagonal(5.0);
+  lattice.reset();
+  CHECK(lattice.Volume == Approx(125));
+  lattice.SetLRCutoffs(lattice.Rv);
+  //lattice.printCutoffs(app_log());
+  CHECK(Approx(lattice.LR_rc) == 2.5);
+  CHECK(Approx(lattice.LR_kc) == 12);
 
-  const SimulationCell simulation_cell(Lattice);
+  const SimulationCell simulation_cell(lattice);
   ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
   ref.createSK();
   LRHandlerSRCoulomb<EslerCoulomb3D_ForSRCOUL, LPQHISRCoulombBasis> handler(ref);

--- a/src/Particle/LongRange/tests/test_temp.cpp
+++ b/src/Particle/LongRange/tests/test_temp.cpp
@@ -36,18 +36,18 @@ struct EslerCoulomb3D
  */
 TEST_CASE("temp3d", "[lrhandler]")
 {
-  Lattice Lattice;
-  Lattice.BoxBConds     = true;
-  Lattice.LR_dim_cutoff = 30.;
-  Lattice.R.diagonal(5.0);
-  Lattice.reset();
-  CHECK(Approx(Lattice.Volume) == 125);
-  Lattice.SetLRCutoffs(Lattice.Rv);
-  //Lattice.printCutoffs(app_log());
-  CHECK(Approx(Lattice.LR_rc) == 2.5);
-  CHECK(Approx(Lattice.LR_kc) == 12);
+  Lattice lattice;
+  lattice.BoxBConds     = true;
+  lattice.LR_dim_cutoff = 30.;
+  lattice.R.diagonal(5.0);
+  lattice.reset();
+  CHECK(Approx(lattice.Volume) == 125);
+  lattice.SetLRCutoffs(lattice.Rv);
+  //lattice.printCutoffs(app_log());
+  CHECK(Approx(lattice.LR_rc) == 2.5);
+  CHECK(Approx(lattice.LR_kc) == 12);
 
-  const SimulationCell simulation_cell(Lattice);
+  const SimulationCell simulation_cell(lattice);
   ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
   ref.createSK();
   LRHandlerTemp<EslerCoulomb3D, LPQHIBasis> handler(ref);

--- a/src/Particle/LongRange/tests/test_temp.cpp
+++ b/src/Particle/LongRange/tests/test_temp.cpp
@@ -36,7 +36,7 @@ struct EslerCoulomb3D
  */
 TEST_CASE("temp3d", "[lrhandler]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice Lattice;
   Lattice.BoxBConds     = true;
   Lattice.LR_dim_cutoff = 30.;
   Lattice.R.diagonal(5.0);

--- a/src/Particle/ParticleIO/LatticeIO.cpp
+++ b/src/Particle/ParticleIO/LatticeIO.cpp
@@ -37,7 +37,7 @@ bool LatticeParser::put(xmlNodePtr cur)
   int nptcl                 = 0;
   int nsh                   = 0; //for backwards compatibility w/ odd heg initialization style
   int pol                   = 0;
-  using SingleParticleIndex = ParticleLayout::SingleParticleIndex;
+
   TinyVector<std::string, DIM> bconds("p");
 
   Tensor<OHMMS_PRECISION_FULL, DIM> lattice_in;

--- a/src/Particle/ParticleIO/LatticeIO.h
+++ b/src/Particle/ParticleIO/LatticeIO.h
@@ -22,7 +22,7 @@ namespace qmcplusplus
 {
 class LatticeParser
 {
-  using ParticleLayout = PtclOnLatticeTraits::ParticleLayout;
+  using ParticleLayout = Lattice;
   ParticleLayout& ref_;
 
 public:
@@ -33,7 +33,7 @@ public:
 
 class LatticeXMLWriter
 {
-  using ParticleLayout = PtclOnLatticeTraits::ParticleLayout;
+  using ParticleLayout = Lattice;
   const ParticleLayout& ref_;
 
 public:

--- a/src/Particle/ParticleIO/tests/test_lattice_parser.cpp
+++ b/src/Particle/ParticleIO/tests/test_lattice_parser.cpp
@@ -49,7 +49,7 @@ TEST_CASE("read_lattice_xml", "[particle_io][xml]")
 
     xmlNodePtr root = doc.getRoot();
 
-    CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> uLattice;
+    Lattice uLattice;
     LatticeParser lp(uLattice);
     REQUIRE_NOTHROW(lp.put(root));
 
@@ -81,7 +81,7 @@ TEST_CASE("read_lattice_xml", "[particle_io][xml]")
 
     xmlNodePtr root = doc.getRoot();
 
-    CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> uLattice;
+    Lattice uLattice;
     LatticeParser lp(uLattice);
     REQUIRE_THROWS_WITH(lp.put(root),
                         "LatticeParser::put. In \"bconds\", non periodic directions must be placed after the periodic "
@@ -110,7 +110,7 @@ TEST_CASE("read_lattice_xml", "[particle_io][xml]")
 
     xmlNodePtr root = doc.getRoot();
 
-    CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> uLattice;
+    Lattice uLattice;
     LatticeParser lp(uLattice);
     REQUIRE_THROWS_WITH(lp.put(root),
                         "LatticeParser::put. In \"bconds\", non periodic directions must be placed after the periodic "
@@ -143,7 +143,7 @@ TEST_CASE("read_lattice_xml_lrhandle", "[particle_io][xml]")
 
     xmlNodePtr root = doc.getRoot();
 
-    CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> uLattice;
+    Lattice uLattice;
     LatticeParser lp(uLattice);
     REQUIRE_NOTHROW(lp.put(root));
 
@@ -174,7 +174,7 @@ TEST_CASE("read_lattice_xml_lrhandle", "[particle_io][xml]")
 
     xmlNodePtr root = doc.getRoot();
 
-    CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> uLattice;
+    Lattice uLattice;
     LatticeParser lp(uLattice);
     REQUIRE_NOTHROW(lp.put(root));
   }
@@ -202,7 +202,7 @@ TEST_CASE("read_lattice_xml_lrhandle", "[particle_io][xml]")
 
     xmlNodePtr root = doc.getRoot();
 
-    CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> uLattice;
+    Lattice uLattice;
     LatticeParser lp(uLattice);
     REQUIRE_THROWS_WITH(lp.put(root),
                         "LatticeParser::put. Quasi 2D Ewald only works with boundary condition 'p p n'!");

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -249,7 +249,7 @@ public:
 
   const auto& getSimulationCell() const { return simulation_cell_; }
   const auto& getLattice() const { return simulation_cell_.getLattice(); }
-  auto& getPrimitiveLattice() const { return const_cast<ParticleLayout&>(simulation_cell_.getPrimLattice()); }
+  auto& getPrimitiveLattice() const { return const_cast<Lattice&>(simulation_cell_.getPrimLattice()); }
   const auto& getLRBox() const { return simulation_cell_.getLRBox(); }
 
   inline bool isSameMass() const { return same_mass_; }

--- a/src/Particle/SimulationCell.h
+++ b/src/Particle/SimulationCell.h
@@ -23,7 +23,6 @@ class ParticleSetPool;
 class SimulationCell
 {
 public:
-  using Lattice = PtclOnLatticeTraits::ParticleLayout;
 
   SimulationCell();
   SimulationCell(const Lattice& lattice);

--- a/src/Particle/tests/test_ParticleSet.cpp
+++ b/src/Particle/tests/test_ParticleSet.cpp
@@ -91,7 +91,7 @@ TEST_CASE("symmetric_distance_table OpenBC", "[particle]")
 
 TEST_CASE("symmetric_distance_table PBC", "[particle]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice Lattice;
   Lattice.BoxBConds = true; // periodic
   Lattice.R = ParticleSet::Tensor_t(6.74632230, 6.74632230, 0.00000000, 0.00000000, 3.37316115, 3.37316115, 3.37316115,
                                     0.00000000, 3.37316115);
@@ -123,7 +123,7 @@ TEST_CASE("symmetric_distance_table PBC", "[particle]")
 TEST_CASE("particle set lattice with vacuum", "[particle]")
 {
   // PPP case
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice Lattice;
   Lattice.BoxBConds          = true;
   Lattice.R                  = {1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
   Lattice.explicitly_defined = true;

--- a/src/Particle/tests/test_ParticleSet.cpp
+++ b/src/Particle/tests/test_ParticleSet.cpp
@@ -91,13 +91,13 @@ TEST_CASE("symmetric_distance_table OpenBC", "[particle]")
 
 TEST_CASE("symmetric_distance_table PBC", "[particle]")
 {
-  Lattice Lattice;
-  Lattice.BoxBConds = true; // periodic
-  Lattice.R = ParticleSet::Tensor_t(6.74632230, 6.74632230, 0.00000000, 0.00000000, 3.37316115, 3.37316115, 3.37316115,
+  Lattice lattice;
+  lattice.BoxBConds = true; // periodic
+  lattice.R = ParticleSet::Tensor_t(6.74632230, 6.74632230, 0.00000000, 0.00000000, 3.37316115, 3.37316115, 3.37316115,
                                     0.00000000, 3.37316115);
-  Lattice.reset();
+  lattice.reset();
 
-  const SimulationCell simulation_cell(Lattice);
+  const SimulationCell simulation_cell(lattice);
   ParticleSet source(simulation_cell);
 
   source.setName("electrons");
@@ -123,50 +123,50 @@ TEST_CASE("symmetric_distance_table PBC", "[particle]")
 TEST_CASE("particle set lattice with vacuum", "[particle]")
 {
   // PPP case
-  Lattice Lattice;
-  Lattice.BoxBConds          = true;
-  Lattice.R                  = {1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
-  Lattice.explicitly_defined = true;
+  Lattice lattice;
+  lattice.BoxBConds          = true;
+  lattice.R                  = {1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+  lattice.explicitly_defined = true;
 
-  Lattice.VacuumScale = 2.0;
-  Lattice.reset();
+  lattice.VacuumScale = 2.0;
+  lattice.reset();
   {
-    const SimulationCell simulation_cell(Lattice);
+    const SimulationCell simulation_cell(lattice);
     ParticleSet source(simulation_cell);
     source.setName("electrons");
     source.createSK();
 
-    CHECK(Lattice.SuperCellEnum == SUPERCELL_BULK);
+    CHECK(lattice.SuperCellEnum == SUPERCELL_BULK);
     CHECK(source.getLRBox().R(0, 0) == 1.0);
     CHECK(source.getLRBox().R(0, 1) == 2.0);
     CHECK(source.getLRBox().R(0, 2) == 3.0);
   }
 
   // PPN case
-  Lattice.BoxBConds[2] = false;
-  Lattice.reset();
+  lattice.BoxBConds[2] = false;
+  lattice.reset();
   {
-    const SimulationCell simulation_cell(Lattice);
+    const SimulationCell simulation_cell(lattice);
     ParticleSet source(simulation_cell);
     source.setName("electrons");
     source.createSK();
 
-    CHECK(Lattice.SuperCellEnum == SUPERCELL_SLAB);
+    CHECK(lattice.SuperCellEnum == SUPERCELL_SLAB);
     CHECK(source.getLRBox().R(2, 0) == 0.0);
     CHECK(source.getLRBox().R(2, 1) == 0.0);
     CHECK(source.getLRBox().R(2, 2) == 2.0);
   }
 
   // PNN case
-  Lattice.BoxBConds[1] = false;
-  Lattice.reset();
+  lattice.BoxBConds[1] = false;
+  lattice.reset();
   {
-    const SimulationCell simulation_cell(Lattice);
+    const SimulationCell simulation_cell(lattice);
     ParticleSet source(simulation_cell);
     source.setName("electrons");
     source.createSK();
 
-    CHECK(Lattice.SuperCellEnum == SUPERCELL_WIRE);
+    CHECK(lattice.SuperCellEnum == SUPERCELL_WIRE);
     CHECK(source.getLRBox().R(0, 0) == 1.0);
     CHECK(source.getLRBox().R(0, 1) == 2.0);
     CHECK(source.getLRBox().R(0, 2) == 3.0);

--- a/src/Particle/tests/test_distance_table.cpp
+++ b/src/Particle/tests/test_distance_table.cpp
@@ -338,7 +338,7 @@ SimulationCell parse_pbc_fcc_lattice()
   xmlNodePtr part1 = xmlFirstElementChild(root);
 
   // read lattice
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   LatticeParser lp(lattice);
   lp.put(part1);
   lattice.print(app_log(), 0);
@@ -371,7 +371,7 @@ SimulationCell parse_pbc_lattice()
   xmlNodePtr part1 = xmlFirstElementChild(root);
 
   // read lattice
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   LatticeParser lp(lattice);
   lp.put(part1);
   lattice.print(app_log(), 0);

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -35,7 +35,7 @@ public:
   using Grad_t      = GradType;
   using ValueVector = SPOSet::ValueVector;
   using GradVector  = SPOSet::GradVector;
-  using Lattice_t   = ParticleSet::ParticleLayout;
+  using Lattice_t   = Lattice;
   using Vector_t    = Vector<Value_t>;
   using Matrix_t    = Matrix<Value_t>;
   using pts_t       = std::vector<PosType>;

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -44,7 +44,7 @@ public:
   ///reference to the trial wavefunction for ratio evaluations
   TrialWaveFunction& refPsi;
   ///lattice vector
-  const ParticleSet::ParticleLayout& lattice_;
+  const Lattice& lattice_;
   ///normalization factor for n(k)
   RealType norm_nofK;
   ///random generator

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -113,7 +113,7 @@ public:
 
   using ValueVector = SPOSet::ValueVector;
   using GradVector  = SPOSet::GradVector;
-  using Lattice_t   = ParticleSet::ParticleLayout;
+  using Lattice_t   = Lattice;
   using PSPool      = std::map<std::string, const std::unique_ptr<ParticleSet>>;
 
   ///derivative types

--- a/src/QMCHamiltonians/SelfHealingOverlapLegacy.h
+++ b/src/QMCHamiltonians/SelfHealingOverlapLegacy.h
@@ -23,7 +23,6 @@ namespace qmcplusplus
 class SelfHealingOverlapLegacy : public OperatorBase
 {
 public:
-  using LatticeType = PtclOnLatticeTraits::ParticleLayout;
   using RealType    = QMCTraits::RealType;
   using ComplexType = QMCTraits::ComplexType;
   using ValueType   = QMCTraits::ValueType;

--- a/src/QMCHamiltonians/SpinDensity.h
+++ b/src/QMCHamiltonians/SpinDensity.h
@@ -22,7 +22,7 @@ namespace qmcplusplus
 class SpinDensity : public OperatorBase
 {
 public:
-  using Lattice_t = ParticleSet::ParticleLayout;
+  using Lattice_t = Lattice;
   using dens_t    = std::vector<RealType>;
   using pts_t     = std::vector<PosType>;
 

--- a/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
@@ -69,7 +69,7 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
   using Position     = QMCTraits::PosType;
   using testing::getParticularListener;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(20.0);
   lattice.LR_dim_cutoff = 15;

--- a/src/QMCHamiltonians/tests/test_RotatedSPOs_NLPP.cpp
+++ b/src/QMCHamiltonians/tests/test_RotatedSPOs_NLPP.cpp
@@ -47,7 +47,7 @@ void test_hcpBe_rotation(bool use_single_det, bool use_nlpp_batched)
 
   ParticleSetPool pp(c);
 
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R(0, 0) = 4.32747284;
   lattice.R(0, 1) = 0.00000000;
   lattice.R(0, 2) = 0.00000000;

--- a/src/QMCHamiltonians/tests/test_SOECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_SOECPotential.cpp
@@ -83,7 +83,7 @@ void doSOECPotentialTest(bool use_VPs)
 
   //Cell definition:
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = false; // periodic
   lattice.R.diagonal(20);
   lattice.LR_dim_cutoff = 15;

--- a/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
+++ b/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
@@ -96,7 +96,7 @@ TEST_CASE("Bare KE Pulay PBC", "[hamiltonian]")
 
   //Cell definition:
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(20);
   lattice.LR_dim_cutoff = 15;

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -43,7 +43,7 @@ TEST_CASE("Coulomb PBC A-A", "[hamiltonian]")
   const double vmad_sc               = -1.4186487397403098;
   LRCoulombSingleton::CoulombHandler = 0;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(1.0);
   lattice.reset();
@@ -82,7 +82,7 @@ TEST_CASE("Coulomb PBC A-A BCC H", "[hamiltonian]")
   const double vmad_sc               = -1.4186487397403098 / alat;
   LRCoulombSingleton::CoulombHandler = 0;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(alat);
   lattice.reset();
@@ -120,7 +120,7 @@ TEST_CASE("Coulomb PBC A-A elec", "[hamiltonian]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(1.0);
   lattice.reset();
@@ -158,7 +158,7 @@ TEST_CASE("Coulomb PBC A-A BCC", "[hamiltonian]")
   const double vmad_bcc              = -1.819616724754322 / alat;
   LRCoulombSingleton::CoulombHandler = 0;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R         = 0.5 * alat;
   lattice.R(0, 0)   = -0.5 * alat;
@@ -199,7 +199,7 @@ void test_CoulombPBCAA_3p(DynamicCoordinateKind kind)
   const double vmad_bcc              = -1.819616724754322 / alat;
   LRCoulombSingleton::CoulombHandler = 0;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R         = 0.5 * alat;
   lattice.R(0, 0)   = -0.5 * alat;
@@ -277,7 +277,7 @@ TEST_CASE("CoulombAA::mw_evaluatePerParticle", "[hamiltonian]")
   LRCoulombSingleton::CoulombHandler = 0;
 
   // Constructing a mock "golden" set of walker elements
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(1.0);
   lattice.reset();

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA_ewald.cpp
@@ -27,7 +27,7 @@ namespace qmcplusplus
 {
 TEST_CASE("Coulomb PBC A-A Ewald3D", "[hamiltonian]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(1.0);
   lattice.reset();
@@ -61,7 +61,7 @@ TEST_CASE("Coulomb PBC A-A Ewald3D", "[hamiltonian]")
 
 TEST_CASE("Coulomb PBC A-A BCC H Ewald3D", "[hamiltonian]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(3.77945227);
   lattice.reset();
@@ -97,7 +97,7 @@ TEST_CASE("Coulomb PBC A-A BCC H Ewald3D", "[hamiltonian]")
 
 TEST_CASE("Coulomb PBC A-A elec Ewald3D", "[hamiltonian]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(1.0);
   lattice.reset();

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Coulomb PBC A-B", "[hamiltonian]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(1.0);
   lattice.reset();
@@ -95,7 +95,7 @@ TEST_CASE("Coulomb PBC A-B BCC H", "[hamiltonian]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(3.77945227);
   lattice.reset();
@@ -157,7 +157,7 @@ TEST_CASE("CoulombAB::Listener", "[hamiltonian]")
 
   LRCoulombSingleton::CoulombHandler = 0;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(3.77945227);
   lattice.reset();

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
@@ -28,7 +28,7 @@ namespace qmcplusplus
 {
 TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(1.0);
   lattice.reset();
@@ -93,7 +93,7 @@ TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
 
 TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(3.77945227);
   lattice.reset();

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -161,7 +161,7 @@ TEST_CASE("Evaluate_ecp", "[hamiltonian]")
 
   //Cell definition:
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(20);
   lattice.LR_dim_cutoff = 15;
@@ -432,7 +432,7 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
 
   //Cell definition:
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = false; // periodic
   lattice.R.diagonal(20);
   lattice.LR_dim_cutoff = 15;

--- a/src/QMCHamiltonians/tests/test_ewald2d.cpp
+++ b/src/QMCHamiltonians/tests/test_ewald2d.cpp
@@ -22,7 +22,7 @@ TEST_CASE("Coulomb PBC A-A Ewald2D square", "[hamiltonian]")
   LRCoulombSingleton::CoulombHandler = 0;
   LRCoulombSingleton::this_lr_type = LRCoulombSingleton::STRICT2D;
   const double vmad_sq = -1.95013246;
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.ndim = 2;
   lattice.R.diagonal(1.0);
@@ -57,7 +57,7 @@ TEST_CASE("Coulomb PBC A-A Ewald2D body center", "[hamiltonian]")
   LRCoulombSingleton::this_lr_type = LRCoulombSingleton::STRICT2D;
   const double vmad_bc = -2.7579038;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.ndim = 2;
   lattice.R = 0.0;
@@ -101,7 +101,7 @@ TEST_CASE("Coulomb PBC A-A Ewald2D triangular", "[hamiltonian]")
   const double vmad_tri = -1.1061025865191676;
   const double alat = std::sqrt(2.0*M_PI/std::sqrt(3));
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.ndim = 2;
   lattice.R = 0.0;
@@ -141,7 +141,7 @@ TEST_CASE("Coulomb PBC A-A Ewald2D honeycomb", "[hamiltonian]")
   const double vmad_hon = -1.510964233;
   const double alat = std::sqrt(2.0*M_PI/std::sqrt(3));
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.ndim = 2;
   lattice.R = 0.0;
@@ -189,7 +189,7 @@ TEST_CASE("Coulomb PBC A-A Ewald2D tri. in rect.", "[hamiltonian]")
   const double vmad_tri = -1.1061025865191676;
   const RealType alat = std::sqrt(2.0*M_PI/std::sqrt(3));
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.ndim = 2;
   lattice.R = 0.0;

--- a/src/QMCHamiltonians/tests/test_ewald_quasi2d.cpp
+++ b/src/QMCHamiltonians/tests/test_ewald_quasi2d.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Coulomb PBC A-A Ewald Quasi2D exception", "[hamiltonian]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
   LRCoulombSingleton::this_lr_type = LRCoulombSingleton::QUASI2D;
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true;
   lattice.BoxBConds[2] = false; // ppn
   lattice.ndim = 2;
@@ -52,7 +52,7 @@ TEST_CASE("Coulomb PBC A-A Ewald Quasi2D square", "[hamiltonian]")
   LRCoulombSingleton::CoulombHandler = 0;
   LRCoulombSingleton::this_lr_type = LRCoulombSingleton::QUASI2D;
   const double vmad_sq = -1.95013246;
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true;
   lattice.BoxBConds[2] = false; // ppn
   lattice.ndim = 2;
@@ -89,7 +89,7 @@ TEST_CASE("Coulomb PBC A-A Ewald Quasi2D triangular", "[hamiltonian]")
   const double vmad_tri = -1.106102587;
   const double alat = std::sqrt(2.0*M_PI/std::sqrt(3));
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true;
   lattice.BoxBConds[2] = false; // ppn
   lattice.ndim = 2;
@@ -127,7 +127,7 @@ TEST_CASE("Coulomb PBC A-A Ewald Quasi2D staggered square", "[hamiltonian]")
 {
   LRCoulombSingleton::CoulombHandler = 0; // !!!! crucial if not first test
   LRCoulombSingleton::this_lr_type = LRCoulombSingleton::QUASI2D;
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true;
   lattice.BoxBConds[2] = false; // ppn
   lattice.ndim = 2;
@@ -177,7 +177,7 @@ TEST_CASE("Coulomb PBC A-A Ewald Quasi2D staggered square 2x2", "[hamiltonian]")
   LRCoulombSingleton::CoulombHandler = 0; // !!!! crucial if not first test
   LRCoulombSingleton::this_lr_type = LRCoulombSingleton::QUASI2D;
   //const double vmad_sq = -1.95013246;
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true;
   lattice.BoxBConds[2] = false; // ppn
   lattice.ndim = 2;
@@ -232,7 +232,7 @@ TEST_CASE("Coulomb PBC A-A Ewald Quasi2D staggered triangle", "[hamiltonian]")
 {
   LRCoulombSingleton::CoulombHandler = 0; // !!!! crucial if not first test
   LRCoulombSingleton::this_lr_type = LRCoulombSingleton::QUASI2D;
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true;
   lattice.BoxBConds[2] = false; // ppn
   lattice.ndim = 2;
@@ -288,7 +288,7 @@ TEST_CASE("Coulomb PBC A-A Ewald Quasi2D staggered triangle 2x2", "[hamiltonian]
 {
   LRCoulombSingleton::CoulombHandler = 0; // !!!! crucial if not first test
   LRCoulombSingleton::this_lr_type = LRCoulombSingleton::QUASI2D;
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true;
   lattice.BoxBConds[2] = false; // ppn
   lattice.ndim = 2;

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -129,7 +129,7 @@ void check_force_copy(ForceChiesaPBCAA& force, ForceChiesaPBCAA& force2)
 // PBC case
 TEST_CASE("Chiesa Force", "[hamiltonian]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(5.0);
   lattice.LR_dim_cutoff = 25;

--- a/src/QMCHamiltonians/tests/test_force_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_force_ewald.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Chiesa Force BCC H Ewald3D", "[hamiltonian]")
 {
   Communicate* c = OHMMS::Controller;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(3.77945227);
   lattice.LR_dim_cutoff = 40;
@@ -111,7 +111,7 @@ TEST_CASE("Chiesa Force BCC H Ewald3D", "[hamiltonian]")
 // test SR and LR pieces separately
 TEST_CASE("fccz sr lr clone", "[hamiltonian]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(3.77945227);
   lattice.LR_dim_cutoff = 40;
@@ -201,7 +201,7 @@ TEST_CASE("fccz sr lr clone", "[hamiltonian]")
 // 3 H atoms randomly distributed in a box
 TEST_CASE("fccz h3", "[hamiltonian]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(3.77945227);
   lattice.LR_dim_cutoff = 40;

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -1299,7 +1299,7 @@ TEST_CASE("Eloc_Derivatives:slater_fastderiv_complex_pbc", "[hamiltonian]")
 
   Communicate* c = OHMMS::Controller;
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds[0]             = 1; // periodic
   lattice.BoxBConds[1]             = 1; // periodic
   lattice.BoxBConds[2]             = 1; // periodic

--- a/src/QMCHamiltonians/tests/test_stress.cpp
+++ b/src/QMCHamiltonians/tests/test_stress.cpp
@@ -30,7 +30,7 @@ namespace qmcplusplus
 // PBC case
 TEST_CASE("Stress BCC H Ewald3D", "[hamiltonian]")
 {
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true; // periodic
   lattice.R.diagonal(3.24957306);
   lattice.LR_dim_cutoff = 40;

--- a/src/QMCWaveFunctions/PlaneWave/PWBasis.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWBasis.h
@@ -40,7 +40,7 @@ namespace qmcplusplus
 class PWBasis : public QMCTraits
 {
 public:
-  using ParticleLayout = ParticleSet::ParticleLayout;
+  using ParticleLayout = qmcplusplus::Lattice;
   using GIndex_t       = TinyVector<IndexType, 3>;
 
 private:

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.cpp
@@ -273,7 +273,7 @@ void PWOrbitalSetBuilder::transform2GridData(PWBasis::GIndex_t& nG, int spinInde
   TinyVector<double, OHMMS_DIM> TwistAngle_DP;
   TwistAngle_DP = TwistAngle;
   hfile.write(TwistAngle_DP, "twist_angle");
-  const ParticleSet::ParticleLayout& lattice(targetPtcl.getLattice());
+  const Lattice& lattice(targetPtcl.getLattice());
   RealType dx = 1.0 / static_cast<RealType>(nG[0] - 1);
   RealType dy = 1.0 / static_cast<RealType>(nG[1] - 1);
   RealType dz = 1.0 / static_cast<RealType>(nG[2] - 1);

--- a/src/QMCWaveFunctions/tests/test_2d_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_2d_jastrow.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Jastrow 2D", "[wavefunction]")
   //   TwoBodyJastrow<BsplineFunctor<RealType>> j2;
   //   RadialJastrowBuilder jastrow(Communicator, ParticleSet);
   //   ParticleSet( SimulationCell( CrystalLattice ) )
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  Lattice lattice;
   lattice.BoxBConds = true;
   lattice.R.diagonal(70.89815403622065);
   lattice.ndim = 2;

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -469,7 +469,7 @@ void test_DiracDeterminant_spinor_update(const DetMatInvertor inverter_kind)
   using ParticleLaplacian = ParticleSet::ParticleLaplacian;
 
   // O2 test example from pwscf non-collinear calculation.
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R = {5.10509515, -3.23993545, 0.00000000, 5.10509515, 3.23993545,
                0.00000000, -6.49690625, 0.00000000, 7.08268015};
 

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -499,7 +499,7 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   using ParticleLaplacian = ParticleSet::ParticleLaplacian;
 
   // O2 test example from pwscf non-collinear calculation.
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R = {5.10509515, -3.23993545, 0.00000000, 5.10509515, 3.23993545,
                0.00000000, -6.49690625, 0.00000000, 7.08268015};
 

--- a/src/QMCWaveFunctions/tests/test_LCAO_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_LCAO_diamondC_2x1x1.cpp
@@ -55,7 +55,7 @@ void test_LCAO_DiamondC_2x1x1_real(const bool useOffload)
   REQUIRE(doc_lattice.parseFromString(particles));
 
   // read lattice
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   LatticeParser lp(lattice);
   lp.put(doc_lattice.getRoot());
   lattice.print(app_log(), 0);
@@ -472,7 +472,7 @@ void test_LCAO_DiamondC_2x1x1_cplx(const bool useOffload)
   REQUIRE(doc_lattice.parseFromString(particles));
 
   // read lattice
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   LatticeParser lp(lattice);
   lp.put(doc_lattice.getRoot());
   lattice.print(app_log(), 0);

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -48,7 +48,7 @@ TEST_CASE("RotatedSPOs via SplineR2R", "[wavefunction]")
   Communicate* c = OHMMS::Controller;
 
   // We get a "Mismatched supercell lattices" error due to default ctor?
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
 
   // diamondC_1x1x1
   lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
@@ -566,7 +566,7 @@ TEST_CASE("RotatedSPOs hcpBe", "[wavefunction]")
   using RealType = QMCTraits::RealType;
   Communicate* c = OHMMS::Controller;
 
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R = {4.32747284, 0.00000000, 0.00000000, -2.16373642, 3.74770142,
                0.00000000, 0.00000000, 0.00000000, 6.78114995};
 

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -50,7 +50,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   const DynamicCoordinateKind kind_selected = DynamicCoordinateKind::DC_POS;
 #endif
   // diamondC_1x1x1
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R         = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
   lattice.BoxBConds = {1, 1, 1};
   lattice.reset();

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -63,7 +63,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
       offload_switches.jas ? DynamicCoordinateKind::DC_POS_OFFLOAD : DynamicCoordinateKind::DC_POS;
 
   // diamondC_2x1x1
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R         = {6.7463223, 6.7463223, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
   lattice.BoxBConds = {1, 1, 1};
   lattice.reset();

--- a/src/QMCWaveFunctions/tests/test_einset_LiH.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_LiH.cpp
@@ -39,7 +39,7 @@ void test_einset_LiH_x(bool use_offload)
 {
   Communicate* c = OHMMS::Controller;
 
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R = {-3.55, 0.0, 3.55, 0.0, 3.55, 3.55, -3.55, 3.55, 0.0};
 
   ParticleSetPool ptcl = ParticleSetPool(c);

--- a/src/QMCWaveFunctions/tests/test_einset_NiO_a16.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_NiO_a16.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Einspline SPO from HDF NiO a16 97 electrons", "[wavefunction]")
 {
   Communicate* c = OHMMS::Controller;
 
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R = {3.94055, 3.94055, 7.8811, 3.94055, 3.94055, -7.8811, -7.8811, 7.8811, 0};
 
   ParticleSetPool ptcl = ParticleSetPool(c);

--- a/src/QMCWaveFunctions/tests/test_einset_diamondC.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_diamondC.cpp
@@ -34,7 +34,7 @@ void test_einset_diamond_1x1x1(bool use_offload)
 {
   Communicate* c = OHMMS::Controller;
 
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   // monoO
   // lattice.R(0,0) = {5.10509515, -3.23993545,  0.0, 5.10509515, 3.23993545, 0.0, -6.49690625, 0.0, 7.08268015};
 
@@ -305,7 +305,7 @@ TEST_CASE("Einspline SPO from HDF diamond_2x1x1 5 electrons", "[wavefunction]")
 {
   Communicate* c = OHMMS::Controller;
 
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   // diamondC_2x1x1
   lattice.R = {6.7463223, 6.7463223, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
@@ -503,7 +503,7 @@ TEST_CASE("EinsplineSetBuilder CheckLattice", "[wavefunction]")
 {
   Communicate* c = OHMMS::Controller;
 
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R       = 0.0;
   lattice.R(0, 0) = 1.0;
   lattice.R(1, 1) = 1.0;

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -43,7 +43,7 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
   using RealType  = SPOSet::RealType;
   Communicate* c  = OHMMS::Controller;
 
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   // O2 test example from pwscf non-collinear calculation.
   lattice.R = {5.10509515, -3.23993545, 0.00000000, 5.10509515, 3.23993545,
                0.00000000, -6.49690625, 0.00000000, 7.08268015};

--- a/src/QMCWaveFunctions/tests/test_hybridrep.cpp
+++ b/src/QMCWaveFunctions/tests/test_hybridrep.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Hybridrep SPO from HDF diamond_1x1x1", "[wavefunction]")
 {
   Communicate* c = OHMMS::Controller;
 
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   // diamondC_1x1x1
   lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
@@ -193,7 +193,7 @@ TEST_CASE("Hybridrep SPO from HDF diamond_2x1x1", "[wavefunction]")
 {
   Communicate* c = OHMMS::Controller;
 
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   // diamondC_2x1x1
   lattice.R = {6.7463223, 6.7463223, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 

--- a/src/QMCWaveFunctions/tests/test_kspace_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_kspace_jastrow.cpp
@@ -54,7 +54,7 @@ TEST_CASE("kspace jastrow", "[wavefunction]")
   xmlNodePtr part1 = xmlFirstElementChild(root);
 
   // read lattice
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   LatticeParser lp(lattice);
   lp.put(part1);
   lattice.print(app_log(), 0);

--- a/src/QMCWaveFunctions/tests/test_lattice_gaussian.cpp
+++ b/src/QMCWaveFunctions/tests/test_lattice_gaussian.cpp
@@ -36,7 +36,7 @@ TEST_CASE("lattice gaussian", "[wavefunction]")
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   // initialize simulationcell for kvectors
   const char* xmltext = R"(<tmp>
   <simulationcell>

--- a/src/QMCWaveFunctions/tests/test_pw.cpp
+++ b/src/QMCWaveFunctions/tests/test_pw.cpp
@@ -31,7 +31,7 @@ TEST_CASE("PlaneWave SPO from HDF for BCC H", "[wavefunction]")
   Communicate* c = OHMMS::Controller;
 
   // BCC H
-  PtclOnLatticeTraits::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R = {3.77945227, 0.0, 0.0, 0.0, 3.77945227, 0.0, 0.0, 0.0, 3.77945227};
   lattice.reset();
 
@@ -133,7 +133,7 @@ TEST_CASE("PlaneWave SPO from HDF for LiH arb", "[wavefunction]")
   Communicate* c = OHMMS::Controller;
 
   // LiH
-  PtclOnLatticeTraits::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R = {-3.55, 0.0, 3.55, 0.0, 3.55, 3.55, -3.55, 3.55, 0.0};
   lattice.reset();
 

--- a/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
@@ -44,7 +44,7 @@ void test_C_diamond()
     REQUIRE(okay);
     xmlNodePtr root = doc.getRoot();
 
-    ParticleSet::ParticleLayout lattice;
+    Lattice lattice;
     // BCC H
     lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
     lattice.reset();

--- a/src/QMCWaveFunctions/tests/test_rpa_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_rpa_jastrow.cpp
@@ -52,7 +52,7 @@ TEST_CASE("RPA Jastrow", "[wavefunction]")
   xmlNodePtr part1 = xmlFirstElementChild(root);
 
   // read lattice
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   LatticeParser lp(lattice);
   lp.put(part1);
   lattice.print(app_log(), 0);

--- a/src/QMCWaveFunctions/tests/test_spline_applyrotation.cpp
+++ b/src/QMCWaveFunctions/tests/test_spline_applyrotation.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Spline applyRotation zero rotation", "[wavefunction]")
   Communicate* c = OHMMS::Controller;
 
   // diamondC_1x1x1
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
@@ -171,7 +171,7 @@ TEST_CASE("Spline applyRotation one rotation", "[wavefunction]")
   Communicate* c = OHMMS::Controller;
 
   // diamondC_1x1x1
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
@@ -380,7 +380,7 @@ TEST_CASE("Spline applyRotation two rotations", "[wavefunction]")
   Communicate* c = OHMMS::Controller;
 
   // diamondC_1x1x1
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
@@ -684,7 +684,7 @@ TEST_CASE("Spline applyRotation complex rotation", "[wavefunction]")
   Communicate* c = OHMMS::Controller;
 
   // diamondC_1x1x1
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
@@ -32,7 +32,7 @@ void test_diamond_2x1x1_xml_input(const std::string& spo_xml_string)
   Communicate* c = OHMMS::Controller;
 
   // diamondC_2x1x1
-  ParticleSet::ParticleLayout lattice;
+  Lattice lattice;
   lattice.R = {6.7463223, 6.7463223, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);

--- a/src/Sandbox/ParticleIOUtility.h
+++ b/src/Sandbox/ParticleIOUtility.h
@@ -20,8 +20,6 @@
 namespace qmcplusplus
 {
 
-using Lattice = ParticleSet::ParticleLayout;
-
 /** create super lattice */
 Lattice createSuperLattice(const Lattice& in, const Tensor<int, OHMMS_DIM>& tmat);
 /** expand a particleset */

--- a/src/Sandbox/diff_distancetables.cpp
+++ b/src/Sandbox/diff_distancetables.cpp
@@ -78,7 +78,6 @@ int main(int argc, char** argv)
 
   using RealType    = QMCTraits::RealType;
   using ParticlePos = ParticleSet::ParticlePos;
-  using LatticeType = ParticleSet::ParticleLayout;
   using TensorType  = ParticleSet::TensorType;
   using PosType     = ParticleSet::PosType;
 

--- a/src/Sandbox/diff_ylm.cpp
+++ b/src/Sandbox/diff_ylm.cpp
@@ -40,7 +40,6 @@ int main(int argc, char** argv)
 
   //using RealType = QMCTraits::RealType          ;
   //using ParticlePos = ParticleSet::ParticlePos   ;
-  //using LatticeType = ParticleSet::ParticleLayout;
   //using TensorType = ParticleSet::TensorType      ;
   //using PosType = ParticleSet::PosType         ;
   //use the global generator

--- a/src/Sandbox/einspline_spo.cpp
+++ b/src/Sandbox/einspline_spo.cpp
@@ -43,7 +43,6 @@ int main(int argc, char** argv)
 
   using RealType    = QMCTraits::RealType;
   using ParticlePos = ParticleSet::ParticlePos;
-  using LatticeType = ParticleSet::ParticleLayout;
   using TensorType  = ParticleSet::TensorType;
   using PosType     = ParticleSet::PosType;
 

--- a/src/Sandbox/einspline_spo_nested.cpp
+++ b/src/Sandbox/einspline_spo_nested.cpp
@@ -43,7 +43,6 @@ int main(int argc, char** argv)
 
   using RealType    = QMCTraits::RealType;
   using ParticlePos = ParticleSet::ParticlePos;
-  using LatticeType = ParticleSet::ParticleLayout;
   using TensorType  = ParticleSet::TensorType;
   using PosType     = ParticleSet::PosType;
 

--- a/src/Sandbox/input/graphite.hpp
+++ b/src/Sandbox/input/graphite.hpp
@@ -19,7 +19,7 @@ inline int count_electrons(const ParticleSet& ions) { return ions.getTotalNum() 
 inline auto create_prim_lattice()
 {
   Lattice::Tensor_t graphite_cell = {4.65099, 0.0, 0.0, -2.3255, 4.02788, 0.0, 0.0, 0.0, 12.67609393};
-  ParticleSet::ParticleLayout prim_lat;
+  Lattice prim_lat;
   // set PBC in x,y,z directions
   prim_lat.BoxBConds = 1;
   // set the lattice

--- a/src/Sandbox/input/nio.hpp
+++ b/src/Sandbox/input/nio.hpp
@@ -17,7 +17,7 @@ inline int count_electrons(const ParticleSet& ions) { return ions.getTotalNum() 
 inline auto create_prim_lattice()
 {
   Lattice::Tensor_t nio_cell = {7.8811, 7.8811, 0.0, -7.8811, 7.8811, 0.0, 0.0, 0.0, 15.7622};
-  ParticleSet::ParticleLayout prim_lat;
+  Lattice prim_lat;
   // set PBC in x,y,z directions
   prim_lat.BoxBConds = 1;
   // set the lattice

--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -56,7 +56,6 @@ int main(int argc, char** argv)
   using RealType         = QMCTraits::RealType;
   using FullPrecRealType = QMCTraits::FullPrecRealType;
   using ParticlePos      = ParticleSet::ParticlePos;
-  using LatticeType      = ParticleSet::ParticleLayout;
   using TensorType       = ParticleSet::TensorType;
   using PosType          = ParticleSet::PosType;
   using uint_type        = RandomGenerator::uint_type;


### PR DESCRIPTION
## Proposed changes
~~This is a prototype not ready for merge. Unit tests were not fixed. QMCPACK can compile and run.~~

Consider there is little performance impact if we keep our use of CrystalLattice in full precision, we can just make the lattice of SimulationCell in full precision.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- New feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)
- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation or build script changes
- Other (please describe):

### Does this introduce a breaking change?

- Yes
- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes/No. This PR is up to date with current the current state of 'develop'
- Yes/No. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
