### PR TITLE
Move sposet ownership from DiracDeterminant to SlaterDet

### DIFF
--- a/src/Estimators/tests/test_MagnetizationDensity.cpp
+++ b/src/Estimators/tests/test_MagnetizationDensity.cpp
@@ -376,11 +376,13 @@ TEST_CASE("MagnetizationDensity::IntegrationTest", "[estimators]")
   auto spinor_set = std::make_unique<SpinorSet>("ConstSpinorSet");
   spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
 
-  auto dd = std::make_unique<DiracDeterminant<>>(std::move(spinor_set), 0, nelec);
+  auto dd = std::make_unique<DiracDeterminant<>>(*spinor_set, 0, nelec);
 
+  std::vector<std::unique_ptr<SPOSet>> sposets;
+  sposets.push_back(std::move(spinor_set));
   std::vector<std::unique_ptr<DiracDeterminantBase>> dirac_dets;
   dirac_dets.push_back(std::move(dd));
-  auto sd = std::make_unique<SlaterDet>(elec_, std::move(dirac_dets));
+  auto sd = std::make_unique<SlaterDet>(elec_, std::move(sposets), std::move(dirac_dets));
 
   RuntimeOptions runtime_options;
   TrialWaveFunction psi(runtime_options);

--- a/src/QMCDrivers/WaveFunctionTester.cpp
+++ b/src/QMCDrivers/WaveFunctionTester.cpp
@@ -831,11 +831,11 @@ bool WaveFunctionTester::checkGradientAtConfiguration(MCWalkerConfiguration::Wal
     SlaterDet* sd = dynamic_cast<SlaterDet*>(orb.get());
     if (sd)
     {
-      for (int isd = 0; isd < sd->Dets.size(); isd++)
+      for (int isd = 0; isd < sd->getNumDets(); isd++)
       {
         ParticleSet::ParticleGradient G(nat), tmpG(nat), G1(nat);
         ParticleSet::ParticleLaplacian L(nat), tmpL(nat), L1(nat);
-        DiracDeterminantBase& det = *sd->Dets[isd];
+        DiracDeterminantBase& det = sd->getDet(isd);
         LogValue logpsi2          = det.evaluateLog(W, G, L); // this won't work with backflow
         fail_log << "  Slater Determiant " << isd << " (for particles " << det.getFirstIndex() << " to "
                  << det.getLastIndex() << ") log psi = " << logpsi2 << std::endl;

--- a/src/QMCHamiltonians/tests/test_SOECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_SOECPotential.cpp
@@ -152,16 +152,18 @@ void doSOECPotentialTest(bool use_VPs)
   auto spo_up = std::make_unique<FreeOrbital>("free_orb_up", kup);
   auto spo_dn = std::make_unique<FreeOrbital>("free_orb_dn", kdn);
 
-  auto spinor_set = std::make_unique<SpinorSet>("free_orb_spinor");
+  auto spinor_set = std::make_unique<SpinorSet>("free_orsposetsb_spinor");
   spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
   QMCTraits::IndexType norb = spinor_set->getOrbitalSetSize();
   REQUIRE(norb == 2);
 
   auto dd = std::make_unique<DiracDeterminantBatched<PlatformKind::OMPTARGET, QMCTraits::ValueType,
-                                                     QMCTraits::QTFull::ValueType>>(std::move(spinor_set), 0, nelec);
+                                                     QMCTraits::QTFull::ValueType>>(*spinor_set, 0, nelec);
+  std::vector<std::unique_ptr<SPOSet>> sposets;
+  sposets.push_back(std::move(spinor_set));
   std::vector<std::unique_ptr<DiracDeterminantBase>> dirac_dets;
   dirac_dets.push_back(std::move(dd));
-  auto sd = std::make_unique<SlaterDet>(elec, std::move(dirac_dets));
+  auto sd = std::make_unique<SlaterDet>(elec, std::move(sposets), std::move(dirac_dets));
   psi.addComponent(std::move(sd));
 
   //Add the two body jastrow, parameters from test_J2_bspline

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -501,7 +501,7 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
   QMCTraits::IndexType norb = spinor_set->getOrbitalSetSize();
   REQUIRE(norb == 2);
 
-  auto dd = std::make_unique<DiracDeterminant<>>(std::move(spinor_set), 0, nelec);
+  auto dd = std::make_unique<DiracDeterminant<>>(*spinor_set, 0, nelec);
 
   psi.addComponent(std::move(dd));
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -790,40 +790,6 @@ std::unique_ptr<DiracDeterminantBase> DiracDeterminant<PL, VT, FPVT>::makeCopy(S
   return std::make_unique<DiracDeterminant<PL, VT, FPVT>>(phi, FirstIndex, LastIndex, ndelay_, matrix_inverter_kind_);
 }
 
-template<PlatformKind PL, typename VT, typename FPVT>
-void DiracDeterminant<PL, VT, FPVT>::createResource(ResourceCollection& collection) const
-{
-  phi_.createResource(collection);
-}
-
-template<PlatformKind PL, typename VT, typename FPVT>
-void DiracDeterminant<PL, VT, FPVT>::acquireResource(ResourceCollection& collection,
-                                                     const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
-{
-  auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminant<PL, VT, FPVT>>();
-  RefVectorWithLeader<SPOSet> phi_list(wfc_leader.phi_);
-  for (WaveFunctionComponent& wfc : wfc_list)
-  {
-    auto& det = static_cast<DiracDeterminant<PL, VT, FPVT>&>(wfc);
-    phi_list.push_back(det.phi_);
-  }
-  wfc_leader.phi_.acquireResource(collection, phi_list);
-}
-
-template<PlatformKind PL, typename VT, typename FPVT>
-void DiracDeterminant<PL, VT, FPVT>::releaseResource(ResourceCollection& collection,
-                                                     const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
-{
-  auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminant<PL, VT, FPVT>>();
-  RefVectorWithLeader<SPOSet> phi_list(wfc_leader.phi_);
-  for (WaveFunctionComponent& wfc : wfc_list)
-  {
-    auto& det = static_cast<DiracDeterminant<PL, VT, FPVT>&>(wfc);
-    phi_list.push_back(det.phi_);
-  }
-  wfc_leader.phi_.releaseResource(collection, phi_list);
-}
-
 template class DiracDeterminant<>;
 #if defined(ENABLE_CUDA)
 template class DiracDeterminant<PlatformKind::CUDA, QMCTraits::ValueType, QMCTraits::QTFull::ValueType>;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -30,19 +30,19 @@ namespace qmcplusplus
  *@param first index of the first particle
  */
 template<PlatformKind PL, typename VT, typename FPVT>
-DiracDeterminant<PL, VT, FPVT>::DiracDeterminant(std::unique_ptr<SPOSet>&& spos,
+DiracDeterminant<PL, VT, FPVT>::DiracDeterminant(SPOSet& phi,
                                                  int first,
                                                  int last,
                                                  int ndelay,
                                                  DetMatInvertor matrix_inverter_kind)
-    : DiracDeterminantBase(getClassName(), std::move(spos), first, last),
+    : DiracDeterminantBase(getClassName(), phi, first, last),
       ndelay_(ndelay),
       invRow_id(-1),
       matrix_inverter_kind_(matrix_inverter_kind)
 {
   resize(NumPtcls, NumPtcls);
 
-  RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
+  RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(&phi_);
   if (rot_spo)
     rot_spo->buildOptVariables(NumPtcls);
 }
@@ -50,7 +50,7 @@ DiracDeterminant<PL, VT, FPVT>::DiracDeterminant(std::unique_ptr<SPOSet>&& spos,
 template<PlatformKind PL, typename VT, typename FPVT>
 DiracDeterminant<PL, VT, FPVT>::~DiracDeterminant()
 {
-  if(!psiM.isAttached())
+  if (!psiM.isAttached())
     accel_engine_.update_eng_.releaseFromDeviceCopy(psiM);
   accel_engine_.update_eng_.releaseFromDeviceCopy(psiM_temp);
 }
@@ -163,7 +163,7 @@ typename DiracDeterminant<PL, VT, FPVT>::GradType DiracDeterminant<PL, VT, FPVT>
     int iat,
     ComplexType& spingrad)
 {
-  Phi->evaluate_spin(P, iat, psiV, dspin_psiV);
+  phi_.evaluate_spin(P, iat, psiV, dspin_psiV);
   ScopedTimer local_timer(RatioTimer);
   const int WorkingIndex = iat - FirstIndex;
   assert(WorkingIndex >= 0);
@@ -183,7 +183,7 @@ typename DiracDeterminant<PL, VT, FPVT>::PsiValue DiracDeterminant<PL, VT, FPVT>
 {
   {
     ScopedTimer local_timer(SPOVGLTimer);
-    Phi->evaluateVGL(P, iat, psiV, dpsiV, d2psiV);
+    phi_.evaluateVGL(P, iat, psiV, dpsiV, d2psiV);
   }
   return ratioGrad_compute(iat, grad_iat);
 }
@@ -221,7 +221,7 @@ typename DiracDeterminant<PL, VT, FPVT>::PsiValue DiracDeterminant<PL, VT, FPVT>
 {
   {
     ScopedTimer local_timer(SPOVGLTimer);
-    Phi->evaluateVGL_spin(P, iat, psiV, dpsiV, d2psiV, dspin_psiV);
+    phi_.evaluateVGL_spin(P, iat, psiV, dpsiV, d2psiV, dspin_psiV);
   }
 
   {
@@ -257,7 +257,7 @@ void DiracDeterminant<PL, VT, FPVT>::mw_ratioGrad(const RefVectorWithLeader<Wave
 {
   {
     ScopedTimer local_timer(SPOVGLTimer);
-    RefVectorWithLeader<SPOSet> phi_list(*Phi);
+    RefVectorWithLeader<SPOSet> phi_list(phi_);
     phi_list.reserve(wfc_list.size());
     RefVector<ValueVector> psi_v_list;
     psi_v_list.reserve(wfc_list.size());
@@ -269,13 +269,13 @@ void DiracDeterminant<PL, VT, FPVT>::mw_ratioGrad(const RefVectorWithLeader<Wave
     for (WaveFunctionComponent& wfc : wfc_list)
     {
       auto& det = static_cast<DiracDeterminant<PL, VT, FPVT>&>(wfc);
-      phi_list.push_back(*det.Phi);
+      phi_list.push_back(det.phi_);
       psi_v_list.push_back(det.psiV);
       dpsi_v_list.push_back(det.dpsiV);
       d2psi_v_list.push_back(det.d2psiV);
     }
 
-    Phi->mw_evaluateVGL(phi_list, p_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list);
+    phi_.mw_evaluateVGL(phi_list, p_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list);
   }
 
   for (int iw = 0; iw < wfc_list.size(); iw++)
@@ -335,7 +335,7 @@ void DiracDeterminant<PL, VT, FPVT>::updateAfterSweep(const ParticleSet& P,
   if (UpdateMode == ORB_PBYP_RATIO)
   { //need to compute dpsiM and d2psiM. Do not touch psiM!
     ScopedTimer local_timer(SPOVGLTimer);
-    Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp, dpsiM, d2psiM);
+    phi_.evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp, dpsiM, d2psiM);
     UpdateMode = ORB_WALKER;
   }
 
@@ -422,7 +422,7 @@ void DiracDeterminant<PL, VT, FPVT>::copyFromBuffer(ParticleSet& P, WFBufferType
 template<PlatformKind PL, typename VT, typename FPVT>
 void DiracDeterminant<PL, VT, FPVT>::registerTWFFastDerivWrapper(const ParticleSet& P, TWFFastDerivWrapper& twf) const
 {
-  twf.addGroup(P, P.getGroupID(FirstIndex), Phi.get());
+  twf.addGroup(P, P.getGroupID(FirstIndex), &phi_);
 }
 
 /** return the ratio only for the  iat-th partcle move
@@ -437,7 +437,7 @@ typename DiracDeterminant<PL, VT, FPVT>::PsiValue DiracDeterminant<PL, VT, FPVT>
   assert(WorkingIndex >= 0);
   {
     ScopedTimer local_timer(SPOVTimer);
-    Phi->evaluateValue(P, iat, psiV);
+    phi_.evaluateValue(P, iat, psiV);
   }
   {
     ScopedTimer local_timer(RatioTimer);
@@ -465,7 +465,7 @@ void DiracDeterminant<PL, VT, FPVT>::evaluateRatios(const VirtualParticleSet& VP
   }
   {
     ScopedTimer local_timer(SPOVTimer);
-    Phi->evaluateDetRatios(VP, psiV, invRow, ratios);
+    phi_.evaluateDetRatios(VP, psiV, invRow, ratios);
   }
 }
 
@@ -482,7 +482,7 @@ void DiracDeterminant<PL, VT, FPVT>::evaluateSpinorRatios(const VirtualParticleS
   }
   {
     ScopedTimer local_timer(SPOVTimer);
-    Phi->evaluateDetSpinorRatios(VP, psiV, spinor_multiplier, invRow, ratios);
+    phi_.evaluateDetSpinorRatios(VP, psiV, spinor_multiplier, invRow, ratios);
   }
 }
 
@@ -493,7 +493,7 @@ void DiracDeterminant<PL, VT, FPVT>::mw_evaluateRatios(const RefVectorWithLeader
 {
   const size_t nw = wfc_list.size();
 
-  RefVectorWithLeader<SPOSet> phi_list(*Phi);
+  RefVectorWithLeader<SPOSet> phi_list(phi_);
   RefVector<ValueVector> psiV_list;
   std::vector<const ValueType*> invRow_ptr_list;
   phi_list.reserve(nw);
@@ -512,7 +512,7 @@ void DiracDeterminant<PL, VT, FPVT>::mw_evaluateRatios(const RefVectorWithLeader
       // That is at minimum a call to evaluateLog and ...
       // std::copy_n(det.psiM[WorkingIndex], det.invRow.s.ize(), det.invRow.data());
       // build lists
-      phi_list.push_back(*det.Phi);
+      phi_list.push_back(det.phi_);
       psiV_list.push_back(det.psiV);
       invRow_ptr_list.push_back(det.psiM[WorkingIndex]);
     }
@@ -520,16 +520,16 @@ void DiracDeterminant<PL, VT, FPVT>::mw_evaluateRatios(const RefVectorWithLeader
 
   {
     ScopedTimer local_timer(SPOVTimer);
-    // Phi->isOMPoffload() requires device invRow pointers for mw_evaluateDetRatios.
+    // phi_.isOMPoffload() requires device invRow pointers for mw_evaluateDetRatios.
     // evaluateDetRatios only requires host invRow pointers.
-    if (Phi->isOMPoffload())
+    if (phi_.isOMPoffload())
       for (int iw = 0; iw < phi_list.size(); iw++)
       {
         Vector<ValueType> invRow(const_cast<ValueType*>(invRow_ptr_list[iw]), psiV_list[iw].get().size());
         phi_list[iw].evaluateDetRatios(vp_list[iw], psiV_list[iw], invRow, ratios[iw]);
       }
     else
-      Phi->mw_evaluateDetRatios(phi_list, vp_list, psiV_list, invRow_ptr_list, ratios);
+      phi_.mw_evaluateDetRatios(phi_list, vp_list, psiV_list, invRow_ptr_list, ratios);
   }
 }
 
@@ -542,7 +542,7 @@ void DiracDeterminant<PL, VT, FPVT>::evaluateDerivRatios(const VirtualParticleSe
   const int WorkingIndex = VP.refPtcl - FirstIndex;
   assert(WorkingIndex >= 0);
   std::copy_n(psiM[WorkingIndex], invRow.size(), invRow.data());
-  Phi->evaluateDerivRatios(VP, optvars, psiV, invRow, ratios, dratios, FirstIndex, LastIndex);
+  phi_.evaluateDerivRatios(VP, optvars, psiV, invRow, ratios, dratios, FirstIndex, LastIndex);
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>
@@ -556,14 +556,14 @@ void DiracDeterminant<PL, VT, FPVT>::evaluateSpinorDerivRatios(
   const int WorkingIndex = VP.refPtcl - FirstIndex;
   assert(WorkingIndex >= 0);
   std::copy_n(psiM[WorkingIndex], invRow.size(), invRow.data());
-  Phi->evaluateSpinorDerivRatios(VP, spinor_multiplier, optvars, psiV, invRow, ratios, dratios, FirstIndex, LastIndex);
+  phi_.evaluateSpinorDerivRatios(VP, spinor_multiplier, optvars, psiV, invRow, ratios, dratios, FirstIndex, LastIndex);
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>
 void DiracDeterminant<PL, VT, FPVT>::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios)
 {
   ScopedTimer local_timer(SPOVTimer);
-  Phi->evaluateValue(P, -1, psiV);
+  phi_.evaluateValue(P, -1, psiV);
   Vector<ValueType> ratios_this_det(ratios.data() + FirstIndex, NumPtcls);
   MatrixOperators::product(psiM, psiV, ratios_this_det);
 }
@@ -587,10 +587,10 @@ typename DiracDeterminant<PL, VT, FPVT>::GradType DiracDeterminant<PL, VT, FPVT>
                                                                                                  int iat)
 {
   GradType g(0.0);
-  if (Phi->hasIonDerivs())
+  if (phi_.hasIonDerivs())
   {
     resizeScratchObjectsForIonDerivs();
-    Phi->evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM);
+    phi_.evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM);
     g = simd::dot(psiM.data(), grad_source_psiM.data(), psiM.size());
   }
 
@@ -603,7 +603,7 @@ void DiracDeterminant<PL, VT, FPVT>::evaluateHessian(ParticleSet& P, HessVector&
   // Hessian is not often used, so only resize/allocate if used
   grad_grad_source_psiM.resize(psiM.rows(), psiM.cols());
   //IM A HACK.  Assumes evaluateLog has already been executed.
-  Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp, dpsiM, grad_grad_source_psiM);
+  phi_.evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp, dpsiM, grad_grad_source_psiM);
   invertPsiM(psiM_temp, psiM);
 
   phi_alpha_Minv      = 0.0;
@@ -632,13 +632,13 @@ typename DiracDeterminant<PL, VT, FPVT>::GradType DiracDeterminant<PL, VT, FPVT>
     TinyVector<ParticleSet::ParticleLaplacian, OHMMS_DIM>& lapl_grad)
 {
   GradType gradPsi(0.0);
-  if (Phi->hasIonDerivs())
+  if (phi_.hasIonDerivs())
   {
     resizeScratchObjectsForIonDerivs();
-    Phi->evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM, grad_grad_source_psiM,
+    phi_.evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM, grad_grad_source_psiM,
                             grad_lapl_source_psiM);
     // HACK HACK HACK
-    // Phi->evaluateVGL(P, FirstIndex, LastIndex, psiM, dpsiM, d2psiM);
+    // phi_.evaluateVGL(P, FirstIndex, LastIndex, psiM, dpsiM, d2psiM);
     // psiM_temp = psiM;
     // LogValue=InvertWithLog(psiM.data(),NumPtcls,NumOrbitals,
     // 			   WorkSpace.data(),Pivot.data(),PhaseValue);
@@ -758,7 +758,7 @@ void DiracDeterminant<PL, VT, FPVT>::recompute(const ParticleSet& P)
   {
     ScopedTimer local_timer(SPOVGLTimer);
     UpdateMode = ORB_WALKER;
-    Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp, dpsiM, d2psiM);
+    phi_.evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp, dpsiM, d2psiM);
   }
 
   invertPsiM(psiM_temp, psiM);
@@ -773,7 +773,7 @@ void DiracDeterminant<PL, VT, FPVT>::evaluateDerivatives(ParticleSet& P,
                                                          Vector<ValueType>& dlogpsi,
                                                          Vector<ValueType>& dhpsioverpsi)
 {
-  Phi->evaluateDerivatives(P, active, dlogpsi, dhpsioverpsi, FirstIndex, LastIndex);
+  phi_.evaluateDerivatives(P, active, dlogpsi, dhpsioverpsi, FirstIndex, LastIndex);
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>
@@ -781,20 +781,19 @@ void DiracDeterminant<PL, VT, FPVT>::evaluateDerivativesWF(ParticleSet& P,
                                                            const opt_variables_type& active,
                                                            Vector<ValueType>& dlogpsi)
 {
-  Phi->evaluateDerivativesWF(P, active, dlogpsi, FirstIndex, LastIndex);
+  phi_.evaluateDerivativesWF(P, active, dlogpsi, FirstIndex, LastIndex);
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>
-std::unique_ptr<DiracDeterminantBase> DiracDeterminant<PL, VT, FPVT>::makeCopy(std::unique_ptr<SPOSet>&& spo) const
+std::unique_ptr<DiracDeterminantBase> DiracDeterminant<PL, VT, FPVT>::makeCopy(SPOSet& phi) const
 {
-  return std::make_unique<DiracDeterminant<PL, VT, FPVT>>(std::move(spo), FirstIndex, LastIndex, ndelay_,
-                                                          matrix_inverter_kind_);
+  return std::make_unique<DiracDeterminant<PL, VT, FPVT>>(phi, FirstIndex, LastIndex, ndelay_, matrix_inverter_kind_);
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>
 void DiracDeterminant<PL, VT, FPVT>::createResource(ResourceCollection& collection) const
 {
-  Phi->createResource(collection);
+  phi_.createResource(collection);
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>
@@ -802,13 +801,13 @@ void DiracDeterminant<PL, VT, FPVT>::acquireResource(ResourceCollection& collect
                                                      const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
   auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminant<PL, VT, FPVT>>();
-  RefVectorWithLeader<SPOSet> phi_list(*wfc_leader.Phi);
+  RefVectorWithLeader<SPOSet> phi_list(wfc_leader.phi_);
   for (WaveFunctionComponent& wfc : wfc_list)
   {
     auto& det = static_cast<DiracDeterminant<PL, VT, FPVT>&>(wfc);
-    phi_list.push_back(*det.Phi);
+    phi_list.push_back(det.phi_);
   }
-  wfc_leader.Phi->acquireResource(collection, phi_list);
+  wfc_leader.phi_.acquireResource(collection, phi_list);
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>
@@ -816,13 +815,13 @@ void DiracDeterminant<PL, VT, FPVT>::releaseResource(ResourceCollection& collect
                                                      const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
   auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminant<PL, VT, FPVT>>();
-  RefVectorWithLeader<SPOSet> phi_list(*wfc_leader.Phi);
+  RefVectorWithLeader<SPOSet> phi_list(wfc_leader.phi_);
   for (WaveFunctionComponent& wfc : wfc_list)
   {
     auto& det = static_cast<DiracDeterminant<PL, VT, FPVT>&>(wfc);
-    phi_list.push_back(*det.Phi);
+    phi_list.push_back(det.phi_);
   }
-  wfc_leader.Phi->releaseResource(collection, phi_list);
+  wfc_leader.phi_.releaseResource(collection, phi_list);
 }
 
 template class DiracDeterminant<>;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -266,12 +266,6 @@ public:
 
   void evaluateHessian(ParticleSet& P, HessVector& grad_grad_psi) override;
 
-  void createResource(ResourceCollection& collection) const override;
-  void acquireResource(ResourceCollection& collection,
-                       const RefVectorWithLeader<WaveFunctionComponent>& wf_list) const override;
-  void releaseResource(ResourceCollection& collection,
-                       const RefVectorWithLeader<WaveFunctionComponent>& wf_list) const override;
-
   /** cloning function
    * @param tqp target particleset
    * @param spo spo set

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -108,7 +108,7 @@ public:
    *@param last index of last particle
    *@param ndelay delayed update rank
    */
-  DiracDeterminant(std::unique_ptr<SPOSet>&& spos,
+  DiracDeterminant(SPOSet& phi,
                    int first,
                    int last,
                    int ndelay                          = 1,
@@ -279,7 +279,7 @@ public:
    * This interface is exposed only to SlaterDet and its derived classes
    * can overwrite to clone itself correctly.
    */
-  std::unique_ptr<DiracDeterminantBase> makeCopy(std::unique_ptr<SPOSet>&& spo) const override;
+  std::unique_ptr<DiracDeterminantBase> makeCopy(SPOSet& phi) const override;
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override;
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -38,14 +38,14 @@ public:
    *@param first index of the first particle
    *@param last index of last particle
    */
-  DiracDeterminantBase(const std::string& class_name, std::unique_ptr<SPOSet>&& spos, int first, int last)
+  DiracDeterminantBase(const std::string& class_name, SPOSet& phi, int first, int last)
       : UpdateTimer(createGlobalTimer(class_name + "::update", timer_level_fine)),
         RatioTimer(createGlobalTimer(class_name + "::ratio", timer_level_fine)),
         InverseTimer(createGlobalTimer(class_name + "::inverse", timer_level_fine)),
         BufferTimer(createGlobalTimer(class_name + "::buffer", timer_level_fine)),
         SPOVTimer(createGlobalTimer(class_name + "::spoval", timer_level_fine)),
         SPOVGLTimer(createGlobalTimer(class_name + "::spovgl", timer_level_fine)),
-        Phi(std::move(spos)),
+        phi_(phi),
         FirstIndex(first),
         LastIndex(last),
         NumOrbitals(last - first),
@@ -60,7 +60,7 @@ public:
   DiracDeterminantBase& operator=(const DiracDeterminantBase& s) = delete;
 
   // get the SPO pointer
-  inline SPOSetPtr getPhi() const { return Phi.get(); }
+  inline SPOSet& getPhi() { return phi_; }
 
   // get FirstIndex, Last Index
   inline int getFirstIndex() const { return FirstIndex; }
@@ -71,17 +71,17 @@ public:
 #endif
 
   bool isFermionic() const final { return true; }
-  inline bool isOptimizable() const final { return Phi->isOptimizable(); }
+  inline bool isOptimizable() const final { return phi_.isOptimizable(); }
 
   void extractOptimizableObjectRefs(UniqueOptObjRefs& opt_obj_refs) final
   {
-    Phi->extractOptimizableObjectRefs(opt_obj_refs);
+    phi_.extractOptimizableObjectRefs(opt_obj_refs);
   }
 
   inline void checkOutVariables(const opt_variables_type& active) final
   {
-    if (Phi->isOptimizable())
-      Phi->checkOutVariables(active);
+    if (phi_.isOptimizable())
+      phi_.checkOutVariables(active);
   }
 
   virtual void registerTWFFastDerivWrapper(const ParticleSet& P, TWFFastDerivWrapper& twf) const override
@@ -175,13 +175,13 @@ public:
    * This interface is exposed only to SlaterDet and its derived classes
    * can overwrite to clone itself correctly.
    */
-  virtual std::unique_ptr<DiracDeterminantBase> makeCopy(std::unique_ptr<SPOSet>&& spo) const = 0;
+  virtual std::unique_ptr<DiracDeterminantBase> makeCopy(SPOSet& phi) const = 0;
 
 protected:
   /// Timers
   NewTimer &UpdateTimer, &RatioTimer, &InverseTimer, &BufferTimer, &SPOVTimer, &SPOVGLTimer;
   /// a set of single-particle orbitals used to fill in the  values of the matrix
-  const std::unique_ptr<SPOSet> Phi;
+  SPOSet& phi_;
   ///index of the first particle with respect to the particle set
   const int FirstIndex;
   ///index of the last particle with respect to the particle set

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -73,17 +73,6 @@ public:
   bool isFermionic() const final { return true; }
   inline bool isOptimizable() const final { return phi_.isOptimizable(); }
 
-  void extractOptimizableObjectRefs(UniqueOptObjRefs& opt_obj_refs) final
-  {
-    phi_.extractOptimizableObjectRefs(opt_obj_refs);
-  }
-
-  inline void checkOutVariables(const opt_variables_type& active) final
-  {
-    if (phi_.isOptimizable())
-      phi_.checkOutVariables(active);
-  }
-
   virtual void registerTWFFastDerivWrapper(const ParticleSet& P, TWFFastDerivWrapper& twf) const override
   {
     throw std::runtime_error("DiracDeterminantBase::registerTWFFastDerivWrapper must be overridden\n");

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -78,12 +78,12 @@ struct DiracDeterminantBatched<PL, VT, FPVT>::DiracDeterminantBatchedMultiWalker
  *@param first index of the first particle
  */
 template<PlatformKind PL, typename VT, typename FPVT>
-DiracDeterminantBatched<PL, VT, FPVT>::DiracDeterminantBatched(std::unique_ptr<SPOSet>&& spos,
+DiracDeterminantBatched<PL, VT, FPVT>::DiracDeterminantBatched(SPOSet& phi,
                                                                int first,
                                                                int last,
                                                                int ndelay,
                                                                DetMatInvertor matrix_inverter_kind)
-    : DiracDeterminantBase("DiracDeterminantBatched", std::move(spos), first, last),
+    : DiracDeterminantBase("DiracDeterminantBatched", phi, first, last),
       det_engine_(NumOrbitals, ndelay),
       ndelay_(ndelay),
       matrix_inverter_kind_(matrix_inverter_kind),
@@ -94,7 +94,7 @@ DiracDeterminantBatched<PL, VT, FPVT>::DiracDeterminantBatched(std::unique_ptr<S
   resize(NumPtcls, NumPtcls);
 
 #ifndef QMC_COMPLEX
-  RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
+  RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(&phi_);
   if (rot_spo)
     rot_spo->buildOptVariables(NumPtcls);
 #endif
@@ -216,7 +216,7 @@ typename DiracDeterminantBatched<PL, VT, FPVT>::Grad DiracDeterminantBatched<PL,
     int iat,
     ComplexType& spingrad)
 {
-  Phi->evaluate_spin(P, iat, psiV_host_view, dspin_psiV_host_view);
+  phi_.evaluate_spin(P, iat, psiV_host_view, dspin_psiV_host_view);
   ScopedTimer local_timer(RatioTimer);
   const int WorkingIndex = iat - FirstIndex;
   Grad g                 = simd::dot(psiMinv_[WorkingIndex], dpsiM[WorkingIndex], NumOrbitals);
@@ -240,20 +240,20 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_evalGradWithSpin(
   ScopedTimer local_timer(RatioTimer);
 
   const int nw           = wfc_list.size();
-  const int num_orbitals = wfc_leader.Phi->size();
+  const int num_orbitals = wfc_leader.phi_.size();
   mw_dspin.resize(nw, num_orbitals);
 
   //Here, we are just always recomputing the spin gradients from the SPOSet for simplicity.
   //If we stored and modified the accept/reject to include updating stored spin gradients, we could the
   //mw_evaluateVGLWithSpin call below and just use the stored spin gradients.
   //May revisit this in the future.
-  RefVectorWithLeader<SPOSet> phi_list(*Phi);
+  RefVectorWithLeader<SPOSet> phi_list(phi_);
   RefVector<SPOSet::ValueVector> psi_v_list, lap_v_list;
   RefVector<SPOSet::GradVector> grad_v_list;
   for (int iw = 0; iw < wfc_list.size(); iw++)
   {
     auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<PL, VT, FPVT>>(iw);
-    phi_list.push_back(*det.Phi);
+    phi_list.push_back(det.phi_);
     psi_v_list.push_back(det.psiV_host_view);
     grad_v_list.push_back(det.dpsiV_host_view);
     lap_v_list.push_back(det.d2psiV_host_view);
@@ -291,7 +291,7 @@ typename DiracDeterminantBatched<PL, VT, FPVT>::PsiValue DiracDeterminantBatched
 
   {
     ScopedTimer local_timer(SPOVGLTimer);
-    Phi->evaluateVGL(P, iat, psiV_host_view, dpsiV_host_view, d2psiV_host_view);
+    phi_.evaluateVGL(P, iat, psiV_host_view, dpsiV_host_view, d2psiV_host_view);
   }
 
   {
@@ -319,7 +319,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_ratioGrad(const RefVectorWithLead
   auto& grad_new_local = mw_res.grad_new_local;
   {
     ScopedTimer local_timer(SPOVGLTimer);
-    RefVectorWithLeader<SPOSet> phi_list(*Phi);
+    RefVectorWithLeader<SPOSet> phi_list(phi_);
     phi_list.reserve(wfc_list.size());
     RefVectorWithLeader<UpdateEngine> engine_list(wfc_leader.det_engine_);
     engine_list.reserve(wfc_list.size());
@@ -327,19 +327,19 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_ratioGrad(const RefVectorWithLead
     for (int iw = 0; iw < wfc_list.size(); iw++)
     {
       auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<PL, VT, FPVT>>(iw);
-      phi_list.push_back(*det.Phi);
+      phi_list.push_back(det.phi_);
       engine_list.push_back(det.det_engine_);
     }
 
     auto psiMinv_row_dev_ptr_list =
         UpdateEngine::mw_getInvRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs,
-                                   WorkingIndex, !Phi->isOMPoffload());
+                                   WorkingIndex, !phi_.isOMPoffload());
 
     phi_vgl_v.resize(SPOSet::DIM_VGL, wfc_list.size(), NumOrbitals);
     ratios_local.resize(wfc_list.size());
     grad_new_local.resize(wfc_list.size());
 
-    wfc_leader.Phi->mw_evaluateVGLandDetRatioGrads(phi_list, p_list, iat, psiMinv_row_dev_ptr_list, phi_vgl_v,
+    wfc_leader.phi_.mw_evaluateVGLandDetRatioGrads(phi_list, p_list, iat, psiMinv_row_dev_ptr_list, phi_vgl_v,
                                                    ratios_local, grad_new_local);
   }
 
@@ -371,7 +371,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_ratioGradWithSpin(
   auto& spingrad_new_local = mw_res.spingrad_new_local;
   {
     ScopedTimer local_timer(SPOVGLTimer);
-    RefVectorWithLeader<SPOSet> phi_list(*Phi);
+    RefVectorWithLeader<SPOSet> phi_list(phi_);
     phi_list.reserve(wfc_list.size());
     RefVectorWithLeader<UpdateEngine> engine_list(wfc_leader.det_engine_);
     engine_list.reserve(wfc_list.size());
@@ -379,20 +379,20 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_ratioGradWithSpin(
     for (int iw = 0; iw < wfc_list.size(); iw++)
     {
       auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<PL, VT, FPVT>>(iw);
-      phi_list.push_back(*det.Phi);
+      phi_list.push_back(det.phi_);
       engine_list.push_back(det.det_engine_);
     }
 
     auto psiMinv_row_dev_ptr_list =
         UpdateEngine::mw_getInvRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs,
-                                   WorkingIndex, !Phi->isOMPoffload());
+                                   WorkingIndex, !phi_.isOMPoffload());
 
     phi_vgl_v.resize(SPOSet::DIM_VGL, wfc_list.size(), NumOrbitals);
     ratios_local.resize(wfc_list.size());
     grad_new_local.resize(wfc_list.size());
     spingrad_new_local.resize(wfc_list.size());
 
-    wfc_leader.Phi->mw_evaluateVGLandDetRatioGradsWithSpin(phi_list, p_list, iat, psiMinv_row_dev_ptr_list, phi_vgl_v,
+    wfc_leader.phi_.mw_evaluateVGLandDetRatioGradsWithSpin(phi_list, p_list, iat, psiMinv_row_dev_ptr_list, phi_vgl_v,
                                                            ratios_local, grad_new_local, spingrad_new_local);
   }
 
@@ -418,7 +418,7 @@ typename DiracDeterminantBatched<PL, VT, FPVT>::PsiValue DiracDeterminantBatched
 
   {
     ScopedTimer local_timer(SPOVGLTimer);
-    Phi->evaluateVGL_spin(P, iat, psiV_host_view, dpsiV_host_view, d2psiV_host_view, dspin_psiV_host_view);
+    phi_.evaluateVGL_spin(P, iat, psiV_host_view, dpsiV_host_view, d2psiV_host_view, dspin_psiV_host_view);
   }
 
   {
@@ -618,7 +618,7 @@ typename DiracDeterminantBatched<PL, VT, FPVT>::LogValue DiracDeterminantBatched
     if (UpdateMode == ORB_PBYP_RATIO)
     { //need to compute dpsiM and d2psiM. Do not touch psiM!
       ScopedTimer spo_timer(SPOVGLTimer);
-      Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_host, dpsiM, d2psiM);
+      phi_.evaluate_notranspose(P, FirstIndex, LastIndex, psiM_host, dpsiM, d2psiM);
     }
     UpdateMode = ORB_WALKER;
     computeGL(G, L);
@@ -647,7 +647,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_evaluateGL(const RefVectorWithLea
     { //need to compute dpsiM and d2psiM. psiMinv is not touched!
       ScopedTimer spo_timer(SPOVGLTimer);
 
-      RefVectorWithLeader<SPOSet> phi_list(*Phi);
+      RefVectorWithLeader<SPOSet> phi_list(phi_);
       RefVector<Matrix<Value>> psiM_temp_list;
       RefVector<Matrix<Grad>> dpsiM_list;
       RefVector<Matrix<Value>> d2psiM_list;
@@ -660,13 +660,13 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_evaluateGL(const RefVectorWithLea
       {
         auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<PL, VT, FPVT>>(iw);
         engine_list.push_back(det.det_engine_);
-        phi_list.push_back(*det.Phi);
+        phi_list.push_back(det.phi_);
         psiM_temp_list.push_back(det.psiM_host);
         dpsiM_list.push_back(det.dpsiM);
         d2psiM_list.push_back(det.d2psiM);
       }
 
-      Phi->mw_evaluate_notranspose(phi_list, p_list, FirstIndex, LastIndex, psiM_temp_list, dpsiM_list, d2psiM_list);
+      phi_.mw_evaluate_notranspose(phi_list, p_list, FirstIndex, LastIndex, psiM_temp_list, dpsiM_list, d2psiM_list);
     }
 
     for (int iw = 0; iw < nw; iw++)
@@ -729,7 +729,7 @@ typename DiracDeterminantBatched<PL, VT, FPVT>::PsiValue DiracDeterminantBatched
   const int WorkingIndex = iat - FirstIndex;
   {
     ScopedTimer local_timer(SPOVTimer);
-    Phi->evaluateValue(P, iat, psiV_host_view);
+    phi_.evaluateValue(P, iat, psiV_host_view);
   }
   {
     ScopedTimer local_timer(RatioTimer);
@@ -753,7 +753,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_calcRatio(const RefVectorWithLead
 
   {
     ScopedTimer local_timer(SPOVTimer);
-    RefVectorWithLeader<SPOSet> phi_list(*Phi);
+    RefVectorWithLeader<SPOSet> phi_list(phi_);
     phi_list.reserve(wfc_list.size());
     RefVectorWithLeader<UpdateEngine> engine_list(wfc_leader.det_engine_);
     engine_list.reserve(wfc_list.size());
@@ -762,21 +762,21 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_calcRatio(const RefVectorWithLead
     for (int iw = 0; iw < wfc_list.size(); iw++)
     {
       auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<PL, VT, FPVT>>(iw);
-      phi_list.push_back(*det.Phi);
+      phi_list.push_back(det.phi_);
       engine_list.push_back(det.det_engine_);
     }
 
     auto psiMinv_row_dev_ptr_list =
         UpdateEngine::mw_getInvRow(engine_list, wfc_leader.mw_res_handle_.getResource().engine_rsc, mw_res.psiMinv_refs,
-                                   WorkingIndex, !Phi->isOMPoffload());
+                                   WorkingIndex, !phi_.isOMPoffload());
 
     phi_vgl_v.resize(SPOSet::DIM_VGL, wfc_list.size(), NumOrbitals);
     ratios_local.resize(wfc_list.size());
     grad_new_local.resize(wfc_list.size());
 
-    // calling Phi->mw_evaluateVGLandDetRatioGrads is a temporary workaround.
+    // calling phi_.mw_evaluateVGLandDetRatioGrads is a temporary workaround.
     // We may implement mw_evaluateVandDetRatio in the future.
-    wfc_leader.Phi->mw_evaluateVGLandDetRatioGrads(phi_list, p_list, iat, psiMinv_row_dev_ptr_list, phi_vgl_v,
+    wfc_leader.phi_.mw_evaluateVGLandDetRatioGrads(phi_list, p_list, iat, psiMinv_row_dev_ptr_list, phi_vgl_v,
                                                    ratios_local, grad_new_local);
   }
 
@@ -799,7 +799,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::evaluateRatios(const VirtualParticle
   }
   {
     ScopedTimer local_timer(SPOVTimer);
-    Phi->evaluateDetRatios(VP, psiV_host_view, d2psiV_host_view, ratios);
+    phi_.evaluateDetRatios(VP, psiV_host_view, d2psiV_host_view, ratios);
   }
 }
 
@@ -816,7 +816,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::evaluateSpinorRatios(
   }
   {
     ScopedTimer local_timer(SPOVTimer);
-    Phi->evaluateDetSpinorRatios(VP, psiV_host_view, spinor_multiplier, d2psiV_host_view, ratios);
+    phi_.evaluateDetSpinorRatios(VP, psiV_host_view, spinor_multiplier, d2psiV_host_view, ratios);
   }
 }
 
@@ -829,7 +829,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_evaluateRatios(
   assert(this == &wfc_list.getLeader());
   const size_t nw = wfc_list.size();
 
-  RefVectorWithLeader<SPOSet> phi_list(*Phi);
+  RefVectorWithLeader<SPOSet> phi_list(phi_);
   RefVector<Vector<Value>> psiV_list;
   std::vector<const Value*> invRow_ptr_list;
   phi_list.reserve(nw);
@@ -844,9 +844,9 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_evaluateRatios(
       const VirtualParticleSet& vp(vp_list[iw]);
       const int WorkingIndex = vp.refPtcl - FirstIndex;
       // build lists
-      phi_list.push_back(*det.Phi);
+      phi_list.push_back(det.phi_);
       psiV_list.push_back(det.psiV_host_view);
-      if (Phi->isOMPoffload())
+      if (phi_.isOMPoffload())
         invRow_ptr_list.push_back(det.psiMinv_.device_data() + WorkingIndex * psiMinv_.cols());
       else
         invRow_ptr_list.push_back(det.psiMinv_[WorkingIndex]);
@@ -855,7 +855,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_evaluateRatios(
 
   {
     ScopedTimer local_timer(SPOVTimer);
-    Phi->mw_evaluateDetRatios(phi_list, vp_list, psiV_list, invRow_ptr_list, ratios);
+    phi_.mw_evaluateDetRatios(phi_list, vp_list, psiV_list, invRow_ptr_list, ratios);
   }
 }
 
@@ -868,7 +868,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::evaluateDerivRatios(const VirtualPar
   const int WorkingIndex = VP.refPtcl - FirstIndex;
   assert(WorkingIndex >= 0);
   std::copy_n(psiMinv_[WorkingIndex], d2psiV.size(), d2psiV.data());
-  Phi->evaluateDerivRatios(VP, optvars, psiV_host_view, d2psiV_host_view, ratios, dratios, FirstIndex, LastIndex);
+  phi_.evaluateDerivRatios(VP, optvars, psiV_host_view, d2psiV_host_view, ratios, dratios, FirstIndex, LastIndex);
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>
@@ -882,7 +882,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::evaluateSpinorDerivRatios(
   const int WorkingIndex = VP.refPtcl - FirstIndex;
   assert(WorkingIndex >= 0);
   std::copy_n(psiMinv_[WorkingIndex], d2psiV.size(), d2psiV.data());
-  Phi->evaluateSpinorDerivRatios(VP, spinor_multiplier, optvars, psiV_host_view, d2psiV_host_view, ratios, dratios,
+  phi_.evaluateSpinorDerivRatios(VP, spinor_multiplier, optvars, psiV_host_view, d2psiV_host_view, ratios, dratios,
                                  FirstIndex, LastIndex);
 }
 
@@ -891,7 +891,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::evaluateRatiosAlltoOne(ParticleSet& 
 {
   {
     ScopedTimer local_timer(SPOVTimer);
-    Phi->evaluateValue(P, -1, psiV_host_view);
+    phi_.evaluateValue(P, -1, psiV_host_view);
   }
   for (int i = 0; i < psiMinv_.rows(); i++)
     ratios[FirstIndex + i] = simd::dot(psiMinv_[i], psiV.data(), NumOrbitals);
@@ -916,10 +916,10 @@ typename DiracDeterminantBatched<PL, VT, FPVT>::Grad DiracDeterminantBatched<PL,
     int iat)
 {
   Grad g(0.0);
-  if (Phi->hasIonDerivs())
+  if (phi_.hasIonDerivs())
   {
     resizeScratchObjectsForIonDerivs();
-    Phi->evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM);
+    phi_.evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM);
     // psiMinv columns have padding but grad_source_psiM ones don't
     for (int i = 0; i < psiMinv_.rows(); i++)
       g += simd::dot(psiMinv_[i], grad_source_psiM[i], NumOrbitals);
@@ -935,7 +935,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::evaluateHessian(ParticleSet& P, Hess
   grad_grad_source_psiM.resize(psiMinv_.rows(), NumOrbitals);
   //IM A HACK.  Assumes evaluateLog has already been executed.
   Matrix<Value> psiM_temp_host(psiM_temp.data(), psiM_temp.rows(), psiM_temp.cols());
-  Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp_host, dpsiM, grad_grad_source_psiM);
+  phi_.evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp_host, dpsiM, grad_grad_source_psiM);
   invertPsiM(psiM_temp, psiMinv_);
 
   phi_alpha_Minv      = 0.0;
@@ -964,10 +964,10 @@ typename DiracDeterminantBatched<PL, VT, FPVT>::Grad DiracDeterminantBatched<PL,
     TinyVector<ParticleSet::ParticleLaplacian, OHMMS_DIM>& lapl_grad)
 {
   Grad gradPsi(0.0);
-  if (Phi->hasIonDerivs())
+  if (phi_.hasIonDerivs())
   {
     resizeScratchObjectsForIonDerivs();
-    Phi->evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM, grad_grad_source_psiM,
+    phi_.evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM, grad_grad_source_psiM,
                             grad_lapl_source_psiM);
 
     // Compute matrices
@@ -1082,7 +1082,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::recompute(const ParticleSet& P)
     ScopedTimer spo_timer(SPOVGLTimer);
 
     UpdateMode = ORB_WALKER;
-    Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_host, dpsiM, d2psiM);
+    phi_.evaluate_notranspose(P, FirstIndex, LastIndex, psiM_host, dpsiM, d2psiM);
     auto* psiM_vgl_ptr = psiM_vgl.data();
     // transfer host to device, total size 4, g(3) + l(1)
     PRAGMA_OFFLOAD("omp target update to(psiM_vgl_ptr[psiM_vgl.capacity():psiM_vgl.capacity()*4])")
@@ -1100,7 +1100,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_recompute(const RefVectorWithLead
 
   RefVectorWithLeader<WaveFunctionComponent> wfc_filtered_list(wfc_list.getLeader());
   RefVectorWithLeader<ParticleSet> p_filtered_list(p_list.getLeader());
-  RefVectorWithLeader<SPOSet> phi_list(*wfc_leader.Phi);
+  RefVectorWithLeader<SPOSet> phi_list(wfc_leader.phi_);
   std::vector<Matrix<Value>> psiM_host_views;
   RefVector<const DualMatrix<Value>> psiM_temp_list;
   RefVector<Matrix<Value>> psiM_host_list;
@@ -1124,7 +1124,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_recompute(const RefVectorWithLead
       p_filtered_list.push_back(p_list[iw]);
 
       auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<PL, VT, FPVT>>(iw);
-      phi_list.push_back(*det.Phi);
+      phi_list.push_back(det.phi_);
       psiM_temp_list.push_back(det.psiM_temp);
       psiM_host_list.push_back(det.psiM_host);
       dpsiM_list.push_back(det.dpsiM);
@@ -1140,7 +1140,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_recompute(const RefVectorWithLead
     // I think through the magic of OMPtarget psiM_host_list actually results in psiM_temp being updated
     // on the device. For dspiM_list, d2psiM_list I think they are calculated on CPU and this is not true
     // This is the reason for the strange look omp target update to below.
-    wfc_leader.Phi->mw_evaluate_notranspose(phi_list, p_filtered_list, wfc_leader.FirstIndex, wfc_leader.LastIndex,
+    wfc_leader.phi_.mw_evaluate_notranspose(phi_list, p_filtered_list, wfc_leader.FirstIndex, wfc_leader.LastIndex,
                                             psiM_host_list, dpsiM_list, d2psiM_list);
   }
 
@@ -1175,7 +1175,7 @@ void DiracDeterminantBatched<PL, VT, FPVT>::evaluateDerivatives(ParticleSet& P,
                                                                 Vector<Value>& dlogpsi,
                                                                 Vector<Value>& dhpsioverpsi)
 {
-  Phi->evaluateDerivatives(P, active, dlogpsi, dhpsioverpsi, FirstIndex, LastIndex);
+  phi_.evaluateDerivatives(P, active, dlogpsi, dhpsioverpsi, FirstIndex, LastIndex);
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>
@@ -1183,21 +1183,20 @@ void DiracDeterminantBatched<PL, VT, FPVT>::evaluateDerivativesWF(ParticleSet& P
                                                                   const opt_variables_type& active,
                                                                   Vector<ValueType>& dlogpsi)
 {
-  Phi->evaluateDerivativesWF(P, active, dlogpsi, FirstIndex, LastIndex);
+  phi_.evaluateDerivativesWF(P, active, dlogpsi, FirstIndex, LastIndex);
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>
 void DiracDeterminantBatched<PL, VT, FPVT>::registerTWFFastDerivWrapper(const ParticleSet& P,
                                                                         TWFFastDerivWrapper& twf) const
 {
-  twf.addGroup(P, P.getGroupID(FirstIndex), Phi.get());
+  twf.addGroup(P, P.getGroupID(FirstIndex), &phi_);
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>
-std::unique_ptr<DiracDeterminantBase> DiracDeterminantBatched<PL, VT, FPVT>::makeCopy(
-    std::unique_ptr<SPOSet>&& spo) const
+std::unique_ptr<DiracDeterminantBase> DiracDeterminantBatched<PL, VT, FPVT>::makeCopy(SPOSet& phi) const
 {
-  return std::make_unique<DiracDeterminantBatched<PL, VT, FPVT>>(std::move(spo), FirstIndex, LastIndex, ndelay_,
+  return std::make_unique<DiracDeterminantBatched<PL, VT, FPVT>>(phi, FirstIndex, LastIndex, ndelay_,
                                                                  matrix_inverter_kind_);
 }
 
@@ -1205,7 +1204,7 @@ template<PlatformKind PL, typename VT, typename FPVT>
 void DiracDeterminantBatched<PL, VT, FPVT>::createResource(ResourceCollection& collection) const
 {
   collection.addResource(std::make_unique<DiracDeterminantBatchedMultiWalkerResource>());
-  Phi->createResource(collection);
+  phi_.createResource(collection);
   if (matrix_inverter_kind_ == DetMatInvertor::ACCEL)
     collection.addResource(std::make_unique<typename DetInverterSelector<PL, FPVT, VT>::Inverter>());
   else
@@ -1222,14 +1221,14 @@ void DiracDeterminantBatched<PL, VT, FPVT>::acquireResource(
   auto& mw_res              = wfc_leader.mw_res_handle_.getResource();
   mw_res.psiMinv_refs.reserve(wfc_list.size());
 
-  RefVectorWithLeader<SPOSet> phi_list(*wfc_leader.Phi);
+  RefVectorWithLeader<SPOSet> phi_list(wfc_leader.phi_);
   for (WaveFunctionComponent& wfc : wfc_list)
   {
     auto& det = static_cast<DiracDeterminantBatched<PL, VT, FPVT>&>(wfc);
-    phi_list.push_back(*det.Phi);
+    phi_list.push_back(det.phi_);
     mw_res.psiMinv_refs.push_back(det.psiMinv_);
   }
-  wfc_leader.Phi->acquireResource(collection, phi_list);
+  wfc_leader.phi_.acquireResource(collection, phi_list);
   wfc_leader.accel_inverter_ = collection.lendResource<DiracMatrixInverter<FPVT, VT>>();
 }
 
@@ -1241,13 +1240,13 @@ void DiracDeterminantBatched<PL, VT, FPVT>::releaseResource(
   auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminantBatched<PL, VT, FPVT>>();
   wfc_leader.mw_res_handle_.getResource().psiMinv_refs.clear();
   collection.takebackResource(wfc_leader.mw_res_handle_);
-  RefVectorWithLeader<SPOSet> phi_list(*wfc_leader.Phi);
+  RefVectorWithLeader<SPOSet> phi_list(wfc_leader.phi_);
   for (WaveFunctionComponent& wfc : wfc_list)
   {
     auto& det = static_cast<DiracDeterminantBatched<PL, VT, FPVT>&>(wfc);
-    phi_list.push_back(*det.Phi);
+    phi_list.push_back(det.phi_);
   }
-  wfc_leader.Phi->releaseResource(collection, phi_list);
+  wfc_leader.phi_.releaseResource(collection, phi_list);
   collection.takebackResource(wfc_leader.accel_inverter_);
 }
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -86,7 +86,7 @@ public:
    *@param last index of last particle
    *@param ndelay delayed update rank
    */
-  DiracDeterminantBatched(std::unique_ptr<SPOSet>&& spos,
+  DiracDeterminantBatched(SPOSet& phi,
                           int first,
                           int last,
                           int ndelay                          = 1,
@@ -229,7 +229,7 @@ public:
 
   void recompute(const ParticleSet& P) override;
 
-  /** Does a Phi->mw_evaluate_notranspose then mw_invertPsiM over a set of
+  /** Does a phi_.mw_evaluate_notranspose then mw_invertPsiM over a set of
    *  elements filtered based on the recompute mask.
    *
    */
@@ -264,7 +264,7 @@ public:
    * This interface is exposed only to SlaterDet and its derived classes
    * can overwrite to clone itself correctly.
    */
-  std::unique_ptr<DiracDeterminantBase> makeCopy(std::unique_ptr<SPOSet>&& spo) const override;
+  std::unique_ptr<DiracDeterminantBase> makeCopy(SPOSet& phi) const override;
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<Value>& ratios) override;
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
@@ -46,7 +46,7 @@ public:
    *@param spos the single-particle orbital set
    *@param first index of the first particle
    */
-  DiracDeterminantWithBackflow(std::unique_ptr<SPOSet>&& spos, BackflowTransformation& BF, int first, int last);
+  DiracDeterminantWithBackflow(SPOSet& phi, BackflowTransformation& BF, int first, int last);
 
   ///default destructor
   ~DiracDeterminantWithBackflow() override;
@@ -121,9 +121,9 @@ public:
    * This interface is exposed only to SlaterDet and its derived classes
    * can overwrite to clone itself correctly.
    */
-  std::unique_ptr<DiracDeterminantWithBackflow> makeCopyWithBF(std::unique_ptr<SPOSet>&& spo,
-                                                               BackflowTransformation& BF) const;
-  [[noreturn]] std::unique_ptr<DiracDeterminantBase> makeCopy(std::unique_ptr<SPOSet>&& spo) const override
+  std::unique_ptr<DiracDeterminantWithBackflow> makeCopyWithBF(SPOSet& phi, BackflowTransformation& BF) const;
+
+  [[noreturn]] std::unique_ptr<DiracDeterminantBase> makeCopy(SPOSet& phi) const override
   {
     throw std::runtime_error("makeCopy spo should not be called.");
   }

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -28,7 +28,7 @@ SlaterDet::SlaterDet(ParticleSet& targetPtcl,
                      std::vector<std::unique_ptr<SPOSet>>&& sposets,
                      std::vector<std::unique_ptr<Determinant_t>>&& dets,
                      const std::string& class_name)
-    : Dets(std::move(dets)), sposets_(std::move(sposets))
+    : sposets_(std::move(sposets)), Dets(std::move(dets))
 {
   assert(Dets.size() == targetPtcl.groups());
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -42,20 +42,20 @@ SlaterDet::~SlaterDet() = default;
 
 bool SlaterDet::isOptimizable() const
 {
-  return std::any_of(Dets.begin(), Dets.end(), [](const auto& det) { return det->isOptimizable(); });
+  return std::any_of(sposets_.begin(), sposets_.end(), [](const auto& phi) { return phi->isOptimizable(); });
 }
 
 void SlaterDet::extractOptimizableObjectRefs(UniqueOptObjRefs& opt_obj_refs)
 {
-  for (int i = 0; i < Dets.size(); i++)
-    Dets[i]->extractOptimizableObjectRefs(opt_obj_refs);
+  for (const auto& sposet : sposets_)
+    sposet->extractOptimizableObjectRefs(opt_obj_refs);
 }
 
 void SlaterDet::checkOutVariables(const opt_variables_type& active)
 {
-  if (isOptimizable())
-    for (int i = 0; i < Dets.size(); i++)
-      Dets[i]->checkOutVariables(active);
+  for (const auto& sposet : sposets_)
+    if (sposet->isOptimizable())
+      sposet->checkOutVariables(active);
 }
 
 PsiValue SlaterDet::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -317,7 +317,7 @@ private:
   ///the last particle of each group
   std::vector<int> Last;
 
-  ///container for the SPOSets
+  ///container for the unique SPOSets
   const std::vector<std::unique_ptr<SPOSet>> sposets_;
 };
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -27,8 +27,6 @@ class SlaterDet : public WaveFunctionComponent
 {
 public:
   using Determinant_t = DiracDeterminantBase;
-  ///container for the DiracDeterminants
-  const std::vector<std::unique_ptr<Determinant_t>> Dets;
 
   /**  constructor
    * @param targetPtcl target Particleset
@@ -79,9 +77,6 @@ public:
                     const std::vector<bool>& recompute) const override;
 
   void evaluateHessian(ParticleSet& P, HessVector& grad_grad_psi) override;
-
-  ///return the total number of Dirac determinants
-  inline int size() const { return Dets.size(); }
 
   void registerData(ParticleSet& P, WFBufferType& buf) override;
 
@@ -188,7 +183,7 @@ public:
   GradType evalGradSource(ParticleSet& P, ParticleSet& src, int iat) override
   {
     GradType G = GradType();
-    for (int iz = 0; iz < size(); iz++)
+    for (int iz = 0; iz < Dets.size(); iz++)
       G += Dets[iz]->evalGradSource(P, src, iat);
     return G;
   }
@@ -200,7 +195,7 @@ public:
                           TinyVector<ParticleSet::ParticleLaplacian, OHMMS_DIM>& lapl_grad) override
   {
     GradType G = GradType();
-    for (int iz = 0; iz < size(); iz++)
+    for (int iz = 0; iz < Dets.size(); iz++)
       G += Dets[iz]->evalGradSource(P, src, iat, grad_grad, lapl_grad);
     return G;
   }
@@ -269,8 +264,6 @@ public:
 
   std::unique_ptr<WaveFunctionComponent> makeClone(ParticleSet& tqp) const override;
 
-  SPOSet& getPhi(int i = 0) { return Dets[i]->getPhi(); }
-
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override;
 
   void evaluateDerivatives(ParticleSet& P,
@@ -289,6 +282,13 @@ public:
     for (int i = 0; i < Dets.size(); i++)
       Dets[i]->evaluateDerivativesWF(P, active, dlogpsi);
   }
+
+  ///return the total number of Dirac determinants
+  inline int getNumDets() const { return Dets.size(); }
+  ///return the i-th determinant
+  inline auto& getDet(const int i) { return *Dets[i]; }
+  ///return the sposet of the i-th determinant
+  SPOSet& getPhi(int i = 0) { return Dets[i]->getPhi(); }
 
 private:
   //get Det ID
@@ -317,6 +317,9 @@ private:
 
   ///container for the unique SPOSets
   const std::vector<std::unique_ptr<SPOSet>> sposets_;
+
+  ///container for the DiracDeterminants
+  const std::vector<std::unique_ptr<Determinant_t>> Dets;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -19,8 +19,6 @@
 #define QMCPLUSPLUS_SLATERDETERMINANT_WITHBASE_H
 #include "QMCWaveFunctions/Fermion/DiracDeterminantBase.h"
 
-#include <map>
-
 namespace qmcplusplus
 {
 class TWFFastDerivWrapper;

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -36,7 +36,8 @@ public:
    * @param targetPtcl target Particleset
    */
   SlaterDet(ParticleSet& targetPtcl,
-            std::vector<std::unique_ptr<Determinant_t>> dets,
+            std::vector<std::unique_ptr<SPOSet>>&& sposets,
+            std::vector<std::unique_ptr<Determinant_t>>&& dets,
             const std::string& class_name = "SlaterDet");
 
   ///destructor
@@ -270,7 +271,7 @@ public:
 
   std::unique_ptr<WaveFunctionComponent> makeClone(ParticleSet& tqp) const override;
 
-  SPOSetPtr getPhi(int i = 0) { return Dets[i]->getPhi(); }
+  SPOSet& getPhi(int i = 0) { return Dets[i]->getPhi(); }
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override;
 
@@ -315,6 +316,9 @@ private:
 
   ///the last particle of each group
   std::vector<int> Last;
+
+  ///container for the SPOSets
+  const std::vector<std::unique_ptr<SPOSet>> sposets_;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
@@ -72,10 +72,10 @@ private:
    * @param spin_group the spin group of the created determinant
    * @return BFTrans backflow transformations
    */
-  std::unique_ptr<DiracDeterminantBase> putDeterminant(
-      xmlNodePtr cur,
-      int spin_group,
-      const std::unique_ptr<BackflowTransformation>& BFTrans);
+  std::unique_ptr<DiracDeterminantBase> putDeterminant(xmlNodePtr cur,
+                                                       int spin_group,
+                                                       std::vector<std::unique_ptr<SPOSet>>& unique_sposets,
+                                                       const std::unique_ptr<BackflowTransformation>& BFTrans);
 
   std::unique_ptr<MultiSlaterDetTableMethod> createMSDFast(xmlNodePtr cur,
                                                            ParticleSet& target_ptcl,

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.h
@@ -136,7 +136,7 @@ public:
   void testDerivGL(ParticleSet& P);
 
 private:
-  ///container for the SPOSets
+  ///container for the unique SPOSets
   const std::vector<std::unique_ptr<SPOSet>> sposets_;
 
   /// backflow transformation

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.h
@@ -31,8 +31,9 @@ public:
    * @param rn release node
    */
   SlaterDetWithBackflow(ParticleSet& targetPtcl,
-                        std::vector<std::unique_ptr<Determinant_t>> dets,
-                        std::unique_ptr<BackflowTransformation> BF);
+                        std::vector<std::unique_ptr<SPOSet>>&& sposets,
+                        std::unique_ptr<BackflowTransformation> BF,
+                        std::vector<std::unique_ptr<Determinant_t>>&& dets);
 
   ///destructor
   ~SlaterDetWithBackflow() override;
@@ -123,7 +124,7 @@ public:
 
   std::unique_ptr<WaveFunctionComponent> makeClone(ParticleSet& tqp) const override;
 
-  SPOSetPtr getPhi(int i = 0) const { return Dets[i]->getPhi(); }
+  SPOSet& getPhi(int i = 0) { return Dets[i]->getPhi(); }
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override;
 
@@ -135,10 +136,14 @@ public:
   void testDerivGL(ParticleSet& P);
 
 private:
-  ///container for the DiracDeterminants
-  const std::vector<std::unique_ptr<Determinant_t>> Dets;
+  ///container for the SPOSets
+  const std::vector<std::unique_ptr<SPOSet>> sposets_;
+
   /// backflow transformation
   const std::unique_ptr<BackflowTransformation> BFTrans;
+
+  ///container for the DiracDeterminants
+  const std::vector<std::unique_ptr<Determinant_t>> Dets;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -447,7 +447,7 @@ public:
    */
   virtual RealType KECorrection();
 
-  /** if true, this contains optimizable components
+  /** if true, *this contains optimizable components. It is inclusive.
    */
   virtual bool isOptimizable() const { return false; }
 

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -527,7 +527,7 @@ void test_DiracDeterminant_spinor_update(const DetMatInvertor inverter_kind)
   auto spinor_set = std::make_unique<SpinorSet>("free_orb_spinor");
   spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
 
-  DET dd(std::move(spinor_set), 0, nelec, 1, inverter_kind);
+  DET dd(*spinor_set, 0, nelec, 1, inverter_kind);
   app_log() << " nelec=" << nelec << std::endl;
 
   ParticleGradient G;

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -54,8 +54,8 @@ void test_DiracDeterminant_first(const DetMatInvertor inverter_kind)
   auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 3;
   spo_init->setOrbitalSetSize(norb);
-  DET ddb(std::move(spo_init), 0, norb, 1, inverter_kind);
-  auto spo = dynamic_cast<FakeSPO<Value>*>(ddb.getPhi());
+  DET ddb(*spo_init, 0, norb, 1, inverter_kind);
+  auto spo = dynamic_cast<FakeSPO<Value>&>(ddb.getPhi());
 
   // occurs in call to registerData
   ddb.dpsiV.resize(norb);
@@ -162,8 +162,8 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
   auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);
-  DET ddb(std::move(spo_init), 0, norb, 1, inverter_kind);
-  auto spo = dynamic_cast<FakeSPO<Value>*>(ddb.getPhi());
+  DET ddb(*spo_init, 0, norb, 1, inverter_kind);
+  auto spo = dynamic_cast<FakeSPO<Value>&>(ddb.getPhi());
 
   // occurs in call to registerData
   ddb.dpsiV.resize(norb);
@@ -177,13 +177,13 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
 
   Matrix<Value> orig_a;
   orig_a.resize(4, 4);
-  orig_a = spo->a2;
+  orig_a = spo.a2;
 
   for (int i = 0; i < 3; i++)
   {
     for (int j = 0; j < norb; j++)
     {
-      orig_a(j, i) = spo->v2(i, j);
+      orig_a(j, i) = spo.v2(i, j);
     }
   }
 
@@ -193,29 +193,29 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
   Matrix<Value> a_update1, scratchT;
   a_update1.resize(4, 4);
   scratchT.resize(4, 4);
-  a_update1 = spo->a2;
+  a_update1 = spo.a2;
   for (int j = 0; j < norb; j++)
   {
-    a_update1(j, 0) = spo->v2(0, j);
+    a_update1(j, 0) = spo.v2(0, j);
   }
 
   Matrix<Value> a_update2;
   a_update2.resize(4, 4);
-  a_update2 = spo->a2;
+  a_update2 = spo.a2;
   for (int j = 0; j < norb; j++)
   {
-    a_update2(j, 0) = spo->v2(0, j);
-    a_update2(j, 1) = spo->v2(1, j);
+    a_update2(j, 0) = spo.v2(0, j);
+    a_update2(j, 1) = spo.v2(1, j);
   }
 
   Matrix<Value> a_update3;
   a_update3.resize(4, 4);
-  a_update3 = spo->a2;
+  a_update3 = spo.a2;
   for (int j = 0; j < norb; j++)
   {
-    a_update3(j, 0) = spo->v2(0, j);
-    a_update3(j, 1) = spo->v2(1, j);
-    a_update3(j, 2) = spo->v2(2, j);
+    a_update3(j, 0) = spo.v2(0, j);
+    a_update3(j, 1) = spo.v2(1, j);
+    a_update3(j, 2) = spo.v2(2, j);
   }
 
   ParticleSet::GradType grad;
@@ -304,8 +304,8 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);
   // maximum delay 2
-  DET ddc(std::move(spo_init), 0, norb, 2, inverter_kind);
-  auto spo = dynamic_cast<FakeSPO<Value>*>(ddc.getPhi());
+  DET ddc(*spo_init, 0, norb, 2, inverter_kind);
+  auto spo = dynamic_cast<FakeSPO<Value>&>(ddc.getPhi());
 
   // occurs in call to registerData
   ddc.dpsiV.resize(norb);
@@ -319,13 +319,13 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
 
   Matrix<Value> orig_a;
   orig_a.resize(4, 4);
-  orig_a = spo->a2;
+  orig_a = spo.a2;
 
   for (int i = 0; i < 3; i++)
   {
     for (int j = 0; j < norb; j++)
     {
-      orig_a(j, i) = spo->v2(i, j);
+      orig_a(j, i) = spo.v2(i, j);
     }
   }
 
@@ -335,29 +335,29 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
   Matrix<Value> a_update1, scratchT;
   scratchT.resize(4, 4);
   a_update1.resize(4, 4);
-  a_update1 = spo->a2;
+  a_update1 = spo.a2;
   for (int j = 0; j < norb; j++)
   {
-    a_update1(j, 0) = spo->v2(0, j);
+    a_update1(j, 0) = spo.v2(0, j);
   }
 
   Matrix<Value> a_update2;
   a_update2.resize(4, 4);
-  a_update2 = spo->a2;
+  a_update2 = spo.a2;
   for (int j = 0; j < norb; j++)
   {
-    a_update2(j, 0) = spo->v2(0, j);
-    a_update2(j, 1) = spo->v2(1, j);
+    a_update2(j, 0) = spo.v2(0, j);
+    a_update2(j, 1) = spo.v2(1, j);
   }
 
   Matrix<Value> a_update3;
   a_update3.resize(4, 4);
-  a_update3 = spo->a2;
+  a_update3 = spo.a2;
   for (int j = 0; j < norb; j++)
   {
-    a_update3(j, 0) = spo->v2(0, j);
-    a_update3(j, 1) = spo->v2(1, j);
-    a_update3(j, 2) = spo->v2(2, j);
+    a_update3(j, 0) = spo.v2(0, j);
+    a_update3(j, 1) = spo.v2(1, j);
+    a_update3(j, 2) = spo.v2(2, j);
   }
 
 

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -40,8 +40,8 @@ void test_DiracDeterminantBatched_first()
   auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 3;
   spo_init->setOrbitalSetSize(norb);
-  Det ddb(std::move(spo_init), 0, norb);
-  auto spo = dynamic_cast<FakeSPO<Value>*>(ddb.getPhi());
+  Det ddb(*spo_init, 0, norb);
+  auto spo = dynamic_cast<FakeSPO<Value>&>(ddb.getPhi());
 
   const SimulationCell simulation_cell;
   ParticleSet elec(simulation_cell);
@@ -143,8 +143,8 @@ void test_DiracDeterminantBatched_second()
   auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);
-  Det ddb(std::move(spo_init), 0, norb);
-  auto spo = dynamic_cast<FakeSPO<Value>*>(ddb.getPhi());
+  Det ddb(*spo_init, 0, norb);
+  auto spo = dynamic_cast<FakeSPO<Value>&>(ddb.getPhi());
 
   const SimulationCell simulation_cell;
   ParticleSet elec(simulation_cell);
@@ -154,13 +154,13 @@ void test_DiracDeterminantBatched_second()
 
   Matrix<Value> orig_a;
   orig_a.resize(4, 4);
-  orig_a = spo->a2;
+  orig_a = spo.a2;
 
   for (int i = 0; i < 3; i++)
   {
     for (int j = 0; j < norb; j++)
     {
-      orig_a(j, i) = spo->v2(i, j);
+      orig_a(j, i) = spo.v2(i, j);
     }
   }
 
@@ -170,29 +170,29 @@ void test_DiracDeterminantBatched_second()
   Matrix<Value> a_update1, scratchT;
   a_update1.resize(4, 4);
   scratchT.resize(4, 4);
-  a_update1 = spo->a2;
+  a_update1 = spo.a2;
   for (int j = 0; j < norb; j++)
   {
-    a_update1(j, 0) = spo->v2(0, j);
+    a_update1(j, 0) = spo.v2(0, j);
   }
 
   Matrix<Value> a_update2;
   a_update2.resize(4, 4);
-  a_update2 = spo->a2;
+  a_update2 = spo.a2;
   for (int j = 0; j < norb; j++)
   {
-    a_update2(j, 0) = spo->v2(0, j);
-    a_update2(j, 1) = spo->v2(1, j);
+    a_update2(j, 0) = spo.v2(0, j);
+    a_update2(j, 1) = spo.v2(1, j);
   }
 
   Matrix<Value> a_update3;
   a_update3.resize(4, 4);
-  a_update3 = spo->a2;
+  a_update3 = spo.a2;
   for (int j = 0; j < norb; j++)
   {
-    a_update3(j, 0) = spo->v2(0, j);
-    a_update3(j, 1) = spo->v2(1, j);
-    a_update3(j, 2) = spo->v2(2, j);
+    a_update3(j, 0) = spo.v2(0, j);
+    a_update3(j, 1) = spo.v2(1, j);
+    a_update3(j, 2) = spo.v2(2, j);
   }
 
   ParticleSet::GradType grad;
@@ -278,8 +278,8 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 4;
   spo_init->setOrbitalSetSize(norb);
-  Det ddc(std::move(spo_init), 0, norb, delay_rank, matrix_inverter_kind);
-  auto spo = dynamic_cast<FakeSPO<Value>*>(ddc.getPhi());
+  Det ddc(*spo_init, 0, norb, delay_rank, matrix_inverter_kind);
+  auto spo = dynamic_cast<FakeSPO<Value>&>(ddc.getPhi());
 
   const SimulationCell simulation_cell;
   ParticleSet elec(simulation_cell);
@@ -289,13 +289,13 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
 
   Matrix<Value> orig_a;
   orig_a.resize(4, 4);
-  orig_a = spo->a2;
+  orig_a = spo.a2;
 
   for (int i = 0; i < 3; i++)
   {
     for (int j = 0; j < norb; j++)
     {
-      orig_a(j, i) = spo->v2(i, j);
+      orig_a(j, i) = spo.v2(i, j);
     }
   }
 
@@ -305,29 +305,29 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   Matrix<Value> a_update1, scratchT;
   scratchT.resize(4, 4);
   a_update1.resize(4, 4);
-  a_update1 = spo->a2;
+  a_update1 = spo.a2;
   for (int j = 0; j < norb; j++)
   {
-    a_update1(j, 0) = spo->v2(0, j);
+    a_update1(j, 0) = spo.v2(0, j);
   }
 
   Matrix<Value> a_update2;
   a_update2.resize(4, 4);
-  a_update2 = spo->a2;
+  a_update2 = spo.a2;
   for (int j = 0; j < norb; j++)
   {
-    a_update2(j, 0) = spo->v2(0, j);
-    a_update2(j, 1) = spo->v2(1, j);
+    a_update2(j, 0) = spo.v2(0, j);
+    a_update2(j, 1) = spo.v2(1, j);
   }
 
   Matrix<Value> a_update3;
   a_update3.resize(4, 4);
-  a_update3 = spo->a2;
+  a_update3 = spo.a2;
   for (int j = 0; j < norb; j++)
   {
-    a_update3(j, 0) = spo->v2(0, j);
-    a_update3(j, 1) = spo->v2(1, j);
-    a_update3(j, 2) = spo->v2(2, j);
+    a_update3(j, 0) = spo.v2(0, j);
+    a_update3(j, 1) = spo.v2(1, j);
+    a_update3(j, 2) = spo.v2(2, j);
   }
 
 
@@ -421,7 +421,8 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
 
   // make a clones
   ParticleSet elec_clone(elec);
-  std::unique_ptr<WaveFunctionComponent> ddc_clone(ddc.makeCopy(ddc.getPhi()->makeClone()));
+  auto spo_clone = ddc.getPhi().makeClone();
+  std::unique_ptr<WaveFunctionComponent> ddc_clone(ddc.makeCopy(*spo_clone));
   auto& ddc_clone_ref = dynamic_cast<Det&>(*ddc_clone);
 
   // testing batched interfaces

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
@@ -674,11 +674,11 @@ TEST_CASE("Rotated LCAO rotation consistency", "[qmcapp]")
   // Use the SPOs from different spins to separately track rotation applied using the stored coefficients
   // versus the regular coefficients.
   // The coefficient matrices should match after the same rotations are applied to each.
-  SPOSetPtr spoptr     = sdet->getPhi(0);
+  SPOSetPtr spoptr     = &sdet->getPhi(0);
   RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(spoptr);
   REQUIRE(rot_spo != nullptr);
 
-  SPOSetPtr spoptr1           = sdet->getPhi(1);
+  SPOSetPtr spoptr1           = &sdet->getPhi(1);
   RotatedSPOs* global_rot_spo = dynamic_cast<RotatedSPOs*>(spoptr1);
   REQUIRE(global_rot_spo != nullptr);
 

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -116,10 +116,12 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   REQUIRE(spo != nullptr);
 
   std::vector<std::unique_ptr<DiracDeterminantBase>> dets;
-  dets.push_back(std::make_unique<DiracDet>(spo->makeClone(), 0, 2));
-  dets.push_back(std::make_unique<DiracDet>(spo->makeClone(), 2, 4));
+  dets.push_back(std::make_unique<DiracDet>(*spo, 0, 2));
+  dets.push_back(std::make_unique<DiracDet>(*spo, 2, 4));
 
-  auto slater_det = std::make_unique<SlaterDet>(elec_, std::move(dets));
+  std::vector<std::unique_ptr<SPOSet>> unique_sposets;
+  unique_sposets.emplace_back(std::move(spo));
+  auto slater_det = std::make_unique<SlaterDet>(elec_, std::move(unique_sposets), std::move(dets));
 
   RuntimeOptions runtime_options;
   TrialWaveFunction psi(runtime_options);

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -135,12 +135,14 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
   REQUIRE(spo != nullptr);
 
   std::vector<std::unique_ptr<DiracDeterminantBase>> dets;
-  auto det_up_ptr = std::make_unique<DiracDet>(spo->makeClone(), 0, 2, ndelay);
+  auto det_up_ptr = std::make_unique<DiracDet>(*spo, 0, 2, ndelay);
   auto det_up     = det_up_ptr.get();
   dets.push_back(std::move(det_up_ptr));
-  dets.push_back(std::make_unique<DiracDet>(spo->makeClone(), 2, 4, ndelay));
+  dets.push_back(std::make_unique<DiracDet>(*spo, 2, 4, ndelay));
 
-  auto slater_det = std::make_unique<SlaterDet>(elec_, std::move(dets));
+  std::vector<std::unique_ptr<SPOSet>> unique_sposets;
+  unique_sposets.emplace_back(std::move(spo));
+  auto slater_det = std::make_unique<SlaterDet>(elec_, std::move(unique_sposets), std::move(dets));
 
   RuntimeOptions runtime_options;
   TrialWaveFunction psi(runtime_options);


### PR DESCRIPTION
Depends on #5461
## Proposed changes
This PR move sposet ownership from DiracDeterminant to SlaterDet.
SlaterDet has the proper knowledge how many unique sposets are actually used by the deterimants.
This is a necessary step to have clean handling of optimization in the case of restricted HF.

## What type(s) of changes does this code introduce?
- Bugfix. More of a conceptual bug.

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with current the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
