### PR TITLE
Fix Angstrom escape in qdens

### DIFF
--- a/nexus/bin/qdens
+++ b/nexus/bin/qdens
@@ -835,8 +835,8 @@ class StatFile(QDBase):
                 r = dr/2+dr*np.arange(len(lmean),dtype=float)
                 lmean/=dr
                 lerror/=dr
-                xlab = sdim+' ($\AA$)'.format(dim)
-                ylab = '$N_e/\AA$'
+                xlab = sdim+' ($\\AA$)'.format(dim)
+                ylab = '$N_e/\\AA$'
             #end if
             plt.figure(tight_layout=True)
             plt.errorbar(r,lmean,lerror,fmt='b.-')


### PR DESCRIPTION
## Proposed changes

Allow qdens to run without warnings

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

nitrogen2, nightly python config

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
