### PR TITLE
Change Kshell sorting precision to full precision

### DIFF
--- a/src/Particle/LongRange/KContainer.cpp
+++ b/src/Particle/LongRange/KContainer.cpp
@@ -106,8 +106,6 @@ void KContainer::BuildKLists(const ParticleLayout& lattice, const PosType& twist
 {
   TinyVector<int, DIM + 1> TempActualMax;
   TinyVector<int, DIM> kvec;
-  TinyVector<RealType, DIM> kvec_cart;
-  RealType modk2;
   std::vector<TinyVector<int, DIM>> kpts_tmp;
   std::vector<PosType> kpts_cart_tmp;
   std::vector<RealType> ksq_tmp;
@@ -129,9 +127,9 @@ void KContainer::BuildKLists(const ParticleLayout& lattice, const PosType& twist
           if (i == 0 && j == 0 && k == 0)
             continue;
           //Convert kvec to Cartesian
-          kvec_cart = lattice.k_cart(kvec + twist);
+          auto kvec_cart = lattice.k_cart(kvec + twist);
           //Find modk
-          modk2 = dot(kvec_cart, kvec_cart);
+          const auto modk2 = dot(kvec_cart, kvec_cart);
           if (modk2 > kcut2)
             continue; //Inside cutoff?
           //This k-point should be added to the list
@@ -171,8 +169,8 @@ void KContainer::BuildKLists(const ParticleLayout& lattice, const PosType& twist
           if (kvec[2] > mmax[2])
             kvec[2] -= kdimsize;
           // get cartesian location and modk2
-          kvec_cart = lattice.k_cart(kvec);
-          modk2     = dot(kvec_cart, kvec_cart);
+          auto kvec_cart   = lattice.k_cart(kvec);
+          const auto modk2 = dot(kvec_cart, kvec_cart);
           // add k-point to lists
           kpts_tmp.push_back(kvec);
           kpts_cart_tmp.push_back(kvec_cart);

--- a/src/Particle/LongRange/tests/test_ewald3d.cpp
+++ b/src/Particle/LongRange/tests/test_ewald3d.cpp
@@ -45,9 +45,8 @@ TEST_CASE("ewald3d", "[lrhandler]")
   handler.initBreakup(ref);
   CHECK(handler.Sigma == Approx(std::sqrt(lattice.LR_kc / (2.0 * lattice.LR_rc))));
 
-  std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
-  CHECK( (std::is_same<OHMMS_PRECISION, OHMMS_PRECISION_FULL>::value ?
-     handler.MaxKshell == 78 : handler.MaxKshell >= 117 && handler.MaxKshell <= 128 ));
+  app_log() << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
+  CHECK(handler.MaxKshell == 78);
   CHECK(handler.LR_rc == Approx(2.5));
   CHECK(handler.LR_kc == Approx(12));
 
@@ -94,9 +93,8 @@ TEST_CASE("ewald3d df", "[lrhandler]")
   handler.initBreakup(ref);
   CHECK(handler.Sigma == Approx(std::sqrt(lattice.LR_kc / (2.0 * lattice.LR_rc))));
 
-  std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
-  CHECK( (std::is_same<OHMMS_PRECISION, OHMMS_PRECISION_FULL>::value ?
-     handler.MaxKshell == 78 : handler.MaxKshell >= 117 && handler.MaxKshell <= 128 ));
+  app_log() << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
+  CHECK(handler.MaxKshell == 78);
   CHECK(handler.LR_rc == Approx(2.5));
   CHECK(handler.LR_kc == Approx(12));
 

--- a/src/Particle/LongRange/tests/test_lrhandler.cpp
+++ b/src/Particle/LongRange/tests/test_lrhandler.cpp
@@ -47,9 +47,8 @@ TEST_CASE("dummy", "[lrhandler]")
 
   handler.initBreakup(ref);
 
-  std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
-  CHECK( (std::is_same<OHMMS_PRECISION, OHMMS_PRECISION_FULL>::value ?
-     handler.MaxKshell == 78 : handler.MaxKshell >= 117 && handler.MaxKshell <= 128 ));
+  app_log() << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
+  CHECK(handler.MaxKshell == 78);
   CHECK(handler.LR_kc == Approx(12));
   CHECK(handler.LR_rc == Approx(0));
 

--- a/src/Particle/LongRange/tests/test_srcoul.cpp
+++ b/src/Particle/LongRange/tests/test_srcoul.cpp
@@ -53,9 +53,8 @@ TEST_CASE("srcoul", "[lrhandler]")
 
   handler.initBreakup(ref);
 
-  std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
-  CHECK( (std::is_same<OHMMS_PRECISION, OHMMS_PRECISION_FULL>::value ?
-     handler.MaxKshell == 78 : handler.MaxKshell >= 117 && handler.MaxKshell <= 128 ));
+  app_log() << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
+  CHECK(handler.MaxKshell == 78);
   CHECK(Approx(handler.LR_rc) == 2.5);
   CHECK(Approx(handler.LR_kc) == 12);
 
@@ -98,9 +97,8 @@ TEST_CASE("srcoul df", "[lrhandler]")
 
   handler.initBreakup(ref);
 
-  std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
-  CHECK( (std::is_same<OHMMS_PRECISION, OHMMS_PRECISION_FULL>::value ?
-     handler.MaxKshell == 78 : handler.MaxKshell >= 117 && handler.MaxKshell <= 128 ));
+  app_log() << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
+  CHECK(handler.MaxKshell == 78);
   CHECK(Approx(handler.LR_rc) == 2.5);
   CHECK(Approx(handler.LR_kc) == 12);
 

--- a/src/Particle/LongRange/tests/test_temp.cpp
+++ b/src/Particle/LongRange/tests/test_temp.cpp
@@ -54,9 +54,8 @@ TEST_CASE("temp3d", "[lrhandler]")
 
   handler.initBreakup(ref);
 
-  std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
-  CHECK( (std::is_same<OHMMS_PRECISION, OHMMS_PRECISION_FULL>::value ?
-     handler.MaxKshell == 78 : handler.MaxKshell >= 117 && handler.MaxKshell <= 128 ));
+  app_log() << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
+  CHECK(handler.MaxKshell == 78);
   CHECK(Approx(handler.LR_rc) == 2.5);
   CHECK(Approx(handler.LR_kc) == 12);
 


### PR DESCRIPTION
## Proposed changes
Having `modk2` in full precision seems fixing kshell counting issue.
fixes #5384

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-serer

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'