### PR TITLE
Fix a few spinor related batched API bugs

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -414,6 +414,7 @@ void ParticleSet::mw_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
   {
     auto& p           = p_list[iw];
     p.active_ptcl_    = iat;
+    p.active_spin_val_ = p.spins[iat];
     new_positions[iw] = p.active_pos_ = p.R[iat] + displs[iw];
   }
 

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -412,8 +412,8 @@ void ParticleSet::mw_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
 
   for (int iw = 0; iw < p_list.size(); iw++)
   {
-    auto& p           = p_list[iw];
-    p.active_ptcl_    = iat;
+    auto& p            = p_list[iw];
+    p.active_ptcl_     = iat;
     p.active_spin_val_ = p.spins[iat];
     new_positions[iw] = p.active_pos_ = p.R[iat] + displs[iw];
   }

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -554,10 +554,12 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
       const auto& displ = myTable.getDisplRow(jel);
       for (int iat = 0; iat < ions.getTotalNum(); iat++)
         if (sopp != nullptr && dist[iat] < sopp->getRmax())
+        {
           if (exact)
             Value1 += sopp->evaluateOneExactSpinIntegration(elec, iat, psi, jel, dist[iat], RealType(-1) * displ[iat]);
           else
             Value1 += sopp->evaluateOne(elec, iat, psi, jel, dist[iat], RealType(-1) * displ[iat]);
+        }
     }
     REQUIRE(Value1 == Approx(-3.530511241));
   };
@@ -613,12 +615,14 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
       const auto& displ = myTable.getDisplRow(jel);
       for (int iat = 0; iat < ions.getTotalNum(); iat++)
         if (sopp != nullptr && dist[iat] < sopp->getRmax())
+        {
           if (exact)
             Value1 += sopp->evaluateValueAndDerivativesExactSpinIntegration(elec, iat, psi, jel, dist[iat], -displ[iat],
                                                                             optvars, dlogpsi, dhpsioverpsi);
           else
             Value1 += sopp->evaluateValueAndDerivatives(elec, iat, psi, jel, dist[iat], -displ[iat], optvars, dlogpsi,
                                                         dhpsioverpsi);
+        }
     }
     REQUIRE(Value1 == Approx(-3.530511241).epsilon(2.e-5));
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -158,21 +158,6 @@ typename DiracDeterminant<DU_TYPE>::GradType DiracDeterminant<DU_TYPE>::evalGrad
 }
 
 template<typename DU_TYPE>
-void DiracDeterminant<DU_TYPE>::mw_evalGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                                    const RefVectorWithLeader<ParticleSet>& p_list,
-                                                    int iat,
-                                                    std::vector<GradType>& grad_now,
-                                                    std::vector<ComplexType>& spingrad_now) const
-{
-  assert(this == &wfc_list.getLeader());
-  for (int iw = 0; iw < wfc_list.size(); iw++)
-  {
-    spingrad_now[iw] = 0;
-    grad_now[iw]     = wfc_list[iw].evalGradWithSpin(p_list[iw], iat, spingrad_now[iw]);
-  }
-}
-
-template<typename DU_TYPE>
 typename DiracDeterminant<DU_TYPE>::PsiValue DiracDeterminant<DU_TYPE>::ratioGrad(ParticleSet& P,
                                                                                   int iat,
                                                                                   GradType& grad_iat)
@@ -275,20 +260,6 @@ void DiracDeterminant<DU_TYPE>::mw_ratioGrad(const RefVectorWithLeader<WaveFunct
   for (int iw = 0; iw < wfc_list.size(); iw++)
     ratios[iw] = wfc_list.getCastedElement<DiracDeterminant<DU_TYPE>>(iw).ratioGrad_compute(iat, grad_new[iw]);
 }
-
-template<typename DU_TYPE>
-void DiracDeterminant<DU_TYPE>::mw_ratioGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                                     const RefVectorWithLeader<ParticleSet>& p_list,
-                                                     int iat,
-                                                     std::vector<PsiValue>& ratios,
-                                                     std::vector<GradType>& grad_new,
-                                                     std::vector<ComplexType>& spingrad_new) const
-{
-  assert(this == &wfc_list.getLeader());
-  for (int iw = 0; iw < wfc_list.size(); iw++)
-    ratios[iw] = wfc_list[iw].ratioGradWithSpin(p_list[iw], iat, grad_new[iw], spingrad_new[iw]);
-}
-
 
 /** move was accepted, update the real container
 */

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -140,7 +140,10 @@ public:
                             int iat,
                             std::vector<PsiValue>& ratios,
                             std::vector<GradType>& grad_new,
-                            std::vector<ComplexType>& spingrad_new) const override;
+                            std::vector<ComplexType>& spingrad_new) const override
+  {
+    mw_ratioGradWithSpin_serialized(wfc_list, p_list, iat, ratios, grad_new, spingrad_new);
+  }
 
   GradType evalGrad(ParticleSet& P, int iat) override;
 
@@ -150,7 +153,10 @@ public:
                            const RefVectorWithLeader<ParticleSet>& p_list,
                            int iat,
                            std::vector<GradType>& grad_now,
-                           std::vector<ComplexType>& spingrad_now) const override;
+                           std::vector<ComplexType>& spingrad_now) const override
+  {
+    mw_evalGradWithSpin_serialized(wfc_list, p_list, iat, grad_now, spingrad_now);
+  }
 
   GradType evalGradSource(ParticleSet& P, ParticleSet& source, int iat) override;
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -131,6 +131,15 @@ public:
   using WaveFunctionComponent::evaluateSpinorRatios;
   using WaveFunctionComponent::mw_evaluateRatios;
 
+  inline virtual void mw_evaluateSpinorRatios(
+      const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+      const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+      const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+      std::vector<std::vector<ValueType>>& ratios) const override
+  {
+    mw_evaluateSpinorRatios_serialized(wfc_list, vp_list, spinor_multiplier_list, ratios);
+  }
+
   // used by DiracDeterminantWithBackflow
   virtual void evaluateDerivatives(ParticleSet& P,
                                    const opt_variables_type& active,
@@ -188,7 +197,6 @@ protected:
   // it is frequently Dual and its consistency not guaranteed.
   ValueMatrix dummy_vmt;
 #endif
-
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
@@ -433,21 +433,6 @@ void MultiSlaterDetTableMethod::mw_evalGrad(const RefVectorWithLeader<WaveFuncti
   mw_evalGrad_impl(WFC_list, P_list, iat, false, grad_now, psi_list);
 }
 
-void MultiSlaterDetTableMethod::mw_evalGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                                    const RefVectorWithLeader<ParticleSet>& p_list,
-                                                    int iat,
-                                                    std::vector<GradType>& grad_now,
-                                                    std::vector<ComplexType>& spingrad_now) const
-{
-  assert(this == &wfc_list.getLeader());
-  for (int iw = 0; iw < wfc_list.size(); iw++)
-  {
-    spingrad_now[iw] = 0;
-    grad_now[iw]     = wfc_list[iw].evalGradWithSpin(p_list[iw], iat, spingrad_now[iw]);
-  }
-}
-
-
 WaveFunctionComponent::PsiValue MultiSlaterDetTableMethod::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
   ScopedTimer local_timer(RatioGradTimer);
@@ -524,18 +509,6 @@ void MultiSlaterDetTableMethod::mw_ratioGrad(const RefVectorWithLeader<WaveFunct
       det.curRatio *= psi_list[iw] / det.psi_ratio_to_ref_det_;
     ratios[iw] = det.curRatio;
   }
-}
-
-void MultiSlaterDetTableMethod::mw_ratioGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                                     const RefVectorWithLeader<ParticleSet>& p_list,
-                                                     int iat,
-                                                     std::vector<PsiValue>& ratios,
-                                                     std::vector<GradType>& grad_new,
-                                                     std::vector<ComplexType>& spingrad_new) const
-{
-  assert(this == &wfc_list.getLeader());
-  for (int iw = 0; iw < wfc_list.size(); iw++)
-    ratios[iw] = wfc_list[iw].ratioGradWithSpin(p_list[iw], iat, grad_new[iw], spingrad_new[iw]);
 }
 
 WaveFunctionComponent::PsiValue MultiSlaterDetTableMethod::computeRatio_NewMultiDet_to_NewRefDet(int det_id) const

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
@@ -143,7 +143,10 @@ public:
                            const RefVectorWithLeader<ParticleSet>& p_list,
                            int iat,
                            std::vector<GradType>& grad_now,
-                           std::vector<ComplexType>& spingrad_now) const override;
+                           std::vector<ComplexType>& spingrad_now) const override
+  {
+    mw_evalGradWithSpin_serialized(wfc_list, p_list, iat, grad_now, spingrad_now);
+  }
 
   void mw_ratioGrad(const RefVectorWithLeader<WaveFunctionComponent>& WFC_list,
                     const RefVectorWithLeader<ParticleSet>& P_list,
@@ -156,7 +159,10 @@ public:
                             int iat,
                             std::vector<PsiValue>& ratios,
                             std::vector<GradType>& grad_new,
-                            std::vector<ComplexType>& spingrad_new) const override;
+                            std::vector<ComplexType>& spingrad_new) const override
+  {
+    mw_ratioGradWithSpin_serialized(wfc_list, p_list, iat, ratios, grad_new, spingrad_new);
+  }
 
   void mw_calcRatio(const RefVectorWithLeader<WaveFunctionComponent>& WFC_list,
                     const RefVectorWithLeader<ParticleSet>& P_list,

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
@@ -174,6 +174,13 @@ public:
                             const std::pair<ValueVector, ValueVector>& spinor_multiplier,
                             std::vector<ValueType>& ratios) override;
 
+  inline void mw_evaluateSpinorRatios(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                      const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+                                      const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+                                      std::vector<std::vector<ValueType>>& ratios) const override
+  {
+    mw_evaluateSpinorRatios_serialized(wfc_list, vp_list, spinor_multiplier_list, ratios);
+  }
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override
   {

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -133,6 +133,20 @@ public:
     }
   }
 
+  inline void mw_evaluateSpinorRatios(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                      const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+                                      const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+                                      std::vector<std::vector<ValueType>>& ratios) const final
+  {
+    if (wfc_list.size())
+    {
+      // assuming all the VP.refPtcl are identical
+      const int det_id = getDetID(vp_list[0].refPtcl);
+      Dets[det_id]->mw_evaluateSpinorRatios(extract_DetRef_list(wfc_list, det_id), vp_list, spinor_multiplier_list,
+                                            ratios);
+    }
+  }
+
   PsiValue ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override;
 
   PsiValue ratioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ComplexType& spingrad_iat) override;

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -728,6 +728,7 @@ void TrialWaveFunction::mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunc
         ratios[iw] *= ratios_z[iw];
     }
   }
+
   for (int iw = 0; iw < wf_list.size(); iw++)
   {
     wf_list[iw].PhaseDiff = std::arg(ratios[iw]);

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -259,6 +259,15 @@ void WaveFunctionComponent::mw_evaluateSpinorRatios(
     const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
     std::vector<std::vector<ValueType>>& ratios) const
 {
+  mw_evaluateRatios(wfc_list, vp_list, ratios);
+}
+
+void WaveFunctionComponent::mw_evaluateSpinorRatios_serialized(
+    const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+    const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+    const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+    std::vector<std::vector<ValueType>>& ratios) const
+{
   assert(this == &wfc_list.getLeader());
   for (int iw = 0; iw < wfc_list.size(); iw++)
     wfc_list[iw].evaluateSpinorRatios(vp_list[iw], spinor_multiplier_list[iw], ratios[iw]);

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -98,6 +98,20 @@ void WaveFunctionComponent::mw_evalGradWithSpin(const RefVectorWithLeader<WaveFu
     spingrad_now[iw] = 0;
 }
 
+void WaveFunctionComponent::mw_evalGradWithSpin_serialized(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                                           const RefVectorWithLeader<ParticleSet>& p_list,
+                                                           int iat,
+                                                           std::vector<GradType>& grad_now,
+                                                           std::vector<ComplexType>& spingrad_now) const
+{
+  assert(this == &wfc_list.getLeader());
+  for (int iw = 0; iw < wfc_list.size(); iw++)
+  {
+    spingrad_now[iw] = 0;
+    grad_now[iw]     = wfc_list[iw].evalGradWithSpin(p_list[iw], iat, spingrad_now[iw]);
+  }
+}
+
 void WaveFunctionComponent::mw_calcRatio(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                                          const RefVectorWithLeader<ParticleSet>& p_list,
                                          int iat,
@@ -147,6 +161,18 @@ void WaveFunctionComponent::mw_ratioGradWithSpin(const RefVectorWithLeader<WaveF
                                                  std::vector<ComplexType>& spingrad_new) const
 {
   mw_ratioGrad(wfc_list, p_list, iat, ratios, grad_new);
+}
+
+void WaveFunctionComponent::mw_ratioGradWithSpin_serialized(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                                            const RefVectorWithLeader<ParticleSet>& p_list,
+                                                            int iat,
+                                                            std::vector<PsiValue>& ratios,
+                                                            std::vector<GradType>& grad_new,
+                                                            std::vector<ComplexType>& spingrad_new) const
+{
+  assert(this == &wfc_list.getLeader());
+  for (int iw = 0; iw < wfc_list.size(); iw++)
+    ratios[iw] = wfc_list[iw].ratioGradWithSpin(p_list[iw], iat, grad_new[iw], spingrad_new[iw]);
 }
 
 void WaveFunctionComponent::mw_accept_rejectMove(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -147,8 +147,6 @@ void WaveFunctionComponent::mw_ratioGradWithSpin(const RefVectorWithLeader<WaveF
                                                  std::vector<ComplexType>& spingrad_new) const
 {
   mw_ratioGrad(wfc_list, p_list, iat, ratios, grad_new);
-  for (int iw = 0; iw < wfc_list.size(); iw++)
-    spingrad_new[iw] = 0;
 }
 
 void WaveFunctionComponent::mw_accept_rejectMove(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -570,6 +570,21 @@ public:
                                     std::vector<ComplexType>& spingrad_new) const;
 
 protected:
+  // Batched version of evalGradWithSpin, serialize over walkers
+  void mw_evalGradWithSpin_serialized(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                      const RefVectorWithLeader<ParticleSet>& p_list,
+                                      int iat,
+                                      std::vector<GradType>& grad_now,
+                                      std::vector<ComplexType>& spingrad_now) const;
+
+  // Batched version of ratioGradWithSpin, serialize over walkers
+  void mw_ratioGradWithSpin_serialized(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                       const RefVectorWithLeader<ParticleSet>& p_list,
+                                       int iat,
+                                       std::vector<PsiValue>& ratios,
+                                       std::vector<GradType>& grad_new,
+                                       std::vector<ComplexType>& spingrad_new) const;
+
   // Batched version of evaluateSpinorRatios, serialize over walkers
   void mw_evaluateSpinorRatios_serialized(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                                           const RefVectorWithLeader<const VirtualParticleSet>& vp_list,

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -568,6 +568,13 @@ public:
                                     std::vector<PsiValue>& ratios,
                                     std::vector<GradType>& grad_new,
                                     std::vector<ComplexType>& spingrad_new) const;
+
+protected:
+  // Batched version of evaluateSpinorRatios, serialize over walkers
+  void mw_evaluateSpinorRatios_serialized(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                          const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+                                          const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+                                          std::vector<std::vector<ValueType>>& ratios) const;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -36,9 +36,12 @@ using DiracDet = DiracDeterminant<DelayedUpdateCUDA<QMCTraits::ValueType, QMCTra
 using DiracDet = DiracDeterminant<DelayedUpdate<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>;
 #endif
 
-using LogValue = TrialWaveFunction::LogValue;
-using PsiValue = TrialWaveFunction::PsiValue;
-using GradType = TrialWaveFunction::GradType;
+using LogValue  = TrialWaveFunction::LogValue;
+using PsiValue  = TrialWaveFunction::PsiValue;
+using GradType  = TrialWaveFunction::GradType;
+using PosType   = QMCTraits::PosType;
+using RealType  = QMCTraits::RealType;
+using ValueType = QMCTraits::ValueType;
 
 TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 {
@@ -164,10 +167,6 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 #endif
 
   const int moved_elec_id = 0;
-
-  using PosType   = QMCTraits::PosType;
-  using RealType  = QMCTraits::RealType;
-  using ValueType = QMCTraits::ValueType;
   PosType delta(0.1, 0.1, 0.2);
 
   elec_.makeMove(moved_elec_id, delta);
@@ -398,8 +397,15 @@ TEST_CASE("TrialWaveFunction::mw_evalGrad for spinors", "[wavefunction]")
 
   elec.update();
   auto logpsi = psi_noJ.evaluateLog(elec);
-  WaveFunctionComponent::ComplexType spingrad_ref(0);
-  WaveFunctionComponent::GradType grad = psi_noJ.evalGradWithSpin(elec, 0, spingrad_ref);
+
+  const int moved_elec_id = 0;
+  WaveFunctionComponent::ComplexType spingrad_ref(0), spingrad_ref2(0);
+  WaveFunctionComponent::GradType grad = psi_noJ.evalGradWithSpin(elec, moved_elec_id, spingrad_ref);
+
+  PosType delta(0.1, 0.1, 0.2);
+  elec.makeMove(moved_elec_id, delta);
+  psi_noJ.calcRatioGradWithSpin(elec, moved_elec_id, grad, spingrad_ref2);
+  elec.rejectMove(moved_elec_id);
 
   // Now tack on a jastrow to make sure it is still the same since jastrows don't contribute
   auto wavefunction_pool2 =
@@ -423,10 +429,22 @@ TEST_CASE("TrialWaveFunction::mw_evalGrad for spinors", "[wavefunction]")
 
   ParticleSet::mw_update(elec_ref_list);
   TrialWaveFunction::mw_evaluateLog(psi_ref_list, elec_ref_list);
+
   TWFGrads<CoordsType::POS_SPIN> grads(2);
-  TrialWaveFunction::mw_evalGrad(psi_ref_list, elec_ref_list, 0, grads);
+  TrialWaveFunction::mw_evalGrad(psi_ref_list, elec_ref_list, moved_elec_id, grads);
   for (size_t iw = 0; iw < 2; iw++)
     CHECK(grads.grads_spins[iw] == ComplexApprox(spingrad_ref));
+
+  PosType delta_zero(0, 0, 0);
+  std::vector<PosType> displs{delta_zero, delta};
+  ParticleSet::mw_makeMove(elec_ref_list, moved_elec_id, displs);
+  std::vector<PsiValue> ratios(2);
+  TrialWaveFunction::mw_calcRatioGrad(psi_ref_list, elec_ref_list, moved_elec_id, ratios, grads);
+  CHECK(grads.grads_spins[0] == ComplexApprox(spingrad_ref));
+  CHECK(grads.grads_spins[1] == ComplexApprox(spingrad_ref2));
+
+  std::vector<bool> isAccepted{false, true};
+  TrialWaveFunction::mw_accept_rejectMove(psi_ref_list, elec_ref_list, moved_elec_id, isAccepted);
 }
 #endif
 

--- a/src/Utilities/tests/for_testing/test_NativeInitializerPrint.cpp
+++ b/src/Utilities/tests/for_testing/test_NativeInitializerPrint.cpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <array>
 #include <unordered_map>
-#include <strstream>
+#include <sstream>
 #include "NativeInitializerPrint.hpp"
 
 /** \file

--- a/tests/solids/bccMo_2x1x1_SOREP/CMakeLists.txt
+++ b/tests/solids/bccMo_2x1x1_SOREP/CMakeLists.txt
@@ -100,50 +100,27 @@ if(QMC_COMPLEX)
       DET_BCC_MO_VMC_SCALARS # VMC
     )
 
-    if(NOT ENABLE_OFFLOAD)
-      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "totenergy" "-136.83168203 0.000002")
-      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "kinetic" "47.51512677 0.000001")
-      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "potential" "-184.34680880 0.000002")
-      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "eeenergy" "1.70262948 0.000001")
-      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "ionion" "-119.82754227 0.000002")
-      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "localecp" "-92.25629590 0.000001")
-      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "nonlocalecp" "26.06677301 0.000001")
-      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "soecp" "-0.03237245 0.000001")
-      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "samples" "144 0.0")
+    list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "totenergy" "-136.83168203 0.000002")
+    list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "kinetic" "47.51512677 0.000001")
+    list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "potential" "-184.34680880 0.000002")
+    list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "eeenergy" "1.70262948 0.000001")
+    list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "ionion" "-119.82754227 0.000002")
+    list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "localecp" "-92.25629590 0.000001")
+    list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "nonlocalecp" "26.06677301 0.000001")
+    list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "soecp" "-0.03237245 0.000001")
+    list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "samples" "144 0.0")
 
-      qmc_run_and_check(
-        deterministic-bccMo_2x1x1_SOREP-vmcbatch_sdj
-        "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
-        det_Mo-vmcbatch
-        det_Mo-vmcbatch.in.xml
-        1
-        1
-        TRUE
-        0
-	DET_BCC_MO_VMCBATCH_SCALARS # VMC
-      )
-
-      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "totenergy" "-135.77458823 0.000002")
-      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "kinetic" "33.81023399 0.000001")
-      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "potential" "-169.58482222 0.000002")
-      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "eeenergy" "-1.89565777 0.000001")
-      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "ionion" "-119.82754227 0.000002")
-      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "localecp" "-65.93483104 0.000001")
-      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "nonlocalecp" "18.10088733 0.000001")
-      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "soecp" "-0.02767779 0.000001")
-
-      qmc_run_and_check(
-        deterministic-bccMo_2x1x1_SOREP-dmcbatch_sdj
-        "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
-        det_Mo-vmcbatch-dmcbatch
-        det_Mo-vmcbatch-dmcbatch.in.xml
-        1
-        1
-        TRUE
-        1
-	DET_BCC_MO_DMCBATCH_SCALARS # DMC
-      )
-    endif()
+    qmc_run_and_check(
+      deterministic-bccMo_2x1x1_SOREP-vmcbatch_sdj
+      "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
+      det_Mo-vmcbatch
+      det_Mo-vmcbatch.in.xml
+      1
+      1
+      TRUE
+      0
+      DET_BCC_MO_VMCBATCH_SCALARS # VMC
+    )
 
     list(APPEND DET_BCC_MO_DMC_SCALARS "totenergy" "-135.34032696 0.000002")
     list(APPEND DET_BCC_MO_DMC_SCALARS "kinetic" "29.19088964 0.000001")
@@ -164,6 +141,27 @@ if(QMC_COMPLEX)
       TRUE
       1
       DET_BCC_MO_DMC_SCALARS # DMC
+    )
+
+    list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "totenergy" "-135.77458823 0.000002")
+    list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "kinetic" "33.81023399 0.000001")
+    list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "potential" "-169.58482222 0.000002")
+    list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "eeenergy" "-1.89565777 0.000001")
+    list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "ionion" "-119.82754227 0.000002")
+    list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "localecp" "-65.93483104 0.000001")
+    list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "nonlocalecp" "18.10088733 0.000001")
+    list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "soecp" "-0.02767779 0.000001")
+
+    qmc_run_and_check(
+      deterministic-bccMo_2x1x1_SOREP-dmcbatch_sdj
+      "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
+      det_Mo-vmcbatch-dmcbatch
+      det_Mo-vmcbatch-dmcbatch.in.xml
+      1
+      1
+      TRUE
+      1
+      DET_BCC_MO_DMCBATCH_SCALARS # DMC
     )
   endif()
 endif()

--- a/tests/solids/bccMo_2x1x1_SOREP/CMakeLists.txt
+++ b/tests/solids/bccMo_2x1x1_SOREP/CMakeLists.txt
@@ -1,126 +1,169 @@
 if(QMC_COMPLEX)
-  if(NOT ENABLE_OFFLOAD)
-    list(APPEND BCC_MO_VMC_SCALARS "totenergy" "-136.52078308 0.016914")
-    list(APPEND BCC_MO_VMC_SCALARS "kinetic" "47.99405288 0.094614")
-    list(APPEND BCC_MO_VMC_SCALARS "potential" "-184.51483596 0.095482")
-    list(APPEND BCC_MO_VMC_SCALARS "eeenergy" "1.57730687 0.047504")
-    list(APPEND BCC_MO_VMC_SCALARS "ionion" "-119.82754015 0.00002")
-    list(APPEND BCC_MO_VMC_SCALARS "localecp" "-91.69929753 0.183567")
-    list(APPEND BCC_MO_VMC_SCALARS "nonlocalecp" "25.45993896 0.126237")
-    list(APPEND BCC_MO_VMC_SCALARS "soecp" "-0.02524410 0.000991")
-    list(APPEND BCC_MO_VMC_SCALARS "samples" "40000 0.0")
+  list(APPEND BCC_MO_VMC_SCALARS "totenergy" "-136.52078308 0.016914")
+  list(APPEND BCC_MO_VMC_SCALARS "kinetic" "47.99405288 0.094614")
+  list(APPEND BCC_MO_VMC_SCALARS "potential" "-184.51483596 0.095482")
+  list(APPEND BCC_MO_VMC_SCALARS "eeenergy" "1.57730687 0.047504")
+  list(APPEND BCC_MO_VMC_SCALARS "ionion" "-119.82754015 0.00002")
+  list(APPEND BCC_MO_VMC_SCALARS "localecp" "-91.69929753 0.183567")
+  list(APPEND BCC_MO_VMC_SCALARS "nonlocalecp" "25.45993896 0.126237")
+  list(APPEND BCC_MO_VMC_SCALARS "soecp" "-0.02524410 0.000991")
+  list(APPEND BCC_MO_VMC_SCALARS "samples" "40000 0.0")
+
+  qmc_run_and_check(
+    short-bccMo_2x1x1_SOREP-vmc_sdj
+    "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
+    Mo-vmc-short
+    Mo-vmc-short.in.xml
+    1
+    16
+    TRUE
+    0
+    BCC_MO_VMC_SCALARS # VMC
+  )
+
+  #
+  # Long tests
+  #
+
+  list(APPEND LONG_BCC_MO_VMC_SCALARS "totenergy" "-136.52078308 0.002674")
+  list(APPEND LONG_BCC_MO_VMC_SCALARS "soecp" "-0.02524410 0.000157")
+  list(APPEND LONG_BCC_MO_VMC_SCALARS "samples" "1600000 0.0")
+  qmc_run_and_check(
+    long-bccMo_2x1x1_SOREP-vmc_sdj
+    "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
+    Mo-vmc-long
+    Mo-vmc-long.in.xml
+    1
+    16
+    TRUE
+    0
+    LONG_BCC_MO_VMC_SCALARS # VMC
+  )
+
+  list(APPEND BCC_MO_DMC_SCALARS "totenergy" "-136.77956168 0.063003")
+  list(APPEND BCC_MO_DMC_SCALARS "kinetic" "48.07180161 0.451909")
+  list(APPEND BCC_MO_DMC_SCALARS "potential" "-184.85136330 0.454768")
+  list(APPEND BCC_MO_DMC_SCALARS "eeenergy" "1.53598049 0.291135")
+  list(APPEND BCC_MO_DMC_SCALARS "ionion" "-119.82754015 0.00002")
+  list(APPEND BCC_MO_DMC_SCALARS "localecp" "-92.14260260 1.147154")
+  list(APPEND BCC_MO_DMC_SCALARS "nonlocalecp" "25.60831010 0.643639")
+  list(APPEND BCC_MO_DMC_SCALARS "soecp" "-0.02551113 0.003011")
+
+  qmc_run_and_check(
+    short-bccMo_2x1x1_SOREP-dmc_sdj
+    "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
+    Mo-vmc-dmc-short
+    Mo-vmc-dmc-short.in.xml
+    1
+    16
+    TRUE
+    1
+    BCC_MO_DMC_SCALARS # DMC
+  )
+
+  list(APPEND LONG_BCC_MO_DMC_SCALARS "totenergy" "-136.77956168 0.009961")
+  list(APPEND LONG_BCC_MO_DMC_SCALARS "soecp" "-0.02551113 0.000476")
+  qmc_run_and_check(
+    long-bccMo_2x1x1_SOREP-dmc_sdj
+    "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
+    Mo-vmc-dmc-long
+    Mo-vmc-dmc-long.in.xml
+    1
+    16
+    TRUE
+    1
+    LONG_BCC_MO_DMC_SCALARS # DMC
+  )
+
+  #Deterministic test
+
+  if(NOT QMC_MIXED_PRECISION)
+    list(APPEND DET_BCC_MO_VMC_SCALARS "totenergy" "-136.88580235 0.000002")
+    list(APPEND DET_BCC_MO_VMC_SCALARS "kinetic" "48.19451127 0.000001")
+    list(APPEND DET_BCC_MO_VMC_SCALARS "potential" "-185.08031362 0.000002")
+    list(APPEND DET_BCC_MO_VMC_SCALARS "eeenergy" "0.73302788 0.000001")
+    list(APPEND DET_BCC_MO_VMC_SCALARS "ionion" "-119.82754227 0.000002")
+    list(APPEND DET_BCC_MO_VMC_SCALARS "localecp" "-90.13681859 0.000001")
+    list(APPEND DET_BCC_MO_VMC_SCALARS "nonlocalecp" "24.16783601 0.000001")
+    list(APPEND DET_BCC_MO_VMC_SCALARS "soecp" "-0.01681613 0.000001")
+    list(APPEND DET_BCC_MO_VMC_SCALARS "samples" "144 0.0")
 
     qmc_run_and_check(
-      short-bccMo_2x1x1_SOREP-vmc_sdj
+      deterministic-bccMo_2x1x1_SOREP-vmc_sdj
       "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
-      Mo-vmc-short
-      Mo-vmc-short.in.xml
+      det_Mo-vmc
+      det_Mo-vmc.in.xml
       1
-      16
+      1
       TRUE
       0
-      BCC_MO_VMC_SCALARS # VMC
+      DET_BCC_MO_VMC_SCALARS # VMC
     )
 
-    #
-    # Long tests
-    #
-
-    list(APPEND LONG_BCC_MO_VMC_SCALARS "totenergy" "-136.52078308 0.002674")
-    list(APPEND LONG_BCC_MO_VMC_SCALARS "soecp" "-0.02524410 0.000157")
-    list(APPEND LONG_BCC_MO_VMC_SCALARS "samples" "1600000 0.0")
-    qmc_run_and_check(
-      long-bccMo_2x1x1_SOREP-vmc_sdj
-      "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
-      Mo-vmc-long
-      Mo-vmc-long.in.xml
-      1
-      16
-      TRUE
-      0
-      LONG_BCC_MO_VMC_SCALARS # VMC
-    )
-
-    list(APPEND BCC_MO_DMC_SCALARS "totenergy" "-136.77956168 0.063003")
-    list(APPEND BCC_MO_DMC_SCALARS "kinetic" "48.07180161 0.451909")
-    list(APPEND BCC_MO_DMC_SCALARS "potential" "-184.85136330 0.454768")
-    list(APPEND BCC_MO_DMC_SCALARS "eeenergy" "1.53598049 0.291135")
-    list(APPEND BCC_MO_DMC_SCALARS "ionion" "-119.82754015 0.00002")
-    list(APPEND BCC_MO_DMC_SCALARS "localecp" "-92.14260260 1.147154")
-    list(APPEND BCC_MO_DMC_SCALARS "nonlocalecp" "25.60831010 0.643639")
-    list(APPEND BCC_MO_DMC_SCALARS "soecp" "-0.02551113 0.003011")
-
-    qmc_run_and_check(
-      short-bccMo_2x1x1_SOREP-dmc_sdj
-      "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
-      Mo-vmc-dmc-short
-      Mo-vmc-dmc-short.in.xml
-      1
-      16
-      TRUE
-      1
-      BCC_MO_DMC_SCALARS # DMC
-    )
-
-    list(APPEND LONG_BCC_MO_DMC_SCALARS "totenergy" "-136.77956168 0.009961")
-    list(APPEND LONG_BCC_MO_DMC_SCALARS "soecp" "-0.02551113 0.000476")
-    qmc_run_and_check(
-      long-bccMo_2x1x1_SOREP-dmc_sdj
-      "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
-      Mo-vmc-dmc-long
-      Mo-vmc-dmc-long.in.xml
-      1
-      16
-      TRUE
-      1
-      LONG_BCC_MO_DMC_SCALARS # DMC
-    )
-
-    #Deterministic test
-
-    if(NOT QMC_MIXED_PRECISION)
-      list(APPEND DET_BCC_MO_VMC_SCALARS "totenergy" "-136.88580235 0.000002")
-      list(APPEND DET_BCC_MO_VMC_SCALARS "kinetic" "48.19451127 0.000001")
-      list(APPEND DET_BCC_MO_VMC_SCALARS "potential" "-185.08031362 0.000002")
-      list(APPEND DET_BCC_MO_VMC_SCALARS "eeenergy" "0.73302788 0.000001")
-      list(APPEND DET_BCC_MO_VMC_SCALARS "ionion" "-119.82754227 0.000002")
-      list(APPEND DET_BCC_MO_VMC_SCALARS "localecp" "-90.13681859 0.000001")
-      list(APPEND DET_BCC_MO_VMC_SCALARS "nonlocalecp" "24.16783601 0.000001")
-      list(APPEND DET_BCC_MO_VMC_SCALARS "soecp" "-0.01681613 0.000001")
-      list(APPEND DET_BCC_MO_VMC_SCALARS "samples" "144 0.0")
+    if(NOT ENABLE_OFFLOAD)
+      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "totenergy" "-136.83168203 0.000002")
+      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "kinetic" "47.51512677 0.000001")
+      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "potential" "-184.34680880 0.000002")
+      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "eeenergy" "1.70262948 0.000001")
+      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "ionion" "-119.82754227 0.000002")
+      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "localecp" "-92.25629590 0.000001")
+      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "nonlocalecp" "26.06677301 0.000001")
+      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "soecp" "-0.03237245 0.000001")
+      list(APPEND DET_BCC_MO_VMCBATCH_SCALARS "samples" "144 0.0")
 
       qmc_run_and_check(
-        deterministic-bccMo_2x1x1_SOREP-vmc_sdj
+        deterministic-bccMo_2x1x1_SOREP-vmcbatch_sdj
         "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
-        det_Mo-vmc
-        det_Mo-vmc.in.xml
+        det_Mo-vmcbatch
+        det_Mo-vmcbatch.in.xml
         1
         1
         TRUE
         0
-        DET_BCC_MO_VMC_SCALARS # VMC
+	DET_BCC_MO_VMCBATCH_SCALARS # VMC
       )
 
-      list(APPEND DET_BCC_MO_DMC_SCALARS "totenergy" "-135.34032696 0.000002")
-      list(APPEND DET_BCC_MO_DMC_SCALARS "kinetic" "29.19088964 0.000001")
-      list(APPEND DET_BCC_MO_DMC_SCALARS "potential" "-164.53121661 0.000002")
-      list(APPEND DET_BCC_MO_DMC_SCALARS "eeenergy" "-2.19402623 0.000001")
-      list(APPEND DET_BCC_MO_DMC_SCALARS "ionion" "-119.82754227 0.000002")
-      list(APPEND DET_BCC_MO_DMC_SCALARS "localecp" "-64.57264081 0.000001")
-      list(APPEND DET_BCC_MO_DMC_SCALARS "nonlocalecp" "22.07409626 0.000001")
-      list(APPEND DET_BCC_MO_DMC_SCALARS "soecp" "-0.01110304 0.000001")
+      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "totenergy" "-135.77458823 0.000002")
+      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "kinetic" "33.81023399 0.000001")
+      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "potential" "-169.58482222 0.000002")
+      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "eeenergy" "-1.89565777 0.000001")
+      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "ionion" "-119.82754227 0.000002")
+      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "localecp" "-65.93483104 0.000001")
+      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "nonlocalecp" "18.10088733 0.000001")
+      list(APPEND DET_BCC_MO_DMCBATCH_SCALARS "soecp" "-0.02767779 0.000001")
 
       qmc_run_and_check(
-        deterministic-bccMo_2x1x1_SOREP-dmc_sdj
+        deterministic-bccMo_2x1x1_SOREP-dmcbatch_sdj
         "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
-        det_Mo-vmc-dmc
-        det_Mo-vmc-dmc.in.xml
+        det_Mo-vmcbatch-dmcbatch
+        det_Mo-vmcbatch-dmcbatch.in.xml
         1
         1
         TRUE
         1
-        DET_BCC_MO_DMC_SCALARS # DMC
+	DET_BCC_MO_DMCBATCH_SCALARS # DMC
       )
     endif()
+
+    list(APPEND DET_BCC_MO_DMC_SCALARS "totenergy" "-135.34032696 0.000002")
+    list(APPEND DET_BCC_MO_DMC_SCALARS "kinetic" "29.19088964 0.000001")
+    list(APPEND DET_BCC_MO_DMC_SCALARS "potential" "-164.53121661 0.000002")
+    list(APPEND DET_BCC_MO_DMC_SCALARS "eeenergy" "-2.19402623 0.000001")
+    list(APPEND DET_BCC_MO_DMC_SCALARS "ionion" "-119.82754227 0.000002")
+    list(APPEND DET_BCC_MO_DMC_SCALARS "localecp" "-64.57264081 0.000001")
+    list(APPEND DET_BCC_MO_DMC_SCALARS "nonlocalecp" "22.07409626 0.000001")
+    list(APPEND DET_BCC_MO_DMC_SCALARS "soecp" "-0.01110304 0.000001")
+
+    qmc_run_and_check(
+      deterministic-bccMo_2x1x1_SOREP-dmc_sdj
+      "${qmcpack_SOURCE_DIR}/tests/solids/bccMo_2x1x1_SOREP"
+      det_Mo-vmc-dmc
+      det_Mo-vmc-dmc.in.xml
+      1
+      1
+      TRUE
+      1
+      DET_BCC_MO_DMC_SCALARS # DMC
+    )
   endif()
 endif()

--- a/tests/solids/bccMo_2x1x1_SOREP/det_Mo-vmcbatch-dmcbatch.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/det_Mo-vmcbatch-dmcbatch.in.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0"?>
+<simulation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.mcc.uiuc.edu/qmc/schema/molecu.xsd">
+  <project id="det_Mo-vmcbatch-dmcbatch" series="0"> 
+    <application name="qmcapp" role="molecu" class="serial" version="0.2"/>
+    <parameter name="driver_version">batch</parameter>
+  </project>
+
+  <random seed="192"/>
+  <qmcsystem>
+  <simulationcell>
+      <parameter name="lattice">
+     5.952636864   5.952636864   5.952636864
+      -2.976318432   2.976318432   2.976318432
+      -2.976318432   -2.976318432   2.976318432
+      </parameter>
+      <parameter name="bconds">p p p </parameter>
+      <parameter name="LR_dim_cutoff">15</parameter>
+  </simulationcell>
+  </qmcsystem>
+  <particleset name="i" size="2">
+    <group name="Mo">
+      <parameter name="charge">14</parameter>
+      <parameter name="valence">14</parameter>
+      <parameter name="atomicnumber">0</parameter>
+    </group>
+    <attrib name="position" datatype="posArray" condition="1">
+    0   0   0
+   0.5  0   0
+    </attrib>
+    <attrib name="ionid" datatype="stringArray">
+      Mo  Mo
+    </attrib>
+  </particleset>
+  <particleset name="e" random="yes" randomsrc="i" spinor="yes">
+    <group name="u" size="28">
+      <parameter name="charge">-1</parameter>
+    </group>
+  </particleset>
+  <wavefunction name="psi0" target="e">
+ <sposet_collection name="spo_builder" type="spinorbspline" href="eshdf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="i" size="28" meshfactor="1.0">
+      <sposet type="bspline" name="myspo" size="28">
+        <occupation mode="ground"/>
+      </sposet>
+    </sposet_collection>
+    <determinantset>
+      <slaterdeterminant>
+         <determinant sposet="myspo"/>
+      </slaterdeterminant>
+    </determinantset>
+    <jastrow name="J2" type="Two-Body" function="Bspline" print="yes">
+      <correlation speciesA="u" speciesB="u" size="10">
+        <coefficients id="uu" type="Array"> 0.4377052539 0.3234564151 0.2407991166 0.1759617013 0.1277362253 0.09146430044 0.06325631389 0.0418800602 0.0240753101 0.01263463938</coefficients>
+      </correlation>
+    </jastrow>
+    <jastrow name="J1" type="One-Body" function="Bspline" print="yes" source="i">
+      <correlation elementType="Mo" cusp="0.0" size="10">
+        <coefficients id="Mo" type="Array"> -1.233031829 -0.6150743239 -0.716666697 -0.6458417055 -0.5113032038 -0.4243777586 -0.3130696067 -0.2080519783 -0.1335840987 -0.06559165286</coefficients>
+      </correlation>
+    </jastrow>    
+  </wavefunction>
+  <hamiltonian name="h0" type="generic" target="e">
+      <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes">
+      <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="total_walkers">    16 </parameter>
+     <parameter name="substeps">  1 </parameter>
+     <parameter name="warmupSteps">  1 </parameter>
+     <parameter name="steps">  1 </parameter>
+     <parameter name="blocks">  1 </parameter>
+     <parameter name="timestep">  1.0 </parameter>
+   </qmc>
+   <qmc method="dmc" move="pbyp" checkpoint="-1">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="total_walkers"> 16 </parameter>
+     <parameter name="reconfiguration">   no </parameter>
+     <parameter name="warmupSteps">  3 </parameter>
+     <parameter name="timestep">  0.005 </parameter>
+     <parameter name="steps">   3  </parameter>
+     <parameter name="blocks">  3  </parameter>
+   </qmc>
+  
+</simulation>

--- a/tests/solids/bccMo_2x1x1_SOREP/det_Mo-vmcbatch.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/det_Mo-vmcbatch.in.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<simulation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.mcc.uiuc.edu/qmc/schema/molecu.xsd">
+  <project id="det_Mo-vmcbatch" series="0"> 
+    <application name="qmcapp" role="molecu" class="serial" version="0.2"/>
+    <parameter name="driver_version">batch</parameter>
+  </project>
+
+  <random seed="382"/>
+  <qmcsystem>
+  <simulationcell>
+      <parameter name="lattice">
+     5.952636864   5.952636864   5.952636864
+      -2.976318432   2.976318432   2.976318432
+      -2.976318432   -2.976318432   2.976318432
+      </parameter>
+      <parameter name="bconds">p p p </parameter>
+      <parameter name="LR_dim_cutoff">15</parameter>
+  </simulationcell>
+  </qmcsystem>
+  <particleset name="i" size="2">
+    <group name="Mo">
+      <parameter name="charge">14</parameter>
+      <parameter name="valence">14</parameter>
+      <parameter name="atomicnumber">0</parameter>
+    </group>
+    <attrib name="position" datatype="posArray" condition="1">
+    0   0   0
+   0.5  0   0
+    </attrib>
+    <attrib name="ionid" datatype="stringArray">
+      Mo  Mo
+    </attrib>
+  </particleset>
+  <particleset name="e" random="yes" randomsrc="i" spinor="yes">
+    <group name="u" size="28">
+      <parameter name="charge">-1</parameter>
+    </group>
+  </particleset>
+  <wavefunction name="psi0" target="e">
+ <sposet_collection name="spo_builder" type="spinorbspline" href="eshdf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="i" size="28" meshfactor="1.0">
+      <sposet type="bspline" name="myspo" size="28">
+        <occupation mode="ground"/>
+      </sposet>
+    </sposet_collection>
+    <determinantset>
+      <slaterdeterminant>
+         <determinant sposet="myspo"/>
+      </slaterdeterminant>
+    </determinantset>
+    <jastrow name="J2" type="Two-Body" function="Bspline" print="yes">
+      <correlation speciesA="u" speciesB="u" size="10">
+        <coefficients id="uu" type="Array"> 0.4377052539 0.3234564151 0.2407991166 0.1759617013 0.1277362253 0.09146430044 0.06325631389 0.0418800602 0.0240753101 0.01263463938</coefficients>
+      </correlation>
+    </jastrow>
+    <jastrow name="J1" type="One-Body" function="Bspline" print="yes" source="i">
+      <correlation elementType="Mo" cusp="0.0" size="10">
+        <coefficients id="Mo" type="Array"> -1.233031829 -0.6150743239 -0.716666697 -0.6458417055 -0.5113032038 -0.4243777586 -0.3130696067 -0.2080519783 -0.1335840987 -0.06559165286</coefficients>
+      </correlation>
+    </jastrow>    
+  </wavefunction>
+  <hamiltonian name="h0" type="generic" target="e">
+      <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes">
+      <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
+      <parameter name="total_walkers"       >    16              </parameter>
+      <parameter name="blocks"              >    3               </parameter>
+      <parameter name="steps"               >    3               </parameter>
+      <parameter name="subSteps"            >    2               </parameter>
+      <parameter name="timestep"            >    0.3             </parameter>
+      <parameter name="warmupSteps"         >    3               </parameter>
+   </qmc>
+  
+</simulation>


### PR DESCRIPTION
## Proposed changes
There is a bug introduced in #5360 and discovered when adding unit test coverage.
`WaveFunctionComponent::mw_ratioGradWithSpin` should not overwrite `spingrad_new` which should be accumulative.
I also fixed `ParticleSet::mw_makeMove` to align with `ParticleSet::makeMove` behavior, it affects unit tests but not actual simulation.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted