### PR TITLE
Renaming `DelayedUpdateCUDA` -> `DelayedUpdateAccel`

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DelayedUpdateAccel.h
+++ b/src/QMCWaveFunctions/Fermion/DelayedUpdateAccel.h
@@ -9,8 +9,8 @@
 // File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 
-#ifndef QMCPLUSPLUS_DELAYED_UPDATE_CUDA_H
-#define QMCPLUSPLUS_DELAYED_UPDATE_CUDA_H
+#ifndef QMCPLUSPLUS_DELAYED_UPDATE_ACCEL_H
+#define QMCPLUSPLUS_DELAYED_UPDATE_ACCEL_H
 
 #include "OhmmsPETE/OhmmsVector.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
@@ -26,7 +26,7 @@ namespace qmcplusplus
  * @tparam T base precision for most computation
  */
 template<PlatformKind PL, typename T>
-class DelayedUpdateCUDA
+class DelayedUpdateAccel
 {
   template<typename VALUE>
   using DeviceAllocator = typename compute::MemManage<PL>::template DeviceAllocator<VALUE>;
@@ -51,7 +51,7 @@ class DelayedUpdateCUDA
   // Ainv prefetch buffer
   Matrix<T, HostAllocator<T>> Ainv_buffer;
 
-  // CUDA specific variables
+  // Accelerator specific variables
   compute::Queue<PL> queue_;
   compute::BLASHandle<PL> blas_handle_;
 
@@ -64,7 +64,7 @@ class DelayedUpdateCUDA
 
 public:
   /// default constructor
-  DelayedUpdateCUDA() : delay_count(0), blas_handle_(queue_) {}
+  DelayedUpdateAccel() : delay_count(0), blas_handle_(queue_) {}
 
   /** resize the internal storage
    * @param norb number of electrons/orbitals
@@ -215,4 +215,4 @@ public:
 };
 } // namespace qmcplusplus
 
-#endif // QMCPLUSPLUS_DELAYED_UPDATE_CUDA_H
+#endif // QMCPLUSPLUS_DELAYED_UPDATE_ACCEL_H

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -27,7 +27,7 @@
 #include "DiracMatrix.h"
 #include "QMCWaveFunctions/Fermion/DelayedUpdate.h"
 #if defined(ENABLE_CUDA) || defined(ENABLE_SYCL)
-#include "QMCWaveFunctions/Fermion/DelayedUpdateCUDA.h"
+#include "QMCWaveFunctions/Fermion/DelayedUpdateAccel.h"
 #if defined(ENABLE_CUDA)
 #if defined(QMC_CUDA2HIP)
 #include "rocSolverInverter.hpp"
@@ -57,7 +57,7 @@ template<typename T, typename FP_T>
 struct AccelEngine<PlatformKind::CUDA, T, FP_T>
 {
   static constexpr bool inverter_supported = true;
-  DelayedUpdateCUDA<PlatformKind::CUDA, T> update_eng_;
+  DelayedUpdateAccel<PlatformKind::CUDA, T> update_eng_;
 #if defined(QMC_CUDA2HIP)
   rocSolverInverter<FP_T> inverter_;
 #else
@@ -71,7 +71,7 @@ template<typename T, typename FP_T>
 struct AccelEngine<PlatformKind::SYCL, T, FP_T>
 {
   static constexpr bool inverter_supported = true;
-  DelayedUpdateCUDA<PlatformKind::SYCL, T> update_eng_;
+  DelayedUpdateAccel<PlatformKind::SYCL, T> update_eng_;
   syclSolverInverter<FP_T> inverter_;
 };
 #endif


### PR DESCRIPTION
## Proposed changes

After #5442, `DelayedUpdateCUDA` can handle both CUDA and SYCL cases. This PR renames it to `DelayedUpdateAccel`.

## What type(s) of changes does this code introduce?

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
