### PR TITLE
Nexus: Add ORNL baseline machine

### DIFF
--- a/nexus/lib/machines.py
+++ b/nexus/lib/machines.py
@@ -3208,6 +3208,37 @@ class Inti(Supercomputer):
 #end class Inti
 
 
+# Baseline at ORNL https://docs.cades.olcf.ornl.gov/baseline_user_guide/baseline_user_guide.html
+class Baseline(Supercomputer):
+    name = 'baseline'
+    requires_account = True
+    batch_capable    = True
+
+    def write_job_header(self,job):
+        if job.queue is None:
+            job.queue = 'batch_cnms'
+        #end if
+
+        c  = '#!/bin/bash\n'
+        c += '#SBATCH -A {}\n'.format(job.account)
+        c += '#SBATCH -p {}\n'.format(job.queue)
+        c += '#SBATCH -J {}\n'.format(job.name)
+        c += '#SBATCH -t {}\n'.format(job.sbatch_walltime())
+        c += '#SBATCH -N {}\n'.format(job.nodes)
+        c += '#SBATCH --ntasks-per-node={0}\n'.format(job.processes_per_node)
+        c += '#SBATCH --cpus-per-task={0}\n'.format(job.threads)
+        c += '#SBATCH -o '+job.outfile+'\n'
+        c += '#SBATCH -e '+job.errfile+'\n'
+        if job.user_env:
+            c += '#SBATCH --export=ALL\n'   # equiv to PBS -V
+        else:
+            c += '#SBATCH --export=NONE\n'
+        #end if
+
+        return c
+    #end def write_job_header
+#end class Baseline
+
 
 # Summit at ORNL
 class Summit(Supercomputer):
@@ -3912,6 +3943,7 @@ Lassen(        756,   2,    21,  512,  100,   'lrun',     'bsub',   'bjobs',   '
 Ruby(         1480,   2,    28,  192,  100,   'srun',   'sbatch',  'squeue', 'scancel')
 Kestrel(      2144,   2,    52,  256,  100,   'srun',   'sbatch',  'squeue', 'scancel')
 Inti(           13,   2,    64,  256,  100,   'srun',   'sbatch',  'squeue', 'scancel')
+Baseline(       20,   2,    64,  512,  100,   'srun',   'sbatch',  'squeue', 'scancel')
 
 
 #machine accessor functions

--- a/nexus/tests/unit/test_machines.py
+++ b/nexus/tests/unit/test_machines.py
@@ -1293,6 +1293,12 @@ def test_job_run_command():
         ('inti'           , 'n2_t2'         ) : 'srun test.x',
         ('inti'           , 'n2_t2_e'       ) : 'srun test.x',
         ('inti'           , 'n2_t2_p2'      ) : 'srun test.x',
+        ('baseline'       , 'n1'            ) : 'srun test.x',
+        ('baseline'       , 'n1_p1'         ) : 'srun test.x',
+        ('baseline'       , 'n2'            ) : 'srun test.x',
+        ('baseline'       , 'n2_t2'         ) : 'srun test.x',
+        ('baseline'       , 'n2_t2_e'       ) : 'srun test.x',
+        ('baseline'       , 'n2_t2_p2'      ) : 'srun test.x',
         })
 
     if testing.global_data['job_ref_table']:
@@ -2094,7 +2100,21 @@ srun test.x''',
 export ENV_VAR=1
 export OMP_NUM_THREADS=1
 srun test.x''',
+        baseline = '''#!/bin/bash
+#SBATCH -A ABC123
+#SBATCH -p batch_cnms
+#SBATCH -J jobname
+#SBATCH -t 06:30:00
+#SBATCH -N 2
+#SBATCH --ntasks-per-node=128
+#SBATCH --cpus-per-task=1
+#SBATCH -o test.out
+#SBATCH -e test.err
+#SBATCH --export=ALL
 
+export ENV_VAR=1
+export OMP_NUM_THREADS=1
+srun test.x''',
         )
 
     def process_job_file(jf):


### PR DESCRIPTION
## Proposed changes

This slurm-based largely CPU machine ( https://docs.cades.olcf.ornl.gov/baseline_user_guide/baseline_user_guide.html#baseline-user-guide ) has a few different accessible maximum node counts and memory sizes depending on the user's project. I will evolve the machine definition as I gain access to other projects. Current version should be enough for <20 node & low memory runs in all queues, which is likely the majority of usage.

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Baseline. No issues found using in full production (PySCF->DMC).

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
