### PR TITLE
Sign comparison fixes: TraceManager, OhmmsArray, OhmmsVector, hdf_stl, MemoryUsage

### DIFF
--- a/src/Containers/OhmmsPETE/OhmmsArray.h
+++ b/src/Containers/OhmmsPETE/OhmmsArray.h
@@ -64,7 +64,7 @@ public:
   template<typename SIZET = size_t, typename = std::is_integral<SIZET>>
   void resize(const std::array<SIZET, D>& dims)
   {
-    for (int i = 0; i < dims.size(); i++)
+    for (size_t i = 0; i < dims.size(); i++)
       Length[i] = dims[i];
     X.resize(full_size(Length));
   }
@@ -214,7 +214,7 @@ public:
   inline Type_t sum() const
   {
     Type_t s = 0;
-    for (int i = 0; i < X.size(); ++i)
+    for (size_t i = 0; i < X.size(); ++i)
       s += X[i];
     return s;
   }
@@ -238,7 +238,7 @@ private:
   size_t full_size(const std::array<size_t, D>& dims) const
   {
     size_t total = dims[0];
-    for (int i = 1; i < dims.size(); i++)
+    for (size_t i = 1; i < dims.size(); i++)
       total *= dims[i];
     return total;
   }
@@ -247,7 +247,7 @@ private:
   SIZET compute_offset(const std::array<SIZET, D>& indices) const
   {
     SIZET offset = indices[0];
-    for (int i = 1; i < indices.size(); i++)
+    for (size_t i = 1; i < indices.size(); i++)
       offset = offset * Length[i] + indices[i];
     return offset;
   }
@@ -260,7 +260,7 @@ bool operator==(const Array<T, D, Alloc>& lhs, const Array<T, D, Alloc>& rhs)
                 "operator== requires host accessible Vector.");
   if (lhs.size() == rhs.size())
   {
-    for (int i = 0; i < rhs.size(); i++)
+    for (size_t i = 0; i < rhs.size(); i++)
       if (lhs(i) != rhs(i))
         return false;
     return true;

--- a/src/Containers/OhmmsPETE/OhmmsVector.h
+++ b/src/Containers/OhmmsPETE/OhmmsVector.h
@@ -395,7 +395,7 @@ inline void evaluate(Vector<T, C>& lhs, const Op& op, const Expression<RHS>& rhs
   {
     // We get here if the vectors on the RHS are the same size as those on
     // the LHS.
-    for (int i = 0; i < lhs.size(); ++i)
+    for (size_t i = 0; i < lhs.size(); ++i)
     {
       // The actual assignment operation is performed here.
       // PETE operator tags all define operator() to perform the operation.
@@ -419,7 +419,7 @@ bool operator==(const Vector<T, Alloc>& lhs, const Vector<T, Alloc>& rhs)
   static_assert(qmc_allocator_traits<Alloc>::is_host_accessible, "operator== requires host accessible Vector.");
   if (lhs.size() == rhs.size())
   {
-    for (int i = 0; i < rhs.size(); i++)
+    for (size_t i = 0; i < rhs.size(); i++)
       if (lhs[i] != rhs[i])
         return false;
     return true;
@@ -440,7 +440,7 @@ template<class T, class Alloc>
 std::ostream& operator<<(std::ostream& out, const Vector<T, Alloc>& rhs)
 {
   static_assert(qmc_allocator_traits<Alloc>::is_host_accessible, "operator<< requires host accessible Vector.");
-  for (int i = 0; i < rhs.size(); i++)
+  for (size_t i = 0; i < rhs.size(); i++)
     out << rhs[i] << std::endl;
   return out;
 }
@@ -450,7 +450,7 @@ std::istream& operator>>(std::istream& is, Vector<T, Alloc>& rhs)
 {
   static_assert(qmc_allocator_traits<Alloc>::is_host_accessible, "operator>> requires host accessible Vector.");
   //printTinyVector<TinyVector<T,D> >::print(out,rhs);
-  for (int i = 0; i < rhs.size(); i++)
+  for (size_t i = 0; i < rhs.size(); i++)
     is >> rhs[i];
   return is;
 }

--- a/src/Estimators/TraceManager.h
+++ b/src/Estimators/TraceManager.h
@@ -710,11 +710,11 @@ struct CombinedTraceSample : public TraceSample<T>
   inline void combine()
   {
     std::fill(this->sample.begin(), this->sample.end(), T(0));
-    for (int i = 0; i < components.size(); ++i)
+    for (size_t i = 0; i < components.size(); ++i)
     {
       T weight        = weights[i];
       auto& component = components[i]->sample;
-      for (int j = 0; j < this->sample.size(); ++j)
+      for (size_t j = 0; j < this->sample.size(); ++j)
         this->sample[j] += weight * component[j];
     }
     combined = true;
@@ -729,7 +729,7 @@ struct CombinedTraceSample : public TraceSample<T>
     app_log() << pad2 << "domain      = " << this->domain << std::endl;
     app_log() << pad2 << "ncomponents = " << components.size() << std::endl;
     app_log() << pad2 << "components" << std::endl;
-    for (int i = 0; i < components.size(); ++i)
+    for (size_t i = 0; i < components.size(); ++i)
     {
       TraceSample<T>& c = *components[i];
       app_log() << pad3 << c.name << " " << c.index << " " << weights[i] << std::endl;
@@ -819,7 +819,7 @@ struct TraceSamples
   inline TraceSample<T>* get_trace(const std::string& domain, const std::string& name)
   {
     TraceSample<T>* ts = NULL;
-    for (int i = 0; i < samples.size(); ++i)
+    for (size_t i = 0; i < samples.size(); ++i)
     {
       TraceSample<T>& tsc = *samples[i];
       if (tsc.domain == domain && tsc.name == name)
@@ -837,7 +837,7 @@ struct TraceSamples
   inline CombinedTraceSample<T>* get_combined_trace(const std::string& domain, const std::string& name)
   {
     CombinedTraceSample<T>* ts = NULL;
-    for (int i = 0; i < combined_samples.size(); ++i)
+    for (size_t i = 0; i < combined_samples.size(); ++i)
     {
       CombinedTraceSample<T>& tsc = *combined_samples[i];
       if (tsc.domain == domain && tsc.name == name)
@@ -863,14 +863,14 @@ struct TraceSamples
       std::string domain                  = it->first;
       std::map<std::string, int>& indices = it->second;
       bool any_present                    = false;
-      for (int i = 0; i < names.size(); ++i)
+      for (size_t i = 0; i < names.size(); ++i)
         any_present = any_present || indices.count(names[i]) > 0;
       if (any_present)
       {
         int index                        = samples.size();
         auto* sample                     = new Vector<T>;
         CombinedTraceSample<T>* combined = new CombinedTraceSample<T>(domain, name, index, 0, *sample);
-        for (int i = 0; i < names.size(); ++i)
+        for (size_t i = 0; i < names.size(); ++i)
         {
           if (indices.count(names[i]) > 0)
           {
@@ -891,14 +891,14 @@ struct TraceSamples
 
   inline void set_unit_size(int usize)
   {
-    for (int i = 0; i < samples.size(); i++)
+    for (size_t i = 0; i < samples.size(); i++)
       samples[i]->set_unit_size(usize);
   }
 
 
   inline void screen_writes(TraceRequest& request)
   {
-    for (int i = 0; i < samples.size(); i++)
+    for (size_t i = 0; i < samples.size(); i++)
     {
       TraceSample<T>& s = *samples[i];
       bool stream       = request.screen_sample(s.domain, s.name, s.write);
@@ -915,7 +915,7 @@ struct TraceSamples
 
   inline void order_by_size()
   {
-    for (int i = 0; i < samples.size(); i++)
+    for (size_t i = 0; i < samples.size(); i++)
       samples[i]->set_data_size();
     ordered_samples.resize(samples.size());
     copy(samples.begin(), samples.end(), ordered_samples.begin());
@@ -925,7 +925,7 @@ struct TraceSamples
 
   inline void set_buffer_ranges(int& starting_index)
   {
-    for (int i = 0; i < ordered_samples.size(); i++)
+    for (size_t i = 0; i < ordered_samples.size(); i++)
     {
       TraceSample<T>& sample = *ordered_samples[i];
       sample.set_buffer_range(starting_index);
@@ -936,7 +936,7 @@ struct TraceSamples
   inline int total_size()
   {
     int s = 0;
-    for (int i = 0; i < samples.size(); i++)
+    for (size_t i = 0; i < samples.size(); i++)
       s += samples[i]->sample.size() * samples[i]->unit_size;
     return s;
   }
@@ -945,7 +945,7 @@ struct TraceSamples
   inline int min_buffer_index()
   {
     int min_index = 2000000000;
-    for (int i = 0; i < samples.size(); i++)
+    for (size_t i = 0; i < samples.size(); i++)
       min_index = std::min(min_index, samples[i]->buffer_start);
     return min_index;
   }
@@ -954,7 +954,7 @@ struct TraceSamples
   inline int max_buffer_index()
   {
     int max_index = -1;
-    for (int i = 0; i < samples.size(); i++)
+    for (size_t i = 0; i < samples.size(); i++)
       max_index = std::max(max_index, samples[i]->buffer_end);
     return max_index;
   }
@@ -962,14 +962,14 @@ struct TraceSamples
 
   inline void combine_samples()
   {
-    for (int i = 0; i < combined_samples.size(); ++i)
+    for (size_t i = 0; i < combined_samples.size(); ++i)
       combined_samples[i]->combine();
   }
 
 
   inline void reset_combined_samples()
   {
-    for (int i = 0; i < combined_samples.size(); ++i)
+    for (size_t i = 0; i < combined_samples.size(); ++i)
       combined_samples[i]->reset();
   }
 
@@ -1039,15 +1039,15 @@ struct TraceSamples
     }
     app_log() << pad2 << "end sample_indices" << std::endl;
     app_log() << pad2 << "combined_sample_vectors = ";
-    for (int i = 0; i < combined_sample_vectors.size(); ++i)
+    for (size_t i = 0; i < combined_sample_vectors.size(); ++i)
       app_log() << (size_t)combined_sample_vectors[i] << " ";
     app_log() << std::endl;
     app_log() << pad2 << "combined_samples" << std::endl;
-    for (int i = 0; i < combined_samples.size(); ++i)
+    for (size_t i = 0; i < combined_samples.size(); ++i)
       combined_samples[i]->write_summary_combined(i, pad3);
     app_log() << pad2 << "end combined_samples" << std::endl;
     app_log() << pad2 << "samples" << std::endl;
-    for (int i = 0; i < ordered_samples.size(); ++i)
+    for (size_t i = 0; i < ordered_samples.size(); ++i)
       ordered_samples[i]->write_summary(i, pad3);
     //for(int i=0; i<samples.size(); ++i)
     //  samples[i]->write_summary(i,pad3);
@@ -1198,13 +1198,13 @@ struct TraceBuffer
       //collect data from all samples into the buffer row
       {
         std::vector<TraceSample<T>*>& ordered_samples = samples->ordered_samples;
-        for (int s = 0; s < ordered_samples.size(); s++)
+        for (size_t s = 0; s < ordered_samples.size(); s++)
         {
           TraceSample<T>& tsample = *ordered_samples[s];
           if (tsample.write)
           {
             auto& sample = tsample.sample;
-            for (int i = 0; i < sample.size(); ++i)
+            for (size_t i = 0; i < sample.size(); ++i)
               buffer(current_row, tsample.buffer_start + i) = sample[i];
           }
         }
@@ -1212,13 +1212,13 @@ struct TraceBuffer
       if (has_complex)
       {
         std::vector<TraceSample<std::complex<T>>*>& ordered_samples = complex_samples->ordered_samples;
-        for (int s = 0; s < ordered_samples.size(); s++)
+        for (size_t s = 0; s < ordered_samples.size(); s++)
         {
           TraceSample<std::complex<T>>& tsample = *ordered_samples[s];
           if (tsample.write)
           {
             auto& sample = tsample.sample;
-            for (int i = 0, ib = 0; i < sample.size(); ++i, ib += 2)
+            for (size_t i = 0, ib = 0; i < sample.size(); ++i, ib += 2)
             {
               buffer(current_row, tsample.buffer_start + ib)     = sample[i].real();
               buffer(current_row, tsample.buffer_start + ib + 1) = sample[i].imag();
@@ -1338,7 +1338,7 @@ struct TraceBuffer
       {
         int boffset;
         std::vector<TraceSample<T>*>& ordered_samples = samples->ordered_samples;
-        for (int s = 0; s < ordered_samples.size(); s++)
+        for (size_t s = 0; s < ordered_samples.size(); s++)
         {
           TraceSample<T>& tsample = *ordered_samples[s];
           std::vector<T>& sample  = tsample.sample;
@@ -1351,7 +1351,7 @@ struct TraceBuffer
       {
         int boffset;
         std::vector<TraceSample<std::complex<T>>*>& ordered_samples = complex_samples->ordered_samples;
-        for (int s = 0; s < ordered_samples.size(); s++)
+        for (size_t s = 0; s < ordered_samples.size(); s++)
         {
           TraceSample<std::complex<T>>& tsample = *ordered_samples[s];
           std::vector<std::complex<T>>& sample  = tsample.sample;
@@ -1877,7 +1877,7 @@ public:
       bool int_same;
       bool real_same;
       TraceManager& ref = *clones[0];
-      for (int i = 0; i < clones.size(); ++i)
+      for (size_t i = 0; i < clones.size(); ++i)
       {
         TraceManager& tm = *clones[i];
         int_same         = tm.int_buffer.same_as(ref.int_buffer);
@@ -1886,7 +1886,7 @@ public:
       }
       if (!all_same)
       {
-        for (int i = 0; i < clones.size(); ++i)
+        for (size_t i = 0; i < clones.size(); ++i)
           clones[i]->write_summary();
         APP_ABORT("TraceManager::check_clones  trace buffer widths of clones do not match\n  contiguous write is "
                   "impossible\n  this was first caused by clones contributing array traces from identical, but "
@@ -2102,7 +2102,7 @@ public:
   {
     if (verbose)
       app_log() << "TraceManager::write_buffers_hdf " << master_copy << std::endl;
-    for (int ip = 0; ip < clones.size(); ++ip)
+    for (size_t ip = 0; ip < clones.size(); ++ip)
     {
       TraceManager& tm = *clones[ip];
       tm.int_buffer.write_hdf(*hdf_file, int_buffer.hdf_file_pointer);

--- a/src/Platforms/MemoryUsage.cpp
+++ b/src/Platforms/MemoryUsage.cpp
@@ -23,7 +23,7 @@ namespace qmcplusplus
 void print_mem(const std::string& title, std::ostream& log)
 {
   std::string line_separator;
-  for (int i = 0; i < title.size() + 30; i++)
+  for (std::string::size_type i = 0; i < title.size() + 30; i++)
     line_separator += "=";
   log << line_separator << std::endl;
   log << "--- Memory usage report : " << title << " ---" << std::endl;

--- a/src/io/hdf/hdf_stl.h
+++ b/src/io/hdf/hdf_stl.h
@@ -214,7 +214,7 @@ struct h5data_proxy<std::vector<std::string>>
       char_list.resize(dim_out);
       ret = H5Dread(dataset, datatype, H5S_ALL, H5S_ALL, xfer_plist, char_list.data());
 
-      for (int i = 0; i < dim_out; i++)
+      for (std::size_t i = 0; i < dim_out; i++)
         ref.push_back(char_list[i]);
 
       H5Dvlen_reclaim(datatype, dataspace, xfer_plist, char_list.data());
@@ -240,7 +240,7 @@ struct h5data_proxy<std::vector<std::string>>
 
     // Create vector of pointers to the actual string data
     std::vector<const char*> char_list;
-    for (int i = 0; i < ref.size(); i++)
+    for (std::size_t i = 0; i < ref.size(); i++)
       char_list.push_back(ref[i].data());
 
     hid_t h1   = H5Dopen(grp, aname.c_str(), H5P_DEFAULT);


### PR DESCRIPTION
## Proposed changes

Sign comparison fixes to fully clean TraceManager, OhmmsArray, OhmmsVector. Couple of fixes to hdf_stl and MemoryUsage but they need more work.

This gets us below 10^4 sign comparison warnings (!) when compiled with gcc13 and -Wsign-compare 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

GCC13, Ubuntu 24 LTS

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
