### PR TITLE
More template classes derived from `SPOSetT<T>`

### DIFF
--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -84,7 +84,7 @@ private:
   /** @} */
 
   //data members \todo analyze lifecycles allocation optimization or state?
-  CompositeSPOSet basis_functions_;
+  CompositeSPOSet<Value> basis_functions_;
   Vector<Value> basis_values_;
   Vector<Value> basis_norms_;
   Vector<Grad> basis_gradients_;

--- a/src/Estimators/tests/test_MagnetizationDensity.cpp
+++ b/src/Estimators/tests/test_MagnetizationDensity.cpp
@@ -368,8 +368,8 @@ TEST_CASE("MagnetizationDensity::IntegrationTest", "[estimators]")
     mup(1, iorb) = uprow1[iorb];
     mdn(1, iorb) = dnrow1[iorb];
   }
-  auto spo_up = std::make_unique<ConstantSPOSet>("ConstantUpSet", nelec, norb);
-  auto spo_dn = std::make_unique<ConstantSPOSet>("ConstantDnSet", nelec, norb);
+  auto spo_up = std::make_unique<ConstantSPOSet<Value>>("ConstantUpSet", nelec, norb);
+  auto spo_dn = std::make_unique<ConstantSPOSet<Value>>("ConstantDnSet", nelec, norb);
 
   spo_up->setRefVals(mup);
   spo_dn->setRefVals(mdn);

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -65,7 +65,7 @@ public:
 
   //data members
   bool energy_mat;
-  CompositeSPOSet basis_functions;
+  CompositeSPOSet<Value_t> basis_functions;
   ValueVector basis_values;
   ValueVector basis_norms;
   GradVector basis_gradients;

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -39,13 +39,15 @@ inline void insert_columns(const MAT1& small, MAT2& big, int offset_c)
 }
 } // namespace MatrixOperators
 
-CompositeSPOSet::CompositeSPOSet(const std::string& my_name) : SPOSet(my_name)
+template<typename T>
+CompositeSPOSet<T>::CompositeSPOSet(const std::string& my_name) : SPOSetT<T>(my_name)
 {
-  OrbitalSetSize = 0;
+  this->OrbitalSetSize = 0;
   component_offsets.reserve(4);
 }
 
-CompositeSPOSet::CompositeSPOSet(const CompositeSPOSet& other) : SPOSet(other)
+template<typename T>
+CompositeSPOSet<T>::CompositeSPOSet(const CompositeSPOSet& other) : SPOSet(other)
 {
   for (auto& element : other.components)
   {
@@ -53,9 +55,11 @@ CompositeSPOSet::CompositeSPOSet(const CompositeSPOSet& other) : SPOSet(other)
   }
 }
 
-CompositeSPOSet::~CompositeSPOSet() = default;
+template<typename T>
+CompositeSPOSet<T>::~CompositeSPOSet() = default;
 
-void CompositeSPOSet::add(std::unique_ptr<SPOSet> component)
+template<typename T>
+void CompositeSPOSet<T>::add(std::unique_ptr<SPOSet> component)
 {
   if (components.empty())
     component_offsets.push_back(0); //add 0
@@ -67,11 +71,12 @@ void CompositeSPOSet::add(std::unique_ptr<SPOSet> component)
   component_laplacians.emplace_back(norbs);
   component_spin_gradients.emplace_back(norbs);
 
-  OrbitalSetSize += norbs;
-  component_offsets.push_back(OrbitalSetSize);
+  this->OrbitalSetSize += norbs;
+  component_offsets.push_back(this->OrbitalSetSize);
 }
 
-void CompositeSPOSet::report()
+template<typename T>
+void CompositeSPOSet<T>::report()
 {
   app_log() << "CompositeSPOSet" << std::endl;
   app_log() << "  ncomponents = " << components.size() << std::endl;
@@ -83,9 +88,11 @@ void CompositeSPOSet::report()
   }
 }
 
-std::unique_ptr<SPOSet> CompositeSPOSet::makeClone() const { return std::make_unique<CompositeSPOSet>(*this); }
+template<typename T>
+std::unique_ptr<SPOSetT<T>> CompositeSPOSet<T>::makeClone() const { return std::make_unique<CompositeSPOSet>(*this); }
 
-void CompositeSPOSet::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
+template<typename T>
+void CompositeSPOSet<T>::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
 {
   int n = 0;
   for (int c = 0; c < components.size(); ++c)
@@ -98,7 +105,8 @@ void CompositeSPOSet::evaluateValue(const ParticleSet& P, int iat, ValueVector& 
   }
 }
 
-void CompositeSPOSet::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)
+template<typename T>
+void CompositeSPOSet<T>::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)
 {
   int n = 0;
   for (int c = 0; c < components.size(); ++c)
@@ -115,12 +123,13 @@ void CompositeSPOSet::evaluateVGL(const ParticleSet& P, int iat, ValueVector& ps
   }
 }
 
-void CompositeSPOSet::evaluateVGL_spin(const ParticleSet& P,
-                                       int iat,
-                                       ValueVector& psi,
-                                       GradVector& dpsi,
-                                       ValueVector& d2psi,
-                                       ValueVector& dspin_psi)
+template<typename T>
+void CompositeSPOSet<T>::evaluateVGL_spin(const ParticleSet& P,
+                                          int iat,
+                                          ValueVector& psi,
+                                          GradVector& dpsi,
+                                          ValueVector& d2psi,
+                                          ValueVector& dspin_psi)
 {
   int n = 0;
   for (int c = 0; c < components.size(); ++c)
@@ -139,12 +148,13 @@ void CompositeSPOSet::evaluateVGL_spin(const ParticleSet& P,
   }
 }
 
-void CompositeSPOSet::evaluate_notranspose(const ParticleSet& P,
-                                           int first,
-                                           int last,
-                                           ValueMatrix& logdet,
-                                           GradMatrix& dlogdet,
-                                           ValueMatrix& d2logdet)
+template<typename T>
+void CompositeSPOSet<T>::evaluate_notranspose(const ParticleSet& P,
+                                              int first,
+                                              int last,
+                                              ValueMatrix& logdet,
+                                              GradMatrix& dlogdet,
+                                              ValueMatrix& d2logdet)
 {
   const int nat = last - first;
   for (int c = 0; c < components.size(); ++c)
@@ -161,12 +171,13 @@ void CompositeSPOSet::evaluate_notranspose(const ParticleSet& P,
   }
 }
 
-void CompositeSPOSet::evaluate_notranspose(const ParticleSet& P,
-                                           int first,
-                                           int last,
-                                           ValueMatrix& logdet,
-                                           GradMatrix& dlogdet,
-                                           HessMatrix& grad_grad_logdet)
+template<typename T>
+void CompositeSPOSet<T>::evaluate_notranspose(const ParticleSet& P,
+                                              int first,
+                                              int last,
+                                              ValueMatrix& logdet,
+                                              GradMatrix& dlogdet,
+                                              HessMatrix& grad_grad_logdet)
 {
   const int nat = last - first;
   for (int c = 0; c < components.size(); ++c)
@@ -183,13 +194,14 @@ void CompositeSPOSet::evaluate_notranspose(const ParticleSet& P,
   }
 }
 
-void CompositeSPOSet::evaluate_notranspose(const ParticleSet& P,
-                                           int first,
-                                           int last,
-                                           ValueMatrix& logdet,
-                                           GradMatrix& dlogdet,
-                                           HessMatrix& grad_grad_logdet,
-                                           GGGMatrix& grad_grad_grad_logdet)
+template<typename T>
+void CompositeSPOSet<T>::evaluate_notranspose(const ParticleSet& P,
+                                              int first,
+                                              int last,
+                                              ValueMatrix& logdet,
+                                              GradMatrix& dlogdet,
+                                              HessMatrix& grad_grad_logdet,
+                                              GGGMatrix& grad_grad_grad_logdet)
 {
   not_implemented("evaluate_notranspose(P,first,last,logdet,dlogdet,ddlogdet,dddlogdet)");
 }
@@ -204,7 +216,7 @@ std::unique_ptr<SPOSet> CompositeSPOSetBuilder::createSPOSetFromXML(xmlNodePtr c
     return nullptr;
   }
 
-  auto spo_now = std::make_unique<CompositeSPOSet>(getXMLAttributeValue(cur, "name"));
+  auto spo_now = std::make_unique<CompositeSPOSet<ValueType>>(getXMLAttributeValue(cur, "name"));
   for (int i = 0; i < spolist.size(); ++i)
   {
     const SPOSet* spo = sposet_builder_factory_.getSPOSet(spolist[i]);
@@ -218,5 +230,12 @@ std::unique_ptr<SPOSet> CompositeSPOSetBuilder::createSPOSet(xmlNodePtr cur, SPO
 {
   return createSPOSetFromXML(cur);
 }
+
+#if !defined(MIXED_PRECISION)
+template class CompositeSPOSet<double>;
+template class CompositeSPOSet<std::complex<double>>;
+#endif
+template class CompositeSPOSet<float>;
+template class CompositeSPOSet<std::complex<float>>;
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -42,7 +42,7 @@ inline void insert_columns(const MAT1& small, MAT2& big, int offset_c)
 template<typename T>
 CompositeSPOSet<T>::CompositeSPOSet(const std::string& my_name) : SPOSetT<T>(my_name)
 {
-  this->OrbitalSetSize = 0;
+  SPOSet::OrbitalSetSize = 0;
   component_offsets.reserve(4);
 }
 
@@ -71,8 +71,8 @@ void CompositeSPOSet<T>::add(std::unique_ptr<SPOSet> component)
   component_laplacians.emplace_back(norbs);
   component_spin_gradients.emplace_back(norbs);
 
-  this->OrbitalSetSize += norbs;
-  component_offsets.push_back(this->OrbitalSetSize);
+  SPOSet::OrbitalSetSize += norbs;
+  component_offsets.push_back(SPOSet::OrbitalSetSize);
 }
 
 template<typename T>

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -22,9 +22,20 @@
 
 namespace qmcplusplus
 {
-class CompositeSPOSet : public SPOSet
+
+template<typename T>
+class CompositeSPOSet : public SPOSetT<T>
 {
 public:
+  using SPOSet = SPOSetT<T>;
+
+  using ValueVector = typename SPOSet::ValueVector;
+  using ValueMatrix = typename SPOSet::ValueMatrix;
+  using GradVector  = typename SPOSet::GradVector;
+  using GradMatrix  = typename SPOSet::GradMatrix;
+  using HessMatrix  = typename SPOSet::HessMatrix;
+  using GGGMatrix   = typename SPOSet::GGGMatrix;
+
   ///component SPOSets
   std::vector<std::unique_ptr<SPOSet>> components;
   ///temporary storage for values

--- a/src/QMCWaveFunctions/tests/ConstantSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/ConstantSPOSet.cpp
@@ -18,10 +18,10 @@ template<typename T>
 ConstantSPOSet<T>::ConstantSPOSet(const std::string& my_name, const int nparticles, const int norbitals)
     : SPOSetT<T>(my_name), numparticles_(nparticles)
 {
-  this->OrbitalSetSize = norbitals;
-  ref_psi_.resize(numparticles_, this->OrbitalSetSize);
-  ref_egrad_.resize(numparticles_, this->OrbitalSetSize);
-  ref_elapl_.resize(numparticles_, this->OrbitalSetSize);
+  SPOSet::OrbitalSetSize = norbitals;
+  ref_psi_.resize(numparticles_, SPOSet::OrbitalSetSize);
+  ref_egrad_.resize(numparticles_, SPOSet::OrbitalSetSize);
+  ref_elapl_.resize(numparticles_, SPOSet::OrbitalSetSize);
 
   ref_psi_   = 0.0;
   ref_egrad_ = 0.0;
@@ -31,7 +31,7 @@ ConstantSPOSet<T>::ConstantSPOSet(const std::string& my_name, const int nparticl
 template<typename T>
 std::unique_ptr<SPOSetT<T>> ConstantSPOSet<T>::makeClone() const
 {
-  auto myclone = std::make_unique<ConstantSPOSet>(this->my_name_, numparticles_, this->OrbitalSetSize);
+  auto myclone = std::make_unique<ConstantSPOSet>(SPOSet::my_name_, numparticles_, SPOSet::OrbitalSetSize);
   myclone->setRefVals(ref_psi_);
   myclone->setRefEGrads(ref_egrad_);
   myclone->setRefELapls(ref_elapl_);
@@ -53,7 +53,7 @@ void ConstantSPOSet<T>::setOrbitalSetSize(int norbs) { APP_ABORT("ConstantSPOSet
 template<typename T>
 void ConstantSPOSet<T>::setRefVals(const ValueMatrix& vals)
 {
-  assert(vals.cols() == this->OrbitalSetSize);
+  assert(vals.cols() == SPOSet::OrbitalSetSize);
   assert(vals.rows() == numparticles_);
   ref_psi_ = vals;
 };
@@ -61,7 +61,7 @@ void ConstantSPOSet<T>::setRefVals(const ValueMatrix& vals)
 template<typename T>
 void ConstantSPOSet<T>::setRefEGrads(const GradMatrix& grads)
 {
-  assert(grads.cols() == this->OrbitalSetSize);
+  assert(grads.cols() == SPOSet::OrbitalSetSize);
   assert(grads.rows() == numparticles_);
   ref_egrad_ = grads;
 };
@@ -69,7 +69,7 @@ void ConstantSPOSet<T>::setRefEGrads(const GradMatrix& grads)
 template<typename T>
 void ConstantSPOSet<T>::setRefELapls(const ValueMatrix& lapls)
 {
-  assert(lapls.cols() == this->OrbitalSetSize);
+  assert(lapls.cols() == SPOSet::OrbitalSetSize);
   assert(lapls.rows() == numparticles_);
   ref_elapl_ = lapls;
 };
@@ -79,8 +79,8 @@ void ConstantSPOSet<T>::evaluateValue(const ParticleSet& P, int iat, ValueVector
 {
   const auto* vp = dynamic_cast<const VirtualParticleSet*>(&P);
   int ptcl = vp ? vp->refPtcl : iat;
-  assert(psi.size() == this->OrbitalSetSize);
-  for (int iorb = 0; iorb < this->OrbitalSetSize; iorb++)
+  assert(psi.size() == SPOSet::OrbitalSetSize);
+  for (int iorb = 0; iorb < SPOSet::OrbitalSetSize; iorb++)
     psi[iorb] = ref_psi_(ptcl, iorb);
 };
 
@@ -91,7 +91,7 @@ void ConstantSPOSet<T>::evaluateVGL(const ParticleSet& P,
                                     GradVector& dpsi,
                                     ValueVector& d2psi)
 {
-  for (int iorb = 0; iorb < this->OrbitalSetSize; iorb++)
+  for (int iorb = 0; iorb < SPOSet::OrbitalSetSize; iorb++)
   {
     psi[iorb]   = ref_psi_(iat, iorb);
     dpsi[iorb]  = ref_egrad_(iat, iorb);

--- a/src/QMCWaveFunctions/tests/ConstantSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/ConstantSPOSet.cpp
@@ -13,68 +13,81 @@
 
 namespace qmcplusplus
 {
-ConstantSPOSet::ConstantSPOSet(const std::string& my_name, const int nparticles, const int norbitals)
-    : SPOSet(my_name), numparticles_(nparticles)
+
+template<typename T>
+ConstantSPOSet<T>::ConstantSPOSet(const std::string& my_name, const int nparticles, const int norbitals)
+    : SPOSetT<T>(my_name), numparticles_(nparticles)
 {
-  OrbitalSetSize = norbitals;
-  ref_psi_.resize(numparticles_, OrbitalSetSize);
-  ref_egrad_.resize(numparticles_, OrbitalSetSize);
-  ref_elapl_.resize(numparticles_, OrbitalSetSize);
+  this->OrbitalSetSize = norbitals;
+  ref_psi_.resize(numparticles_, this->OrbitalSetSize);
+  ref_egrad_.resize(numparticles_, this->OrbitalSetSize);
+  ref_elapl_.resize(numparticles_, this->OrbitalSetSize);
 
   ref_psi_   = 0.0;
   ref_egrad_ = 0.0;
   ref_elapl_ = 0.0;
 };
 
-std::unique_ptr<SPOSet> ConstantSPOSet::makeClone() const
+template<typename T>
+std::unique_ptr<SPOSetT<T>> ConstantSPOSet<T>::makeClone() const
 {
-  auto myclone = std::make_unique<ConstantSPOSet>(my_name_, numparticles_, OrbitalSetSize);
+  auto myclone = std::make_unique<ConstantSPOSet>(this->my_name_, numparticles_, this->OrbitalSetSize);
   myclone->setRefVals(ref_psi_);
   myclone->setRefEGrads(ref_egrad_);
   myclone->setRefELapls(ref_elapl_);
   return myclone;
 };
 
-std::string ConstantSPOSet::getClassName() const { return "ConstantSPOSet"; };
+template<typename T>
+std::string ConstantSPOSet<T>::getClassName() const { return "ConstantSPOSet"; };
 
-void ConstantSPOSet::checkOutVariables(const opt_variables_type& active)
+template<typename T>
+void ConstantSPOSet<T>::checkOutVariables(const opt_variables_type& active)
 {
   APP_ABORT("ConstantSPOSet should not call checkOutVariables");
 };
 
-void ConstantSPOSet::setOrbitalSetSize(int norbs) { APP_ABORT("ConstantSPOSet should not call setOrbitalSetSize()"); }
+template<typename T>
+void ConstantSPOSet<T>::setOrbitalSetSize(int norbs) { APP_ABORT("ConstantSPOSet should not call setOrbitalSetSize()"); }
 
-void ConstantSPOSet::setRefVals(const ValueMatrix& vals)
+template<typename T>
+void ConstantSPOSet<T>::setRefVals(const ValueMatrix& vals)
 {
-  assert(vals.cols() == OrbitalSetSize);
+  assert(vals.cols() == this->OrbitalSetSize);
   assert(vals.rows() == numparticles_);
   ref_psi_ = vals;
 };
-void ConstantSPOSet::setRefEGrads(const GradMatrix& grads)
+
+template<typename T>
+void ConstantSPOSet<T>::setRefEGrads(const GradMatrix& grads)
 {
-  assert(grads.cols() == OrbitalSetSize);
+  assert(grads.cols() == this->OrbitalSetSize);
   assert(grads.rows() == numparticles_);
   ref_egrad_ = grads;
 };
-void ConstantSPOSet::setRefELapls(const ValueMatrix& lapls)
+
+template<typename T>
+void ConstantSPOSet<T>::setRefELapls(const ValueMatrix& lapls)
 {
-  assert(lapls.cols() == OrbitalSetSize);
+  assert(lapls.cols() == this->OrbitalSetSize);
   assert(lapls.rows() == numparticles_);
   ref_elapl_ = lapls;
 };
 
-void ConstantSPOSet::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
+template<typename T>
+void ConstantSPOSet<T>::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
 {
   const auto* vp = dynamic_cast<const VirtualParticleSet*>(&P);
   int ptcl = vp ? vp->refPtcl : iat;
-  assert(psi.size() == OrbitalSetSize);
-  for (int iorb = 0; iorb < OrbitalSetSize; iorb++)
+  assert(psi.size() == this->OrbitalSetSize);
+  for (int iorb = 0; iorb < this->OrbitalSetSize; iorb++)
     psi[iorb] = ref_psi_(ptcl, iorb);
 };
 
-void ConstantSPOSet::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)
+template<typename T>
+void ConstantSPOSet<T>::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)
 {
-  for (int iorb = 0; iorb < OrbitalSetSize; iorb++)
+  for (int iorb = 0; iorb < this->OrbitalSetSize; iorb++)
   {
     psi[iorb]   = ref_psi_(iat, iorb);
     dpsi[iorb]  = ref_egrad_(iat, iorb);
@@ -82,12 +95,13 @@ void ConstantSPOSet::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi
   }
 };
 
-void ConstantSPOSet::evaluate_notranspose(const ParticleSet& P,
-                                          int first,
-                                          int last,
-                                          ValueMatrix& logdet,
-                                          GradMatrix& dlogdet,
-                                          ValueMatrix& d2logdet)
+template<typename T>
+void ConstantSPOSet<T>::evaluate_notranspose(const ParticleSet& P,
+                                             int first,
+                                             int last,
+                                             ValueMatrix& logdet,
+                                             GradMatrix& dlogdet,
+                                             ValueMatrix& d2logdet)
 {
   for (int iat = first, i = 0; iat < last; ++iat, ++i)
   {
@@ -97,4 +111,13 @@ void ConstantSPOSet::evaluate_notranspose(const ParticleSet& P,
     evaluateVGL(P, iat, v, g, l);
   }
 }
+
+#if !defined(MIXED_PRECISION)
+template class ConstantSPOSet<double>;
+template class ConstantSPOSet<std::complex<double>>;
+#endif
+template class ConstantSPOSet<float>;
+template class ConstantSPOSet<std::complex<float>>;
+
+
 } //namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/ConstantSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/ConstantSPOSet.cpp
@@ -85,7 +85,11 @@ void ConstantSPOSet<T>::evaluateValue(const ParticleSet& P, int iat, ValueVector
 };
 
 template<typename T>
-void ConstantSPOSet<T>::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)
+void ConstantSPOSet<T>::evaluateVGL(const ParticleSet& P,
+                                    int iat,
+                                    ValueVector& psi,
+                                    GradVector& dpsi,
+                                    ValueVector& d2psi)
 {
   for (int iorb = 0; iorb < this->OrbitalSetSize; iorb++)
   {

--- a/src/QMCWaveFunctions/tests/ConstantSPOSet.h
+++ b/src/QMCWaveFunctions/tests/ConstantSPOSet.h
@@ -22,9 +22,17 @@ namespace qmcplusplus
    *  Exists to provide deterministic and known output to objects requiring SPOSet evaluations.      
    *
    */
-class ConstantSPOSet : public SPOSet
+template<typename T>
+class ConstantSPOSet : public SPOSetT<T>
 {
 public:
+  using SPOSet = SPOSetT<T>;
+
+  using ValueVector = typename SPOSet::ValueVector;
+  using ValueMatrix = typename SPOSet::ValueMatrix;
+  using GradVector  = typename SPOSet::GradVector;
+  using GradMatrix  = typename SPOSet::GradMatrix;
+
   ConstantSPOSet(const std::string& my_name) = delete;
 
   //Constructor needs number of particles and number of orbitals.  This is the minimum

--- a/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
@@ -35,7 +35,7 @@ TEST_CASE("CompositeSPO::diamond_1x1x1", "[wavefunction")
   auto& pset = *particle_pool.getParticleSet("e");
   auto& twf  = *wavefunction_pool.getWaveFunction("wavefunction");
 
-  CompositeSPOSet comp_sposet("one_composite_set");
+  CompositeSPOSet<SPOSet::ValueType> comp_sposet("one_composite_set");
 
   std::vector<std::string> sposets{"spo_ud", "spo_dm"};
   for (auto sposet_str : sposets)

--- a/src/QMCWaveFunctions/tests/test_ConstantSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/test_ConstantSPOSet.cpp
@@ -74,7 +74,7 @@ TEST_CASE("ConstantSPOSet", "[wavefunction]")
   psiG.resize(norb);
 
   //Test of value only constructor.
-  auto sposet = std::make_unique<ConstantSPOSet>("constant_spo", nelec, norb);
+  auto sposet = std::make_unique<ConstantSPOSet<Value>>("constant_spo", nelec, norb);
   sposet->setRefVals(spomat);
   sposet->setRefEGrads(gradspomat);
   sposet->setRefELapls(laplspomat);

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -963,10 +963,10 @@ TEST_CASE("RotatedSPOs mw_ APIs", "[wavefunction]")
     //In the case that the underlying SPOSet doesn't specialize the mw_ API,
     //the underlying SPOSet will fall back to the default SPOSet mw_, which is
     //just a loop over the single walker API.
-    using ValueType = SPOSet::ValueType;
+    using Value = SPOSet::ValueType;
 
-    RotatedSPOs rot_spo0("rotated0", std::make_unique<DummySPOSetWithoutMW<ValueType>>("no mw 0"));
-    RotatedSPOs rot_spo1("rotated1", std::make_unique<DummySPOSetWithoutMW<ValueType>>("no mw 1"));
+    RotatedSPOs rot_spo0("rotated0", std::make_unique<DummySPOSetWithoutMW<Value>>("no mw 0"));
+    RotatedSPOs rot_spo1("rotated1", std::make_unique<DummySPOSetWithoutMW<Value>>("no mw 1"));
     RefVectorWithLeader<SPOSet> spo_list(rot_spo0, {rot_spo0, rot_spo1});
 
     ResourceCollection spo_res("test_rot_res");
@@ -1023,10 +1023,10 @@ TEST_CASE("RotatedSPOs mw_ APIs", "[wavefunction]")
     //in the underlying SPO and not using the default SPOSet implementation which
     //loops over single walker APIs (which have different values enforced in
     // DummySPOSetWithoutMW
-    using ValueType = SPOSet::ValueType;
+    using Value = SPOSet::ValueType;
 
-    RotatedSPOs rot_spo0("rotated0", std::make_unique<DummySPOSetWithMW<ValueType>>("mw 0"));
-    RotatedSPOs rot_spo1("rotated1", std::make_unique<DummySPOSetWithMW<ValueType>>("mw 1"));
+    RotatedSPOs rot_spo0("rotated0", std::make_unique<DummySPOSetWithMW<Value>>("mw 0"));
+    RotatedSPOs rot_spo1("rotated1", std::make_unique<DummySPOSetWithMW<Value>>("mw 1"));
     RefVectorWithLeader<SPOSet> spo_list(rot_spo0, {rot_spo0, rot_spo1});
 
     ResourceCollection spo_res("test_rot_res");

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -841,10 +841,13 @@ class DummySPOSetWithoutMW : public SPOSetT<T>
 {
 public:
   using SPOSet = SPOSetT<T>;
-  using ValueVector = typename SPOSet::ValueVector;
-  using ValueMatrix = typename SPOSet::ValueMatrix;
-  using GradVector  = typename SPOSet::GradVector;
-  using GradMatrix  = typename SPOSet::GradMatrix;
+  using ValueVector   = typename SPOSet::ValueVector;
+  using ValueMatrix   = typename SPOSet::ValueMatrix;
+  using GradVector    = typename SPOSet::GradVector;
+  using GradMatrix    = typename SPOSet::GradMatrix;
+  using ComplexType   = typename SPOSet::ComplexType;
+  template<typename DT>
+  using OffloadMatrix = typename SPOSet::template OffloadMatrix<DT>;
 
   DummySPOSetWithoutMW(const std::string& my_name) : SPOSet(my_name) {}
   void setOrbitalSetSize(int norbs) override {}
@@ -910,7 +913,11 @@ template<typename T>
 class DummySPOSetWithMW : public DummySPOSetWithoutMW<T>
 {
 public:
-  using ValueVector = typename DummySPOSetWithoutMW<T>::ValueVector;
+  using ValueVector   = typename DummySPOSetWithoutMW<T>::ValueVector;
+  using GradVector    = typename DummySPOSetWithoutMW<T>::GradVector;
+  using ComplexType   = typename DummySPOSetWithoutMW<T>::ComplexType;
+  template<typename DT>
+  using OffloadMatrix = typename DummySPOSetWithoutMW<T>::template OffloadMatrix<DT>;
   DummySPOSetWithMW(const std::string& my_name) : DummySPOSetWithoutMW<T>(my_name) {}
   void mw_evaluateValue(const RefVectorWithLeader<SPOSet>& spo_list,
                         const RefVectorWithLeader<ParticleSet>& P_list,

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -906,7 +906,7 @@ public:
                             GradMatrix& dlogdet,
                             ValueMatrix& d2logdet) override
   {}
-  std::string getClassName() const override { return this->my_name_; }
+  std::string getClassName() const override { return SPOSet::my_name_; }
 };
 
 template<typename T>

--- a/src/QMCWaveFunctions/tests/test_SlaterDet.cpp
+++ b/src/QMCWaveFunctions/tests/test_SlaterDet.cpp
@@ -145,6 +145,8 @@ public:
 
 TEST_CASE("SlaterDet mw_ APIs", "[wavefunction]")
 {
+  using Value = typename QMCTraits::ValueType;
+
   Communicate* comm = OHMMS::Controller;
 
   auto particle_pool = MinimalParticlePool::make_O2_spinor(comm);
@@ -152,8 +154,8 @@ TEST_CASE("SlaterDet mw_ APIs", "[wavefunction]")
   auto& elec1        = *(particle_pool).getParticleSet("e");
   RefVectorWithLeader<ParticleSet> p_list(elec0, {elec0, elec1});
 
-  std::unique_ptr<ConstantSPOSet> spo_ptr0 = std::make_unique<ConstantSPOSet>("dummySPO", 3, 3);
-  std::unique_ptr<ConstantSPOSet> spo_ptr1 = std::make_unique<ConstantSPOSet>("dummySPO", 3, 3);
+  std::unique_ptr<ConstantSPOSet<Value>> spo_ptr0 = std::make_unique<ConstantSPOSet<Value>>("dummySPO", 3, 3);
+  std::unique_ptr<ConstantSPOSet<Value>> spo_ptr1 = std::make_unique<ConstantSPOSet<Value>>("dummySPO", 3, 3);
   //Right now, DiracDeterminantBatched has mw_ WithSpin APIs but DiracDeterminant does not.
   //We want to add a test to make sure Slater determinant chooses the mw_ implementation if it has it.
 


### PR DESCRIPTION
## Proposed changes

Introducing templates for the classes derived from `SPOSetT<T>`. This is the following change towards a unified build for real, complex, and mixed-precision, started from #5306, and separated from #5355.

## What type(s) of changes does this code introduce?

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Linux with GCC

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
