### PR TITLE
Bypass calls to Cost() in wavefunction optimization. Avoid derivative computation and excessive printout in finite difference

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -52,24 +52,30 @@ void QMCCostFunctionBatched::GradCost(std::vector<Return_rt>& PGradient,
                                       const std::vector<Return_rt>& PM,
                                       Return_rt FiniteDiff)
 {
+  for (int j = 0; j < NumOptimizables; j++)
+    OptVariables[j] = PM[j];
   if (FiniteDiff > 0)
   {
     QMCTraits::RealType dh = 1.0 / (2.0 * FiniteDiff);
     for (int i = 0; i < NumOptimizables; i++)
     {
-      for (int j = 0; j < NumOptimizables; j++)
-        OptVariables[j] = PM[j];
-      OptVariables[i]               = PM[i] + FiniteDiff;
-      QMCTraits::RealType CostPlus  = this->Cost();
-      OptVariables[i]               = PM[i] - FiniteDiff;
-      QMCTraits::RealType CostMinus = this->Cost();
-      PGradient[i]                  = (CostPlus - CostMinus) * dh;
+      // + FiniteDiff
+      OptVariables[i] = PM[i] + FiniteDiff;
+      resetPsi();
+      correlatedSampling(false);
+      auto CostPlus = computedCost();
+      // - FiniteDiff
+      OptVariables[i] = PM[i] - FiniteDiff;
+      resetPsi();
+      correlatedSampling(false);
+      auto CostMinus = computedCost();
+      // calculate gradient
+      PGradient[i]    = (CostPlus - CostMinus) * dh;
+      OptVariables[i] = PM[i]; // revert parameter change
     }
   }
   else
   {
-    for (int j = 0; j < NumOptimizables; j++)
-      OptVariables[j] = PM[j];
     resetPsi();
     //evaluate new local energies and derivatives
     EffectiveWeight effective_weight = correlatedSampling(true);


### PR DESCRIPTION
## Proposed changes
Should make GradientTest faster.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with current the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
