### PR TITLE
Spline dump should only be read by rank 0.

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
@@ -148,7 +148,7 @@ std::unique_ptr<SPOSet> HybridRepSetReader<SA>::create_spline_set(const std::str
   bool foundspline = spline_reader_.createSplineDataSpaceLookforDumpFile(bandgroup, *bspline);
   typename SA::HYBRIDBASE& hybrid_center_orbs = *bspline;
   hybrid_center_orbs.resizeStorage(bspline->myV.size());
-  if (foundspline)
+  if (foundspline && myComm->rank() == 0)
   {
     Timer now;
     hdf_archive h5f(myComm);

--- a/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<SPOSet> SplineSetReader<SA>::create_spline_set(const std::string
   auto bspline = std::make_unique<SA>(my_name, use_offload);
   app_log() << "  ClassName = " << bspline->getClassName() << std::endl;
   bool foundspline = createSplineDataSpaceLookforDumpFile(bandgroup, *bspline);
-  if (foundspline)
+  if (foundspline && myComm->rank() == 0)
   {
     Timer now;
     hdf_archive h5f(myComm);
@@ -80,6 +80,7 @@ std::unique_ptr<SPOSet> SplineSetReader<SA>::create_spline_set(const std::string
   }
 
   {
+    myComm->barrier();
     Timer now;
     bspline->bcast_tables(myComm);
     app_log() << "  Time to bcast the table = " << now.elapsed() << std::endl;


### PR DESCRIPTION
## Proposed changes
Fixed a bug introduced in https://github.com/QMCPACK/qmcpack/pull/4849/files
It caused reading the same dump file from every MPI rank.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Aurora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'