### PR TITLE
More verbose test name r1-t16-s2 instead of 1-16-2

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -360,7 +360,7 @@ else(QMC_NO_SLOW_CUSTOM_TESTING_COMMANDS)
 
     set(TEST_ADDED FALSE)
     set(TEST_LABELS "")
-    set(FULL_NAME "${BASE_NAME}-${PROCS}-${THREADS}")
+    set(FULL_NAME "${BASE_NAME}-r${PROCS}-t${THREADS}")
     message(VERBOSE "Adding test ${FULL_NAME}")
     run_qmc_app(
       ${FULL_NAME}
@@ -404,7 +404,7 @@ else(QMC_NO_SLOW_CUSTOM_TESTING_COMMANDS)
               if(IDX0 LESS 2)
                 set(TEST_NAME "${FULL_NAME}-${SCALAR_CHECK}")
               else()
-                set(TEST_NAME "${FULL_NAME}-${SERIES}-${SCALAR_CHECK}")
+                set(TEST_NAME "${FULL_NAME}-s${SERIES}-${SCALAR_CHECK}")
               endif()
               #MESSAGE("Adding scalar check ${TEST_NAME}")
               set(CHECK_CMD
@@ -492,7 +492,7 @@ else(QMC_NO_SLOW_CUSTOM_TESTING_COMMANDS)
 
     set(TEST_ADDED FALSE)
     set(TEST_LABELS "")
-    set(FULL_NAME "${BASE_NAME}-${PROCS}-${THREADS}")
+    set(FULL_NAME "${BASE_NAME}-r${PROCS}-t${THREADS}")
     message(VERBOSE "Adding test ${FULL_NAME}")
     run_qmc_app(
       ${FULL_NAME}
@@ -528,7 +528,7 @@ else(QMC_NO_SLOW_CUSTOM_TESTING_COMMANDS)
         set(SERIES 0)
         if(QRC_SERIES)
           set(SERIES ${QRC_SERIES})
-          set(TEST_NAME "${FULL_NAME}-${SERIES}-${SCALAR_NAME}")
+          set(TEST_NAME "${FULL_NAME}-s${SERIES}-${SCALAR_NAME}")
         else()
           set(TEST_NAME "${FULL_NAME}-${SCALAR_NAME}")
         endif()

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -20,7 +20,7 @@ function(
   #  2. run $check_script located in the same folder
 
   # build test name
-  set(full_name "${base_name}-${procs}-${threads}")
+  set(full_name "${base_name}-r${procs}-t${threads}")
   message(VERBOSE "Adding test ${full_name}")
 
   # add run (task 1)
@@ -37,7 +37,7 @@ function(
   if(test_added)
 
     # add restart (task 2)
-    set(restart_name "${base_name}-${procs}-${threads}-restart")
+    set(restart_name "${base_name}-r${procs}-t${threads}-restart")
     #set (test_added false)
     set(test_labels "")
     run_qmc_app_no_copy(

--- a/tests/performance/C-graphite/CMakeLists.txt
+++ b/tests/performance/C-graphite/CMakeLists.txt
@@ -33,7 +33,7 @@ function(
 
   maybe_symlink("${QMC_DATA}/C-graphite/${H5_FILE}" "${WDIR}/../${H5_FILE}")
 
-  set(TEST_NAME ${TEST_NAME}-${PROCS}-${THREADS})
+  set(TEST_NAME ${TEST_NAME}-r${PROCS}-t${THREADS})
   math(EXPR TOT_PROCS "${PROCS} * ${THREADS}")
   if(HAVE_MPI)
     add_test(NAME ${TEST_NAME} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${PROCS} ${MPIEXEC_PREFLAGS}

--- a/tests/performance/C-molecule/CMakeLists.txt
+++ b/tests/performance/C-molecule/CMakeLists.txt
@@ -40,7 +40,7 @@ if(NOT QMC_COMPLEX)
       COMMAND ${Python3_EXECUTABLE} ${qmcpack_SOURCE_DIR}/tests/performance/adjust_qmcpack_input.py ${ADJUST_INPUT}
               ${TEST_DIR}/${INPUT_FILE} WORKING_DIRECTORY "${qmcpack_BINARY_DIR}/tests/performance/C-molecule")
 
-    set(TEST_NAME ${TEST_NAME}-${PROCS}-${THREADS})
+    set(TEST_NAME ${TEST_NAME}-r${PROCS}-t${THREADS})
     math(EXPR TOT_PROCS "${PROCS} * ${THREADS}")
     if(HAVE_MPI)
       add_test(NAME ${TEST_NAME} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${PROCS} ${MPIEXEC_PREFLAGS}

--- a/tests/performance/NiO/CMakeLists.txt
+++ b/tests/performance/NiO/CMakeLists.txt
@@ -38,7 +38,7 @@ function(
     COMMAND ${Python3_EXECUTABLE} ${qmcpack_SOURCE_DIR}/tests/performance/adjust_qmcpack_input.py ${ADJUST_INPUT}
             ${TEST_DIR}/${INPUT_FILE} WORKING_DIRECTORY "${qmcpack_BINARY_DIR}/tests/performance/NiO")
 
-  set(TEST_NAME ${TEST_NAME}-${PROCS}-${THREADS})
+  set(TEST_NAME ${TEST_NAME}-r${PROCS}-t${THREADS})
   math(EXPR TOT_PROCS "${PROCS} * ${THREADS}")
   if(HAVE_MPI)
     add_test(NAME ${TEST_NAME} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${PROCS} ${MPIEXEC_PREFLAGS}


### PR DESCRIPTION
## Proposed changes
 `r` MPI rank, `t` thread, `s` series
The new nomenclature allows accurate filtering.
 
## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
