### PR TITLE
Bypass tasklist feature in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,8 +32,8 @@ _Delete the items that do not apply_
 _Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
 simply a reminder of what we are going to look for before merging your code._
 
-- [ ] I have read the pull request guidance and develop docs
-- [ ] This PR is up to date with current the current state of 'develop'
-- [ ] Code added or changed in the PR has been clang-formatted
-- [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
-- [ ] Documentation has been added (if appropriate)
+* * [ ] I have read the pull request guidance and develop docs
+* * [ ] This PR is up to date with current the current state of 'develop'
+* * [ ] Code added or changed in the PR has been clang-formatted
+* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
+* * [ ] Documentation has been added (if appropriate)


### PR DESCRIPTION
## Proposed changes

Attempt to avoid tasklist feature that shows "N of 5" tasks complete for items that are not a list of tasks to be completed

Preview on GitHub shows bulleted list with check boxes

## What type(s) of changes does this code introduce?

- Bugfix
- Documentation or build script changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None.

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [X] I have read the pull request guidance and develop docs
- [X] This PR is up to date with current the current state of 'develop'
- [ ] Code added or changed in the PR has been clang-formatted
- [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] Documentation has been added (if appropriate)
