### PR TITLE
Add SYCL benchmark for `SolverInverters`

### DIFF
--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -196,11 +196,13 @@ foreach(CATEGORY common trialwf sposet jastrow determinant)
   set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${UTEST_DIR})
 endforeach()
 
-if(ENABLE_CUDA AND BUILD_MICRO_BENCHMARKS)
+if((ENABLE_CUDA OR ENABLE_SYCL) AND BUILD_MICRO_BENCHMARKS)
   set(UTEST_EXE benchmark_diracmatrixcompute)
   set(UTEST_NAME deterministic-unit_${UTEST_EXE})
-  set(BENCHMARK_SRC benchmark_DiracMatrixInverterCUDA.cpp)
-  set(BENCHMARK_SRC ${BENCHMARK_SRC} benchmark_SolverInverters.cpp)
+  set(BENCHMARK_SRC benchmark_SolverInverters.cpp)
+  if(ENABLE_CUDA)
+    set(BENCHMARK_SRC ${BENCHMARK_SRC} benchmark_DiracMatrixInverterCUDA.cpp)
+  endif()
   add_executable(${UTEST_EXE} ${BENCHMARK_SRC})
   target_link_libraries(
     ${UTEST_EXE}

--- a/src/QMCWaveFunctions/tests/benchmark_SolverInverters.cpp
+++ b/src/QMCWaveFunctions/tests/benchmark_SolverInverters.cpp
@@ -60,7 +60,12 @@ TEST_CASE("SolverInverter_bench", "[wavefunction][benchmark]")
 #else
   using FullPrecValue = double;
 #endif
+#if defined(ENABLE_CUDA)
   benchmark_solver<PlatformKind::CUDA, Value, FullPrecValue>(1024);
+#endif
+#if defined(ENABLE_SYCL)
+  benchmark_solver<PlatformKind::SYCL, Value, FullPrecValue>(1024);
+#endif
 }
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/benchmark_SolverInverters.cpp
+++ b/src/QMCWaveFunctions/tests/benchmark_SolverInverters.cpp
@@ -24,28 +24,28 @@ namespace qmcplusplus
 template<PlatformKind PL, typename T>
 using DeviceAllocator = typename compute::MemManage<PL>::template DeviceAllocator<T>;
 
-template<PlatformKind PL, typename FP_T>
+template<PlatformKind PL, typename T, typename FP_T>
 void benchmark_solver(const size_t N)
 {
   typename InverterAccel<PL, FP_T>::Inverter solver;
   compute::Queue<PL> queue;
 
-  Matrix<FP_T> m(N, N);
-  Matrix<FP_T> m_invT(N, N);
-  Matrix<FP_T> m_invT_CPU(N, N);
-  Matrix<FP_T, DeviceAllocator<PL, FP_T>> m_invGPU;
+  Matrix<T> m(N, N);
+  Matrix<T> m_invT(N, N);
+  Matrix<T> m_invT_CPU(N, N);
+  Matrix<T, DeviceAllocator<PL, T>> m_invGPU;
   std::complex<double> log_value;
   m.resize(N, N);
   m_invT.resize(N, N);
   m_invT_CPU.resize(N, N);
   m_invGPU.resize(N, N);
 
-  testing::MakeRngSpdMatrix<FP_T> makeRngSpdMatrix{};
+  testing::MakeRngSpdMatrix<T> makeRngSpdMatrix{};
   makeRngSpdMatrix(m);
 
   BENCHMARK("SolverInverter") { solver.invert_transpose(m, m_invT, m_invGPU, log_value, queue.getNative()); };
 
-  DiracMatrix<FP_T> dmat;
+  DiracMatrix<T> dmat;
   BENCHMARK("CPU") { dmat.invert_transpose(m, m_invT_CPU, log_value); };
 
   auto check_matrix_result = checkMatrix(m_invT, m_invT_CPU);
@@ -54,12 +54,13 @@ void benchmark_solver(const size_t N)
 
 TEST_CASE("SolverInverter_bench", "[wavefunction][benchmark]")
 {
+  using Value         = typename QMCTraits::ValueType;
 #ifdef QMC_COMPLEX
   using FullPrecValue = std::complex<double>;
 #else
   using FullPrecValue = double;
 #endif
-  benchmark_solver<PlatformKind::CUDA, FullPrecValue>(1024);
+  benchmark_solver<PlatformKind::CUDA, Value, FullPrecValue>(1024);
 }
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/benchmark_SolverInverters.cpp
+++ b/src/QMCWaveFunctions/tests/benchmark_SolverInverters.cpp
@@ -54,7 +54,7 @@ void benchmark_solver(const size_t N)
 
 TEST_CASE("SolverInverter_bench", "[wavefunction][benchmark]")
 {
-  using Value         = typename QMCTraits::ValueType;
+  using Value = typename QMCTraits::ValueType;
 #ifdef QMC_COMPLEX
   using FullPrecValue = std::complex<double>;
 #else

--- a/src/QMCWaveFunctions/tests/benchmark_SolverInverters.cpp
+++ b/src/QMCWaveFunctions/tests/benchmark_SolverInverters.cpp
@@ -45,7 +45,7 @@ void benchmark_solver(const size_t N)
 
   BENCHMARK("SolverInverter") { solver.invert_transpose(m, m_invT, m_invGPU, log_value, queue.getNative()); };
 
-  DiracMatrix<T> dmat;
+  DiracMatrix<FP_T> dmat;
   BENCHMARK("CPU") { dmat.invert_transpose(m, m_invT_CPU, log_value); };
 
   auto check_matrix_result = checkMatrix(m_invT, m_invT_CPU);


### PR DESCRIPTION
## Proposed changes

- Now `benchmark_SolverInverters` takes normal precision value, alongside the full precision.
- Add benchmark test for `SolverInverters` with SYCL case. Related to #5485

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Aurora

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
