### PR TITLE
Utilities checkVector for vector of TinyVector, more strict C++ for simple parser

### DIFF
--- a/src/Utilities/SimpleParser.cpp
+++ b/src/Utilities/SimpleParser.cpp
@@ -27,7 +27,9 @@
 
 char* readLine(char* s, int max, std::istream& fp)
 {
-  char ch;
+  // not initializing this risks in undefined behavior in the case of empty input since
+  // anything including \n or ; could be in this.
+  char ch = '\0';
   int i = 0;
   while (fp.get(ch) && !(ch == '\n' || ch == ';'))
   {

--- a/src/Utilities/SimpleParser.h
+++ b/src/Utilities/SimpleParser.h
@@ -26,6 +26,10 @@
 #include <list>
 #include <sstream>
 
+/** Legacy readLine function, this readline eats the \n and treats ; as \n
+ *  weird side effect if fp is empty and max > 0 then s[0] set to '\0'
+ *  plus some corner cases with line continuation character and \n or ; following
+ */
 char* readLine(char* s, int max, std::istream& fp);
 
 int getwords(std::vector<std::string>& slist, std::istream& fp, int dummy = 0, const std::string& extra_tokens = "");

--- a/src/Utilities/for_testing/CMakeLists.txt
+++ b/src/Utilities/for_testing/CMakeLists.txt
@@ -10,4 +10,4 @@
 set(test_utilities_src RandomForTest.cpp ApproximateEquality.cpp)
 add_library(utilities_for_test ${test_utilities_src})
 target_include_directories(utilities_for_test PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-target_link_libraries(utilities_for_test PRIVATE qmcutil qmc_external_catch2)
+target_link_libraries(utilities_for_test PRIVATE qmcutil qmc_external_catch2 containers)

--- a/src/Utilities/for_testing/checkVector.hpp
+++ b/src/Utilities/for_testing/checkVector.hpp
@@ -23,6 +23,7 @@
 #include <complex>
 #include <type_traits>
 #include <optional>
+#include "OhmmsPETE/TinyVector.h"
 #include "type_traits/complex_help.hpp"
 #include "ApproximateEquality.hpp"
 namespace qmcplusplus

--- a/src/Utilities/for_testing/checkVector.hpp
+++ b/src/Utilities/for_testing/checkVector.hpp
@@ -64,6 +64,33 @@ struct CheckVectorResult
  *  \param[in] eps       - add a tolerance for Catch Approx checks. Default to same as in Approx.
  *  The semantics of the return value are discussed above.
  */
+template<unsigned D>
+CheckVectorResult checkVector(const std::vector<TinyVector<int, D>>& a_vec,
+                              const std::vector<TinyVector<int, D>>& b_vec,
+                              const bool check_all = false)
+{
+  // This allows use to check a padded b matrix with a nonpadded a
+  if (a_vec.size() > b_vec.size())
+    return {false, "b_vec is too small for a_vec to be a checkable segment"};
+  std::stringstream result_msg;
+  auto vectorElementError = [&result_msg](int i, auto& a_vec, auto& b_vec) {
+    result_msg << "checkVector found bad element at " << i << "  " << a_vec[i] << " != " << b_vec[i] << '\n';
+  };
+  bool all_elements_match = true;
+  for (int i = 0; i < a_vec.size(); i++)
+  {
+    bool equality = a_vec[i] == b_vec[i];
+    if (!equality)
+    {
+      vectorElementError(i, a_vec, b_vec);
+      all_elements_match = false;
+      if (!check_all)
+        return {false, result_msg.str()};
+    }
+  }
+  return {all_elements_match, result_msg.str()};
+}
+
 template<class M1, class M2>
 CheckVectorResult checkVector(const M1& a_vec,
                               const M2& b_vec,

--- a/src/Utilities/tests/for_testing/test_checkVector.cpp
+++ b/src/Utilities/tests/for_testing/test_checkVector.cpp
@@ -71,4 +71,38 @@ TEST_CASE("checkVector_OhmmsVector_real", "[utilities][for_testing]")
   REQUIRE(check_vector_result.result == false);
 }
 
+// only test std::vector<TinyVector<int> because that is all that is used
+// or supported in the code.
+TEST_CASE("checkVector_TinyVector_int", "[utilities][for_testing]")
+{
+  std::vector<TinyVector<int,3>> a_vec;
+  a_vec.resize(3);
+  a_vec[0] = {1,2,3};
+  a_vec[1] = {4,5,6};
+  a_vec[2] = {7,8,9};
+
+  std::vector<TinyVector<int,3>> b_vec;
+  b_vec.resize(3);
+  b_vec[0] = {1,2,3};
+  b_vec[1] = {4,5,6};
+  b_vec[2] = {7,8,9};
+
+  auto check_vector_result = checkVector(a_vec, b_vec);
+  // This would be how you would fail and print the information about what element failed.
+  CHECKED_ELSE(check_vector_result.result) { FAIL(check_vector_result.result_message); }
+
+  b_vec.resize(4);
+  b_vec[0] = {1,2,3};
+  b_vec[1] = {4,5,6};
+  b_vec[2] = {7,8,9};
+
+  check_vector_result = checkVector(a_vec, b_vec);
+  CHECKED_ELSE(check_vector_result.result) { FAIL(check_vector_result.result_message); }
+
+  a_vec[0][0] = 2;
+  check_vector_result = checkVector(a_vec, b_vec);
+  CHECK(check_vector_result.result == false);
+}
+
+  
 } // namespace qmcplusplus

--- a/src/Utilities/tests/for_testing/test_checkVector.cpp
+++ b/src/Utilities/tests/for_testing/test_checkVector.cpp
@@ -10,7 +10,6 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 #include "catch.hpp"
-#include "OhmmsPETE/TinyVector.h"
 #include "checkVector.hpp"
 #include <iostream>
 #include <string>

--- a/src/Utilities/tests/for_testing/test_checkVector.cpp
+++ b/src/Utilities/tests/for_testing/test_checkVector.cpp
@@ -40,7 +40,7 @@ TEST_CASE("checkVector_OhmmsVector_real", "[utilities][for_testing]")
   CHECKED_ELSE(check_vector_result.result) { FAIL(check_vector_result.result_message); }
 
   //check with epsilon
-  b_vec[2] = 2.6005;
+  b_vec[2]            = 2.6005;
   check_vector_result = checkVector(a_vec, b_vec, false, 1e-4);
   REQUIRE(check_vector_result.result == false);
   check_vector_result = checkVector(a_vec, b_vec, false, 1e-3);
@@ -54,9 +54,9 @@ TEST_CASE("checkVector_OhmmsVector_real", "[utilities][for_testing]")
   check_vector_result = checkVector(a_vec, b_vec);
   CHECKED_ELSE(check_vector_result.result) { FAIL(check_vector_result.result_message); }
 
-  b_vec[0] = 1.0;
-  b_vec[1] = 3.6;
-  check_vector_result = checkVector(a_vec, b_vec, true);
+  b_vec[0]                   = 1.0;
+  b_vec[1]                   = 3.6;
+  check_vector_result        = checkVector(a_vec, b_vec, true);
   std::string::size_type pos = 0;
   int lines                  = 0;
   while (true)
@@ -75,34 +75,33 @@ TEST_CASE("checkVector_OhmmsVector_real", "[utilities][for_testing]")
 // or supported in the code.
 TEST_CASE("checkVector_TinyVector_int", "[utilities][for_testing]")
 {
-  std::vector<TinyVector<int,3>> a_vec;
+  std::vector<TinyVector<int, 3>> a_vec;
   a_vec.resize(3);
-  a_vec[0] = {1,2,3};
-  a_vec[1] = {4,5,6};
-  a_vec[2] = {7,8,9};
+  a_vec[0] = {1, 2, 3};
+  a_vec[1] = {4, 5, 6};
+  a_vec[2] = {7, 8, 9};
 
-  std::vector<TinyVector<int,3>> b_vec;
+  std::vector<TinyVector<int, 3>> b_vec;
   b_vec.resize(3);
-  b_vec[0] = {1,2,3};
-  b_vec[1] = {4,5,6};
-  b_vec[2] = {7,8,9};
+  b_vec[0] = {1, 2, 3};
+  b_vec[1] = {4, 5, 6};
+  b_vec[2] = {7, 8, 9};
 
   auto check_vector_result = checkVector(a_vec, b_vec);
   // This would be how you would fail and print the information about what element failed.
   CHECKED_ELSE(check_vector_result.result) { FAIL(check_vector_result.result_message); }
 
   b_vec.resize(4);
-  b_vec[0] = {1,2,3};
-  b_vec[1] = {4,5,6};
-  b_vec[2] = {7,8,9};
+  b_vec[0] = {1, 2, 3};
+  b_vec[1] = {4, 5, 6};
+  b_vec[2] = {7, 8, 9};
 
   check_vector_result = checkVector(a_vec, b_vec);
   CHECKED_ELSE(check_vector_result.result) { FAIL(check_vector_result.result_message); }
 
-  a_vec[0][0] = 2;
+  a_vec[0][0]         = 2;
   check_vector_result = checkVector(a_vec, b_vec);
   CHECK(check_vector_result.result == false);
 }
 
-  
 } // namespace qmcplusplus

--- a/src/Utilities/tests/for_testing/test_checkVector.cpp
+++ b/src/Utilities/tests/for_testing/test_checkVector.cpp
@@ -10,6 +10,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 #include "catch.hpp"
+#include "OhmmsPETE/TinyVector.h"
 #include "checkVector.hpp"
 #include <iostream>
 #include <string>

--- a/src/Utilities/tests/test_parser.cpp
+++ b/src/Utilities/tests/test_parser.cpp
@@ -109,7 +109,6 @@ TEST_CASE("readLine", "[utilities]")
       {"12345678901234567890extra", {"1234567890123456789"}}, // assuming bufLen=20 below
   };
 
-
   for (auto& tc : tlist)
   {
     SECTION(string("Parsing string: ") + tc.input)
@@ -123,14 +122,62 @@ TEST_CASE("readLine", "[utilities]")
         REQUIRE(buf == tc.output[i]);
         if (i == tc.output.size() - 1)
         {
-          REQUIRE(out == NULL);
+          REQUIRE(out == nullptr);
         }
         else
         {
-          REQUIRE(out != NULL);
+          REQUIRE(out != nullptr);
         }
       }
     }
+  }
+
+  SECTION("empty input legacy side effect")
+  {
+    char buf[1];
+    buf[0] = '\n';
+    std::istringstream input;
+    char* out = readLine(buf, 1, input);
+    CHECK(out == nullptr);
+    CHECK(buf[0] == '\0');
+  }
+
+  SECTION("line continuation character corner cases")
+  {
+    {
+      char buf[1];
+      buf[0] = '\n';
+      std::istringstream input{"\\"};
+      char* out = readLine(buf, 1, input);
+      CHECK(out == nullptr);
+      CHECK(buf[0] == '\0');
+    }
+    {
+      char buf[2];
+      buf[0] = '\n';
+      std::istringstream input{"\\\n"};
+      char* out = readLine(buf, 2, input);
+      CHECK(out == buf);
+      CHECK(buf[0] == '\0');
+    }
+    {
+      char buf[2];
+      buf[0] = '\n';
+      std::istringstream input{"\\;"};
+      char* out = readLine(buf, 2, input);
+      CHECK(out == buf);
+      CHECK(buf[0] == '\\');
+      CHECK(buf[1] == '\0');
+    }
+  }
+  SECTION("semicolon corner case")
+  {
+    char buf[2];
+    buf[0] = '\n';
+    std::istringstream input{";"};
+    char* out = readLine(buf, 2, input);
+    CHECK(out == buf);
+    CHECK(buf[0] == '\0');
   }
 }
 


### PR DESCRIPTION
## Proposed changes

Utilities checkVector for vector of TinyVector, more strict C++ for simple parser.  NULL and nullptr aren't the same thing even if they are often represent as such, some compilers/runtimes can call foul.  Get won't put anything in char if stream is empty so that also can be bad. 

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- New feature
- Other (please describe):

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
