### PR TITLE
Separate `DeviceAllocator`

### DIFF
--- a/src/Platforms/DeviceAllocator.hpp
+++ b/src/Platforms/DeviceAllocator.hpp
@@ -1,0 +1,51 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2025 QMCPACK developers.
+//
+// File developed by: Youngjun Lee, leey@anl.gov, Argonne National Laboratory
+//
+// File created by: Youngjun Lee, leey@anl.gov, Argonne National Laboratory
+//
+//////////////////////////////////////////////////////////////////////////////////////
+// -*- C++ -*-
+/** @file
+ *  This file provides a generic interface for device allocators
+ *  that can be used with different accelerator backends (CUDA, SYCL, OMPTarget).
+ */
+
+#ifndef QMCPLUSPLUS_DEVICE_ALLOCATOR_ALIASES_HPP
+#define QMCPLUSPLUS_DEVICE_ALLOCATOR_ALIASES_HPP
+
+#if (defined(ENABLE_CUDA) || defined(ENABLE_SYCL)) && !defined(ENABLE_OFFLOAD)
+
+#if defined(ENABLE_CUDA)
+#include "CUDA/CUDAallocator.hpp"
+namespace qmcplusplus
+{
+  template<typename T>
+  using DeviceAllocator = CUDAAllocator<T>;
+}
+#elif defined(ENABLE_SYCL)
+#include "SYCL/SYCLallocator.hpp"
+namespace qmcplusplus
+{
+  template<typename T>
+  using DeviceAllocator = SYCLAllocator<T>;
+}
+#else
+#error unhandled platform
+#endif
+
+#else // ENABLE_OFFLOAD or no CUDA or SYCL
+
+#include "OMPTarget/OffloadAlignedAllocators.hpp"
+namespace qmcplusplus
+{
+  template<typename T>
+  using DeviceAllocator = OffloadDeviceAllocator<T>;
+}
+#endif
+
+#endif

--- a/src/Platforms/DeviceAllocator.hpp
+++ b/src/Platforms/DeviceAllocator.hpp
@@ -15,8 +15,8 @@
  *  that can be used with different accelerator backends (CUDA, SYCL, OMPTarget).
  */
 
-#ifndef QMCPLUSPLUS_DEVICE_ALLOCATOR_ALIASES_HPP
-#define QMCPLUSPLUS_DEVICE_ALLOCATOR_ALIASES_HPP
+#ifndef QMCPLUSPLUS_DEVICEALLOCATOR_HPP
+#define QMCPLUSPLUS_DEVICEALLOCATOR_HPP
 
 #if (defined(ENABLE_CUDA) || defined(ENABLE_SYCL)) && !defined(ENABLE_OFFLOAD)
 

--- a/src/Platforms/DeviceAllocator.hpp
+++ b/src/Platforms/DeviceAllocator.hpp
@@ -18,22 +18,26 @@
 #ifndef QMCPLUSPLUS_DEVICEALLOCATOR_HPP
 #define QMCPLUSPLUS_DEVICEALLOCATOR_HPP
 
+#include <config.h>
+
 #if (defined(ENABLE_CUDA) || defined(ENABLE_SYCL)) && !defined(ENABLE_OFFLOAD)
 
 #if defined(ENABLE_CUDA)
 #include "CUDA/CUDAallocator.hpp"
 namespace qmcplusplus
 {
-  template<typename T>
-  using DeviceAllocator = CUDAAllocator<T>;
+template<typename T>
+using DeviceAllocator = CUDAAllocator<T>;
 }
+
 #elif defined(ENABLE_SYCL)
 #include "SYCL/SYCLallocator.hpp"
 namespace qmcplusplus
 {
-  template<typename T>
-  using DeviceAllocator = SYCLAllocator<T>;
+template<typename T>
+using DeviceAllocator = SYCLAllocator<T>;
 }
+
 #else
 #error unhandled platform
 #endif
@@ -43,8 +47,8 @@ namespace qmcplusplus
 #include "OMPTarget/OffloadAlignedAllocators.hpp"
 namespace qmcplusplus
 {
-  template<typename T>
-  using DeviceAllocator = OffloadDeviceAllocator<T>;
+template<typename T>
+using DeviceAllocator = OffloadDeviceAllocator<T>;
 }
 #endif
 

--- a/src/Platforms/DualAllocator.hpp
+++ b/src/Platforms/DualAllocator.hpp
@@ -21,11 +21,7 @@
 #include "config.h"
 #include "allocator_traits.hpp"
 #include "PinnedAllocator.h"
-#if defined(ENABLE_CUDA)
-#include "CUDA/CUDAallocator.hpp"
-#elif defined(ENABLE_SYCL)
-#include "SYCL/SYCLallocator.hpp"
-#endif
+#include "DeviceAllocator.hpp"
 
 namespace qmcplusplus
 {

--- a/src/Platforms/DualAllocator.hpp
+++ b/src/Platforms/DualAllocator.hpp
@@ -15,13 +15,9 @@
 #define QMCPLUSPLUS_DUAL_ALLOCATOR_H
 
 #include <memory>
-#include <type_traits>
 #include <atomic>
 #include <exception>
-#include "config.h"
 #include "allocator_traits.hpp"
-#include "PinnedAllocator.h"
-#include "DeviceAllocator.hpp"
 
 namespace qmcplusplus
 {

--- a/src/Platforms/DualAllocatorAliases.hpp
+++ b/src/Platforms/DualAllocatorAliases.hpp
@@ -4,7 +4,7 @@
 //
 // Copyright (c) 2021 QMCPACK developers.
 //
-// Filef developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
 //
 // File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
 //////////////////////////////////////////////////////////////////////////////////////
@@ -31,8 +31,6 @@ namespace qmcplusplus
   using UnpinnedDualAllocator = DualAllocator<T, CUDAAllocator<T>, aligned_allocator<T>>;
   template<typename T>
   using PinnedDualAllocator = DualAllocator<T, CUDAAllocator<T>, PinnedAlignedAllocator<T>>;
-  template<typename T>
-  using DeviceAllocator = CUDAAllocator<T>;
 }
 #elif defined(ENABLE_SYCL)
 namespace qmcplusplus
@@ -41,8 +39,6 @@ namespace qmcplusplus
   using UnpinnedDualAllocator = DualAllocator<T, SYCLAllocator<T>, aligned_allocator<T>>;
   template<typename T>
   using PinnedDualAllocator = DualAllocator<T, SYCLAllocator<T>, PinnedAlignedAllocator<T>>;
-  template<typename T>
-  using DeviceAllocator = SYCLAllocator<T>;
 }
 #else
 #error unhandled platform
@@ -56,8 +52,6 @@ namespace qmcplusplus
   using UnpinnedDualAllocator = OffloadAllocator<T>;
   template<typename T>
   using PinnedDualAllocator = OffloadPinnedAllocator<T>;
-  template<typename T>
-  using DeviceAllocator = OffloadDeviceAllocator<T>;
 }
 #endif
 

--- a/src/Platforms/DualAllocatorAliases.hpp
+++ b/src/Platforms/DualAllocatorAliases.hpp
@@ -21,25 +21,27 @@
 #ifndef QMCPLUSPLUS_DUAL_ALLOCATOR_ALIASES_HPP
 #define QMCPLUSPLUS_DUAL_ALLOCATOR_ALIASES_HPP
 
+#include <config.h>
+#include "DeviceAllocator.hpp"
 #include "PinnedAllocator.h"
 #if (defined(ENABLE_CUDA) || defined(ENABLE_SYCL)) && !defined(ENABLE_OFFLOAD)
 #include "DualAllocator.hpp"
 #if defined(ENABLE_CUDA)
 namespace qmcplusplus
 {
-  template<typename T>
-  using UnpinnedDualAllocator = DualAllocator<T, CUDAAllocator<T>, aligned_allocator<T>>;
-  template<typename T>
-  using PinnedDualAllocator = DualAllocator<T, CUDAAllocator<T>, PinnedAlignedAllocator<T>>;
-}
+template<typename T>
+using UnpinnedDualAllocator = DualAllocator<T, CUDAAllocator<T>, aligned_allocator<T>>;
+template<typename T>
+using PinnedDualAllocator = DualAllocator<T, CUDAAllocator<T>, PinnedAlignedAllocator<T>>;
+} // namespace qmcplusplus
 #elif defined(ENABLE_SYCL)
 namespace qmcplusplus
 {
-  template<typename T>
-  using UnpinnedDualAllocator = DualAllocator<T, SYCLAllocator<T>, aligned_allocator<T>>;
-  template<typename T>
-  using PinnedDualAllocator = DualAllocator<T, SYCLAllocator<T>, PinnedAlignedAllocator<T>>;
-}
+template<typename T>
+using UnpinnedDualAllocator = DualAllocator<T, SYCLAllocator<T>, aligned_allocator<T>>;
+template<typename T>
+using PinnedDualAllocator = DualAllocator<T, SYCLAllocator<T>, PinnedAlignedAllocator<T>>;
+} // namespace qmcplusplus
 #else
 #error unhandled platform
 #endif
@@ -48,11 +50,11 @@ namespace qmcplusplus
 #include "OMPTarget/OffloadAlignedAllocators.hpp"
 namespace qmcplusplus
 {
-  template<typename T>
-  using UnpinnedDualAllocator = OffloadAllocator<T>;
-  template<typename T>
-  using PinnedDualAllocator = OffloadPinnedAllocator<T>;
-}
+template<typename T>
+using UnpinnedDualAllocator = OffloadAllocator<T>;
+template<typename T>
+using PinnedDualAllocator = OffloadPinnedAllocator<T>;
+} // namespace qmcplusplus
 #endif
 
 #endif


### PR DESCRIPTION
## Proposed changes

Separating `DeviceAllocator` in a dedicated header from `DualAllocatorAlises.hpp` allows the other objects or files to include `DeviceAllocator` specifically.

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
