### PR TITLE
Use const ref in hdf_archive::write APIs

### DIFF
--- a/src/Estimators/EnergyDensityEstimator.cpp
+++ b/src/Estimators/EnergyDensityEstimator.cpp
@@ -348,15 +348,15 @@ void NEEnergyDensityEstimator::registerOperatorEstimator(hdf_archive& file)
 
   hdf_path path_variables = hdf_name / std::string_view("variables");
   file.push(path_variables, true);
-  file.write(const_cast<int&>(n_particles_), "nparticles");
+  file.write(n_particles_, "nparticles");
   auto nspacegrids = input_.get_space_grid_inputs().size();
   file.write(nspacegrids, "nspacegrids");
-  file.write(const_cast<int&>(nsamples_), "nsamples");
+  file.write(nsamples_, "nsamples");
 
   if (input_.get_ion_points())
   {
-    file.write(const_cast<int&>(n_ions_), "nions");
-    file.write(const_cast<Matrix<Real>&>(r_ion_work_), "ion_positions");
+    file.write(n_ions_, "nions");
+    file.write(r_ion_work_, "ion_positions");
   }
   file.pop();
 

--- a/src/Estimators/NEReferencePoints.cpp
+++ b/src/Estimators/NEReferencePoints.cpp
@@ -103,7 +103,7 @@ void NEReferencePoints::write(hdf_archive& file) const
 {
   file.push(std::string_view("reference_points"));
   for (auto it = points_.cbegin(); it != points_.cend(); ++it)
-    file.write(const_cast<Point&>(it->second), it->first);
+    file.write(it->second, it->first);
   file.pop();
 }
 

--- a/src/Estimators/StructureFactorEstimator.cpp
+++ b/src/Estimators/StructureFactorEstimator.cpp
@@ -94,7 +94,7 @@ void StructureFactorEstimator::registerOperatorEstimator(hdf_archive& file)
   file.push(path_variables, true);
   // hdf_archive wants non const references, if that code was better
   // this would be unecessary
-  file.write(const_cast<std::vector<KPt>&>(ions_.getSimulationCell().getKLists().getKptsCartWorking()), "value");
+  file.write(ions_.getSimulationCell().getKLists().getKptsCartWorking(), "value");
   file.pop();
 }
 

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -241,7 +241,7 @@ public:
    * @return true if successful
    */
   template<typename T>
-  bool writeEntry(T& data, const std::string& aname)
+  bool writeEntry(const T& data, const std::string& aname)
   {
     if (Mode[NOIO])
       return true;
@@ -256,7 +256,7 @@ public:
    * runtime error is issued on I/O error
    */
   template<typename T>
-  void write(T& data, const std::string& aname)
+  void write(const T& data, const std::string& aname)
   {
     if (!writeEntry(data, aname))
     {


### PR DESCRIPTION
## Proposed changes
Fix hdf_archive::write const correctness.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
