### PR TITLE
Remove CrayLinuxEnvironment related setting.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,30 +238,6 @@ else(CMAKE_TOOLCHAIN_FILE)
                     "Please use cc/CC as the C/C++ compiler to ensure correct cross-compiling for the compute nodes "
                     "unless you understand cross-compiling and intend not to use Cray compiler wrappers.")
   endif()
-  if(CMAKE_SYSTEM_NAME STREQUAL "CrayLinuxEnvironment")
-    message(STATUS "Running on a Cray machine.")
-
-    if(NOT $ENV{CRAYPE_LINK_TYPE} STREQUAL "dynamic")
-      message(WARNING "Cray Programming Environment uses static linking by default. "
-                      "We prefer dynamic linking which makes library searching easier. "
-                      "Setting environment variable CRAYPE_LINK_TYPE to \"dynamic\" enables dynamic linking.\n")
-    endif()
-
-    if(NOT DEFINED MPIEXEC_EXECUTABLE)
-      find_program(MPIEXEC_EXECUTABLE aprun)
-      if(NOT MPIEXEC_EXECUTABLE)
-        # For slurm use srun
-        find_program(MPIEXEC_EXECUTABLE srun)
-      endif(NOT MPIEXEC_EXECUTABLE)
-    endif()
-  else()
-    if($ENV{CRAYPE_VERSION} MATCHES "." AND BASE_CXX_COMPILER_NAME STREQUAL "CC")
-      message(
-        FATAL_ERROR
-          "Cray compiler wrapper detected. Empty the build folder and rerun cmake with -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment added."
-      )
-    endif()
-  endif()
 
   include(inspectCompiler)
   TestCXXMainCompiles("After_Customization")

--- a/config/build_olcf_frontier_ROCm.sh
+++ b/config/build_olcf_frontier_ROCm.sh
@@ -15,10 +15,8 @@ module load PrgEnv-amd amd/6.3.1
 module unload darshan-runtime
 unset HIP_PATH # it messed up clang as a HIP compiler.
 module unload cray-libsci
-module load cmake
-module load cray-fftw
-module load openblas/0.3.28-omp
-module load cray-hdf5-parallel
+module load cray-fftw cray-hdf5-parallel
+module load Core/25.03 cmake openblas/0.3.28-omp
 
 # edit this line if you are not a member of mat151
 export BOOST_ROOT=/ccs/proj/mat151/opt/boost/1_81_0
@@ -75,7 +73,7 @@ echo "**********************************"
 mkdir $folder
 cd $folder
 if [ ! -f CMakeCache.txt ] ; then
-cmake $CMAKE_FLAGS -DCMAKE_C_COMPILER=cc -DCMAKE_CXX_COMPILER=CC -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment \
+cmake $CMAKE_FLAGS -DCMAKE_C_COMPILER=cc -DCMAKE_CXX_COMPILER=CC \
       -DCMAKE_CXX_FLAGS="-add-runpath" \
       $source_folder
 fi

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -311,7 +311,6 @@ the path to the source directory.
                          Release (create a release/optimized build)
                          RelWithDebInfo (create a release/optimized build with debug info)
                          MinSizeRel (create an executable optimized for size)
-    CMAKE_SYSTEM_NAME    Set value to CrayLinuxEnvironment when cross-compiling in Cray Programming Environment.
     CMAKE_C_COMPILER     Set the C compiler
     CMAKE_CXX_COMPILER   Set the C++ compiler
     CMAKE_C_FLAGS        Set the C flags.  Note: to prevent default
@@ -612,8 +611,7 @@ QMCPACK tried to do its best with CMake to facilitate cross compiling.
 
 - On a machine using a Cray programming environment, we rely on
   compiler wrappers provided by Cray to correctly set architecture-specific
-  flags. Please also add ``-DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment`` to cmake.
-  The CMake configure log should indicate that a Cray machine was detected.
+  flags.
 
 - If not on a Cray machine, by default we assume building for
   the host architecture (e.g., -xHost is added for the Intel compiler


### PR DESCRIPTION
## Proposed changes
HPE/Cray has discontinued CrayLinuxEnvironment for a very long time. The last machine I had access was Theta.
Using this setting is harmful on modern Cray machines. This PR removes the requirement of using `-DDCMAKE_SYSTEM_NAME=CrayLinuxEnvironmen`. In case a user still has access to old machines, this setting can still be activated as supported by CMake.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?

- Yes
- No

## What systems has this change been tested on?
Frontier

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with current the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
