### PR TITLE
Fix error handling in ParallelExecutorOPENMP.hpp

### DIFF
--- a/src/Concurrency/ParallelExecutorOPENMP.hpp
+++ b/src/Concurrency/ParallelExecutorOPENMP.hpp
@@ -48,7 +48,7 @@ void ParallelExecutor<Executor::OPENMP>::operator()(int num_tasks, F&& f, Args&&
     {
       f(task_id, std::forward<Args>(args)...);
     }
-    catch (const std::runtime_error& re)
+    catch (const std::exception& re)
     {
       if (nesting_error == re.what())
         ++nested_throw_count;


### PR DESCRIPTION
## Proposed changes
sycl::exception is based on std::exception not std::runtime_error. The current code swallows it without printing out the what() string.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
