### PR TITLE
[WIP] More templates for the classes derived from `SPOSetT<T>`

### DIFF
--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -84,7 +84,7 @@ private:
   /** @} */
 
   //data members \todo analyze lifecycles allocation optimization or state?
-  CompositeSPOSet basis_functions_;
+  CompositeSPOSet<Value> basis_functions_;
   Vector<Value> basis_values_;
   Vector<Value> basis_norms_;
   Vector<Grad> basis_gradients_;

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -65,7 +65,7 @@ public:
 
   //data members
   bool energy_mat;
-  CompositeSPOSet basis_functions;
+  CompositeSPOSet<Value_t> basis_functions;
   ValueVector basis_values;
   ValueVector basis_norms;
   GradVector basis_gradients;

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -39,13 +39,15 @@ inline void insert_columns(const MAT1& small, MAT2& big, int offset_c)
 }
 } // namespace MatrixOperators
 
-CompositeSPOSet::CompositeSPOSet(const std::string& my_name) : SPOSet(my_name)
+template<typename T>
+CompositeSPOSet<T>::CompositeSPOSet(const std::string& my_name) : SPOSetT<T>(my_name)
 {
-  OrbitalSetSize = 0;
+  this->OrbitalSetSize = 0;
   component_offsets.reserve(4);
 }
 
-CompositeSPOSet::CompositeSPOSet(const CompositeSPOSet& other) : SPOSet(other)
+template<typename T>
+CompositeSPOSet<T>::CompositeSPOSet(const CompositeSPOSet& other) : SPOSet(other)
 {
   for (auto& element : other.components)
   {
@@ -53,9 +55,11 @@ CompositeSPOSet::CompositeSPOSet(const CompositeSPOSet& other) : SPOSet(other)
   }
 }
 
-CompositeSPOSet::~CompositeSPOSet() = default;
+template<typename T>
+CompositeSPOSet<T>::~CompositeSPOSet() = default;
 
-void CompositeSPOSet::add(std::unique_ptr<SPOSet> component)
+template<typename T>
+void CompositeSPOSet<T>::add(std::unique_ptr<SPOSet> component)
 {
   if (components.empty())
     component_offsets.push_back(0); //add 0
@@ -67,11 +71,12 @@ void CompositeSPOSet::add(std::unique_ptr<SPOSet> component)
   component_laplacians.emplace_back(norbs);
   component_spin_gradients.emplace_back(norbs);
 
-  OrbitalSetSize += norbs;
-  component_offsets.push_back(OrbitalSetSize);
+  this->OrbitalSetSize += norbs;
+  component_offsets.push_back(this->OrbitalSetSize);
 }
 
-void CompositeSPOSet::report()
+template<typename T>
+void CompositeSPOSet<T>::report()
 {
   app_log() << "CompositeSPOSet" << std::endl;
   app_log() << "  ncomponents = " << components.size() << std::endl;
@@ -83,9 +88,11 @@ void CompositeSPOSet::report()
   }
 }
 
-std::unique_ptr<SPOSet> CompositeSPOSet::makeClone() const { return std::make_unique<CompositeSPOSet>(*this); }
+template<typename T>
+std::unique_ptr<SPOSetT<T>> CompositeSPOSet<T>::makeClone() const { return std::make_unique<CompositeSPOSet>(*this); }
 
-void CompositeSPOSet::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
+template<typename T>
+void CompositeSPOSet<T>::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
 {
   int n = 0;
   for (int c = 0; c < components.size(); ++c)
@@ -98,7 +105,8 @@ void CompositeSPOSet::evaluateValue(const ParticleSet& P, int iat, ValueVector& 
   }
 }
 
-void CompositeSPOSet::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)
+template<typename T>
+void CompositeSPOSet<T>::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)
 {
   int n = 0;
   for (int c = 0; c < components.size(); ++c)
@@ -115,12 +123,13 @@ void CompositeSPOSet::evaluateVGL(const ParticleSet& P, int iat, ValueVector& ps
   }
 }
 
-void CompositeSPOSet::evaluateVGL_spin(const ParticleSet& P,
-                                       int iat,
-                                       ValueVector& psi,
-                                       GradVector& dpsi,
-                                       ValueVector& d2psi,
-                                       ValueVector& dspin_psi)
+template<typename T>
+void CompositeSPOSet<T>::evaluateVGL_spin(const ParticleSet& P,
+                                          int iat,
+                                          ValueVector& psi,
+                                          GradVector& dpsi,
+                                          ValueVector& d2psi,
+                                          ValueVector& dspin_psi)
 {
   int n = 0;
   for (int c = 0; c < components.size(); ++c)
@@ -139,12 +148,13 @@ void CompositeSPOSet::evaluateVGL_spin(const ParticleSet& P,
   }
 }
 
-void CompositeSPOSet::evaluate_notranspose(const ParticleSet& P,
-                                           int first,
-                                           int last,
-                                           ValueMatrix& logdet,
-                                           GradMatrix& dlogdet,
-                                           ValueMatrix& d2logdet)
+template<typename T>
+void CompositeSPOSet<T>::evaluate_notranspose(const ParticleSet& P,
+                                              int first,
+                                              int last,
+                                              ValueMatrix& logdet,
+                                              GradMatrix& dlogdet,
+                                              ValueMatrix& d2logdet)
 {
   const int nat = last - first;
   for (int c = 0; c < components.size(); ++c)
@@ -161,12 +171,13 @@ void CompositeSPOSet::evaluate_notranspose(const ParticleSet& P,
   }
 }
 
-void CompositeSPOSet::evaluate_notranspose(const ParticleSet& P,
-                                           int first,
-                                           int last,
-                                           ValueMatrix& logdet,
-                                           GradMatrix& dlogdet,
-                                           HessMatrix& grad_grad_logdet)
+template<typename T>
+void CompositeSPOSet<T>::evaluate_notranspose(const ParticleSet& P,
+                                              int first,
+                                              int last,
+                                              ValueMatrix& logdet,
+                                              GradMatrix& dlogdet,
+                                              HessMatrix& grad_grad_logdet)
 {
   const int nat = last - first;
   for (int c = 0; c < components.size(); ++c)
@@ -183,13 +194,14 @@ void CompositeSPOSet::evaluate_notranspose(const ParticleSet& P,
   }
 }
 
-void CompositeSPOSet::evaluate_notranspose(const ParticleSet& P,
-                                           int first,
-                                           int last,
-                                           ValueMatrix& logdet,
-                                           GradMatrix& dlogdet,
-                                           HessMatrix& grad_grad_logdet,
-                                           GGGMatrix& grad_grad_grad_logdet)
+template<typename T>
+void CompositeSPOSet<T>::evaluate_notranspose(const ParticleSet& P,
+                                              int first,
+                                              int last,
+                                              ValueMatrix& logdet,
+                                              GradMatrix& dlogdet,
+                                              HessMatrix& grad_grad_logdet,
+                                              GGGMatrix& grad_grad_grad_logdet)
 {
   not_implemented("evaluate_notranspose(P,first,last,logdet,dlogdet,ddlogdet,dddlogdet)");
 }
@@ -204,7 +216,7 @@ std::unique_ptr<SPOSet> CompositeSPOSetBuilder::createSPOSetFromXML(xmlNodePtr c
     return nullptr;
   }
 
-  auto spo_now = std::make_unique<CompositeSPOSet>(getXMLAttributeValue(cur, "name"));
+  auto spo_now = std::make_unique<CompositeSPOSet<ValueType>>(getXMLAttributeValue(cur, "name"));
   for (int i = 0; i < spolist.size(); ++i)
   {
     const SPOSet* spo = sposet_builder_factory_.getSPOSet(spolist[i]);
@@ -218,5 +230,12 @@ std::unique_ptr<SPOSet> CompositeSPOSetBuilder::createSPOSet(xmlNodePtr cur, SPO
 {
   return createSPOSetFromXML(cur);
 }
+
+#if !defined(MIXED_PRECISION)
+template class CompositeSPOSet<double>;
+template class CompositeSPOSet<std::complex<double>>;
+#endif
+template class CompositeSPOSet<float>;
+template class CompositeSPOSet<std::complex<float>>;
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -22,9 +22,20 @@
 
 namespace qmcplusplus
 {
-class CompositeSPOSet : public SPOSet
+
+template<typename T>
+class CompositeSPOSet : public SPOSetT<T>
 {
 public:
+  using SPOSet = SPOSetT<T>;
+
+  using ValueVector = typename SPOSet::ValueVector;
+  using ValueMatrix = typename SPOSet::ValueMatrix;
+  using GradVector  = typename SPOSet::GradVector;
+  using GradMatrix  = typename SPOSet::GradMatrix;
+  using HessMatrix  = typename SPOSet::HessMatrix;
+  using GGGMatrix   = typename SPOSet::GGGMatrix;
+
   ///component SPOSets
   std::vector<std::unique_ptr<SPOSet>> components;
   ///temporary storage for values

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -42,7 +42,7 @@ DiracDeterminant<DU_TYPE>::DiracDeterminant(std::unique_ptr<SPOSet>&& spos,
 {
   resize(NumPtcls, NumPtcls);
 
-  RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
+  RotatedSPOs<ValueType>* rot_spo = dynamic_cast<RotatedSPOs<ValueType>*>(Phi.get());
   if (rot_spo)
     rot_spo->buildOptVariables(NumPtcls);
 }

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -93,11 +93,12 @@ DiracDeterminantBatched<PL, VT, FPVT>::DiracDeterminantBatched(std::unique_ptr<S
   static_assert(std::is_same<SPOSet::ValueType, typename UpdateEngine::Value>::value);
   resize(NumPtcls, NumPtcls);
 
-#ifndef QMC_COMPLEX
-  RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
-  if (rot_spo)
-    rot_spo->buildOptVariables(NumPtcls);
-#endif
+  if constexpr(IsReal_t<ValueType>::value)
+  {
+    RotatedSPOs<ValueType>* rot_spo = dynamic_cast<RotatedSPOs<ValueType>*>(Phi.get());
+    if (rot_spo)
+      rot_spo->buildOptVariables(NumPtcls);
+  }
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -1174,7 +1174,7 @@ void MultiDiracDeterminant::buildOptVariables(std::vector<size_t>& C2node)
 
 
 #ifndef QMC_COMPLEX
-  RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
+  RotatedSPOs<ValueType>* rot_spo = dynamic_cast<RotatedSPOs<ValueType>*>(Phi.get());
   if (rot_spo)
     rot_spo->buildOptVariables(m_act_rot_inds, full_rot_inds);
 #endif

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -13,22 +13,52 @@
 #ifndef QMCPLUSPLUS_ROTATION_HELPER_H
 #define QMCPLUSPLUS_ROTATION_HELPER_H
 
+#include "ParticleBase/ParticleAttrib.h"
 #include "QMCWaveFunctions/SPOSet.h"
 
 
 namespace qmcplusplus
 {
+template<typename T>
 class RotatedSPOs;
+
 namespace testing
 {
-const opt_variables_type& getMyVars(RotatedSPOs& rot);
-const std::vector<QMCTraits::ValueType>& getMyVarsFull(RotatedSPOs& rot);
-const std::vector<std::vector<QMCTraits::ValueType>>& getHistoryParams(RotatedSPOs& rot);
+template<typename U>
+const opt_variables_type& getMyVars(RotatedSPOs<U>& rot);
+template<typename U>
+const std::vector<typename RotatedSPOs<U>::ValueType>& getMyVarsFull(RotatedSPOs<U>& rot);
+template<typename U>
+const std::vector<std::vector<typename RotatedSPOs<U>::ValueType>>& getHistoryParams(RotatedSPOs<U>& rot);
 } // namespace testing
 
-class RotatedSPOs : public SPOSet, public OptimizableObject
+template<typename T>
+class RotatedSPOs : public SPOSetT<T>, public OptimizableObject
 {
 public:
+
+  using SPOSet = SPOSetT<T>;
+
+  // TODO:using Value instead of ValueType
+  using ValueType         = typename SPOSet::ValueType;
+  using IndexType         = typename SPOSet::IndexType;
+  using RealType          = typename SPOSet::RealType;
+  using ComplexType       = typename SPOSet::ComplexType;
+  using GradType          = typename SPOSet::GradType;
+  using ValueMatrix       = typename SPOSet::ValueMatrix;
+  using GradMatrix        = typename SPOSet::GradMatrix;
+  using HessMatrix        = typename SPOSet::HessMatrix;
+  using GGGMatrix         = typename SPOSet::GGGMatrix;
+  using ValueVector       = typename SPOSet::ValueVector;
+  using GradVector        = typename SPOSet::GradVector;
+  using HessVector        = typename SPOSet::HessVector;
+  using GGGVector         = typename SPOSet::GGGVector;
+  using FullPrecValue     = typename SPOSet::FullPrecValue;
+  using OffloadMWVGLArray = typename SPOSet::OffloadMWVGLArray;
+  using OffloadMWVArray   = typename SPOSet::OffloadMWVArray;
+  template<typename DT>
+  using OffloadMatrix     = typename SPOSet::template OffloadMatrix<DT>;
+
   //constructor
   RotatedSPOs(const std::string& my_name, std::unique_ptr<SPOSet>&& spos);
   //destructor
@@ -134,8 +164,8 @@ public:
   //       It represents \frac{\nabla\psi_{J}}{\psi_{J}}
   // myL_J will be used to represent \frac{\nabla^2\psi_{J}}{\psi_{J}} . The Laplacian portion
   // IMPORTANT NOTE:  The value of P.L holds \nabla^2 ln[\psi] but we need  \frac{\nabla^2 \psi}{\psi} and this is what myL_J will hold
-  ParticleSet::ParticleGradient myG_temp, myG_J;
-  ParticleSet::ParticleLaplacian myL_temp, myL_J;
+  ParticleAttrib<GradType> myG_temp, myG_J;
+  ParticleAttrib<ValueType> myL_temp, myL_J;
 
   ValueMatrix Bbar;
   ValueMatrix psiM_inv;
@@ -480,9 +510,16 @@ private:
   /// Use global rotation or history list
   bool use_global_rot_ = true;
 
-  friend const opt_variables_type& testing::getMyVars(RotatedSPOs& rot);
-  friend const std::vector<ValueType>& testing::getMyVarsFull(RotatedSPOs& rot);
-  friend const std::vector<std::vector<ValueType>>& testing::getHistoryParams(RotatedSPOs& rot);
+  template<typename U>
+  friend const opt_variables_type& testing::getMyVars(RotatedSPOs<U>& rot);
+
+  template<typename U>
+  friend const std::vector<typename RotatedSPOs<U>::ValueType>&
+    testing::getMyVarsFull(RotatedSPOs<U>& rot);
+
+  template<typename U>
+  friend const std::vector<std::vector<typename RotatedSPOs<U>::ValueType>>&
+    testing::getHistoryParams(RotatedSPOs<U>& rot);
 };
 
 

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -98,7 +98,7 @@ std::unique_ptr<SPOSet> SPOSetBuilder::createSPOSet(xmlNodePtr cur)
     if (!sposet_ref.isRotationSupported())
       myComm->barrier_and_abort("Orbital rotation not supported with '" + sposet_ref.getName() + "' of type '" +
                                 sposet_ref.getClassName() + "'.");
-    auto rot_spo    = std::make_unique<RotatedSPOs>(sposet_ref.getName(), std::move(sposet));
+    auto rot_spo    = std::make_unique<RotatedSPOs<SPOSet::ValueType>>(sposet_ref.getName(), std::move(sposet));
     xmlNodePtr tcur = cur->xmlChildrenNode;
     while (tcur != NULL)
     {
@@ -149,7 +149,7 @@ std::unique_ptr<SPOSet> SPOSetBuilder::createRotatedSPOSet(xmlNodePtr cur)
                               sposet->getClassName() + "'.");
 
   sposet->storeParamsBeforeRotation();
-  auto rot_spo = std::make_unique<RotatedSPOs>(spo_object_name, std::move(sposet));
+  auto rot_spo = std::make_unique<RotatedSPOs<SPOSet::ValueType>>(spo_object_name, std::move(sposet));
 
   if (method == "history")
     rot_spo->set_use_global_rotation(false);

--- a/src/QMCWaveFunctions/tests/ConstantSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/ConstantSPOSet.cpp
@@ -13,68 +13,81 @@
 
 namespace qmcplusplus
 {
-ConstantSPOSet::ConstantSPOSet(const std::string& my_name, const int nparticles, const int norbitals)
-    : SPOSet(my_name), numparticles_(nparticles)
+
+template<typename T>
+ConstantSPOSet<T>::ConstantSPOSet(const std::string& my_name, const int nparticles, const int norbitals)
+    : SPOSetT<T>(my_name), numparticles_(nparticles)
 {
-  OrbitalSetSize = norbitals;
-  ref_psi_.resize(numparticles_, OrbitalSetSize);
-  ref_egrad_.resize(numparticles_, OrbitalSetSize);
-  ref_elapl_.resize(numparticles_, OrbitalSetSize);
+  this->OrbitalSetSize = norbitals;
+  ref_psi_.resize(numparticles_, this->OrbitalSetSize);
+  ref_egrad_.resize(numparticles_, this->OrbitalSetSize);
+  ref_elapl_.resize(numparticles_, this->OrbitalSetSize);
 
   ref_psi_   = 0.0;
   ref_egrad_ = 0.0;
   ref_elapl_ = 0.0;
 };
 
-std::unique_ptr<SPOSet> ConstantSPOSet::makeClone() const
+template<typename T>
+std::unique_ptr<SPOSetT<T>> ConstantSPOSet<T>::makeClone() const
 {
-  auto myclone = std::make_unique<ConstantSPOSet>(my_name_, numparticles_, OrbitalSetSize);
+  auto myclone = std::make_unique<ConstantSPOSet>(this->my_name_, numparticles_, this->OrbitalSetSize);
   myclone->setRefVals(ref_psi_);
   myclone->setRefEGrads(ref_egrad_);
   myclone->setRefELapls(ref_elapl_);
   return myclone;
 };
 
-std::string ConstantSPOSet::getClassName() const { return "ConstantSPOSet"; };
+template<typename T>
+std::string ConstantSPOSet<T>::getClassName() const { return "ConstantSPOSet"; };
 
-void ConstantSPOSet::checkOutVariables(const opt_variables_type& active)
+template<typename T>
+void ConstantSPOSet<T>::checkOutVariables(const opt_variables_type& active)
 {
   APP_ABORT("ConstantSPOSet should not call checkOutVariables");
 };
 
-void ConstantSPOSet::setOrbitalSetSize(int norbs) { APP_ABORT("ConstantSPOSet should not call setOrbitalSetSize()"); }
+template<typename T>
+void ConstantSPOSet<T>::setOrbitalSetSize(int norbs) { APP_ABORT("ConstantSPOSet should not call setOrbitalSetSize()"); }
 
-void ConstantSPOSet::setRefVals(const ValueMatrix& vals)
+template<typename T>
+void ConstantSPOSet<T>::setRefVals(const ValueMatrix& vals)
 {
-  assert(vals.cols() == OrbitalSetSize);
+  assert(vals.cols() == this->OrbitalSetSize);
   assert(vals.rows() == numparticles_);
   ref_psi_ = vals;
 };
-void ConstantSPOSet::setRefEGrads(const GradMatrix& grads)
+
+template<typename T>
+void ConstantSPOSet<T>::setRefEGrads(const GradMatrix& grads)
 {
-  assert(grads.cols() == OrbitalSetSize);
+  assert(grads.cols() == this->OrbitalSetSize);
   assert(grads.rows() == numparticles_);
   ref_egrad_ = grads;
 };
-void ConstantSPOSet::setRefELapls(const ValueMatrix& lapls)
+
+template<typename T>
+void ConstantSPOSet<T>::setRefELapls(const ValueMatrix& lapls)
 {
-  assert(lapls.cols() == OrbitalSetSize);
+  assert(lapls.cols() == this->OrbitalSetSize);
   assert(lapls.rows() == numparticles_);
   ref_elapl_ = lapls;
 };
 
-void ConstantSPOSet::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
+template<typename T>
+void ConstantSPOSet<T>::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
 {
   const auto* vp = dynamic_cast<const VirtualParticleSet*>(&P);
   int ptcl = vp ? vp->refPtcl : iat;
-  assert(psi.size() == OrbitalSetSize);
-  for (int iorb = 0; iorb < OrbitalSetSize; iorb++)
+  assert(psi.size() == this->OrbitalSetSize);
+  for (int iorb = 0; iorb < this->OrbitalSetSize; iorb++)
     psi[iorb] = ref_psi_(ptcl, iorb);
 };
 
-void ConstantSPOSet::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)
+template<typename T>
+void ConstantSPOSet<T>::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)
 {
-  for (int iorb = 0; iorb < OrbitalSetSize; iorb++)
+  for (int iorb = 0; iorb < this->OrbitalSetSize; iorb++)
   {
     psi[iorb]   = ref_psi_(iat, iorb);
     dpsi[iorb]  = ref_egrad_(iat, iorb);
@@ -82,12 +95,13 @@ void ConstantSPOSet::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi
   }
 };
 
-void ConstantSPOSet::evaluate_notranspose(const ParticleSet& P,
-                                          int first,
-                                          int last,
-                                          ValueMatrix& logdet,
-                                          GradMatrix& dlogdet,
-                                          ValueMatrix& d2logdet)
+template<typename T>
+void ConstantSPOSet<T>::evaluate_notranspose(const ParticleSet& P,
+                                             int first,
+                                             int last,
+                                             ValueMatrix& logdet,
+                                             GradMatrix& dlogdet,
+                                             ValueMatrix& d2logdet)
 {
   for (int iat = first, i = 0; iat < last; ++iat, ++i)
   {
@@ -97,4 +111,13 @@ void ConstantSPOSet::evaluate_notranspose(const ParticleSet& P,
     evaluateVGL(P, iat, v, g, l);
   }
 }
+
+#if !defined(MIXED_PRECISION)
+template class ConstantSPOSet<double>;
+template class ConstantSPOSet<std::complex<double>>;
+#endif
+template class ConstantSPOSet<float>;
+template class ConstantSPOSet<std::complex<float>>;
+
+
 } //namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/ConstantSPOSet.h
+++ b/src/QMCWaveFunctions/tests/ConstantSPOSet.h
@@ -22,9 +22,17 @@ namespace qmcplusplus
    *  Exists to provide deterministic and known output to objects requiring SPOSet evaluations.      
    *
    */
-class ConstantSPOSet : public SPOSet
+template<typename T>
+class ConstantSPOSet : public SPOSetT<T>
 {
 public:
+  using SPOSet = SPOSetT<T>;
+
+  using ValueVector = typename SPOSet::ValueVector;
+  using ValueMatrix = typename SPOSet::ValueMatrix;
+  using GradVector  = typename SPOSet::GradVector;
+  using GradMatrix  = typename SPOSet::GradMatrix;
+
   ConstantSPOSet(const std::string& my_name) = delete;
 
   //Constructor needs number of particles and number of orbitals.  This is the minimum

--- a/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
@@ -35,7 +35,7 @@ TEST_CASE("CompositeSPO::diamond_1x1x1", "[wavefunction")
   auto& pset = *particle_pool.getParticleSet("e");
   auto& twf  = *wavefunction_pool.getWaveFunction("wavefunction");
 
-  CompositeSPOSet comp_sposet("one_composite_set");
+  CompositeSPOSet<SPOSet::ValueType> comp_sposet("one_composite_set");
 
   std::vector<std::string> sposets{"spo_ud", "spo_dm"};
   for (auto sposet_str : sposets)

--- a/src/QMCWaveFunctions/tests/test_ConstantSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/test_ConstantSPOSet.cpp
@@ -74,7 +74,7 @@ TEST_CASE("ConstantSPOSet", "[wavefunction]")
   psiG.resize(norb);
 
   //Test of value only constructor.
-  auto sposet = std::make_unique<ConstantSPOSet>("constant_spo", nelec, norb);
+  auto sposet = std::make_unique<ConstantSPOSet<Value>>("constant_spo", nelec, norb);
   sposet->setRefVals(spomat);
   sposet->setRefEGrads(gradspomat);
   sposet->setRefELapls(laplspomat);

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -40,6 +40,7 @@ namespace qmcplusplus
 TEST_CASE("RotatedSPOs via SplineR2R", "[wavefunction]")
 {
   using RealType = QMCTraits::RealType;
+  using ValueType = SPOSet::ValueType;
 
   /*
     BEGIN Boilerplate stuff to make a simple SPOSet. Copied from test_einset.cpp
@@ -106,7 +107,7 @@ TEST_CASE("RotatedSPOs via SplineR2R", "[wavefunction]")
 
   spo->storeParamsBeforeRotation();
   // 1.) Make a RotatedSPOs object so that we can use the rotation routines
-  auto rot_spo = std::make_unique<RotatedSPOs>("one_rotated_set", std::move(spo));
+  auto rot_spo = std::make_unique<RotatedSPOs<ValueType>>("one_rotated_set", std::move(spo));
 
   // Sanity check for orbs. Expect 2 electrons, 8 orbitals, & 79507 coefs/orb.
   const auto orbitalsetsize = rot_spo->getOrbitalSetSize();
@@ -284,34 +285,37 @@ TEST_CASE("RotatedSPOs createRotationIndices", "[wavefunction]")
 {
   // No active-active or virtual-virtual rotations
   // Only active-virtual
-  RotatedSPOs::RotationIndices rot_ind;
+
+  using ValueType = SPOSet::ValueType;
+
+  RotatedSPOs<ValueType>::RotationIndices rot_ind;
   int nel = 1;
   int nmo = 3;
-  RotatedSPOs::createRotationIndices(nel, nmo, rot_ind);
+  RotatedSPOs<ValueType>::createRotationIndices(nel, nmo, rot_ind);
   CHECK(rot_ind.size() == 2);
 
   // Full rotation contains all rotations
   // Size should be number of pairs of orbitals: nmo*(nmo-1)/2
-  RotatedSPOs::RotationIndices full_rot_ind;
-  RotatedSPOs::createRotationIndicesFull(nel, nmo, full_rot_ind);
+  RotatedSPOs<ValueType>::RotationIndices full_rot_ind;
+  RotatedSPOs<ValueType>::createRotationIndicesFull(nel, nmo, full_rot_ind);
   CHECK(full_rot_ind.size() == 3);
 
   nel = 2;
-  RotatedSPOs::RotationIndices rot_ind2;
-  RotatedSPOs::createRotationIndices(nel, nmo, rot_ind2);
+  RotatedSPOs<ValueType>::RotationIndices rot_ind2;
+  RotatedSPOs<ValueType>::createRotationIndices(nel, nmo, rot_ind2);
   CHECK(rot_ind2.size() == 2);
 
-  RotatedSPOs::RotationIndices full_rot_ind2;
-  RotatedSPOs::createRotationIndicesFull(nel, nmo, full_rot_ind2);
+  RotatedSPOs<ValueType>::RotationIndices full_rot_ind2;
+  RotatedSPOs<ValueType>::createRotationIndicesFull(nel, nmo, full_rot_ind2);
   CHECK(full_rot_ind2.size() == 3);
 
   nmo = 4;
-  RotatedSPOs::RotationIndices rot_ind3;
-  RotatedSPOs::createRotationIndices(nel, nmo, rot_ind3);
+  RotatedSPOs<ValueType>::RotationIndices rot_ind3;
+  RotatedSPOs<ValueType>::createRotationIndices(nel, nmo, rot_ind3);
   CHECK(rot_ind3.size() == 4);
 
-  RotatedSPOs::RotationIndices full_rot_ind3;
-  RotatedSPOs::createRotationIndicesFull(nel, nmo, full_rot_ind3);
+  RotatedSPOs<ValueType>::RotationIndices full_rot_ind3;
+  RotatedSPOs<ValueType>::createRotationIndicesFull(nel, nmo, full_rot_ind3);
   CHECK(full_rot_ind3.size() == 6);
 }
 
@@ -320,16 +324,16 @@ TEST_CASE("RotatedSPOs constructAntiSymmetricMatrix", "[wavefunction]")
   using ValueType   = SPOSet::ValueType;
   using ValueMatrix = SPOSet::ValueMatrix;
 
-  RotatedSPOs::RotationIndices rot_ind;
+  RotatedSPOs<ValueType>::RotationIndices rot_ind;
   int nel = 1;
   int nmo = 3;
-  RotatedSPOs::createRotationIndices(nel, nmo, rot_ind);
+  RotatedSPOs<ValueType>::createRotationIndices(nel, nmo, rot_ind);
 
   ValueMatrix m3(nmo, nmo);
   m3                            = ValueType(0);
   std::vector<ValueType> params = {0.1, 0.2};
 
-  RotatedSPOs::constructAntiSymmetricMatrix(rot_ind, params, m3);
+  RotatedSPOs<ValueType>::constructAntiSymmetricMatrix(rot_ind, params, m3);
 
   // clang-format off
   std::vector<ValueType> expected_data = { 0.0,  -0.1, -0.2,
@@ -343,7 +347,7 @@ TEST_CASE("RotatedSPOs constructAntiSymmetricMatrix", "[wavefunction]")
   CHECKED_ELSE(check_matrix_result.result) { FAIL(check_matrix_result.result_message); }
 
   std::vector<ValueType> params_out(2);
-  RotatedSPOs::extractParamsFromAntiSymmetricMatrix(rot_ind, m3, params_out);
+  RotatedSPOs<ValueType>::extractParamsFromAntiSymmetricMatrix(rot_ind, m3, params_out);
   //Using ComplexApprox handles real or complex builds.  In any case, no imaginary component expected.
   CHECK(std::real(params_out[0]) == Approx(0.1));
   CHECK(std::real(params_out[1]) == Approx(0.2));
@@ -358,7 +362,7 @@ TEST_CASE("RotatedSPOs exponentiate matrix", "[wavefunction]")
 
   std::vector<SPOSet::ValueType> mat1_data = {0.0};
   SPOSet::ValueMatrix m1(mat1_data.data(), 1, 1);
-  RotatedSPOs::exponentiate_antisym_matrix(m1);
+  RotatedSPOs<ValueType>::exponentiate_antisym_matrix(m1);
   // Always return 1.0 (the only possible anti-symmetric 1x1 matrix is 0)
   CHECK(m1(0, 0) == ValueApprox(1.0));
 
@@ -368,7 +372,7 @@ TEST_CASE("RotatedSPOs exponentiate matrix", "[wavefunction]")
   // clang-format on
 
   SPOSet::ValueMatrix m2(mat2_data.data(), 2, 2);
-  RotatedSPOs::exponentiate_antisym_matrix(m2);
+  RotatedSPOs<ValueType>::exponentiate_antisym_matrix(m2);
 
   // clang-format off
   std::vector<ValueType> expected_rot2 = {  0.995004165278026,  -0.0998334166468282,
@@ -395,7 +399,7 @@ TEST_CASE("RotatedSPOs exponentiate matrix", "[wavefunction]")
   ValueMatrix m3(m3_input_data.data(), 3, 3);
   ValueMatrix expected_m3(expected_rot3.data(), 3, 3);
 
-  RotatedSPOs::exponentiate_antisym_matrix(m3);
+  RotatedSPOs<ValueType>::exponentiate_antisym_matrix(m3);
 
   CheckMatrixResult check_matrix_result3 = checkMatrix(m3, expected_m3, true);
   CHECKED_ELSE(check_matrix_result3.result) { FAIL(check_matrix_result3.result_message); }
@@ -431,7 +435,7 @@ TEST_CASE("RotatedSPOs log matrix", "[wavefunction]")
   std::vector<SPOSet::ValueType> mat1_data = {1.0};
   SPOSet::ValueMatrix m1(mat1_data.data(), 1, 1);
   SPOSet::ValueMatrix out_m1(1, 1);
-  RotatedSPOs::log_antisym_matrix(m1, out_m1);
+  RotatedSPOs<ValueType>::log_antisym_matrix(m1, out_m1);
   // Should always be 1.0 (the only possible anti-symmetric 1x1 matrix is 0)
   CHECK(out_m1(0, 0) == ValueApprox(0.0));
 
@@ -445,7 +449,7 @@ TEST_CASE("RotatedSPOs log matrix", "[wavefunction]")
 
   ValueMatrix rot_m2(start_rot2.data(), 2, 2);
   ValueMatrix out_m2(2, 2);
-  RotatedSPOs::log_antisym_matrix(rot_m2, out_m2);
+  RotatedSPOs<ValueType>::log_antisym_matrix(rot_m2, out_m2);
 
   SPOSet::ValueMatrix m2(mat2_data.data(), 2, 2);
   CheckMatrixResult check_matrix_result2 = checkMatrix(m2, out_m2, true);
@@ -462,7 +466,7 @@ TEST_CASE("RotatedSPOs log matrix", "[wavefunction]")
   // clang-format on
   ValueMatrix rot_m3(start_rot3.data(), 3, 3);
   ValueMatrix out_m3(3, 3);
-  RotatedSPOs::log_antisym_matrix(rot_m3, out_m3);
+  RotatedSPOs<ValueType>::log_antisym_matrix(rot_m3, out_m3);
 
   SPOSet::ValueMatrix m3(m3_input_data.data(), 3, 3);
   CheckMatrixResult check_matrix_result3 = checkMatrix(m3, out_m3, true);
@@ -500,29 +504,29 @@ TEST_CASE("RotatedSPOs exp-log matrix", "[wavefunction]")
   using ValueType   = SPOSet::ValueType;
   using ValueMatrix = SPOSet::ValueMatrix;
 
-  RotatedSPOs::RotationIndices rot_ind;
+  RotatedSPOs<ValueType>::RotationIndices rot_ind;
   int nel = 2;
   int nmo = 4;
-  RotatedSPOs::createRotationIndices(nel, nmo, rot_ind);
+  RotatedSPOs<ValueType>::createRotationIndices(nel, nmo, rot_ind);
 
   ValueMatrix rot_m4(nmo, nmo);
   rot_m4 = ValueType(0);
 
   std::vector<ValueType> params4 = {-1.1, 1.5, 0.2, -0.15};
 
-  RotatedSPOs::constructAntiSymmetricMatrix(rot_ind, params4, rot_m4);
+  RotatedSPOs<ValueType>::constructAntiSymmetricMatrix(rot_ind, params4, rot_m4);
   ValueMatrix orig_rot_m4 = rot_m4;
   ValueMatrix out_m4(nmo, nmo);
 
-  RotatedSPOs::exponentiate_antisym_matrix(rot_m4);
+  RotatedSPOs<ValueType>::exponentiate_antisym_matrix(rot_m4);
 
-  RotatedSPOs::log_antisym_matrix(rot_m4, out_m4);
+  RotatedSPOs<ValueType>::log_antisym_matrix(rot_m4, out_m4);
 
   CheckMatrixResult check_matrix_result4 = checkMatrix(out_m4, orig_rot_m4, true);
   CHECKED_ELSE(check_matrix_result4.result) { FAIL(check_matrix_result4.result_message); }
 
   std::vector<ValueType> params4out(4);
-  RotatedSPOs::extractParamsFromAntiSymmetricMatrix(rot_ind, out_m4, params4out);
+  RotatedSPOs<ValueType>::extractParamsFromAntiSymmetricMatrix(rot_ind, out_m4, params4out);
   for (int i = 0; i < params4.size(); i++)
   {
     CHECK(std::real(params4[i]) == Approx(std::real(params4out[i])));
@@ -615,7 +619,7 @@ TEST_CASE("RotatedSPOs hcpBe", "[wavefunction]")
   REQUIRE(spo);
 
   spo->storeParamsBeforeRotation();
-  auto rot_spo = std::make_unique<RotatedSPOs>("one_rotated_set", std::move(spo));
+  auto rot_spo = std::make_unique<RotatedSPOs<QMCTraits::ValueType>>("one_rotated_set", std::move(spo));
 
   // Sanity check for orbs. Expect 1 electron, 2 orbitals
   const auto orbitalsetsize = rot_spo->getOrbitalSetSize();
@@ -679,10 +683,10 @@ TEST_CASE("RotatedSPOs construct delta matrix", "[wavefunction]")
 
   int nel = 2;
   int nmo = 4;
-  RotatedSPOs::RotationIndices rot_ind;
-  RotatedSPOs::createRotationIndices(nel, nmo, rot_ind);
-  RotatedSPOs::RotationIndices full_rot_ind;
-  RotatedSPOs::createRotationIndicesFull(nel, nmo, full_rot_ind);
+  RotatedSPOs<ValueType>::RotationIndices rot_ind;
+  RotatedSPOs<ValueType>::createRotationIndices(nel, nmo, rot_ind);
+  RotatedSPOs<ValueType>::RotationIndices full_rot_ind;
+  RotatedSPOs<ValueType>::createRotationIndicesFull(nel, nmo, full_rot_ind);
   // rot_ind size is 4 and full rot_ind size is 6
 
   ValueMatrix rot_m4(nmo, nmo);
@@ -697,7 +701,7 @@ TEST_CASE("RotatedSPOs construct delta matrix", "[wavefunction]")
   std::vector<ValueType> delta_params = {0.1, 0.3, 0.2, -0.1};
   std::vector<ValueType> new_params(6);
 
-  RotatedSPOs::constructDeltaRotation(delta_params, old_params, rot_ind, full_rot_ind, new_params, rot_m4);
+  RotatedSPOs<ValueType>::constructDeltaRotation(delta_params, old_params, rot_ind, full_rot_ind, new_params, rot_m4);
 
   // clang-format off
   std::vector<ValueType> rot_data4 =
@@ -723,16 +727,23 @@ TEST_CASE("RotatedSPOs construct delta matrix", "[wavefunction]")
 
   std::vector<ValueType> new_params2(6);
   std::vector<ValueType> reverse_delta_params = {-0.1, -0.3, -0.2, 0.1};
-  RotatedSPOs::constructDeltaRotation(reverse_delta_params, new_params, rot_ind, full_rot_ind, new_params2, rot_m4);
+  RotatedSPOs<ValueType>::constructDeltaRotation(reverse_delta_params, new_params, rot_ind, full_rot_ind, new_params2, rot_m4);
   for (int i = 0; i < new_params2.size(); i++)
     CHECK(new_params2[i] == ValueApprox(old_params[i]));
 }
 
 namespace testing
 {
-const opt_variables_type& getMyVars(RotatedSPOs& rot) { return rot.myVars; }
-const std::vector<QMCTraits::ValueType>& getMyVarsFull(RotatedSPOs& rot) { return rot.myVarsFull_; }
-const std::vector<std::vector<QMCTraits::ValueType>>& getHistoryParams(RotatedSPOs& rot) { return rot.history_params_; }
+template<typename U>
+const opt_variables_type& getMyVars(RotatedSPOs<U>& rot) { return rot.myVars; }
+
+template<typename U>
+const std::vector<typename RotatedSPOs<U>::ValueType>&
+  getMyVarsFull(RotatedSPOs<U>& rot) { return rot.myVarsFull_; }
+
+template<typename U>
+const std::vector<std::vector<typename RotatedSPOs<U>::ValueType>>&
+  getHistoryParams(RotatedSPOs<U>& rot) { return rot.history_params_; }
 } // namespace testing
 
 // Test using global rotation
@@ -742,7 +753,7 @@ TEST_CASE("RotatedSPOs read and write parameters", "[wavefunction]")
   //This needs to be fixed in a future PR.
   auto fake_spo = std::make_unique<FakeSPO<QMCTraits::ValueType>>();
   fake_spo->setOrbitalSetSize(4);
-  RotatedSPOs rot("fake_rot", std::move(fake_spo));
+  RotatedSPOs<QMCTraits::ValueType> rot("fake_rot", std::move(fake_spo));
   int nel = 2;
   rot.buildOptVariables(nel);
 
@@ -765,7 +776,7 @@ TEST_CASE("RotatedSPOs read and write parameters", "[wavefunction]")
   auto fake_spo2 = std::make_unique<FakeSPO<QMCTraits::ValueType>>();
   fake_spo2->setOrbitalSetSize(4);
 
-  RotatedSPOs rot2("fake_rot", std::move(fake_spo2));
+  RotatedSPOs<QMCTraits::ValueType> rot2("fake_rot", std::move(fake_spo2));
   rot2.buildOptVariables(nel);
 
   optimize::VariableSet vs2;
@@ -793,7 +804,7 @@ TEST_CASE("RotatedSPOs read and write parameters history", "[wavefunction]")
   //Problem with h5 parameter parsing for complex build.  To be fixed in future PR.
   auto fake_spo = std::make_unique<FakeSPO<QMCTraits::ValueType>>();
   fake_spo->setOrbitalSetSize(4);
-  RotatedSPOs rot("fake_rot", std::move(fake_spo));
+  RotatedSPOs<QMCTraits::ValueType> rot("fake_rot", std::move(fake_spo));
   rot.set_use_global_rotation(false);
   int nel = 2;
   rot.buildOptVariables(nel);
@@ -817,7 +828,7 @@ TEST_CASE("RotatedSPOs read and write parameters history", "[wavefunction]")
   auto fake_spo2 = std::make_unique<FakeSPO<QMCTraits::ValueType>>();
   fake_spo2->setOrbitalSetSize(4);
 
-  RotatedSPOs rot2("fake_rot", std::move(fake_spo2));
+  RotatedSPOs<QMCTraits::ValueType> rot2("fake_rot", std::move(fake_spo2));
   rot2.buildOptVariables(nel);
 
   optimize::VariableSet vs2;
@@ -947,8 +958,8 @@ TEST_CASE("RotatedSPOs mw_ APIs", "[wavefunction]")
     //In the case that the underlying SPOSet doesn't specialize the mw_ API,
     //the underlying SPOSet will fall back to the default SPOSet mw_, which is
     //just a loop over the single walker API.
-    RotatedSPOs rot_spo0("rotated0", std::make_unique<DummySPOSetWithoutMW>("no mw 0"));
-    RotatedSPOs rot_spo1("rotated1", std::make_unique<DummySPOSetWithoutMW>("no mw 1"));
+    RotatedSPOs<QMCTraits::ValueType> rot_spo0("rotated0", std::make_unique<DummySPOSetWithoutMW>("no mw 0"));
+    RotatedSPOs<QMCTraits::ValueType> rot_spo1("rotated1", std::make_unique<DummySPOSetWithoutMW>("no mw 1"));
     RefVectorWithLeader<SPOSet> spo_list(rot_spo0, {rot_spo0, rot_spo1});
 
     ResourceCollection spo_res("test_rot_res");
@@ -1006,8 +1017,8 @@ TEST_CASE("RotatedSPOs mw_ APIs", "[wavefunction]")
     //loops over single walker APIs (which have different values enforced in
     // DummySPOSetWithoutMW
 
-    RotatedSPOs rot_spo0("rotated0", std::make_unique<DummySPOSetWithMW>("mw 0"));
-    RotatedSPOs rot_spo1("rotated1", std::make_unique<DummySPOSetWithMW>("mw 1"));
+    RotatedSPOs<QMCTraits::ValueType> rot_spo0("rotated0", std::make_unique<DummySPOSetWithMW>("mw 0"));
+    RotatedSPOs<QMCTraits::ValueType> rot_spo1("rotated1", std::make_unique<DummySPOSetWithMW>("mw 1"));
     RefVectorWithLeader<SPOSet> spo_list(rot_spo0, {rot_spo0, rot_spo1});
 
     ResourceCollection spo_res("test_rot_res");

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -847,12 +847,19 @@ TEST_CASE("RotatedSPOs read and write parameters history", "[wavefunction]")
   REQUIRE(hist[0].size() == 4);
 }
 
-class DummySPOSetWithoutMW : public SPOSet
+template<typename T>
+class DummySPOSetWithoutMW : public SPOSetT<T>
 {
 public:
+  using SPOSet = SPOSetT<T>;
+  using ValueVector = typename SPOSet::ValueVector;
+  using ValueMatrix = typename SPOSet::ValueMatrix;
+  using GradVector  = typename SPOSet::GradVector;
+  using GradMatrix  = typename SPOSet::GradMatrix;
+
   DummySPOSetWithoutMW(const std::string& my_name) : SPOSet(my_name) {}
   void setOrbitalSetSize(int norbs) override {}
-  void evaluateValue(const ParticleSet& P, int iat, SPOSet::ValueVector& psi) override
+  void evaluateValue(const ParticleSet& P, int iat, ValueVector& psi) override
   {
     assert(psi.size() == 3);
     psi[0] = 123;
@@ -907,13 +914,15 @@ public:
                             GradMatrix& dlogdet,
                             ValueMatrix& d2logdet) override
   {}
-  std::string getClassName() const override { return my_name_; }
+  std::string getClassName() const override { return this->my_name_; }
 };
 
-class DummySPOSetWithMW : public DummySPOSetWithoutMW
+template<typename T>
+class DummySPOSetWithMW : public DummySPOSetWithoutMW<T>
 {
 public:
-  DummySPOSetWithMW(const std::string& my_name) : DummySPOSetWithoutMW(my_name) {}
+  using ValueVector = typename DummySPOSetWithoutMW<T>::ValueVector;
+  DummySPOSetWithMW(const std::string& my_name) : DummySPOSetWithoutMW<T>(my_name) {}
   void mw_evaluateValue(const RefVectorWithLeader<SPOSet>& spo_list,
                         const RefVectorWithLeader<ParticleSet>& P_list,
                         int iat,
@@ -958,8 +967,10 @@ TEST_CASE("RotatedSPOs mw_ APIs", "[wavefunction]")
     //In the case that the underlying SPOSet doesn't specialize the mw_ API,
     //the underlying SPOSet will fall back to the default SPOSet mw_, which is
     //just a loop over the single walker API.
-    RotatedSPOs<QMCTraits::ValueType> rot_spo0("rotated0", std::make_unique<DummySPOSetWithoutMW>("no mw 0"));
-    RotatedSPOs<QMCTraits::ValueType> rot_spo1("rotated1", std::make_unique<DummySPOSetWithoutMW>("no mw 1"));
+    using ValueType = SPOSet::ValueType;
+
+    RotatedSPOs<ValueType> rot_spo0("rotated0", std::make_unique<DummySPOSetWithoutMW<ValueType>>("no mw 0"));
+    RotatedSPOs<ValueType> rot_spo1("rotated1", std::make_unique<DummySPOSetWithoutMW<ValueType>>("no mw 1"));
     RefVectorWithLeader<SPOSet> spo_list(rot_spo0, {rot_spo0, rot_spo1});
 
     ResourceCollection spo_res("test_rot_res");
@@ -1016,9 +1027,10 @@ TEST_CASE("RotatedSPOs mw_ APIs", "[wavefunction]")
     //in the underlying SPO and not using the default SPOSet implementation which
     //loops over single walker APIs (which have different values enforced in
     // DummySPOSetWithoutMW
+    using ValueType = SPOSet::ValueType;
 
-    RotatedSPOs<QMCTraits::ValueType> rot_spo0("rotated0", std::make_unique<DummySPOSetWithMW>("mw 0"));
-    RotatedSPOs<QMCTraits::ValueType> rot_spo1("rotated1", std::make_unique<DummySPOSetWithMW>("mw 1"));
+    RotatedSPOs<ValueType> rot_spo0("rotated0", std::make_unique<DummySPOSetWithMW<ValueType>>("mw 0"));
+    RotatedSPOs<ValueType> rot_spo1("rotated1", std::make_unique<DummySPOSetWithMW<ValueType>>("mw 1"));
     RefVectorWithLeader<SPOSet> spo_list(rot_spo0, {rot_spo0, rot_spo1});
 
     ResourceCollection spo_res("test_rot_res");

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
@@ -675,11 +675,11 @@ TEST_CASE("Rotated LCAO rotation consistency", "[qmcapp]")
   // versus the regular coefficients.
   // The coefficient matrices should match after the same rotations are applied to each.
   SPOSetPtr spoptr     = sdet->getPhi(0);
-  RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(spoptr);
+  RotatedSPOs<ValueType>* rot_spo = dynamic_cast<RotatedSPOs<ValueType>*>(spoptr);
   REQUIRE(rot_spo != nullptr);
 
   SPOSetPtr spoptr1           = sdet->getPhi(1);
-  RotatedSPOs* global_rot_spo = dynamic_cast<RotatedSPOs*>(spoptr1);
+  RotatedSPOs<ValueType>* global_rot_spo = dynamic_cast<RotatedSPOs<ValueType>*>(spoptr1);
   REQUIRE(global_rot_spo != nullptr);
 
   std::vector<RealType> params1 = {0.1, 0.2};

--- a/src/QMCWaveFunctions/tests/test_SlaterDet.cpp
+++ b/src/QMCWaveFunctions/tests/test_SlaterDet.cpp
@@ -152,6 +152,8 @@ public:
 
 TEST_CASE("SlaterDet mw_ APIs", "[wavefunction]")
 {
+  using Value = typename QMCTraits::ValueType;
+
   Communicate* comm = OHMMS::Controller;
 
   auto particle_pool = MinimalParticlePool::make_O2_spinor(comm);
@@ -159,8 +161,8 @@ TEST_CASE("SlaterDet mw_ APIs", "[wavefunction]")
   auto& elec1        = *(particle_pool).getParticleSet("e");
   RefVectorWithLeader<ParticleSet> p_list(elec0, {elec0, elec1});
 
-  std::unique_ptr<ConstantSPOSet> spo_ptr0 = std::make_unique<ConstantSPOSet>("dummySPO", 3, 3);
-  std::unique_ptr<ConstantSPOSet> spo_ptr1 = std::make_unique<ConstantSPOSet>("dummySPO", 3, 3);
+  std::unique_ptr<ConstantSPOSet<Value>> spo_ptr0 = std::make_unique<ConstantSPOSet<Value>>("dummySPO", 3, 3);
+  std::unique_ptr<ConstantSPOSet<Value>> spo_ptr1 = std::make_unique<ConstantSPOSet<Value>>("dummySPO", 3, 3);
   //Right now, DiracDeterminantBatched has mw_ WithSpin APIs but DiracDeterminant does not.
   //We want to add a test to make sure Slater determinant chooses the mw_ implementation if it has it.
 


### PR DESCRIPTION
## Proposed changes

Introducing templates for the classes derived from `SPOSetT<T>`. This is the following change towards a unified build for real, complex, and mixed-precision, starting from #5306.  

## What type(s) of changes does this code introduce?

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes/No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
