### PR TITLE
Adjust parsing legacy input when sposets are implicitly inside determiants

### DIFF
--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
@@ -70,13 +70,11 @@ private:
   /** process a determinant element
    * @param cur xml node
    * @param spin_group the spin group of the created determinant
-   * @return legacy_input_sposet_builder an sposet builder to handle legacy input
    * @return BFTrans backflow transformations
    */
   std::unique_ptr<DiracDeterminantBase> putDeterminant(
       xmlNodePtr cur,
       int spin_group,
-      const std::unique_ptr<SPOSetBuilder>& legacy_input_sposet_builder,
       const std::unique_ptr<BackflowTransformation>& BFTrans);
 
   std::unique_ptr<MultiSlaterDetTableMethod> createMSDFast(xmlNodePtr cur,

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
@@ -230,13 +230,13 @@ TEST_CASE("SPO input spline from xml He_sto3g", "[wavefunction]")
         </atomicBasisSet>
       </basisset>
       <slaterdeterminant>
-        <determinant name="spo" size="1">
+        <determinant id="spo" size="1">
           <occupation mode="ground"/>
           <coefficient size="1" id="updetC">
             1.00000000000000e+00
           </coefficient>
         </determinant>
-        <determinant name="spo-down" size="1">
+        <determinant id="downdet" size="1">
           <occupation mode="ground"/>
           <coefficient size="1" id="downdetC">
             1.00000000000000e+00

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
@@ -147,7 +147,7 @@ TEST_CASE("SPO input spline from HDF diamond_2x1x1", "[wavefunction]")
   const char* spo_xml_string3 = R"(<wavefunction name="psi0" target="elec">
 <determinantset type="einspline" href="diamondC_2x1x1.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion" meshfactor="1.0" precision="float">
   <slaterdeterminant>
-    <determinant name="spo" size="4" spindataset="0"/>
+    <determinant id="spo" size="4" spindataset="0"/>
   </slaterdeterminant>
 </determinantset>
 </wavefunction>


### PR DESCRIPTION
## Proposed changes
This PR changed how the legacy input was consumed. No change to the input.
I moved spsoet creation outside the determinant parsing/creation.
I also noticed that input tests were not exactly mimicking legacy. So I adjusted them. 
There is one benefit. There was a bug that code crash if a requested sposet name cannot be found.
This PR will report a clean user error message.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with current the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted