### PR TITLE
Nexus: QE HDF5 charge density results support

### DIFF
--- a/nexus/lib/pwscf.py
+++ b/nexus/lib/pwscf.py
@@ -184,8 +184,18 @@ class Pwscf(Simulation):
         if result_name=='charge_density' or result_name=='restart':
             result.locdir   = self.locdir
             result.outdir   = os.path.join(self.locdir,outdir)
-            result.location = os.path.join(self.locdir,outdir,prefix+'.save','charge-density.dat')
-            result.spin_location = os.path.join(self.locdir,outdir,prefix+'.save','spin-polarization.dat')
+            result_save_outdir = os.path.join(self.locdir,outdir,prefix+'.save')
+            if os.path.exists(os.path.join(result_save_outdir,'charge-density.hdf5')):
+                result.location = os.path.join(result_save_outdir,'charge-density.hdf5')
+                chg_dens_format = 'hdf5'
+            else:
+                result.location = os.path.join(result_save_outdir,'charge-density.dat')
+                chg_dens_format = 'dat'
+            
+            if chg_dens_format == 'dat':
+                result.spin_location = os.path.join(result_save_outdir,'spin-polarization.dat')
+            elif chg_dens_format == 'hdf5':
+                result.spin_location = None
         elif result_name=='orbitals':
             result.location = os.path.join(self.locdir,outdir,prefix+'.wfc1')
         elif result_name=='structure':
@@ -243,15 +253,23 @@ class Pwscf(Simulation):
                 cd_loc = result.location
                 cd_rel = os.path.relpath(cd_loc,link_loc)
                 sp_loc = result.spin_location
-                sp_rel = os.path.relpath(sp_loc,link_loc)
+
                 cwd = os.getcwd()
                 if not os.path.exists(link_loc):
                     os.makedirs(link_loc)
                 #end if
+
                 os.chdir(link_loc)
-                os.system('ln -s '+cd_rel+' charge-density.dat')
-                os.system('ln -s '+sp_rel+' spin-polarization.dat')
+                if cd_rel.endswith('charge-density.hdf5'):
+                    os.system('ln -s '+cd_rel+' charge-density.hdf5')
+                elif cd_rel.endswith('charge-density.dat'):
+                    sp_rel = os.path.relpath(sp_loc,link_loc)
+                    os.system('ln -s '+cd_rel+' charge-density.dat')
+                    os.system('ln -s '+sp_rel+' spin-polarization.dat')
+                else:
+                    raise FileNotFoundError('charge-density.dat or charge-density.hdf5 not found in {0}'.format(result_save_outdir))
                 os.chdir(cwd)
+
             #end if
         elif result_name=='structure':
             relstruct = result.structure.copy()


### PR DESCRIPTION
When QE is installed with HDF5 support(default to compile pw2qmcpack.x), instead of the charge-density.dat and spin-polarization.dat files, a single charge_density.hdf5 file is produced. Currently Nexus does not support transferring results between simulation objects with hdf5 extensions. 

I have noticed that while creating these softlinks, Nexus does not actually check if the .dat file exists in the reference directory. I initially tried implementing these checks, but it broke several tests. New code checks if there is a charge-density.hdf5 file in the reference directory, if not then assumes there is a .dat file (which is the current behavior). 

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No. Passes all tests in nxs-test.

## What systems has this change been tested on?
Python 3.12.8

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
