### PR TITLE
Avoid tempate id in quintic spline constructor

### DIFF
--- a/src/Numerics/OneDimQuinticSpline.h
+++ b/src/Numerics/OneDimQuinticSpline.h
@@ -82,9 +82,9 @@ public:
     F.resize(n);
   }
 
-  OneDimQuinticSpline<Td, Tg, CTd, CTg>* makeClone() const { return new OneDimQuinticSpline<Td, Tg, CTd, CTg>(*this); }
+  OneDimQuinticSpline* makeClone() const { return new OneDimQuinticSpline<Td, Tg, CTd, CTg>(*this); }
 
-  OneDimQuinticSpline<Td, Tg, CTd, CTg>(const OneDimQuinticSpline<Td, Tg, CTd, CTg>& a)
+  OneDimQuinticSpline(const OneDimQuinticSpline<Td, Tg, CTd, CTg>& a)
       : OneDimGridFunctor<Td, Tg, CTd, CTg>(a)
   {
     m_Y2.resize(a.m_Y2.size());


### PR DESCRIPTION
## Proposed changes

Minor fix. Avoid since not allowed in C++20.

(Noticed while enabling all warnings for a test build. Blitz, used by ppconvert, is also guilty)

## What type(s) of changes does this code introduce?

- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

gcc14.2 mpi, nightly config

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
