### PR TITLE
Delete `hstream_` data member from `[cu/roc]SolverInverter`

### DIFF
--- a/src/QMCWaveFunctions/Fermion/cuSolverInverter.hpp
+++ b/src/QMCWaveFunctions/Fermion/cuSolverInverter.hpp
@@ -43,7 +43,6 @@ class cuSolverInverter
 
   // CUDA specific variables
   cusolverDnHandle_t h_cusolver_ = nullptr;
-  cudaStream_t hstream_;
 
   /** resize the internal storage
    * @param norb number of electrons/orbitals
@@ -54,7 +53,6 @@ class cuSolverInverter
     if (!h_cusolver_)
     {
       cusolverErrorCheck(cusolverDnCreate(&h_cusolver_), "cusolverCreate failed!");
-      cusolverErrorCheck(cusolverDnSetStream(h_cusolver_, hstream_), "cusolverSetStream failed!");
     }
     if (Mat1_gpu.rows() != norb)
     {
@@ -73,13 +71,12 @@ class cuSolverInverter
 
 public:
   /// default constructor
-  cuSolverInverter() { cudaErrorCheck(cudaStreamCreate(&hstream_), "cudaStreamCreate failed!"); }
+  cuSolverInverter() = default;
 
   ~cuSolverInverter()
   {
     if (h_cusolver_)
       cusolverErrorCheck(cusolverDnDestroy(h_cusolver_), "cusolverDestroy failed!");
-    cudaErrorCheck(cudaStreamDestroy(hstream_), "cudaStreamDestroy failed!");
   }
 
   /** compute the inverse of the transpose of matrix A and its determinant value in log
@@ -95,21 +92,22 @@ public:
   {
     const int norb = logdetT.rows();
     resize(norb);
+    cusolverErrorCheck(cusolverDnSetStream(h_cusolver_, stream), "cusolverSetStream failed!");
     cudaErrorCheck(cudaMemcpyAsync(Mat1_gpu.data(), logdetT.data(), logdetT.size() * sizeof(TMAT),
-                                   cudaMemcpyHostToDevice, hstream_),
+                                   cudaMemcpyHostToDevice, stream),
                    "cudaMemcpyAsync failed!");
     cusolverErrorCheck(cusolver::getrf(h_cusolver_, norb, norb, Mat1_gpu.data(), norb, work_gpu.data(),
                                        ipiv_gpu.data() + 1, ipiv_gpu.data()),
                        "cusolver::getrf failed!");
     cudaErrorCheck(cudaMemcpyAsync(ipiv.data(), ipiv_gpu.data(), ipiv_gpu.size() * sizeof(int), cudaMemcpyDeviceToHost,
-                                   hstream_),
+                                   stream),
                    "cudaMemcpyAsync failed!");
-    extract_matrix_diagonal_cuda(norb, Mat1_gpu.data(), norb, LU_diag_gpu.data(), hstream_);
+    extract_matrix_diagonal_cuda(norb, Mat1_gpu.data(), norb, LU_diag_gpu.data(), stream);
     cudaErrorCheck(cudaMemcpyAsync(LU_diag.data(), LU_diag_gpu.data(), LU_diag.size() * sizeof(T_FP),
-                                   cudaMemcpyDeviceToHost, hstream_),
+                                   cudaMemcpyDeviceToHost, stream),
                    "cudaMemcpyAsync failed!");
     // check LU success
-    cudaErrorCheck(cudaStreamSynchronize(hstream_), "cudaStreamSynchronize after getrf failed!");
+    cudaErrorCheck(cudaStreamSynchronize(stream), "cudaStreamSynchronize after getrf failed!");
     if (ipiv[0] != 0)
     {
       std::ostringstream err;
@@ -117,18 +115,18 @@ public:
       std::cerr << err.str();
       throw std::runtime_error(err.str());
     }
-    make_identity_matrix_cuda(norb, Ainv_gpu.data(), norb, hstream_);
+    make_identity_matrix_cuda(norb, Ainv_gpu.data(), norb, stream);
     cusolverErrorCheck(cusolver::getrs(h_cusolver_, CUBLAS_OP_T, norb, norb, Mat1_gpu.data(), norb, ipiv_gpu.data() + 1,
                                        Ainv_gpu.data(), norb, ipiv_gpu.data()),
                        "cusolver::getrs failed!");
-    cudaErrorCheck(cudaMemcpyAsync(ipiv.data(), ipiv_gpu.data(), sizeof(int), cudaMemcpyDeviceToHost, hstream_),
+    cudaErrorCheck(cudaMemcpyAsync(ipiv.data(), ipiv_gpu.data(), sizeof(int), cudaMemcpyDeviceToHost, stream),
                    "cudaMemcpyAsync failed!");
     computeLogDet(LU_diag.data(), norb, ipiv.data() + 1, log_value);
     cudaErrorCheck(cudaMemcpyAsync(Ainv.data(), Ainv_gpu.data(), Ainv.size() * sizeof(TMAT), cudaMemcpyDeviceToHost,
-                                   hstream_),
+                                   stream),
                    "cudaMemcpyAsync failed!");
     // check solve success
-    cudaErrorCheck(cudaStreamSynchronize(hstream_), "cudaStreamSynchronize after getrs failed!");
+    cudaErrorCheck(cudaStreamSynchronize(stream), "cudaStreamSynchronize after getrs failed!");
     if (ipiv[0] != 0)
     {
       std::ostringstream err;
@@ -151,42 +149,43 @@ public:
   {
     const int norb = logdetT.rows();
     resize(norb);
+    cusolverErrorCheck(cusolverDnSetStream(h_cusolver_, stream), "cusolverSetStream failed!");
     Mat2_gpu.resize(norb, norb);
     cudaErrorCheck(cudaMemcpyAsync(Mat2_gpu.data(), logdetT.data(), logdetT.size() * sizeof(TMAT),
-                                   cudaMemcpyHostToDevice, hstream_),
+                                   cudaMemcpyHostToDevice, stream),
                    "cudaMemcpyAsync failed!");
-    copy_matrix_cuda(norb, norb, (TMAT*)Mat2_gpu.data(), norb, Mat1_gpu.data(), norb, hstream_);
+    copy_matrix_cuda(norb, norb, (TMAT*)Mat2_gpu.data(), norb, Mat1_gpu.data(), norb, stream);
     cusolverErrorCheck(cusolver::getrf(h_cusolver_, norb, norb, Mat1_gpu.data(), norb, work_gpu.data(),
                                        ipiv_gpu.data() + 1, ipiv_gpu.data()),
                        "cusolver::getrf failed!");
     cudaErrorCheck(cudaMemcpyAsync(ipiv.data(), ipiv_gpu.data(), ipiv_gpu.size() * sizeof(int), cudaMemcpyDeviceToHost,
-                                   hstream_),
+                                   stream),
                    "cudaMemcpyAsync failed!");
-    extract_matrix_diagonal_cuda(norb, Mat1_gpu.data(), norb, LU_diag_gpu.data(), hstream_);
+    extract_matrix_diagonal_cuda(norb, Mat1_gpu.data(), norb, LU_diag_gpu.data(), stream);
     cudaErrorCheck(cudaMemcpyAsync(LU_diag.data(), LU_diag_gpu.data(), LU_diag.size() * sizeof(T_FP),
-                                   cudaMemcpyDeviceToHost, hstream_),
+                                   cudaMemcpyDeviceToHost, stream),
                    "cudaMemcpyAsync failed!");
     // check LU success
-    cudaErrorCheck(cudaStreamSynchronize(hstream_), "cudaStreamSynchronize after getrf failed!");
+    cudaErrorCheck(cudaStreamSynchronize(stream), "cudaStreamSynchronize after getrf failed!");
     if (ipiv[0] != 0)
     {
       std::ostringstream err;
       err << "cusolver::getrf calculation failed with devInfo = " << ipiv[0] << std::endl;
       throw std::runtime_error(err.str());
     }
-    make_identity_matrix_cuda(norb, Mat2_gpu.data(), norb, hstream_);
+    make_identity_matrix_cuda(norb, Mat2_gpu.data(), norb, stream);
     cusolverErrorCheck(cusolver::getrs(h_cusolver_, CUBLAS_OP_T, norb, norb, Mat1_gpu.data(), norb, ipiv_gpu.data() + 1,
                                        Mat2_gpu.data(), norb, ipiv_gpu.data()),
                        "cusolver::getrs failed!");
-    copy_matrix_cuda(norb, norb, Mat2_gpu.data(), norb, Ainv_gpu.data(), norb, hstream_);
-    cudaErrorCheck(cudaMemcpyAsync(ipiv.data(), ipiv_gpu.data(), sizeof(int), cudaMemcpyDeviceToHost, hstream_),
+    copy_matrix_cuda(norb, norb, Mat2_gpu.data(), norb, Ainv_gpu.data(), norb, stream);
+    cudaErrorCheck(cudaMemcpyAsync(ipiv.data(), ipiv_gpu.data(), sizeof(int), cudaMemcpyDeviceToHost, stream),
                    "cudaMemcpyAsync failed!");
     computeLogDet(LU_diag.data(), norb, ipiv.data() + 1, log_value);
     cudaErrorCheck(cudaMemcpyAsync(Ainv.data(), Ainv_gpu.data(), Ainv.size() * sizeof(TMAT), cudaMemcpyDeviceToHost,
-                                   hstream_),
+                                   stream),
                    "cudaMemcpyAsync failed!");
     // check solve success
-    cudaErrorCheck(cudaStreamSynchronize(hstream_), "cudaStreamSynchronize after getrs failed!");
+    cudaErrorCheck(cudaStreamSynchronize(stream), "cudaStreamSynchronize after getrs failed!");
     if (ipiv[0] != 0)
     {
       std::ostringstream err;

--- a/src/QMCWaveFunctions/Fermion/rocSolverInverter.hpp
+++ b/src/QMCWaveFunctions/Fermion/rocSolverInverter.hpp
@@ -49,7 +49,6 @@ class rocSolverInverter
 
   // CUDA specific variables
   rocblas_handle h_rocsolver_ = nullptr;
-  hipStream_t hstream_;
 
   /** resize the internal storage
    * @param norb number of electrons/orbitals
@@ -60,7 +59,6 @@ class rocSolverInverter
     if (!h_rocsolver_)
     {
       rocsolverErrorCheck(rocblas_create_handle(&h_rocsolver_), "rocblas_create_handle failed!");
-      rocsolverErrorCheck(rocblas_set_stream(h_rocsolver_, hstream_), "rocblas_set_stream failed!");
     }
 
     if (Mat1_gpu.rows() != norb)
@@ -87,13 +85,12 @@ class rocSolverInverter
 
 public:
   /// default constructor
-  rocSolverInverter() { cudaErrorCheck(hipStreamCreate(&hstream_), "hipStreamCreate failed!"); }
+  rocSolverInverter() = default;
 
   ~rocSolverInverter()
   {
     if (h_rocsolver_)
       rocsolverErrorCheck(rocblas_destroy_handle(h_rocsolver_), "rocblas_destroy_handle failed!");
-    cudaErrorCheck(hipStreamDestroy(hstream_), "hipStreamDestroy failed!");
   }
 
   /** compute the inverse of the transpose of matrix A and its determinant value in log
@@ -109,21 +106,22 @@ public:
   {
     const int norb = logdetT.rows();
     resize(norb);
+    rocsolverErrorCheck(rocblas_set_stream(h_rocsolver_, stream), "rocblas_set_stream failed!");
     cudaErrorCheck(hipMemcpyAsync(Mat1_gpu.data(), logdetT.data(), logdetT.size() * sizeof(TMAT), hipMemcpyHostToDevice,
-                                  hstream_),
+                                  stream),
                    "hipMemcpyAsync for logdetT to Mat1_gpu failed!");
     rocsolverErrorCheck(rocsolver::getrf(h_rocsolver_, norb, norb, Mat1_gpu.data(), norb, ipiv_gpu.data() + 1,
                                          ipiv_gpu.data()),
                         "rocsolver::getrf failed!");
     cudaErrorCheck(hipMemcpyAsync(ipiv.data(), ipiv_gpu.data(), ipiv_gpu.size() * sizeof(int), hipMemcpyDeviceToHost,
-                                  hstream_),
+                                  stream),
                    "hipMemcpyAsync for ipiv failed!");
-    extract_matrix_diagonal_cuda(norb, Mat1_gpu.data(), norb, LU_diag_gpu.data(), hstream_);
+    extract_matrix_diagonal_cuda(norb, Mat1_gpu.data(), norb, LU_diag_gpu.data(), stream);
     cudaErrorCheck(hipMemcpyAsync(LU_diag.data(), LU_diag_gpu.data(), LU_diag.size() * sizeof(T_FP),
-                                  hipMemcpyDeviceToHost, hstream_),
+                                  hipMemcpyDeviceToHost, stream),
                    "hipMemcpyAsync for LU_diag failed!");
     // check LU success
-    cudaErrorCheck(hipStreamSynchronize(hstream_), "hipStreamSynchronize after getrf failed!");
+    cudaErrorCheck(hipStreamSynchronize(stream), "hipStreamSynchronize after getrf failed!");
     if (ipiv[0] != 0)
     {
       std::ostringstream err;
@@ -131,17 +129,17 @@ public:
       std::cerr << err.str();
       throw std::runtime_error(err.str());
     }
-    make_identity_matrix_cuda(norb, Ainv_gpu.data(), norb, hstream_);
+    make_identity_matrix_cuda(norb, Ainv_gpu.data(), norb, stream);
     rocsolverErrorCheck(rocsolver::getrs(h_rocsolver_, rocblas_operation_transpose, norb, norb, Mat1_gpu.data(), norb,
                                          ipiv_gpu.data() + 1, Ainv_gpu.data(), norb),
                         "rocsolver::getrs failed!");
-    cudaErrorCheck(hipMemcpyAsync(ipiv.data(), ipiv_gpu.data(), sizeof(int), hipMemcpyDeviceToHost, hstream_),
+    cudaErrorCheck(hipMemcpyAsync(ipiv.data(), ipiv_gpu.data(), sizeof(int), hipMemcpyDeviceToHost, stream),
                    "hipMemcpyAsync for ipiv failed!");
     computeLogDet(LU_diag.data(), norb, ipiv.data() + 1, log_value);
     cudaErrorCheck(hipMemcpyAsync(Ainv.data(), Ainv_gpu.data(), Ainv.size() * sizeof(TMAT), hipMemcpyDeviceToHost,
-                                  hstream_),
+                                  stream),
                    "hipMemcpyAsync for Ainv failed!");
-    cudaErrorCheck(hipStreamSynchronize(hstream_), "hipStreamSynchronize after getrs failed!");
+    cudaErrorCheck(hipStreamSynchronize(stream), "hipStreamSynchronize after getrs failed!");
     if (ipiv[0] != 0)
     {
       std::ostringstream err;
@@ -164,23 +162,24 @@ public:
   {
     const int norb = logdetT.rows();
     resize(norb);
+    rocsolverErrorCheck(rocblas_set_stream(h_rocsolver_, stream), "rocblas_set_stream failed!");
     Mat2_gpu.resize(norb, norb);
     cudaErrorCheck(hipMemcpyAsync(Mat2_gpu.data(), logdetT.data(), logdetT.size() * sizeof(TMAT), hipMemcpyHostToDevice,
-                                  hstream_),
+                                  stream),
                    "hipMemcpyAsync failed!");
-    copy_matrix_cuda(norb, norb, (TMAT*)Mat2_gpu.data(), norb, Mat1_gpu.data(), norb, hstream_);
+    copy_matrix_cuda(norb, norb, (TMAT*)Mat2_gpu.data(), norb, Mat1_gpu.data(), norb, stream);
     rocsolverErrorCheck(rocsolver::getrf(h_rocsolver_, norb, norb, Mat1_gpu.data(), norb, ipiv_gpu.data() + 1,
                                          ipiv_gpu.data()),
                         "rocsolver::getrf failed!");
     cudaErrorCheck(hipMemcpyAsync(ipiv.data(), ipiv_gpu.data(), ipiv_gpu.size() * sizeof(int), hipMemcpyDeviceToHost,
-                                  hstream_),
+                                  stream),
                    "hipMemcpyAsync failed!");
-    extract_matrix_diagonal_cuda(norb, Mat1_gpu.data(), norb, LU_diag_gpu.data(), hstream_);
+    extract_matrix_diagonal_cuda(norb, Mat1_gpu.data(), norb, LU_diag_gpu.data(), stream);
     cudaErrorCheck(hipMemcpyAsync(LU_diag.data(), LU_diag_gpu.data(), LU_diag.size() * sizeof(T_FP),
-                                  hipMemcpyDeviceToHost, hstream_),
+                                  hipMemcpyDeviceToHost, stream),
                    "hipMemcpyAsync failed!");
     // check LU success
-    cudaErrorCheck(hipStreamSynchronize(hstream_), "hipStreamSynchronize after getrf failed!");
+    cudaErrorCheck(hipStreamSynchronize(stream), "hipStreamSynchronize after getrf failed!");
     if (ipiv[0] != 0)
     {
       std::ostringstream err;
@@ -188,19 +187,19 @@ public:
       std::cerr << err.str();
       throw std::runtime_error(err.str());
     }
-    make_identity_matrix_cuda(norb, Mat2_gpu.data(), norb, hstream_);
+    make_identity_matrix_cuda(norb, Mat2_gpu.data(), norb, stream);
     rocsolverErrorCheck(rocsolver::getrs(h_rocsolver_, rocblas_operation_transpose, norb, norb, Mat1_gpu.data(), norb,
                                          ipiv_gpu.data() + 1, Mat2_gpu.data(), norb),
                         "rocsolver::getrs failed!");
-    copy_matrix_cuda(norb, norb, Mat2_gpu.data(), norb, Ainv_gpu.data(), norb, hstream_);
-    cudaErrorCheck(hipMemcpyAsync(ipiv.data(), ipiv_gpu.data(), sizeof(int), hipMemcpyDeviceToHost, hstream_),
+    copy_matrix_cuda(norb, norb, Mat2_gpu.data(), norb, Ainv_gpu.data(), norb, stream);
+    cudaErrorCheck(hipMemcpyAsync(ipiv.data(), ipiv_gpu.data(), sizeof(int), hipMemcpyDeviceToHost, stream),
                    "hipMemcpyAsync failed!");
     computeLogDet(LU_diag.data(), norb, ipiv.data() + 1, log_value);
     cudaErrorCheck(hipMemcpyAsync(Ainv.data(), Ainv_gpu.data(), Ainv.size() * sizeof(TMAT), hipMemcpyDeviceToHost,
-                                  hstream_),
+                                  stream),
                    "hipMemcpyAsync failed!");
     // check solve success
-    cudaErrorCheck(hipStreamSynchronize(hstream_), "hipStreamSynchronize after getrs failed!");
+    cudaErrorCheck(hipStreamSynchronize(stream), "hipStreamSynchronize after getrs failed!");
     if (ipiv[0] != 0)
     {
       std::ostringstream err;


### PR DESCRIPTION
## Proposed changes

After #5442, the `hstream_` data member is not required in `[cu/roc]SolverInverter`. This PR deletes it.

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Linux with CUDA.

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
