### PR TITLE
Fix RNG copy assign operator

### DIFF
--- a/src/Utilities/FakeRandom.cpp
+++ b/src/Utilities/FakeRandom.cpp
@@ -29,6 +29,12 @@ T FakeRandom<T>::operator()()
   return m_val;
 }
 
+template<typename T>
+RandomBase<T>& FakeRandom<T>::operator=(const RandomBase<T>& other)
+{
+  return *this = dynamic_cast<const FakeRandom<T>&>(other);
+}
+
 template class FakeRandom<float>;
 template class FakeRandom<double>;
 

--- a/src/Utilities/FakeRandom.h
+++ b/src/Utilities/FakeRandom.h
@@ -37,6 +37,7 @@ public:
   void save(std::vector<uint_type>& curstate) const override{};
   size_t state_size() const override { return 0; };
   std::unique_ptr<RandomBase<T>> makeClone() const override { return std::make_unique<FakeRandom<T>>(*this); }
+  RandomBase<T>& operator=(const RandomBase<T>& other) override;
 
   void set_value(double val);
 

--- a/src/Utilities/RandomBase.h
+++ b/src/Utilities/RandomBase.h
@@ -36,6 +36,11 @@ public:
   virtual void save(std::vector<uint_type>& curstate) const = 0;
   virtual size_t state_size() const                         = 0;
   virtual std::unique_ptr<RandomBase<T>> makeClone() const  = 0;
+  virtual RandomBase& operator=(const RandomBase& other) { return *this; }
+
+protected:
+  RandomBase() = default;
+  RandomBase(const RandomBase&) = default;
 };
 
 } // namespace qmcplusplus

--- a/src/Utilities/StdRandom.cpp
+++ b/src/Utilities/StdRandom.cpp
@@ -51,6 +51,12 @@ typename StdRandom<T>::result_type StdRandom<T>::operator()()
   return distribution(engine);
 }
 
+template<typename T>
+RandomBase<T>& StdRandom<T>::operator=(const RandomBase<T>& other)
+{
+  return *this = dynamic_cast<const StdRandom<T>&>(other);
+}
+
 template class StdRandom<double>;
 template class StdRandom<float>;
 } // namespace qmcplusplus

--- a/src/Utilities/StdRandom.h
+++ b/src/Utilities/StdRandom.h
@@ -43,7 +43,8 @@ public:
   result_type operator()(RNG& eng)
   {
     return static_cast<result_type>(eng() - eng.min()) / (static_cast<result_type>(eng.max() - eng.min()) + 1) *
-        (max_ - min_) + min_;
+        (max_ - min_) +
+        min_;
   }
 
 private:
@@ -76,6 +77,7 @@ public:
   void load(const std::vector<uint_type>& newstate) override;
   void save(std::vector<uint_type>& curstate) const override;
   std::unique_ptr<RandomBase<T>> makeClone() const override { return std::make_unique<StdRandom<T>>(*this); }
+  RandomBase<T>& operator=(const RandomBase<T>& other) override;
 
   // Non const allows use of default copy constructor
   std::string ClassName{"StdRand"};

--- a/src/Utilities/tests/test_FakeRandom.cpp
+++ b/src/Utilities/tests/test_FakeRandom.cpp
@@ -92,6 +92,17 @@ TEST_CASE("FakeRandom clone", "[utilities]")
 
   for (auto i = 0; i < 3; ++i)
     CHECK((*rng2)() == rng());
+
+  DoubleRNG rng3;
+  RandomBase<double>& a3 = rng3;
+  RandomBase<double>& a  = rng;
+
+  a3 = a;
+
+  rng.write(stream1);
+  rng3.write(stream2);
+  CHECK(stream1.str() == stream2.str());
+  CHECK(rng3() == rng());
 }
 
 } // namespace qmcplusplus

--- a/src/Utilities/tests/test_StdRandom.cpp
+++ b/src/Utilities/tests/test_StdRandom.cpp
@@ -37,8 +37,8 @@ TEST_CASE("StdRandom save and load", "[utilities]")
 
   rng.init(111);
 
-  std::vector<double> rng_doubles(100,0.0);
-  for(auto& elem : rng_doubles)
+  std::vector<double> rng_doubles(100, 0.0);
+  for (auto& elem : rng_doubles)
     elem = rng();
 
   std::vector<DoubleRNG::uint_type> state;
@@ -84,6 +84,17 @@ TEST_CASE("StdRandom clone", "[utilities]")
 
   CHECK((*rng2)() == rng());
   CHECK((*rng2)() == rng());
+
+  DoubleRNG rng3;
+  RandomBase<double>& a3 = rng3;
+  RandomBase<double>& a  = rng;
+
+  a3 = a;
+
+  rng.write(stream1);
+  rng3.write(stream2);
+  CHECK(stream1.str() == stream2.str());
+  CHECK(rng3() == rng());
 }
 
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes
In https://github.com/QMCPACK/qmcpack/pull/4650, the copy assign operator wasn't implemented properly.
It caused misbehaving https://github.com/QMCPACK/qmcpack/blob/a5ad8e09d8d38d506cb2f806ffd89690d9ed6fa1/src/QMCDrivers/WFOpt/QMCCostFunction.cpp#L520
when invoked via base classes.
Only legacy driver got affected, batched driver didn't due to not using `MoverRng` but its full clones.
This issue got surfaced when investigating the failure of #5435.

## What type(s) of changes does this code introduce?
- Bugfix
### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with current the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
