### PR TITLE
Nexus: support for stochastic reconfiguration and basic orbital rotation

### DIFF
--- a/nexus/lib/qmcpack_input.py
+++ b/nexus/lib/qmcpack_input.py
@@ -1834,9 +1834,15 @@ class sposet(QIxml):
                   'source','version','precision','tilematrix',
                   'meshfactor']
     elements   = ['occupation','coefficient','coefficients']
-    text       = 'spos'
+    #text       = 'spos'
     identifier = 'name'
 #end class sposet
+
+class rotated_sposet(QIxml):
+    attributes = ['name']
+    elements   = ['sposet']
+    identifier = 'name'
+#end class rotated_sposet
 
 class bspline_builder(QIxml):
     tag         = 'sposet_builder'
@@ -1844,7 +1850,7 @@ class bspline_builder(QIxml):
     attributes  = ['type','href','sort','tilematrix','twistnum','twist','source',
                    'version','meshfactor','gpu','transform','precision','truncate',
                    'lr_dim_cutoff','shell','randomize','key','buffer','rmax_core','dilation','tag','hybridrep','gpusharing']
-    elements    = ['sposet']
+    elements    = ['sposet','rotated_sposet']
     write_types = obj(gpu=yesno,sort=onezero,transform=yesno,truncate=yesno,randomize=truefalse,hybridrep=yesno,gpusharing=yesno)
 #end class bspline_builder
 
@@ -1859,7 +1865,7 @@ class molecular_orbital_builder(QIxml):
     tag = 'sposet_builder'
     identifier = 'type'
     attributes = ['name','type','transform','source','cuspcorrection']
-    elements   = ['basisset','sposet'] 
+    elements   = ['basisset','sposet','rotated_sposet'] 
 #end class molecular_orbital_builder
 
 class composite_builder(QIxml):
@@ -2111,7 +2117,7 @@ class constant(QIxml):
 
 class pseudopotential(QIxml):
     tag = 'pairpot'
-    attributes = ['type','name','source','wavefunction','format','target','forces','dla']
+    attributes = ['type','name','source','wavefunction','format','target','forces','dla','algorithm']
     elements   = ['pseudo']
     write_types= obj(forces=yesno,dla=yesno)
     identifier = 'name'
@@ -2510,10 +2516,13 @@ class linear(QIxml):
                   'tries','min_walkers','samplesperthread',
                   'shift_i','shift_s','max_relative_change','max_param_change',
                   'chase_lowest','chase_closest','block_lm','nblocks','nolds',
-                  'nkept','max_seconds', 'spin_mass'
+                  'nkept','max_seconds','spin_mass',
+                  'sr_tau','sr_tolerance','sr_regularization','line_search',
                   ]
     costs      = ['energy','unreweightedvariance','reweightedvariance','variance','difference']
-    write_types = obj(gpu=yesno,usedrift=yesno,nonlocalpp=yesno,usebuffer=yesno,use_nonlocalpp_deriv=yesno,chase_lowest=yesno,chase_closest=yesno,block_lm=yesno)
+    write_types = obj(gpu=yesno,usedrift=yesno,nonlocalpp=yesno,usebuffer=yesno,
+                      use_nonlocalpp_deriv=yesno,chase_lowest=yesno,
+                      chase_closest=yesno,block_lm=yesno,line_search=yesno)
 #end class linear
 
 class cslinear(QIxml):
@@ -2726,7 +2735,7 @@ classes = [   #standard classes
     nofk,mpc_est,flux,distancetable,cpp,element,spline,setparams,
     backflow,transformation,cubicgrid,molecular_orbital_builder,cmc,sk,skall,gofr,
     host,date,user,rpa_jastrow,momentum,override_variational_parameters,
-    momentumdistribution,onebodydensitymatrices,estimators,
+    momentumdistribution,onebodydensitymatrices,estimators,rotated_sposet,
     # afqmc classes
     afqmcinfo,walkerset,propagator,execute,back_propagation,onerdm
     ]
@@ -2773,6 +2782,7 @@ plurals = obj(
     constants       = 'constant',
     mcwalkersets    = 'mcwalkerset',
     transformations = 'transformation',
+    rotated_sposets = 'rotated_sposet',
     )
 plurals_inv = plurals.inverse()
 plural_names = set(plurals.keys())
@@ -4577,6 +4587,7 @@ def generate_sposets(type           = None,
                      sposets        = None,
                      spindatasets   = False,
                      spinor         = None,
+                     rotate         = False,
                      ):
     ndn = ndown
     if type is None:
@@ -4627,6 +4638,14 @@ def generate_sposets(type           = None,
     else:
         QmcpackInput.class_error('cannot generate sposets in occupation mode {0}\n  generate_sposets currently supports the following occupation modes:\n  slater_ground'.format(occupation))
     #end if
+    if rotate:
+        rotated_sposets = []
+        for spo in sposets:
+            rot_spo = rotated_sposet(name='rot_'+spo.name, sposet=spo)
+            rotated_sposets.append(rot_spo)
+        #end for
+        sposets = rotated_sposets
+    #end if
     return make_collection(sposets)
 #end def generate_sposets
 
@@ -4654,6 +4673,7 @@ def generate_bspline_builder(type           = 'bspline',
                              spin_polarized = False,
                              hybridrep      = None,
                              href           = 'MISSING.h5',
+                             rotate         = False,
                              ions           = 'ion0',
                              spo_up         = 'spo_u',
                              spo_down       = 'spo_d',
@@ -4676,16 +4696,22 @@ def generate_bspline_builder(type           = 'bspline',
         version    = version,
         truncate   = truncate,
         source     = ions,
-        sposets    = generate_sposets(
-            type           = type,
-            occupation     = 'slater_ground',
-            spin_polarized = spin_polarized,
-            system         = system,
-            sposets        = sposets,
-            spindatasets   = True,
-            spinor         = spinor,
-            )
         )
+    sposets    = generate_sposets(
+        type           = type,
+        occupation     = 'slater_ground',
+        spin_polarized = spin_polarized,
+        system         = system,
+        sposets        = sposets,
+        spindatasets   = True,
+        spinor         = spinor,
+        rotate         = rotate,
+        )
+    if not rotate:
+        bsb.sposets = sposets
+    else:
+        bsb.rotated_sposets = sposets
+    #end if
     if sort is not None:
         bsb.sort = sort
     #end if
@@ -4820,6 +4846,7 @@ def generate_determinantset(up             = 'u',
                             matrix_inv_cpu = None,
                             system         = None,
                             spinor         = None,
+                            rotate         = False,
                             ):
     if system is None:
         QmcpackInput.class_error('generate_determinantset argument system must not be None')
@@ -4834,6 +4861,10 @@ def generate_determinantset(up             = 'u',
     else:
         spo_u = spo_up
         spo_d = spo_down
+    #end if
+    if rotate:
+        spo_u = 'rot_'+spo_u
+        spo_d = 'rot_'+spo_d
     #end if
     determinants_list = []
     if not use_spinor:
@@ -5313,6 +5344,7 @@ def generate_hamiltonian(name         = 'h0',
                          ions         = 'ion0',
                          wavefunction = 'psi0',
                          pseudos      = None,
+                         algorithm    = None,
                          dla          = None,
                          format       = 'xml',
                          estimators   = None,
@@ -5380,6 +5412,9 @@ def generate_hamiltonian(name         = 'h0',
                     pseudos.add(pseudo(elementtype=label,href=ppfile))
                 #end for
                 pp = pseudopotential(name='PseudoPot',type='pseudo',source=iname,wavefunction=wfname,format=format,pseudos=pseudos)
+                if algorithm is not None:
+                    pp.algorithm = algorithm
+                #end if
                 if dla is not None:
                     pp.dla = dla
                 #end if
@@ -5671,6 +5706,12 @@ def generate_jastrows_alt(
     J3_rcut      = 5.0,
     J1_rcut_open = 5.0,
     J2_rcut_open = 10.0,
+    J1k          = False,
+    J1k_kcut     = 5.0,
+    J1k_symm     = 'crystal',
+    J2k          = False,
+    J2k_kcut     = 5.0,
+    J2k_symm     = 'crystal',
     system       = None,
     ):
     if system is None:
@@ -5746,7 +5787,19 @@ def generate_jastrows_alt(
         J = generate_jastrow('J3','polynomial',J3_esize,J3_isize,J3_rcut,system=system)
         jastrows.append(J)
     #end if
-
+    if J1k or J2k:
+        Jk_inp = obj()
+        if J1k:
+            Jk_inp.kc1   = J1k_kcut
+            Jk_inp.symm1 = J1k_symm
+        #end if
+        if J2k:
+            Jk_inp.kc2   = J2k_kcut
+            Jk_inp.symm2 = J2k_symm
+        #end if
+        J = generate_kspace_jastrow(**Jk_inp)
+        jastrows.append(J)
+    #end if
     return jastrows
 #end def generate_jastrows_alt
 
@@ -6086,8 +6139,16 @@ def generate_jastrow3(function='polynomial',esize=3,isize=3,rcut=4.,coeff=None,i
 #end def generate_jastrow3
 
 
-def generate_kspace_jastrow(kc1=0, kc2=0, nk1=0, nk2=0,
-  symm1='isotropic', symm2='isotropic', coeff1=None, coeff2=None):
+def generate_kspace_jastrow(
+        kc1    = None, 
+        kc2    = None, 
+        nk1    = 0, 
+        nk2    = 0,
+        symm1  = 'isotropic', 
+        symm2  = 'isotropic', 
+        coeff1 = None, 
+        coeff2 = None,
+        ):
   """Generate <jastrow type="kSpace">
 
   Parameters
@@ -6113,40 +6174,45 @@ def generate_kspace_jastrow(kc1=0, kc2=0, nk1=0, nk2=0,
     jk: QIxml
       kspace_jastrow qmcpack_input element
   """
-
+  J1k = kc1 is not None
+  J2k = kc2 is not None
+  if not J1k and not J2k:
+      QmcpackInput.class_error('must have at least one term', 'generate_kspace_jastrow')
+  #end if      
   if coeff1 is None: coeff1 = [0]*nk1
   if coeff2 is None: coeff2 = [0]*nk2
   if len(coeff1) != nk1:
-    QmcpackInput.class_error('coeff1 mismatch', 'generate_kspace_jastrow')
+      QmcpackInput.class_error('coeff1 mismatch', 'generate_kspace_jastrow')
   #end if
   if len(coeff2) != nk2:
-    QmcpackInput.class_error('coeff2 mismatch', 'generate_kspace_jastrow')
+      QmcpackInput.class_error('coeff2 mismatch', 'generate_kspace_jastrow')
   #end if
 
-  corr1 = correlation(
-    type = 'One-Body',
-    symmetry = symm1,
-    kc = kc1,
-    coefficients = section(
-      id = 'cG1', type = 'Array',
-      coeff = coeff1
-    )
-  )
-  corr2 = correlation(
-    type = 'Two-Body',
-    symmetry = symm2,
-    kc = kc2,
-    coefficients = section(
-      id = 'cG2', type = 'Array',
-      coeff = coeff2
-     )
-  )
+  corrs = []
+  if J1k:
+      corr1 = correlation(
+          type         = 'One-Body',
+          symmetry     = symm1,
+          kc           = kc1,
+          coefficients = section(id='cG1', type='Array', coeff=coeff1),
+          )
+      corrs.append(corr1)
+  #end if
+  if J2k:
+      corr2 = correlation(
+          type         = 'Two-Body',
+          symmetry     = symm2,
+          kc           = kc2,
+          coefficients = section(id='cG2', type='Array', coeff=coeff2),
+          )
+      corrs.append(corr2)
+  #end if
   jk = kspace_jastrow(
-    type = 'kSpace',
-    name = 'Jk',
-    source = 'ion0',
-    correlations = collection([corr1, corr2])
-  )
+      type         = 'kSpace',
+      name         = 'Jk',
+      source       = 'ion0',
+      correlations = collection(corrs),
+      )
   return jk
 # end def generate_kspace_jastrow
 
@@ -7317,72 +7383,80 @@ def read_jastrows(filepath):
 
 
 gen_basic_input_defaults = obj(
-    id             = 'qmc',            
-    series         = 0,                
-    purpose        = '',     
-    maxcpusecs     = None,
-    max_seconds    = None,
-    seed           = None,             
-    bconds         = None,             
-    truncate       = False,            
-    buffer         = None,             
-    lr_dim_cutoff  = 15,               
-    lr_tol         = None,               
-    lr_handler     = None,               
-    remove_cell    = False,            
-    randomsrc      = True,            
-    meshfactor     = 1.0,              
-    orbspline      = None,             
-    precision      = 'float',          
-    twistnum       = None,             
-    twist          = None,             
-    gcta           = None,
-    spin_polarized = None,             
-    partition      = None,             
-    partition_mf   = None,             
-    hybridrep      = None,             
-    hybrid_rcut    = None,             
-    hybrid_lmax    = None,             
-    orbitals_h5    = 'MISSING.h5',     
-    run_path       = None,
-    check_paths    = True,
-    excitation     = None,             
-    system         = 'missing',        
-    pseudos        = None,
-    spinor         = None,
-    dla            = None,
-    delay_rank     = None,
-    det_batch      = None,
-    jastrows       = 'generateJ12',    
-    interactions   = 'all',            
-    corrections    = 'default',        
-    observables    = None,             
-    estimators     = None,             
-    traces         = None,             
-    calculations   = None,             
-    det_format     = 'new',            
-    J1             = False,            
-    J2             = False,            
-    J3             = False,            
-    J1_size        = None,             
-    J1_rcut        = None,             
-    J1_dr          = 0.5,              
-    J2_size        = None,             
-    J2_rcut        = None,             
-    J2_dr          = 0.5,              
-    J2_init        = 'zero',           
-    J3_isize       = 3,                
-    J3_esize       = 3,                
-    J3_rcut        = 5.0,              
-    J1_rcut_open   = 5.0,              
-    J2_rcut_open   = 10.0,
-    driver         = 'batched', # legacy,batched
+    id               = 'qmc',            
+    series           = 0,                
+    purpose          = '',     
+    maxcpusecs       = None,
+    max_seconds      = None,
+    seed             = None,             
+    bconds           = None,             
+    truncate         = False,            
+    buffer           = None,             
+    lr_dim_cutoff    = 15,               
+    lr_tol           = None,               
+    lr_handler       = None,               
+    remove_cell      = False,            
+    randomsrc        = True,            
+    meshfactor       = 1.0,              
+    orbspline        = None,             
+    precision        = 'float',          
+    twistnum         = None,             
+    twist            = None,             
+    gcta             = None,
+    spin_polarized   = None,             
+    partition        = None,             
+    partition_mf     = None,             
+    hybridrep        = None,             
+    hybrid_rcut      = None,             
+    hybrid_lmax      = None,             
+    orbitals_h5      = 'MISSING.h5',
+    rotated_orbitals = False,
+    run_path         = None,
+    check_paths      = True,
+    excitation       = None,             
+    system           = 'missing',        
+    pseudos          = None,
+    pseudo_algorithm = None,
+    spinor           = None,
+    dla              = None,
+    delay_rank       = None,
+    det_batch        = None,
+    jastrows         = 'generateJ12',    
+    interactions     = 'all',            
+    corrections      = 'default',        
+    observables      = None,             
+    estimators       = None,             
+    traces           = None,             
+    calculations     = None,             
+    det_format       = 'new',            
+    J1               = False,            
+    J2               = False,            
+    J3               = False,            
+    J1_size          = None,             
+    J1_rcut          = None,             
+    J1_dr            = 0.5,              
+    J2_size          = None,             
+    J2_rcut          = None,             
+    J2_dr            = 0.5,              
+    J2_init          = 'zero',           
+    J3_isize         = 3,                
+    J3_esize         = 3,                
+    J3_rcut          = 5.0,              
+    J1_rcut_open     = 5.0,              
+    J2_rcut_open     = 10.0,
+    J1k              = False,
+    J1k_kcut         = 5.0,
+    J1k_symm         = 'crystal',
+    J2k              = False,
+    J2k_kcut         = 5.0,
+    J2k_symm         = 'crystal',
+    driver           = 'batched', # legacy,batched
     # batched driver inputs
-    orbitals_cpu   = None,     # place/evaluate orbitals on cpu if on gpu
-    matrix_inv_cpu = None,     # evaluate matrix inverse on cpu if on gpu
+    orbitals_cpu     = None,     # place/evaluate orbitals on cpu if on gpu
+    matrix_inv_cpu   = None,     # evaluate matrix inverse on cpu if on gpu
     # legacy cuda inputs
-    gpusharing     = None,
-    qmc            = None,     # opt,vmc,vmc_test,dmc,dmc_test
+    gpusharing       = None,
+    qmc              = None,     # opt,vmc,vmc_test,dmc,dmc_test
     )
 
 def generate_basic_input(**kwargs):
@@ -7541,6 +7615,7 @@ def generate_basic_input(**kwargs):
                 buffer         = kw.buffer,
                 hybridrep      = kw.hybridrep,
                 href           = kw.orbitals_h5,
+                rotate         = kw.rotated_orbitals,
                 spin_polarized = kw.spin_polarized,
                 system         = kw.system,
                 orbitals_cpu   = kw.orbitals_cpu,
@@ -7565,6 +7640,7 @@ def generate_basic_input(**kwargs):
             matrix_inv_cpu = kw.matrix_inv_cpu,
             system         = kw.system,
             spinor         = kw.spinor,
+            rotate         = kw.rotated_orbitals,
             )
     elif kw.det_format=='old':
         spobuilders = None
@@ -7622,6 +7698,12 @@ def generate_basic_input(**kwargs):
             J3_rcut      = kw.J3_rcut     ,
             J1_rcut_open = kw.J1_rcut_open,
             J2_rcut_open = kw.J2_rcut_open,
+            J1k          = kw.J1k         ,
+            J1k_kcut     = kw.J1k_kcut    ,
+            J1k_symm     = kw.J1k_symm    ,
+            J2k          = kw.J2k         ,
+            J2k_kcut     = kw.J2k_kcut    ,
+            J2k_symm     = kw.J2k_symm    ,
             system       = kw.system      ,
             )
     #end if
@@ -7630,30 +7712,32 @@ def generate_basic_input(**kwargs):
     #end if
 
     if kw.spinor is not None and kw.spinor:
-      # remove u-d 
-      # also set correct cusp
-      J2 = wfn.jastrows.get('J2')
-      if J2 is not None:
-        corr = J2.get('correlation')
-        if 'ud' in corr:
-          del corr.ud
-        if 'uu' in corr:
-          corr.uu.cusp = -0.5
-      #end if
-      J3 = wfn.jastrows.get('J3')
-      if J3 is not None:
-        corr = J3.get('correlation')
-        j3_ids = []
-        for j3_term in corr:
-          j3_id = j3_term.coefficients.id
-          j3_ids.append(j3_id)
-        #end for
-        for j3_id in j3_ids:
-          if 'ud' in j3_id:
-            delattr(corr, j3_id)
-          #end if
-        #end for
-      #end if
+        # remove u-d 
+        # also set correct cusp
+        J2 = wfn.jastrows.get('J2')
+        if J2 is not None:
+            corr = J2.get('correlation')
+            if 'ud' in corr:
+                del corr.ud
+                if 'uu' in corr:
+                    corr.uu.cusp = -0.5
+                #end if
+            #end if
+        #end if
+        J3 = wfn.jastrows.get('J3')
+        if J3 is not None:
+            corr = J3.get('correlation')
+            j3_ids = []
+            for j3_term in corr:
+                j3_id = j3_term.coefficients.id
+                j3_ids.append(j3_id)
+            #end for
+            for j3_id in j3_ids:
+                if 'ud' in j3_id:
+                    delattr(corr, j3_id)
+                #end if
+            #end for
+        #end if
     #end if
 
     h_estimators = kw.estimators
@@ -7679,6 +7763,7 @@ def generate_basic_input(**kwargs):
     hmltn = generate_hamiltonian(
         system       = kw.system,
         pseudos      = kw.pseudos,
+        algorithm    = kw.pseudo_algorithm,
         dla          = kw.dla,
         interactions = kw.interactions,
         estimators   = h_estimators,

--- a/nexus/tests/unit/test_qmcpack_analyzer.py
+++ b/nexus/tests/unit/test_qmcpack_analyzer.py
@@ -2,7 +2,7 @@
 import versions
 import testing
 from testing import divert_nexus_log,restore_nexus_log
-from testing import value_eq,object_eq,text_eq
+from testing import value_eq,object_eq,text_eq,print_diff
 
 
 def test_import():
@@ -316,7 +316,7 @@ def test_optimization_analysis():
     opt_wf_text_ref = '''
 <wavefunction name="psi0" target="e">
    <sposet_builder type="bspline" href="../scf/pwscf_output/pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.1" meshfactor="1.0" precision="float" truncate="no">
-      <sposet type="bspline" name="spo_ud" size="4" spindataset="0">                             </sposet>
+      <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
    </sposet_builder>
    <determinantset>
       <slaterdeterminant>
@@ -341,8 +341,8 @@ def test_optimization_analysis():
 </wavefunction>
 '''
 
-    opt_wf_text_ref = opt_wf_text_ref.replace('"',' " ')
-    opt_wf_text     = opt_wf_text.replace('"',' " ')
+    opt_wf_text_ref = opt_wf_text_ref.replace('"',' " ').strip()
+    opt_wf_text     = opt_wf_text.replace('"',' " ').strip()
 
     assert(text_eq(opt_wf_text,opt_wf_text_ref))
 

--- a/nexus/tests/unit/test_qmcpack_input.py
+++ b/nexus/tests/unit/test_qmcpack_input.py
@@ -1399,12 +1399,17 @@ def test_read():
     assert(not qi_read.is_afqmc_input())
 
     # remove extraneous data members for purpose of comparison
-    del qi_read._metadata.spo_u
-    del qi_read._metadata.spo_d
+    m = qi_read._metadata
+    if 'spo_u' in m:
+        del m.spo_u
+    if 'spo_d' in m:
+        del m.spo_d
     spob = qi_read.simulation.qmcsystem.wavefunctions.psi0.sposet_builders
     sposets = spob.bspline.sposets
-    del sposets.spo_u.spos
-    del sposets.spo_d.spos
+    if 'spos' in sposets.spo_u:
+        del sposets.spo_u.spos
+    if 'spos' in sposets.spo_d:
+        del sposets.spo_d.spos
 
     check_vs_serial_reference(qi_read,'VO2_M1_afm.in.xml')
 
@@ -1465,12 +1470,17 @@ def test_write():
     qi_write.pluralize()
 
     # remove extraneous data members for purpose of comparison
-    del qi_write._metadata.spo_u
-    del qi_write._metadata.spo_d
+    m = qi_write._metadata
+    if 'spo_u' in m:
+        del m.spo_u
+    if 'spo_d' in m:
+        del m.spo_d
     spob = qi_write.simulation.qmcsystem.wavefunctions.psi0.sposet_builders
     sposets = spob.bspline.sposets
-    del sposets.spo_u.spos
-    del sposets.spo_d.spos
+    if 'spos' in sposets.spo_u:
+        del sposets.spo_u.spos
+    if 'spos' in sposets.spo_d:
+        del sposets.spo_d.spos
 
     check_vs_serial_reference(qi_write,ref_file)
 


### PR DESCRIPTION
## Proposed changes

Add support for features Cody's project needs:
- stochastic reconfiguration optimizer inputs
- `<rotate_spo>` wrapper around `<sposet>`
- improved k-space jastrow generation

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'

