### PR TITLE
Forgotten call to mw_evaluateV_multiCenter (did not propagate from my branch leading to 62% slowdown compared to my branch)

### DIFF
--- a/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.cpp
@@ -424,7 +424,6 @@ void SoaLocalizedBasisSet<COT, ORBT>::mw_evaluateValueVPs(const RefVectorWithLea
     local_offsets[s_id].push_back(BasisOffset[c]);
   }
 
-  ///Should be done only once at Begining of simulation and made available. 
   using PinnedVecSizeT = Vector<size_t, OffloadPinnedAllocator<size_t>>;
   std::vector<PinnedVecSizeT> species_centers(num_species_);
   std::vector<PinnedVecSizeT> species_center_coffsets(num_species_);


### PR DESCRIPTION


Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

Please also follow the [GitHub Pull Request guidance](https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance). As much as possible, try to avoid the ["Don't"s](https://qmcpack.readthedocs.io/en/develop/developing.html#don-t) to help maintain a high development velocity.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Aurora
Endymion

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [ ] I have read the pull request guidance and develop docs
* * [ ] This PR is up to date with current the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
