### PR TITLE
Update nightlies: add asan build, rmgdft develop version

### DIFF
--- a/tests/test_automation/nightly_test_scripts/nightly_ornl.sh
+++ b/tests/test_automation/nightly_test_scripts/nightly_ornl.sh
@@ -71,7 +71,7 @@ echo --- Host is $ourhostname
 case "$ourhostname" in
     sulfur )
 	if [[ $jobtype == "nightly" ]]; then
-	    buildsys="gccnewmpi_mkl clangnewmpi gccnewnompi gccnewmpi gccoldmpi clangnewmpi_complex gccnewnompi_complex gccnewmpi_complex clangnewmpi_mixed gccnewnompi_mixed gccnewmpi_mixed clangnewmpi_mixed_complex gccnewnompi_mixed_complex gccnewmpi_mixed_complex \
+	    buildsys="gccnewnompi_debug_asan gccnewmpi_mkl clangnewmpi gccnewnompi gccnewmpi gccoldmpi clangnewmpi_complex gccnewnompi_complex gccnewmpi_complex clangnewmpi_mixed gccnewnompi_mixed gccnewmpi_mixed clangnewmpi_mixed_complex gccnewnompi_mixed_complex gccnewmpi_mixed_complex \
 		clangoffloadmpi_offloadcuda \
 		clangoffloadnompi_offloadcuda clangoffloadnompi_offloadcuda_debug \
 		clangoffloadnompi_offloadcuda_complex clangoffloadnompi_offloadcuda_complex_debug \
@@ -496,6 +496,11 @@ else
 	fi
     export QMCPACK_TEST_SUBMIT_NAME=${QMCPACK_TEST_SUBMIT_NAME}-Release
     ctestscriptarg=release
+fi
+
+if [[ $sys == *"asan"* ]]; then
+    export QMCPACK_TEST_SUBMIT_NAME=${QMCPACK_TEST_SUBMIT_NAME}-Asan
+    export QMC_OPTIONS="${QMC_OPTIONS};-DENABLE_SANITIZER=asan"
 fi
 
 echo TEST SUBMIT NAME: $QMCPACK_TEST_SUBMIT_NAME

--- a/tests/test_automation/nightly_test_scripts/ornl_setup.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_setup.sh
@@ -182,12 +182,24 @@ cd $HOME/apps/spack
 
 # For reproducibility, use a specific version of Spack
 # Prefer to use tagged releases https://github.com/spack/spack/releases
-git checkout 75c3d0a053c9705e1c1f88a94c47ffd36f4be1dd
+
+git checkout a3abc1c492f2431f477a63bbccb48aa3a2d34199
+#commit a3abc1c492f2431f477a63bbccb48aa3a2d34199 (HEAD -> develop, tag: develop-2025-03-23, origin/develop, origin/HEAD)
+#Author: Alec Scott <hi@alecbcs.com>
+#Date:   Fri Mar 21 23:17:56 2025 -0400
+#
+#    Fix ci failures after merge of mock tests created before license transition (#49638)
+
+# Previously used:
+
 #commit 75c3d0a053c9705e1c1f88a94c47ffd36f4be1dd (HEAD -> develop, origin/develop, origin/HEAD)
 #Author: Lehman Garrison <lgarrison@flatironinstitute.org>
 #Date:   Wed Feb 19 10:14:35 2025 -0500
 #
 #    py-yt: add 4.4.0 and dependencies (#47571)
+
+# Limit overly strong rmg boost dependency to allow concretizer:unify:true
+sed -ibak 's/boost@1.61.0:1.82.0/boost@1.61.0:1.82.0", when="@:5/g' var/spack/repos/builtin/packages/rmgdft/package.py
 
 echo --- Git version and last log entry
 git log -1

--- a/tests/test_automation/nightly_test_scripts/ornl_setup_environments.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_setup_environments.sh
@@ -112,7 +112,7 @@ spack add quantum-espresso +mpi +qmcpack
 export CMAKE_BUILD_PARALLEL_LEVEL=8 # For PySCF
 spack add py-pyscf
 spack add dftd4
-#spack add rmgdft #Fails to compile with GCC14 due to bug in vendored SCALAPACK 
+spack add rmgdft@develop # Use develop version to avoid vendored SCALPACK compilation bugs (20250324)
 
 #Luxury options for actual science use:
 spack add py-requests # for pseudo helper
@@ -232,7 +232,7 @@ spack add py-h5py ^hdf5@${hdf5_vnew}%gcc@${gcc_vold} +fortran +hl +mpi
 #spack add quantum-espresso +mpi +qmcpack
 #export CMAKE_BUILD_PARALLEL_LEVEL=8 # For PySCF
 #spack add py-pyscf
-spack add rmgdft
+spack add rmgdft@develop # Use develop version to avoid vendored SCALPACK compilation bugs (20250324)
 
 #Luxury options for actual science use:
 spack add py-requests # for pseudo helper
@@ -395,7 +395,7 @@ spack add py-numpy@${numpy_vold}
 spack add py-scipy
 spack add py-h5py ^hdf5@${hdf5_vold}%gcc@${gcc_vold} +fortran +hl +mpi
 spack add quantum-espresso +mpi +qmcpack
-#spack add rmgdft
+spack add rmgdft@develop # Use develop version to avoid vendored SCALPACK compilation bugs (20250324)
 install_environment
 spack env deactivate
 

--- a/tests/test_automation/nightly_test_scripts/ornl_versions.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_versions.sh
@@ -25,7 +25,7 @@ hdf5_vold=${hdf5_vnew}
 
 # CMake 
 # Dates at https://cmake.org/files/
-cmake_vnew=3.31.5
+cmake_vnew=3.31.6
 cmake_vold=${cmake_vnew}
 
 # OpenMPI
@@ -48,9 +48,9 @@ boost_vold=1.79.0 # Released 2022-04-13
 
 # Python
 # Use a single version to reduce dependencies. Ideally the spack prefered version.
-python_version=3.13.1
+python_version=3.13.2
 
-numpy_vnew=2.2.2
-numpy_vold=2.2.2
+numpy_vnew=2.2.4
+numpy_vold=2.2.4
 #numpy_vold=1.26.4
 


### PR DESCRIPTION
## Proposed changes

Latest version of nightlies.

Add a asan build. Will adjust over time, but the intent is to run at least all the short tests in at least one build configuration.

The RMGDFT spack package is modified to allow recent boost.

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

sulfur

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
