### PR TITLE
Make DTD_BConds constructor support flexible precision of CrystalLattice

### DIFF
--- a/src/Particle/Lattice/CrystalLattice.h
+++ b/src/Particle/Lattice/CrystalLattice.h
@@ -220,7 +220,8 @@ public:
   /// return true if any direction of reduced coordinates u goes larger than 0.5
   bool outOfBound(const TinyVector<T, D>& u) const;
 
-  inline void applyMinimumImage(TinyVector<T, D>& c) const
+  template <typename PT>
+  inline void applyMinimumImage(TinyVector<PT, D>& c) const
   {
     if (SuperCellEnum)
     {

--- a/src/Particle/Lattice/ParticleBConds.h
+++ b/src/Particle/Lattice/ParticleBConds.h
@@ -69,7 +69,8 @@ template<class T, unsigned D, int SC>
 struct DTD_BConds
 {
   /** constructor: doing nothing */
-  inline DTD_BConds(const CrystalLattice<T, D>& lat) {}
+  template<typename TT>
+  inline DTD_BConds(const CrystalLattice<TT, D>& lat) {}
 
   /** apply BC on displ and return |displ|^2
    * @param displ a displacement vector in the Cartesian coordinate

--- a/src/Particle/Lattice/ParticleBConds3DSoa.h
+++ b/src/Particle/Lattice/ParticleBConds3DSoa.h
@@ -26,7 +26,9 @@ template<class T>
 struct DTD_BConds<T, 3, SUPERCELL_OPEN + SOA_OFFSET>
 {
   /** constructor: doing nothing */
-  inline DTD_BConds(const CrystalLattice<T, 3>& lat) {}
+  template<typename LT>
+  inline DTD_BConds(const CrystalLattice<LT, 3>& lat)
+  {}
 
   template<typename PT, typename RSOA, typename DISPLSOA>
   void computeDistances(const PT& pos,
@@ -46,7 +48,7 @@ struct DTD_BConds<T, 3, SUPERCELL_OPEN + SOA_OFFSET>
     T* restrict dx       = temp_dr.data(0);
     T* restrict dy       = temp_dr.data(1);
     T* restrict dz       = temp_dr.data(2);
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       dx[iat]     = px[iat] - x0;
@@ -83,10 +85,7 @@ struct DTD_BConds<T, 3, SUPERCELL_OPEN + SOA_OFFSET>
     temp_r[iat] = std::sqrt(dx[iat] * dx[iat] + dy[iat] * dy[iat] + dz[iat] * dz[iat]);
   }
 
-  T computeDist(T dx, T dy, T dz) const
-  {
-    return std::sqrt(dx * dx + dy * dy + dz * dz);
-  }
+  T computeDist(T dx, T dy, T dz) const { return std::sqrt(dx * dx + dy * dy + dz * dz); }
 };
 
 /** specialization for a periodic 3D, orthorombic cell
@@ -96,7 +95,8 @@ struct DTD_BConds<T, 3, PPPO + SOA_OFFSET>
 {
   T Linv0, L0, Linv1, L1, Linv2, L2, r2max, dummy;
 
-  inline DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename LT>
+  inline DTD_BConds(const CrystalLattice<LT, 3>& lat)
       : Linv0(lat.OneOverLength[0]),
         L0(lat.Length[0]),
         Linv1(lat.OneOverLength[1]),
@@ -125,7 +125,7 @@ struct DTD_BConds<T, 3, PPPO + SOA_OFFSET>
     T* restrict dx       = temp_dr.data(0);
     T* restrict dy       = temp_dr.data(1);
     T* restrict dz       = temp_dr.data(2);
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       const T x   = (px[iat] - x0) * Linv0;
@@ -173,9 +173,9 @@ struct DTD_BConds<T, 3, PPPO + SOA_OFFSET>
     T x = dx * Linv0;
     T y = dy * Linv1;
     T z = dz * Linv2;
-    dx = L0 * (x - round(x));
-    dy = L1 * (y - round(y));
-    dz = L2 * (z - round(z));
+    dx  = L0 * (x - round(x));
+    dy  = L1 * (y - round(y));
+    dz  = L2 * (z - round(z));
     return std::sqrt(dx * dx + dy * dy + dz * dz);
   }
 };
@@ -189,7 +189,9 @@ struct DTD_BConds<T, 3, PPPS + SOA_OFFSET>
 {
   T r00, r10, r20, r01, r11, r21, r02, r12, r22;
   T g00, g10, g20, g01, g11, g21, g02, g12, g22;
-  DTD_BConds(const CrystalLattice<T, 3>& lat)
+
+  template<typename LT>
+  DTD_BConds(const CrystalLattice<LT, 3>& lat)
       : r00(lat.R(0)),
         r10(lat.R(3)),
         r20(lat.R(6)),
@@ -231,7 +233,7 @@ struct DTD_BConds<T, 3, PPPS + SOA_OFFSET>
     T* restrict dy = temp_dr.data(1);
     T* restrict dz = temp_dr.data(2);
 
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       T displ_0 = px[iat] - x0;
@@ -331,7 +333,8 @@ struct DTD_BConds<T, 3, PPPG + SOA_OFFSET>
   T r00, r10, r20, r01, r11, r21, r02, r12, r22;
   TinyVector<TinyVector<T, 8>, 3> corners;
 
-  DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename LT>
+  DTD_BConds(const CrystalLattice<LT, 3>& lat)
   {
     TinyVector<TinyVector<T, 3>, 3> rb;
     rb[0] = lat.a(0);
@@ -410,7 +413,7 @@ struct DTD_BConds<T, 3, PPPG + SOA_OFFSET>
 
     constexpr T minusone(-1);
     constexpr T one(1);
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       const T flip    = iat < flip_ind ? one : minusone;
@@ -546,7 +549,8 @@ struct DTD_BConds<T, 3, PPNG + SOA_OFFSET>
   TinyVector<TinyVector<T, 3>, 3> rb;
   TinyVector<TinyVector<T, 4>, 2> corners;
 
-  DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename LT>
+  DTD_BConds(const CrystalLattice<LT, 3>& lat)
   {
     rb[0] = lat.a(0);
     rb[1] = lat.a(1);
@@ -598,7 +602,7 @@ struct DTD_BConds<T, 3, PPNG + SOA_OFFSET>
 
     constexpr T minusone(-1);
     constexpr T one(1);
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       const T flip    = iat < flip_ind ? one : minusone;
@@ -719,7 +723,8 @@ struct DTD_BConds<T, 3, PPNO + SOA_OFFSET>
 {
   T Linv0, L0, Linv1, L1;
 
-  inline DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename LT>
+  inline DTD_BConds(const CrystalLattice<LT, 3>& lat)
       : Linv0(lat.OneOverLength[0]), L0(lat.Length[0]), Linv1(lat.OneOverLength[1]), L1(lat.Length[1])
   {}
 
@@ -742,7 +747,7 @@ struct DTD_BConds<T, 3, PPNO + SOA_OFFSET>
     T* restrict dy       = temp_dr.data(1);
     T* restrict dz       = temp_dr.data(2);
 
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       T x         = (px[iat] - x0) * Linv0;
@@ -787,8 +792,8 @@ struct DTD_BConds<T, 3, PPNO + SOA_OFFSET>
   {
     T x = dx * Linv0;
     T y = dy * Linv1;
-    dx = L0 * (x - round(x));
-    dy = L1 * (y - round(y));
+    dx  = L0 * (x - round(x));
+    dy  = L1 * (y - round(y));
     return std::sqrt(dx * dx + dy * dy + dz * dz);
   }
 };
@@ -800,7 +805,9 @@ struct DTD_BConds<T, 3, PPNS + SOA_OFFSET>
 {
   T r00, r10, r01, r11;
   T g00, g10, g01, g11;
-  DTD_BConds(const CrystalLattice<T, 3>& lat)
+
+  template<typename LT>
+  DTD_BConds(const CrystalLattice<LT, 3>& lat)
       : r00(lat.R(0)),
         r10(lat.R(3)),
         r01(lat.R(1)),
@@ -832,7 +839,7 @@ struct DTD_BConds<T, 3, PPNS + SOA_OFFSET>
     T* restrict dy = temp_dr.data(1);
     T* restrict dz = temp_dr.data(2);
 
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       T displ_0 = px[iat] - x0;
@@ -918,7 +925,9 @@ struct DTD_BConds<T, 3, SUPERCELL_WIRE + SOA_OFFSET>
 {
   T Linv0, L0;
 
-  inline DTD_BConds(const CrystalLattice<T, 3>& lat) : Linv0(lat.OneOverLength[0]), L0(lat.Length[0]) {}
+  template<typename LT>
+  inline DTD_BConds(const CrystalLattice<LT, 3>& lat) : Linv0(lat.OneOverLength[0]), L0(lat.Length[0])
+  {}
   template<typename PT, typename RSOA, typename DISPLSOA>
   void computeDistances(const PT& pos,
                         const RSOA& R0,
@@ -940,7 +949,7 @@ struct DTD_BConds<T, 3, SUPERCELL_WIRE + SOA_OFFSET>
     T* restrict dy = temp_dr.data(1);
     T* restrict dz = temp_dr.data(2);
 
-#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz : QMC_SIMD_ALIGNMENT)
     for (int iat = first; iat < last; ++iat)
     {
       T x         = (px[iat] - x0) * Linv0;
@@ -981,8 +990,8 @@ struct DTD_BConds<T, 3, SUPERCELL_WIRE + SOA_OFFSET>
 
   T computeDist(T dx, T dy, T dz) const
   {
-    T x         = dx * Linv0;
-    dx     = L0 * (x - round(x));
+    T x = dx * Linv0;
+    dx  = L0 * (x - round(x));
     return std::sqrt(dx * dx + dy * dy + dz * dz);
   }
 };
@@ -999,7 +1008,8 @@ struct DTD_BConds<T, 3, PPPX + SOA_OFFSET>
   T r2max;
   TinyVector<TinyVector<T, 26>, 3> nextcells;
 
-  DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename LT>
+  DTD_BConds(const CrystalLattice<LT, 3>& lat)
       : r00(lat.R(0)),
         r10(lat.R(3)),
         r20(lat.R(6)),
@@ -1078,7 +1088,8 @@ struct DTD_BConds<T, 3, PPNX + SOA_OFFSET>
   T r2max;
   TinyVector<TinyVector<T, 8>, 3> nextcells;
 
-  DTD_BConds(const CrystalLattice<T, 3>& lat)
+  template<typename LT>
+  DTD_BConds(const CrystalLattice<LT, 3>& lat)
       : r00(lat.R(0)),
         r10(lat.R(3)),
         r01(lat.R(1)),


### PR DESCRIPTION
## Proposed changes
Make functions as templates to support precision mix.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted