### PR TITLE
Add partial deterministic energy density estimator tests

### DIFF
--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -2301,3 +2301,52 @@ add_test_check_file_existence(deterministic-diamondC_1x1x1_pp-orbital_images-1-1
 add_test_check_file_existence(deterministic-diamondC_1x1x1_pp-orbital_images-1-1 spo_ud_orbital_0003_abs.xsf TRUE)
 add_test_check_file_existence(deterministic-diamondC_1x1x1_pp-orbital_images-1-1 spo_ud_orbital_0003_abs2.xsf TRUE)
 add_test_check_file_existence(deterministic-diamondC_1x1x1_pp-orbital_images-1-1 spo_ud_orbital_0004.xsf FALSE)
+
+# Energy density estimator initial tests
+qmc_run_and_check(
+  deterministic-diamondC_1x1x1_pp-vmc_sdj-estimator-energydensity-cell
+  "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+  det_qmc_short_edens_cell
+  det_qmc_short_edens_cell.in.xml
+  1
+  1
+  TRUE
+  0
+  DET_DIAMOND_SCALARS # VMC
+)
+
+qmc_run_and_check(
+  deterministic-diamondC_1x1x1_pp-vmc_sdj-estimator-energydensity-voronoi
+  "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+  det_qmc_short_edens_voronoi
+  det_qmc_short_edens_voronoi.in.xml
+  1
+  1
+  TRUE
+  0
+  DET_DIAMOND_SCALARS # VMC
+)
+
+qmc_run_and_check(
+  deterministic-diamondC_1x1x1_pp-vmcbatch_sdj-estimator-energydensity-cell
+  "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+  det_qmc_short_vmcbatch_edens_cell
+  det_qmc_short_vmcbatch_edens_cell.in.xml
+  1
+  1
+  TRUE
+#  0
+#  DET_DIAMOND_SCALARS # VMC
+)
+
+qmc_run_and_check(
+  deterministic-diamondC_1x1x1_pp-vmcbatch_sdj-estimator-energydensity-voronoi
+  "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+  det_qmc_short_vmcbatch_edens_voronoi
+  det_qmc_short_vmcbatch_edens_voronoi.in.xml
+  1
+  1
+  TRUE
+#  0
+#  DET_DIAMOND_SCALARS # VMC
+)

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short_edens_cell.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short_edens_cell.in.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="det_qmc_short_edens_cell" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+    <parameter name="driver_version">legacy</parameter>
+   </project>
+   <random seed="71"/>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <sposet_collection type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+            <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
+         </sposet_collection>
+         <determinantset>
+           <slaterdeterminant>
+	      <determinant sposet="spo_ud"/>
+              <determinant sposet="spo_ud"/>		   
+           </slaterdeterminant>
+         </determinantset>	      
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <pairpot name="MPC" type="MPC" source="e" target="e" ecut="60.0" physical="false"/>         
+         <estimator type="flux" name="Flux"/>
+         <estimator type="EnergyDensity" name="EDcell" dynamic="e" static="ion0">
+           <spacegrid coord="cartesian">
+             <origin p1="zero"/>
+             <axis p1="a1" scale=".5" label="x" grid="-1 (.1) 1"/>
+             <axis p1="a2" scale=".5" label="y" grid="-1 (.1) 1"/>
+             <axis p1="a3" scale=".5" label="z" grid="-1 (.1) 1"/>
+           </spacegrid>
+         </estimator>
+         <estimator type="EnergyDensity" name="EDvoronoi" dynamic="e" static="ion0">
+           <spacegrid coord="voronoi"/>
+         </estimator>
+      </hamiltonian>
+   </qmcsystem>
+   <traces array="yes" write="no"/>
+   <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
+      <parameter name="walkers"             >    1               </parameter>
+      <parameter name="blocks"              >    3               </parameter>
+      <parameter name="steps"               >    3               </parameter>
+      <parameter name="subSteps"            >    2               </parameter>
+      <parameter name="timestep"            >    0.3             </parameter>
+      <parameter name="warmupSteps"         >    3               </parameter>
+   </qmc>
+</simulation>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short_edens_voronoi.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short_edens_voronoi.in.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="det_qmc_short_edens_voronoi" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+    <parameter name="driver_version">legacy</parameter>
+   </project>
+   <random seed="71"/>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <sposet_collection type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+            <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
+         </sposet_collection>
+         <determinantset>
+           <slaterdeterminant>
+	      <determinant sposet="spo_ud"/>
+              <determinant sposet="spo_ud"/>		   
+           </slaterdeterminant>
+         </determinantset>	      
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <pairpot name="MPC" type="MPC" source="e" target="e" ecut="60.0" physical="false"/>         
+         <estimator type="flux" name="Flux"/>
+         <estimator type="EnergyDensity" name="EDvoronoi" dynamic="e" static="ion0">
+           <spacegrid coord="voronoi"/>
+         </estimator>
+      </hamiltonian>
+   </qmcsystem>
+   <traces array="yes" write="no"/>
+   <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
+      <parameter name="walkers"             >    1               </parameter>
+      <parameter name="blocks"              >    3               </parameter>
+      <parameter name="steps"               >    3               </parameter>
+      <parameter name="subSteps"            >    2               </parameter>
+      <parameter name="timestep"            >    0.3             </parameter>
+      <parameter name="warmupSteps"         >    3               </parameter>
+   </qmc>
+</simulation>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmcbatch_edens_cell.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmcbatch_edens_cell.in.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="det_qmc_short_edens_cell" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+    <parameter name="driver_version">batched</parameter>
+   </project>
+   <random seed="71"/>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <sposet_collection type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+            <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
+         </sposet_collection>
+         <determinantset>
+           <slaterdeterminant>
+	      <determinant sposet="spo_ud"/>
+              <determinant sposet="spo_ud"/>		   
+           </slaterdeterminant>
+         </determinantset>	      
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <pairpot name="MPC" type="MPC" source="e" target="e" ecut="60.0" physical="false"/>         
+         <estimator type="flux" name="Flux"/>
+         <estimator type="EnergyDensity" name="EDcell" dynamic="e" static="ion0">
+           <spacegrid coord="cartesian">
+             <origin p1="zero"/>
+             <axis p1="a1" scale=".5" label="x" grid="-1 (.1) 1"/>
+             <axis p1="a2" scale=".5" label="y" grid="-1 (.1) 1"/>
+             <axis p1="a3" scale=".5" label="z" grid="-1 (.1) 1"/>
+           </spacegrid>
+         </estimator>
+         <estimator type="EnergyDensity" name="EDvoronoi" dynamic="e" static="ion0">
+           <spacegrid coord="voronoi"/>
+         </estimator>
+      </hamiltonian>
+   </qmcsystem>
+   <traces array="yes" write="no"/>
+   <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
+      <parameter name="totalwalkers"        >    1               </parameter>
+      <parameter name="blocks"              >    3               </parameter>
+      <parameter name="steps"               >    3               </parameter>
+      <parameter name="subSteps"            >    2               </parameter>
+      <parameter name="timestep"            >    0.3             </parameter>
+      <parameter name="warmupSteps"         >    3               </parameter>
+   </qmc>
+</simulation>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmcbatch_edens_voronoi.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmcbatch_edens_voronoi.in.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="det_qmc_short_edens_voronoi" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+    <parameter name="driver_version">batched</parameter>
+   </project>
+   <random seed="71"/>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <sposet_collection type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+            <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
+         </sposet_collection>
+         <determinantset>
+           <slaterdeterminant>
+	      <determinant sposet="spo_ud"/>
+              <determinant sposet="spo_ud"/>		   
+           </slaterdeterminant>
+         </determinantset>	      
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <pairpot name="MPC" type="MPC" source="e" target="e" ecut="60.0" physical="false"/>         
+         <estimator type="flux" name="Flux"/>
+         <estimator type="EnergyDensity" name="EDvoronoi" dynamic="e" static="ion0">
+           <spacegrid coord="voronoi"/>
+         </estimator>
+      </hamiltonian>
+   </qmcsystem>
+   <traces array="yes" write="no"/>
+   <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
+      <parameter name="totalwalkers"        >    1               </parameter>
+      <parameter name="blocks"              >    3               </parameter>
+      <parameter name="steps"               >    3               </parameter>
+      <parameter name="subSteps"            >    2               </parameter>
+      <parameter name="timestep"            >    0.3             </parameter>
+      <parameter name="warmupSteps"         >    3               </parameter>
+   </qmc>
+</simulation>


### PR DESCRIPTION
## Proposed changes

As part of investigating #5468 , add some single core deterministic tests. There are no existing deterministic energy density estimator tests. The new tests currently only verify that the underlying VMC run is not changed by the estimators; the existing proven check data for the VMC only runs is used. Legacy passes. Batched changes the result but I am uncertain if this estimator was fully plumbed or if it is reasonable to keep the old behavior; to be revisited once @PDoakORNL is back. 

Once we understand the issue with the existing tests &/or implementation, these new tests should be updated with a check on the estimator results following the existing pattern for the short tests defined in the same file.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 24 LTS, GCC 14, double precision.

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with current the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
