### PR TITLE
Enhance OhmmsVector/Matrix safety

### DIFF
--- a/src/Containers/OhmmsPETE/OhmmsMatrix.h
+++ b/src/Containers/OhmmsPETE/OhmmsMatrix.h
@@ -107,7 +107,11 @@ public:
   }
 
   // free the matrix storage
-  inline void free() { X.free(); }
+  inline void free()
+  {
+    D1 = D2 = 0;
+    X.free();
+  }
 
   // Attach to pre-allocated memory
   inline void attachReference(T* ref, size_type n, size_type m)

--- a/src/Containers/OhmmsPETE/OhmmsMatrix.h
+++ b/src/Containers/OhmmsPETE/OhmmsMatrix.h
@@ -37,7 +37,7 @@ public:
   using This_t        = Matrix<T, Alloc>;
   using Alloc_t       = Alloc;
 
-  Matrix() : D1(0), D2(0), TotSize(0) {} // Default Constructor initializes to zero.
+  Matrix() : D1(0), D2(0) {} // Default Constructor initializes to zero.
 
   Matrix(size_type n)
   {
@@ -52,7 +52,7 @@ public:
   }
 
   /** constructor with an initialized ref */
-  inline Matrix(T* ref, size_type n, size_type m) : D1(n), D2(m), TotSize(n * m), X(ref, n * m) {}
+  inline Matrix(T* ref, size_type n, size_type m) : D1(n), D2(m), X(ref, n * m) {}
 
   /** This allows construction of a Matrix on another containers owned memory that is using a dualspace allocator.
    *  It can be any span of that memory.
@@ -60,7 +60,7 @@ public:
    *  realspace dualspace allocator "interface"
    */
   template<typename CONTAINER>
-  Matrix(const CONTAINER& other, T* ref, size_type n, size_type m) : D1(n), D2(m), TotSize(n * m), X(other, ref, n * m)
+  Matrix(const CONTAINER& other, T* ref, size_type n, size_type m) : D1(n), D2(m), X(other, ref, n * m)
   {}
 
   // Copy Constructor
@@ -74,7 +74,7 @@ public:
   // Destructor
   ~Matrix() {}
 
-  inline size_type size() const { return TotSize; }
+  inline size_type size() const { return X.size(); }
   inline size_type rows() const { return D1; }
   inline size_type cols() const { return D2; }
   inline size_type size1() const { return D1; }
@@ -101,9 +101,8 @@ public:
   {
     static_assert(std::is_same<value_type, typename Alloc::value_type>::value,
                   "Matrix and Alloc data types must agree!");
-    D1      = n;
-    D2      = m;
-    TotSize = n * m;
+    D1 = n;
+    D2 = m;
     X.resize(n * m);
   }
 
@@ -113,10 +112,9 @@ public:
   // Attach to pre-allocated memory
   inline void attachReference(T* ref, size_type n, size_type m)
   {
-    D1      = n;
-    D2      = m;
-    TotSize = n * m;
-    X.attachReference(ref, TotSize);
+    D1 = n;
+    D2 = m;
+    X.attachReference(ref, n * m);
   }
 
   /** Attach to pre-allocated memory and propagate the allocator of the owning container.
@@ -125,10 +123,9 @@ public:
   template<typename CONTAINER>
   inline void attachReference(const CONTAINER& other, T* ref, size_type n, size_type m)
   {
-    D1      = n;
-    D2      = m;
-    TotSize = n * m;
-    X.attachReference(other, ref, TotSize);
+    D1 = n;
+    D2 = m;
+    X.attachReference(other, ref, n * m);
   }
 
   template<typename Allocator = Alloc, typename = IsHostSafe<Allocator>>
@@ -227,10 +224,10 @@ public:
   // returns a pointer of i-th row
   inline const_pointer first_address() const { return X.data(); }
 
-  inline pointer last_address() { return X.data() + TotSize; }
+  inline pointer last_address() { return X.data() + X.size(); }
 
   // returns a pointer of i-th row
-  inline const Type_t* last_address() const { return X.data() + TotSize; }
+  inline const Type_t* last_address() const { return X.data() + X.size(); }
 
 
   // returns a const pointer of i-th row
@@ -401,7 +398,6 @@ public:
 
 protected:
   size_type D1, D2;
-  size_type TotSize;
   Container_t X;
 };
 

--- a/src/Containers/OhmmsPETE/OhmmsMatrix.h
+++ b/src/Containers/OhmmsPETE/OhmmsMatrix.h
@@ -111,8 +111,6 @@ public:
   inline void free() { X.free(); }
 
   // Attach to pre-allocated memory
-  inline void attachReference(T* ref) { X.attachReference(ref, TotSize); }
-
   inline void attachReference(T* ref, size_type n, size_type m)
   {
     D1      = n;

--- a/src/Containers/OhmmsPETE/OhmmsVector.h
+++ b/src/Containers/OhmmsPETE/OhmmsVector.h
@@ -131,12 +131,7 @@ public:
   inline void attachReference(T* ref, size_type n)
   {
     if (nAllocated)
-    {
-      free();
-      // std::cerr << "Allocated OhmmsVector attachReference called.\n" << std::endl;
-      // Nice idea but "default" constructed WFC elements in the batched driver make this a mess.
-      //throw std::runtime_error("Pointer attaching is not allowed on Vector with allocated memory.");
-    }
+      throw std::runtime_error("Pointer attaching is not allowed on Vector with allocated memory.");
     nLocal     = n;
     nAllocated = 0;
     X          = ref;
@@ -149,9 +144,7 @@ public:
   inline void attachReference(const CONTAINER& other, T* ref, size_type n)
   {
     if (nAllocated)
-    {
-      free();
-    }
+      throw std::runtime_error("Pointer attaching is not allowed on Vector with allocated memory.");
     nLocal     = n;
     nAllocated = 0;
     X          = ref;
@@ -291,9 +284,7 @@ private:
   inline void resize_impl(size_type n)
   {
     if (nAllocated)
-    {
       mAllocator.deallocate(X, nAllocated);
-    }
     X          = mAllocator.allocate(n);
     nLocal     = n;
     nAllocated = n;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -394,9 +394,9 @@ template<PlatformKind PL, typename VT, typename FPVT>
 void DiracDeterminant<PL, VT, FPVT>::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
 {
   ScopedTimer local_timer(BufferTimer);
-  psiM.attachReference(buf.lendReference<ValueType>(psiM.size()));
-  dpsiM.attachReference(buf.lendReference<GradType>(dpsiM.size()));
-  d2psiM.attachReference(buf.lendReference<ValueType>(d2psiM.size()));
+  psiM.attachReference(buf.lendReference<ValueType>(NumPtcls * NumPtcls), NumPtcls, NumPtcls);
+  dpsiM.attachReference(buf.lendReference<GradType>(NumPtcls * NumPtcls), NumPtcls, NumPtcls);
+  d2psiM.attachReference(buf.lendReference<ValueType>(NumPtcls * NumPtcls), NumPtcls, NumPtcls);
   buf.get(log_value_);
   // start with invRow labelled invalid
   invRow_id = -1;


### PR DESCRIPTION
## Proposed changes
https://github.com/QMCPACK/qmcpack/pull/5449 exposed some allowed risky behaviors of OhmmsMatrix and I decided to eliminate all of them. So doing the following.
1. get ride of `OhmmsMatrix::attachReference(*ptr)`, matrix dimensions mush be provided.
2. OhmmsMatrix no longer keeps TotSize, fully relies on the underlying container.
3. OhmmsMatrix::free set D1 and D2 to 0.
4. Forbid calling `attachReference` when containers do own memory effectively blocking lazy free.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with current the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted