### PR TITLE
Nexus: Frontier added in machines.py

### DIFF
--- a/nexus/lib/machines.py
+++ b/nexus/lib/machines.py
@@ -3455,14 +3455,14 @@ class Frontier(Supercomputer):
         if job.constraint is None:
             job.constraint = 'cpu'
         #end if
-        # Account for dual nature of Perlmutter
+        # Account for dual nature of Frontier
         if 'cpu' in job.constraint:
             self.cores_per_node = 56
         elif 'gpu' in job.constraint:
             self.cores_per_node = 56
             self.gpus_per_node  = 4
         else:
-            self.error('SLURM input "constraint" must contain either "cpu" or "gpu" on Perlmutter\nyou provided: {0}'.format(job.constraint))
+            self.error('SLURM input "constraint" must contain either "cpu" or "gpu" on Frontier\nyou provided: {0}'.format(job.constraint))
         #end if
     #end def pre_process_job
     

--- a/nexus/lib/machines.py
+++ b/nexus/lib/machines.py
@@ -3469,16 +3469,16 @@ class Frontier(Supercomputer):
     
 
     def post_process_job(self, job):
-        if job.gpus is None:
+        if 'cpu' in job.constraint:
             job.run_options.add(
                 cpu_bind='--cpu-bind=threads',
                 threads_per_core='--threads-per-core={0}'.format(job.threads)
             )            
-        else:
+        elif 'gpu' in job.constraint:
             gpus_per_task = int(floor(float(self.gpus_per_node)/job.processes_per_node))
             job.run_options.add(
                 gpu_bind='--gpu-bind=closest',
-                gpus_per_task='--gpus-per-task=1'
+                gpus_per_task='--gpus-per-task={0}'.format(gpus_per_task)
             )
         #end if
         job.run_options.add(

--- a/nexus/lib/machines.py
+++ b/nexus/lib/machines.py
@@ -1484,7 +1484,6 @@ class Supercomputer(Machine):
                 self.error('account not specified for job on '+self.name)
             #end if
         #end if
-
         self.post_process_job(job)
 
         job.set_environment(OMP_NUM_THREADS=job.threads)
@@ -3454,7 +3453,7 @@ class Frontier(Supercomputer):
             job.queue = 'batch'
         #end if
         if job.constraint is None:
-            job.constraint = 'gpu'
+            job.constraint = 'cpu'
         #end if
         # Account for dual nature of Perlmutter
         if 'cpu' in job.constraint:

--- a/nexus/lib/machines.py
+++ b/nexus/lib/machines.py
@@ -3427,6 +3427,91 @@ class Baseline(Supercomputer):
     #end def write_job_header
 #end class Baseline
 
+class Frontier(Supercomputer):
+    name = 'frontier'
+    requires_account = True
+    batch_capable    = True
+
+    queue_configs = {
+        'default': 'batch',
+        'batch': {
+            'max_nodes': 9664,
+            'max_walltime': '12:00:00',
+        },
+        'extended': {
+            'max_nodes': 1894,
+            'max_walltime': '24:00:00',
+        },
+        'debug': {
+            'max_nodes': 1,
+            'max_walltime': '01:00:00',
+        }
+    }
+
+    def pre_process_job(self,job):
+        # Set default queue and node type
+        if job.queue is None:
+            job.queue = 'batch'
+        #end if
+        if job.constraint is None:
+            job.constraint = 'gpu'
+        #end if
+        # Account for dual nature of Perlmutter
+        if 'cpu' in job.constraint:
+            self.cores_per_node = 56
+        elif 'gpu' in job.constraint:
+            self.cores_per_node = 56
+            self.gpus_per_node  = 4
+        else:
+            self.error('SLURM input "constraint" must contain either "cpu" or "gpu" on Perlmutter\nyou provided: {0}'.format(job.constraint))
+        #end if
+    #end def pre_process_job
+    
+
+    def post_process_job(self, job):
+        if job.gpus is None:
+            job.run_options.add(
+                cpu_bind='--cpu-bind=threads',
+                threads_per_core='--threads-per-core={0}'.format(job.threads)
+            )            
+        else:
+            gpus_per_task = int(floor(float(self.gpus_per_node)/job.processes_per_node))
+            job.run_options.add(
+                gpu_bind='--gpu-bind=closest',
+                gpus_per_task='--gpus-per-task=1'
+            )
+        #end if
+        job.run_options.add(
+            N='-N {}'.format(job.nodes),
+            n='-n {}'.format(job.processes),
+            c='-c {}'.format(job.threads),
+
+        )
+
+    def write_job_header(self, job):
+        self.validate_queue_config(job)
+        if job.queue is None:
+            job.queue = 'batch'
+        elif job.queue == 'debug':
+            job.qos = 'debug'
+            job.queue = 'batch'
+        #end if
+
+        c = '#!/bin/sh\n'
+        c += '#SBATCH -A {account}\n'.format(account=job.account)
+        c += '#SBATCH -p {queue}\n'.format(queue=job.queue)
+        c += '#SBATCH -J {name}\n'.format(name=job.name)
+        c += '#SBATCH -t {time}\n'.format(time=job.lsf_walltime())
+        c += '#SBATCH -N {nodes}\n'.format(nodes=job.nodes)
+        c += '#SBATCH -S 8\n' # Uses default low-noise mode layout(default), reduces number of cores from 64 to 56. 
+        c += '#SBATCH -o {name}.out\n'.format(name=job.name)
+        c += '#SBATCH -e {name}.err\n'.format(name=job.name)
+        return c
+
+
+#end class Frontier
+
+
 # Active 
 # BESMS is at ORNL 
 class Besms(Supercomputer):
@@ -4181,7 +4266,7 @@ Kestrel(      2144,   2,    52,  256,  100,   'srun',   'sbatch',  'squeue', 'sc
 Inti(           13,   2,    64,  256,  100,   'srun',   'sbatch',  'squeue', 'scancel')
 Baseline(      128,   2,    64,  512,  100,   'srun',   'sbatch',  'squeue', 'scancel')
 Besms(         166,   1,    96,  768, 1000,   'srun',   'sbatch',  'squeue', 'scancel')
-
+Frontier(     9856,   4,    14,   64, 1000,   'srun',   'sbatch',  'squeue', 'scancel')
 
 #machine accessor functions
 get_machine_name = Machine.get_hostname
@@ -4189,6 +4274,8 @@ get_machine      = Machine.get
 
 #rename Job with lowercase
 job=Job
+
+
 
 
 

--- a/nexus/tests/unit/test_machines.py
+++ b/nexus/tests/unit/test_machines.py
@@ -1297,6 +1297,12 @@ def test_job_run_command():
         ('besms'          , 'n2_t2'         ) : 'srun test.x',
         ('besms'          , 'n2_t2_e'       ) : 'srun test.x',
         ('besms'          , 'n2_t2_p2'      ) : 'srun test.x',
+        ('frontier'       , 'n1'            ) : 'srun -N 1 -c 1 --cpu-bind=threads -n 56 --threads-per-core=1 test.x',
+        ('frontier'       , 'n1_p1'         ) : 'srun -N 1 -c 1 --cpu-bind=threads -n 1 --threads-per-core=1 test.x',
+        ('frontier'       , 'n2'            ) : 'srun -N 2 -c 1 --cpu-bind=threads -n 112 --threads-per-core=1 test.x',
+        ('frontier'       , 'n2_t2'         ) : 'srun -N 2 -c 2 --cpu-bind=threads -n 56 --threads-per-core=2 test.x',
+        ('frontier'       , 'n2_t2_e'       ) : 'srun -N 2 -c 2 --cpu-bind=threads -n 56 --threads-per-core=2 test.x',
+        ('frontier'       , 'n2_t2_p2'      ) : 'srun -N 2 -c 2 --cpu-bind=threads -n 4 --threads-per-core=2 test.x',
         })
 
 
@@ -2132,6 +2138,19 @@ srun test.x''',
 export ENV_VAR=1
 export OMP_NUM_THREADS=1
 srun test.x''',
+        frontier = '''#!/bin/sh
+#SBATCH -A ABC123
+#SBATCH -p batch
+#SBATCH -J jobname
+#SBATCH -t 06:30
+#SBATCH -N 2
+#SBATCH -S 8
+#SBATCH -o jobname.out
+#SBATCH -e jobname.err
+
+export ENV_VAR=1
+export OMP_NUM_THREADS=1
+srun -N 2 -c 1 --cpu-bind=threads -n 112 --threads-per-core=1 test.x''',
         )
 
     def process_job_file(jf):


### PR DESCRIPTION
## Proposed changes

Adds Frontier to machine.py. The added tests only cover the CPU-only submissions. I think the tests have a special way to treat gpu runs only for Summit. I think gpu runs are also not tested for other supercomputers. 

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
MacOS, python 3.11

## Checklist

* * [ ] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
