### PR TITLE
Address statistical failures in short-chn_ae_cuspCorrection-vmc-1-16-kinetic 

### DIFF
--- a/tests/molecules/CHN_ae/CMakeLists.txt
+++ b/tests/molecules/CHN_ae/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT QMC_COMPLEX)
   #   "eeenergy" " 55.2876 0.0013") # e-e energy
   #   "samples" "409600000 0") # samples
 
-  list(APPEND CHN_SHORT "kinetic" "93.179 0.85") # kinetic energy
+  list(APPEND CHN_SHORT "kinetic" "93.179 0.95") # kinetic energy
   list(APPEND CHN_SHORT "totenergy" "-93.33934 0.01") # total energy
   list(APPEND CHN_SHORT "eeenergy" "55.2876 0.06") # e-e energy
   list(APPEND CHN_SHORT "samples" "160000 0.0") # samples


### PR DESCRIPTION
## Proposed changes

Fix a few statistical failures https://cdash.qmcpack.org/testSummary.php?project=1&name=short-chn_ae_cuspCorrection-vmc-1-16-kinetic&date=2025-04-11

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None

## Checklist

- [X] I have read the pull request guidance and develop docs
- [X] This PR is up to date with current the current state of 'develop'
- [ ] Code added or changed in the PR has been clang-formatted
- [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] Documentation has been added (if appropriate)
