### PR TITLE
Fix mw_evalGradWithSpin/mw_ratioGradWithSpin fallback.

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -158,6 +158,21 @@ typename DiracDeterminant<DU_TYPE>::GradType DiracDeterminant<DU_TYPE>::evalGrad
 }
 
 template<typename DU_TYPE>
+void DiracDeterminant<DU_TYPE>::mw_evalGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                                    const RefVectorWithLeader<ParticleSet>& p_list,
+                                                    int iat,
+                                                    std::vector<GradType>& grad_now,
+                                                    std::vector<ComplexType>& spingrad_now) const
+{
+  assert(this == &wfc_list.getLeader());
+  for (int iw = 0; iw < wfc_list.size(); iw++)
+  {
+    spingrad_now[iw] = 0;
+    grad_now[iw]     = wfc_list[iw].evalGradWithSpin(p_list[iw], iat, spingrad_now[iw]);
+  }
+}
+
+template<typename DU_TYPE>
 typename DiracDeterminant<DU_TYPE>::PsiValue DiracDeterminant<DU_TYPE>::ratioGrad(ParticleSet& P,
                                                                                   int iat,
                                                                                   GradType& grad_iat)
@@ -259,6 +274,19 @@ void DiracDeterminant<DU_TYPE>::mw_ratioGrad(const RefVectorWithLeader<WaveFunct
 
   for (int iw = 0; iw < wfc_list.size(); iw++)
     ratios[iw] = wfc_list.getCastedElement<DiracDeterminant<DU_TYPE>>(iw).ratioGrad_compute(iat, grad_new[iw]);
+}
+
+template<typename DU_TYPE>
+void DiracDeterminant<DU_TYPE>::mw_ratioGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                                     const RefVectorWithLeader<ParticleSet>& p_list,
+                                                     int iat,
+                                                     std::vector<PsiValue>& ratios,
+                                                     std::vector<GradType>& grad_new,
+                                                     std::vector<ComplexType>& spingrad_new) const
+{
+  assert(this == &wfc_list.getLeader());
+  for (int iw = 0; iw < wfc_list.size(); iw++)
+    ratios[iw] = wfc_list[iw].ratioGradWithSpin(p_list[iw], iat, grad_new[iw], spingrad_new[iw]);
 }
 
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -135,9 +135,22 @@ public:
                     std::vector<PsiValue>& ratios,
                     std::vector<GradType>& grad_new) const override;
 
+  void mw_ratioGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                            const RefVectorWithLeader<ParticleSet>& p_list,
+                            int iat,
+                            std::vector<PsiValue>& ratios,
+                            std::vector<GradType>& grad_new,
+                            std::vector<ComplexType>& spingrad_new) const override;
+
   GradType evalGrad(ParticleSet& P, int iat) override;
 
   GradType evalGradWithSpin(ParticleSet& P, int iat, ComplexType& spingrad) final;
+
+  void mw_evalGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                           const RefVectorWithLeader<ParticleSet>& p_list,
+                           int iat,
+                           std::vector<GradType>& grad_now,
+                           std::vector<ComplexType>& spingrad_now) const override;
 
   GradType evalGradSource(ParticleSet& P, ParticleSet& source, int iat) override;
 

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
@@ -433,6 +433,20 @@ void MultiSlaterDetTableMethod::mw_evalGrad(const RefVectorWithLeader<WaveFuncti
   mw_evalGrad_impl(WFC_list, P_list, iat, false, grad_now, psi_list);
 }
 
+void MultiSlaterDetTableMethod::mw_evalGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                                    const RefVectorWithLeader<ParticleSet>& p_list,
+                                                    int iat,
+                                                    std::vector<GradType>& grad_now,
+                                                    std::vector<ComplexType>& spingrad_now) const
+{
+  assert(this == &wfc_list.getLeader());
+  for (int iw = 0; iw < wfc_list.size(); iw++)
+  {
+    spingrad_now[iw] = 0;
+    grad_now[iw]     = wfc_list[iw].evalGradWithSpin(p_list[iw], iat, spingrad_now[iw]);
+  }
+}
+
 
 WaveFunctionComponent::PsiValue MultiSlaterDetTableMethod::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
@@ -510,6 +524,18 @@ void MultiSlaterDetTableMethod::mw_ratioGrad(const RefVectorWithLeader<WaveFunct
       det.curRatio *= psi_list[iw] / det.psi_ratio_to_ref_det_;
     ratios[iw] = det.curRatio;
   }
+}
+
+void MultiSlaterDetTableMethod::mw_ratioGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                                     const RefVectorWithLeader<ParticleSet>& p_list,
+                                                     int iat,
+                                                     std::vector<PsiValue>& ratios,
+                                                     std::vector<GradType>& grad_new,
+                                                     std::vector<ComplexType>& spingrad_new) const
+{
+  assert(this == &wfc_list.getLeader());
+  for (int iw = 0; iw < wfc_list.size(); iw++)
+    ratios[iw] = wfc_list[iw].ratioGradWithSpin(p_list[iw], iat, grad_new[iw], spingrad_new[iw]);
 }
 
 WaveFunctionComponent::PsiValue MultiSlaterDetTableMethod::computeRatio_NewMultiDet_to_NewRefDet(int det_id) const

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
@@ -139,11 +139,24 @@ public:
                    int iat,
                    std::vector<GradType>& grad_now) const override;
 
+  void mw_evalGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                           const RefVectorWithLeader<ParticleSet>& p_list,
+                           int iat,
+                           std::vector<GradType>& grad_now,
+                           std::vector<ComplexType>& spingrad_now) const override;
+
   void mw_ratioGrad(const RefVectorWithLeader<WaveFunctionComponent>& WFC_list,
                     const RefVectorWithLeader<ParticleSet>& P_list,
                     int iat,
                     std::vector<PsiValue>& ratios,
                     std::vector<GradType>& grad_new) const override;
+
+  void mw_ratioGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                            const RefVectorWithLeader<ParticleSet>& p_list,
+                            int iat,
+                            std::vector<PsiValue>& ratios,
+                            std::vector<GradType>& grad_new,
+                            std::vector<ComplexType>& spingrad_new) const override;
 
   void mw_calcRatio(const RefVectorWithLeader<WaveFunctionComponent>& WFC_list,
                     const RefVectorWithLeader<ParticleSet>& P_list,
@@ -157,7 +170,9 @@ public:
 
   void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios) override;
 
-  void evaluateSpinorRatios(const VirtualParticleSet& VP, const std::pair<ValueVector, ValueVector>& spinor_multiplier, std::vector<ValueType>& ratios) override;
+  void evaluateSpinorRatios(const VirtualParticleSet& VP,
+                            const std::pair<ValueVector, ValueVector>& spinor_multiplier,
+                            std::vector<ValueType>& ratios) override;
 
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -93,12 +93,9 @@ void WaveFunctionComponent::mw_evalGradWithSpin(const RefVectorWithLeader<WaveFu
                                                 std::vector<GradType>& grad_now,
                                                 std::vector<ComplexType>& spingrad_now) const
 {
-  assert(this == &wfc_list.getLeader());
+  mw_evalGrad(wfc_list, p_list, iat, grad_now);
   for (int iw = 0; iw < wfc_list.size(); iw++)
-  {
     spingrad_now[iw] = 0;
-    grad_now[iw]     = wfc_list[iw].evalGradWithSpin(p_list[iw], iat, spingrad_now[iw]);
-  }
 }
 
 void WaveFunctionComponent::mw_calcRatio(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
@@ -149,9 +146,9 @@ void WaveFunctionComponent::mw_ratioGradWithSpin(const RefVectorWithLeader<WaveF
                                                  std::vector<GradType>& grad_new,
                                                  std::vector<ComplexType>& spingrad_new) const
 {
-  assert(this == &wfc_list.getLeader());
+  mw_ratioGrad(wfc_list, p_list, iat, ratios, grad_new);
   for (int iw = 0; iw < wfc_list.size(); iw++)
-    ratios[iw] = wfc_list[iw].ratioGradWithSpin(p_list[iw], iat, grad_new[iw], spingrad_new[iw]);
+    spingrad_new[iw] = 0;
 }
 
 void WaveFunctionComponent::mw_accept_rejectMove(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,

--- a/src/QMCWaveFunctions/tests/test_SlaterDet.cpp
+++ b/src/QMCWaveFunctions/tests/test_SlaterDet.cpp
@@ -21,13 +21,13 @@
 namespace qmcplusplus
 {
 
-class DummyDiracDetWithoutMW : public DiracDeterminantBase
+class DummyDiracDetWithMW : public DiracDeterminantBase
 {
 public:
-  DummyDiracDetWithoutMW(const std::string& class_name, std::unique_ptr<SPOSet>&& spos, int first, int last)
+  DummyDiracDetWithMW(const std::string& class_name, std::unique_ptr<SPOSet>&& spos, int first, int last)
       : DiracDeterminantBase(getClassName(), std::move(spos), first, last)
   {}
-  std::string getClassName() const override { return "DummyDiracDetWithoutMW"; }
+  std::string getClassName() const override { return "DummyDiracDetWithMW"; }
   LogValue evaluateLog(const ParticleSet& P,
                        ParticleSet::ParticleGradient& G,
                        ParticleSet::ParticleLaplacian& L) override
@@ -56,6 +56,7 @@ public:
     spingrad = ComplexType(0.1, 0.2);
     return grad;
   }
+
   PsiValue ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override
   {
     grad_iat[0] = 123.;
@@ -71,26 +72,6 @@ public:
     spingrad_iat = ComplexType(0.1, 0.2);
     return 1;
   }
-  void registerData(ParticleSet& P, WFBufferType& buf) override {}
-  LogValue updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false) override { return 0.0; }
-  void copyFromBuffer(ParticleSet& P, WFBufferType& buf) override {}
-  void evaluateDerivatives(ParticleSet& P,
-                           const opt_variables_type& optvars,
-                           Vector<ValueType>& dlogpsi,
-                           Vector<ValueType>& dhpsioverpsi) override
-  {}
-  std::unique_ptr<DiracDeterminantBase> makeCopy(std::unique_ptr<SPOSet>&& spo) const override
-  {
-    return std::make_unique<DummyDiracDetWithoutMW>(getClassName(), std::move(spo), FirstIndex, LastIndex);
-  }
-};
-
-class DummyDiracDetWithMW : public DummyDiracDetWithoutMW
-{
-public:
-  DummyDiracDetWithMW(const std::string& class_name, std::unique_ptr<SPOSet>&& spos, int first, int last)
-      : DummyDiracDetWithoutMW(getClassName(), std::move(spos), first, last)
-  {}
 
   void mw_evalGrad(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                    const RefVectorWithLeader<ParticleSet>& p_list,
@@ -148,6 +129,18 @@ public:
     for (auto& spingrad : spingrad_new)
       spingrad = ComplexType(0.2, 0.1);
   }
+  void registerData(ParticleSet& P, WFBufferType& buf) override {}
+  LogValue updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false) override { return 0.0; }
+  void copyFromBuffer(ParticleSet& P, WFBufferType& buf) override {}
+  void evaluateDerivatives(ParticleSet& P,
+                           const opt_variables_type& optvars,
+                           Vector<ValueType>& dlogpsi,
+                           Vector<ValueType>& dhpsioverpsi) override
+  {}
+  std::unique_ptr<DiracDeterminantBase> makeCopy(std::unique_ptr<SPOSet>&& spo) const override
+  {
+    return std::make_unique<DummyDiracDetWithMW>(getClassName(), std::move(spo), FirstIndex, LastIndex);
+  }
 };
 
 TEST_CASE("SlaterDet mw_ APIs", "[wavefunction]")
@@ -164,65 +157,6 @@ TEST_CASE("SlaterDet mw_ APIs", "[wavefunction]")
   //Right now, DiracDeterminantBatched has mw_ WithSpin APIs but DiracDeterminant does not.
   //We want to add a test to make sure Slater determinant chooses the mw_ implementation if it has it.
 
-  // First, do without mw_ APIs
-  {
-    std::unique_ptr<DiracDeterminantBase> det_ptr0 =
-        std::make_unique<DummyDiracDetWithoutMW>("dummy", std::move(spo_ptr0), 0, 12);
-    std::unique_ptr<DiracDeterminantBase> det_ptr1 =
-        std::make_unique<DummyDiracDetWithoutMW>("dummy", std::move(spo_ptr1), 0, 12);
-
-    std::vector<std::unique_ptr<DiracDeterminantBase>> dirac_dets0;
-    dirac_dets0.push_back(std::move(det_ptr0));
-    std::vector<std::unique_ptr<DiracDeterminantBase>> dirac_dets1;
-    dirac_dets1.push_back(std::move(det_ptr1));
-
-    SlaterDet slaterdet0(elec0, std::move(dirac_dets0));
-    SlaterDet slaterdet1(elec0, std::move(dirac_dets1));
-
-    RefVectorWithLeader<WaveFunctionComponent> sd_list(slaterdet0, {slaterdet0, slaterdet1});
-    ResourceCollection sd_res("test_sd_res");
-    slaterdet0.createResource(sd_res);
-    ResourceCollectionTeamLock<WaveFunctionComponent> mw_sd_lock(sd_res, sd_list);
-
-    std::vector<SPOSet::GradType> grads(2);
-    std::vector<WaveFunctionComponent::PsiValue> ratios(2);
-    std::vector<SPOSet::ComplexType> spingrads(2);
-    slaterdet0.mw_evalGrad(sd_list, p_list, 0, grads);
-    for (auto grad : grads)
-    {
-      CHECK(grad[0] == ValueApprox(123.));
-      CHECK(grad[1] == ValueApprox(456.));
-      CHECK(grad[2] == ValueApprox(789.));
-    }
-
-    slaterdet0.mw_evalGradWithSpin(sd_list, p_list, 0, grads, spingrads);
-    for (auto grad : grads)
-    {
-      CHECK(grad[0] == ValueApprox(0.123));
-      CHECK(grad[1] == ValueApprox(0.456));
-      CHECK(grad[2] == ValueApprox(0.789));
-    }
-    for (auto sgrad : spingrads)
-      CHECK(sgrad == ComplexApprox(SPOSet::ComplexType(0.1, 0.2)));
-
-    slaterdet0.mw_ratioGrad(sd_list, p_list, 0, ratios, grads);
-    for (auto grad : grads)
-    {
-      CHECK(grad[0] == ValueApprox(123.));
-      CHECK(grad[1] == ValueApprox(456.));
-      CHECK(grad[2] == ValueApprox(789.));
-    }
-
-    slaterdet0.mw_ratioGradWithSpin(sd_list, p_list, 0, ratios, grads, spingrads);
-    for (auto grad : grads)
-    {
-      CHECK(grad[0] == ValueApprox(0.123));
-      CHECK(grad[1] == ValueApprox(0.456));
-      CHECK(grad[2] == ValueApprox(0.789));
-    }
-    for (auto sgrad : spingrads)
-      CHECK(sgrad == ComplexApprox(SPOSet::ComplexType(0.1, 0.2)));
-  }
   //Now do with MW
   {
     std::unique_ptr<DiracDeterminantBase> det_ptr0 =


### PR DESCRIPTION
## Proposed changes
Fixes #5358 and maybe #5283?
WFC::mw_eval/ratioGradWithSpin falling back to WFC::eval/ratioGradWithSpin causes mixing batched and non-batched API calls. proposed the move using non-batched API and then crash in the mw_accept. To prevent this, default fallback should be WFC::mw_eval/ratioGrad.

With this change, spinor aware classes should implement both WFC::mw_eval/ratioGradWithSpin and WFC::eval/ratioGradWithSpin although the batched implementation can be just a loop.

DummyDiracDetWithoutMW class in the unit test is removed due to not satisfying the above requirement.

## What type(s) of changes does this code introduce?
- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted