### PR TITLE
Nexus: Fix spglib compatibility

### DIFF
--- a/nexus/lib/structure.py
+++ b/nexus/lib/structure.py
@@ -5199,7 +5199,14 @@ class Structure(Sobj):
 
     def symmetry_data(self,*args,**kwargs):
         ds = self.get_symmetry_dataset(*args,**kwargs)
-        ds = obj(ds)
+        if isinstance(ds,dict):
+            # Spglib version < v.2.5.0, see https://spglib.readthedocs.io/en/stable/releases.html
+            ds = obj(ds)
+        elif isinstance(ds,spglib.SpglibDataset):
+            # Spglib version >= v.2.5.0
+            ds = obj(ds.__dict__)
+        else:
+            raise TypeError('Invalid symmetry dataset type: {}'.format(type(ds)))
         for k,v in ds.items():
             if isinstance(v,dict):
                 ds[k] = obj(v)


### PR DESCRIPTION
Starting with v2.5.0 SPGLIB returns using SpglibDataset type from get_symmetry_dataset function, rather than using native dictionary. Current PR does type checking to transfer that information to Nexus and preserves compatibility. 

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?

- No: All tests in nxs-test pass. I downgraded spglib to 2.4.0 and upgraded to 2.6.0 then ran the tests after each case. 

## What systems has this change been tested on?
Python 3.12.8

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
