### PR TITLE
Update clang tidy

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -2,7 +2,6 @@
 Checks: "bugprone-*,readability-identifier-*"
 WarningsAsErrors: ""
 HeaderFilterRegex: ""
-AnalyzeTemporaryDtors: false
 FormatStyle: none
 CheckOptions:
   [

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,8 +1,8 @@
 ---
-Checks: "bugprone-*,readability-identifier-*"
+Checks: "bugprone-*,readability-*,-readability-function-size*,-readability-braces-around-statements*,cppcoreguidelines-*,modernize-*,-modernize-use-trailing*,-modernize-use-nodiscard"
 WarningsAsErrors: ""
 HeaderFilterRegex: ""
-FormatStyle: none
+FormatStyle: file
 CheckOptions:
   [
     { key: readability-identifier-naming.NamespaceCase, value: lower_case },
@@ -11,6 +11,4 @@ CheckOptions:
     { key: readability-identifier-naming.ClassMethodCase, value: camelBack },
     { key: readability-identifier-naming.PrivateMemberPostfix, value: _ },
   ]
-
 ---
-


### PR DESCRIPTION
## Proposed changes

The .clang-tidy for the project contained an option no longer supported and when used with clangd 20.1.4 integrated with clang-tidy this causes an error.  With the tooling I'm using this causes a popup everytime a file is saved and clangd rechecks it. From the documentation I can find this check has been deprecated for a very long time.

I turned on some other checks that were useful to me.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

sdgx2

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
