### PR TITLE
Consolidate header file inclusion

### DIFF
--- a/src/Containers/tests/test_dual_allocators_ohmms_containers.cpp
+++ b/src/Containers/tests/test_dual_allocators_ohmms_containers.cpp
@@ -13,8 +13,7 @@
 
 #include <algorithm>
 #include "config.h"
-#include "PinnedAllocator.h"
-#include "OMPTarget/OMPallocator.hpp"
+#include "OMPTarget/OffloadAlignedAllocators.hpp"
 #if defined(ENABLE_CUDA) || defined(ENABLE_SYCL)
 #include <DualAllocatorAliases.hpp>
 #endif
@@ -27,10 +26,6 @@
 
 namespace qmcplusplus
 {
-// This naming is pretty bad but consistent with the naming over much of the code
-// its defined locally all over the place.
-template<typename T>
-using OffloadPinnedAllocator = OMPallocator<T, PinnedAlignedAllocator<T>>;
 #if defined(ENABLE_CUDA) || defined(ENABLE_SYCL)
 template<typename T>
 using VendorDualPinnedAllocator = PinnedDualAllocator<T>;

--- a/src/Particle/RealSpacePositionsOMPTarget.h
+++ b/src/Particle/RealSpacePositionsOMPTarget.h
@@ -17,8 +17,7 @@
 
 #include "Particle/DynamicCoordinates.h"
 #include "OhmmsSoA/VectorSoaContainer.h"
-#include "OMPTarget/OMPallocator.hpp"
-#include "Platforms/PinnedAllocator.h"
+#include "OMPTarget/OffloadAlignedAllocators.hpp"
 #include "ParticleSet.h"
 #include "ResourceCollection.h"
 
@@ -213,19 +212,19 @@ public:
 
 private:
   ///particle positions in SoA layout
-  VectorSoaContainer<RealType, QMCTraits::DIM, OMPallocator<RealType, PinnedAlignedAllocator<RealType>>> RSoA;
+  VectorSoaContainer<RealType, QMCTraits::DIM, OffloadPinnedAllocator<RealType>> RSoA;
 
   ///multi walker shared memory buffer
   struct MultiWalkerMem : public Resource
   {
     ///one particle new/old positions in SoA layout
-    VectorSoaContainer<RealType, QMCTraits::DIM, OMPallocator<RealType, PinnedAlignedAllocator<RealType>>> mw_new_pos;
+    VectorSoaContainer<RealType, QMCTraits::DIM, OffloadPinnedAllocator<RealType>> mw_new_pos;
 
     /// accept list
-    Vector<int, OMPallocator<int, PinnedAlignedAllocator<int>>> mw_accept_indices;
+    Vector<int, OffloadPinnedAllocator<int>> mw_accept_indices;
 
     /// RSoA device ptr list
-    Vector<RealType*, OMPallocator<RealType*, PinnedAlignedAllocator<RealType*>>> mw_rsoa_ptrs;
+    Vector<RealType*, OffloadPinnedAllocator<RealType*>> mw_rsoa_ptrs;
 
     MultiWalkerMem() : Resource("MultiWalkerMem") {}
 

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -16,8 +16,7 @@
 
 #include "Lattice/ParticleBConds3DSoa.h"
 #include "DistanceTable.h"
-#include "OMPTarget/OMPallocator.hpp"
-#include "Platforms/PinnedAllocator.h"
+#include "OMPTarget/OffloadAlignedAllocators.hpp"
 #include "Particle/RealSpacePositionsOMPTarget.h"
 #include "ResourceCollection.h"
 #include "OMPTarget/OMPTargetMath.hpp"
@@ -30,9 +29,11 @@ namespace qmcplusplus
 template<typename T, unsigned D, int SC>
 struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public DistanceTableAA
 {
+  template<typename DT>
+  using OffloadPinnedVector = Vector<DT, OffloadPinnedAllocator<DT>>;
+
   /// actual memory for dist and displacements_
   aligned_vector<RealType> memory_pool_;
-
   /// actual memory for temp_r_
   DistRow temp_r_mem_;
   /// actual memory for temp_dr_
@@ -46,14 +47,14 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   struct DTAAMultiWalkerMem : public Resource
   {
     ///dist displ for temporary and old pairs
-    Vector<RealType, OMPallocator<RealType, PinnedAlignedAllocator<RealType>>> mw_new_old_dist_displ;
+    OffloadPinnedVector<RealType> mw_new_old_dist_displ;
 
     /** distances from a range of indics to the source.
      * for original particle index i (row) and source particle id j (col)
      * j < i,  the element data is dist(r_i - r_j)
      * j > i,  the element data is dist(r_(n - 1 - i) - r_(n - 1 - j))
      */
-    Vector<RealType, OMPallocator<RealType, PinnedAlignedAllocator<RealType>>> mw_distances_subset;
+    OffloadPinnedVector<RealType> mw_distances_subset;
 
     DTAAMultiWalkerMem() : Resource("DTAAMultiWalkerMem") {}
 

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -16,8 +16,7 @@
 
 #include "Lattice/ParticleBConds3DSoa.h"
 #include "DistanceTable.h"
-#include "OMPTarget/OMPallocator.hpp"
-#include "Platforms/PinnedAllocator.h"
+#include "OMPTarget/OffloadAlignedAllocators.hpp"
 #include "Particle/RealSpacePositionsOMPTarget.h"
 #include "ResourceCollection.h"
 #include "OMPTarget/OMPTargetMath.hpp"
@@ -32,7 +31,7 @@ class SoaDistanceTableABOMPTarget : public DTD_BConds<T, D, SC>, public Distance
 {
 private:
   template<typename DT>
-  using OffloadPinnedVector = Vector<DT, OMPallocator<DT, PinnedAlignedAllocator<DT>>>;
+  using OffloadPinnedVector = Vector<DT, OffloadPinnedAllocator<DT>>;
 
   ///accelerator output buffer for r and dr
   OffloadPinnedVector<RealType> r_dr_memorypool_;

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
@@ -19,7 +19,6 @@
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #include "QMCWaveFunctions/Fermion/MultiDiracDeterminant.h"
 #include "Utilities/TimerManager.h"
-#include "Platforms/PinnedAllocator.h"
 #include "OMPTarget/OffloadAlignedAllocators.hpp"
 #include "ResourceCollection.h"
 

--- a/src/QMCWaveFunctions/tests/test_DiracMatrixInverterOMPTarget.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracMatrixInverterOMPTarget.cpp
@@ -21,7 +21,7 @@
 #include "Utilities/Resource.h"
 #include "Utilities/for_testing/checkMatrix.hpp"
 #include "Utilities/for_testing/RandomForTest.h"
-#include "Platforms/PinnedAllocator.h"
+#include "OMPTarget/OffloadAlignedAllocators.hpp"
 
 // Legacy CPU inversion for temporary testing
 #include "QMCWaveFunctions/Fermion/DiracMatrix.h"
@@ -29,9 +29,6 @@
 
 namespace qmcplusplus
 {
-template<typename T>
-using OffloadPinnedAllocator = OMPallocator<T, PinnedAlignedAllocator<T>>;
-
 template<typename T>
 using OffloadPinnedMatrix = Matrix<T, OffloadPinnedAllocator<T>>;
 template<typename T>


### PR DESCRIPTION
## Proposed changes
Only use `OMPTarget/OffloadAlignedAllocators.hpp` outside platforms.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'