### PR TITLE
Update CMake/IntelDPCPPConfig-modified.cmake for oneapi 2025.1

### DIFF
--- a/CMake/IntelDPCPPConfig-modified.cmake
+++ b/CMake/IntelDPCPPConfig-modified.cmake
@@ -207,7 +207,7 @@ if(SYCL_COMPILER)
   # Find Include path from binary
   find_path(SYCL_INCLUDE_DIR
     NAMES
-      CL/sycl.hpp
+      sycl.hpp
     HINTS
       ${SYCL_PACKAGE_DIR}/include/sycl
     NO_DEFAULT_PATH


### PR DESCRIPTION
## Proposed changes
CL/sycl.hpp has been deprecated long time ago.
A fix for oneapi 2025.1

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'