### PR TITLE
Add append support to Hdf archive

### DIFF
--- a/src/io/hdf/hdf_archive.cpp
+++ b/src/io/hdf/hdf_archive.cpp
@@ -26,15 +26,11 @@ hdf_error_suppression hide_hdf_errors;
 
 hdf_archive::~hdf_archive()
 {
-#if defined(ENABLE_PHDF5)
-  if (xfer_plist != H5P_DEFAULT)
-    H5Pclose(xfer_plist);
-  if (access_id != H5P_DEFAULT)
-    H5Pclose(access_id);
-#endif
-  if (lcpl_id != H5P_DEFAULT)
-    H5Pclose(lcpl_id);
   close();
+  H5Pclose(xfer_plist);
+  H5Pclose(file_apl_);
+  H5Pclose(file_cpl_);
+  H5Pclose(lcpl_id);
 }
 
 void hdf_archive::close()
@@ -49,33 +45,48 @@ void hdf_archive::close()
   if (file_id != is_closed)
     H5Fclose(file_id);
   file_id = is_closed;
-  if (file_apl_ != H5I_INVALID_HID)
-  {
-    H5Pclose(file_apl_);
-    file_apl_ = H5I_INVALID_HID;
-  }
-  if (file_cpl_ != H5I_INVALID_HID)
-  {
-    H5Pclose(file_cpl_);
-    file_cpl_ = H5I_INVALID_HID;
-  }
 }
 
 void hdf_archive::set_access_plist()
 {
-  access_id = H5P_DEFAULT;
-  lcpl_id   = H5Pcreate(H5P_LINK_CREATE);
-  H5Pset_create_intermediate_group(lcpl_id, true);
+  create_basic_plist();
   Mode.set(IS_PARALLEL, false);
   Mode.set(IS_MASTER, true);
   Mode.set(NOIO, false);
 }
 
+void hdf_archive::create_basic_plist()
+{
+  file_apl_ = H5Pcreate(H5P_FILE_ACCESS);
+  if (file_apl_ == H5I_INVALID_HID)
+    throw std::runtime_error("hdf_archive failed to create file access properties!");
+  file_cpl_ = H5Pcreate(H5P_FILE_CREATE);
+  if (file_cpl_ == H5I_INVALID_HID)
+  {
+    H5Pclose(file_apl_);
+    throw std::runtime_error("hdf_archive failed to create file create properties!");
+  }
+  lcpl_id = H5Pcreate(H5P_LINK_CREATE);
+  if (lcpl_id == H5I_INVALID_HID)
+  {
+    H5Pclose(file_apl_);
+    H5Pclose(file_cpl_);
+    throw std::runtime_error("hdf_archive failed to create link create properties!");
+  }
+  H5Pset_create_intermediate_group(lcpl_id, true);
+  xfer_plist = H5Pcreate(H5P_DATASET_XFER);
+  if (xfer_plist == H5I_INVALID_HID)
+  {
+    H5Pclose(file_apl_);
+    H5Pclose(file_cpl_);
+    H5Pclose(lcpl_id);
+    throw std::runtime_error("hdf_archive failed to create dataset xfer properties!");
+  }
+}
+
 void hdf_archive::set_access_plist(Communicate* comm, bool request_pio)
 {
-  access_id = H5P_DEFAULT;
-  lcpl_id   = H5Pcreate(H5P_LINK_CREATE);
-  H5Pset_create_intermediate_group(lcpl_id, true);
+  create_basic_plist();
   if (comm && comm->size() > 1) //for parallel communicator
   {
     bool use_phdf5 = false;
@@ -84,11 +95,12 @@ void hdf_archive::set_access_plist(Communicate* comm, bool request_pio)
     {
       // enable parallel I/O
       MPI_Info info = MPI_INFO_NULL;
-      access_id     = H5Pcreate(H5P_FILE_ACCESS);
-      H5Pset_all_coll_metadata_ops(access_id, true);
-      H5Pset_coll_metadata_write(access_id, true);
-      H5Pset_fapl_mpio(access_id, comm->getMPI(), info);
-      xfer_plist = H5Pcreate(H5P_DATASET_XFER);
+      // This in needed as well other resulting logic to support the unlikely
+      // optimization of using the global H5P_DEFAULT instead of just
+      // having hdf_archive own its access plist.
+      H5Pset_all_coll_metadata_ops(file_apl_, true);
+      H5Pset_coll_metadata_write(file_apl_, true);
+      H5Pset_fapl_mpio(file_apl_, comm->getMPI(), info);
       // enable parallel collective I/O
       H5Pset_dxpl_mpio(xfer_plist, H5FD_MPIO_COLLECTIVE);
       use_phdf5 = true;
@@ -112,9 +124,7 @@ void hdf_archive::set_access_plist(Communicate* comm, bool request_pio)
 #ifdef HAVE_MPI
 void hdf_archive::set_access_plist(boost::mpi3::communicator& comm, bool request_pio)
 {
-  access_id = H5P_DEFAULT;
-  lcpl_id   = H5Pcreate(H5P_LINK_CREATE);
-  H5Pset_create_intermediate_group(lcpl_id, true);
+  create_basic_plist();
   if (comm.size() > 1) //for parallel communicator
   {
     bool use_phdf5 = false;
@@ -123,11 +133,9 @@ void hdf_archive::set_access_plist(boost::mpi3::communicator& comm, bool request
 #if defined(ENABLE_PHDF5)
       // enable parallel I/O
       MPI_Info info = MPI_INFO_NULL;
-      access_id     = H5Pcreate(H5P_FILE_ACCESS);
-      H5Pset_all_coll_metadata_ops(access_id, true);
-      H5Pset_coll_metadata_write(access_id, true);
-      H5Pset_fapl_mpio(access_id, comm.get(), info);
-      xfer_plist = H5Pcreate(H5P_DATASET_XFER);
+      H5Pset_all_coll_metadata_ops(file_apl_, true);
+      H5Pset_coll_metadata_write(file_apl_, true);
+      H5Pset_fapl_mpio(file_apl_, comm.get(), info);
       // enable parallel collective I/O
       H5Pset_dxpl_mpio(xfer_plist, H5FD_MPIO_COLLECTIVE);
       use_phdf5 = true;
@@ -151,38 +159,26 @@ void hdf_archive::set_access_plist(boost::mpi3::communicator& comm, bool request
 }
 #endif
 
-
 bool hdf_archive::create(const std::filesystem::path& fname, unsigned mode_flags)
 {
+  close();
   possible_filename_ = fname;
   if (Mode[NOIO])
     return true;
   if (!(Mode[IS_PARALLEL] || Mode[IS_MASTER]))
     throw std::runtime_error("Only create file in parallel or by master but not every rank!");
-  close();
-  file_cpl_ = H5Pcreate(H5P_FILE_CREATE);
-  if (file_cpl_ == H5I_INVALID_HID)
-    throw std::runtime_error("hdf_archive failed to create file create properties!");
-  file_apl_ = H5Pcreate(H5P_FILE_ACCESS);
-  if (file_apl_ == H5I_INVALID_HID)
-  {
-    H5Pclose(file_cpl_);
-    throw std::runtime_error("hdr_archive failed to create file access properties!");
-  }
   file_id = H5Fcreate(fname.c_str(), mode_flags, file_cpl_, file_apl_);
   return file_id != is_closed;
 }
 
 bool hdf_archive::open(const std::filesystem::path& fname, unsigned mode_flags)
 {
+  close();
   possible_filename_ = fname;
   if (Mode[NOIO])
     return true;
   close();
-  file_apl_ = H5Pcreate(H5P_FILE_ACCESS);
-  if (file_apl_ == H5I_INVALID_HID)
-    throw std::runtime_error("hdf_archive failed to create file access properties list!");
-  file_id = H5Fopen(fname.c_str(), mode_flags, access_id);
+  file_id = H5Fopen(fname.c_str(), mode_flags, file_apl_);
   return file_id != is_closed;
 }
 

--- a/src/io/hdf/hdf_archive.cpp
+++ b/src/io/hdf/hdf_archive.cpp
@@ -177,7 +177,6 @@ bool hdf_archive::open(const std::filesystem::path& fname, unsigned mode_flags)
   possible_filename_ = fname;
   if (Mode[NOIO])
     return true;
-  close();
   file_id = H5Fopen(fname.c_str(), mode_flags, file_apl_);
   return file_id != is_closed;
 }

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -71,13 +71,13 @@ private:
   /// file access property list
   hid_t file_apl_{H5I_INVALID_HID};
   ///file id
-  hid_t file_id;
+  hid_t file_id{is_closed};
   ///access id
-  hid_t access_id;
+  hid_t access_id{H5I_INVALID_HID};
   ///transfer property
-  hid_t xfer_plist;
+  hid_t xfer_plist{H5I_INVALID_HID};
   /// Link creation property list identifier
-  hid_t lcpl_id;
+  hid_t lcpl_id{H5I_INVALID_HID};
   ///FILO to handle H5Group
   std::stack<hid_t> group_id;
   ///Track group names corresponding to group_id
@@ -89,7 +89,11 @@ private:
    */
   std::string possible_filename_;
 
-  ///set the access property
+  /** set the access property
+   *  these are exclusively called from the constructor.
+   *  this is a simplifying assumption for other code
+   */
+  void create_basic_plist();
   void set_access_plist(Communicate* comm, bool request_pio);
 #ifdef HAVE_MPI
   void set_access_plist(boost::mpi3::communicator& comm, bool request_pio);
@@ -105,15 +109,14 @@ public:
    *        if false, hdf_archive is in independent IO mode
    */
   template<class Comm = Communicate*>
-  hdf_archive(Comm c, bool request_pio = false)
-      : file_id(is_closed), access_id(H5P_DEFAULT), xfer_plist(H5P_DEFAULT), lcpl_id(H5P_DEFAULT)
+  hdf_archive(Comm c, bool request_pio = false) : file_id(is_closed)
   {
     if (!hdf_error_suppression::enabled)
       throw std::runtime_error("HDF5 library warnings and errors not suppressed from output.\n");
     set_access_plist(c, request_pio);
   }
 
-  hdf_archive() : file_id(is_closed), access_id(H5P_DEFAULT), xfer_plist(H5P_DEFAULT), lcpl_id(H5P_DEFAULT)
+  hdf_archive() : file_id(is_closed)
   {
     if (!hdf_error_suppression::enabled)
       throw std::runtime_error("HDF5 library warnings and errors not suppressed from output.\n");

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -10,7 +10,6 @@
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 
-
 #ifndef QMCPLUSPLUS_HDF5_ARCHIVE_H
 #define QMCPLUSPLUS_HDF5_ARCHIVE_H
 
@@ -273,30 +272,33 @@ public:
 
   /** Append data to a dynamically sized dataspace.
    *
-   *  \param[in]     data                    reference to actual data object, hdf5_proxy, hdf_stl, hdf_pete provide proxies for most.
-   *  \param[in]     aname                   hdf5 path from the current file group on.
-   *  \param[in]     append_index            In a dynamic dataseries which entry will this be, updated to next entry.
+   *  @param[in]     data                    reference to actual data object, hdf5_proxy, hdf_stl, hdf_pete provide proxies for most.
+   *  @param[in]     aname                   hdf5 path from the current file group on.
+   *  @param[in]     append_index            In a dynamic dataseries which entry will this be
+   *  @return                                the next index after data
+   *                                         is appended
    *
-   *  This has no legacy usage and exceptions are thrown in case of error.
+   *  This has no legacy usage and exceptions are thrown in case of
+   *  error since there is a useful return value
    *
-   *  This is pointless unless you do something with the current_append_index
-   *  which is the necessary state to determine where in the data series you
-   *  are writing.
+   *  I can't think of any good reason to discard the return value,
+   *  but it does seem like it will generally make a nice bug hence
+   *  [[nodiscard]]
    */
   template<typename T>
-  hsize_t append(T& data, const std::string& aname, const hsize_t current_append_index)
+  [[nodiscard]] hsize_t append(T& data, const std::string& aname, const hsize_t current_append_index)
   {
     auto local_append_index = current_append_index;
     if (!appendEntry(data, aname, local_append_index))
     {
-      throw std::runtime_error("HDF5 write failure in hdf_archive::write " + aname);
+      throw std::runtime_error("HDF5 append failure in hdf_archive::appendEntry!" + aname);
     }
     return local_append_index;
   }
 
-  /** write the data to the group aname and return status
-   * use write() for inbuilt error checking
-   * @return true if successful
+  /** append the data to aname at the current_append_index and return status
+   *  use write() for inbuilt error checking
+   *  @return true if successful
    */
   template<typename T>
   bool appendEntry(T& data, const std::string& aname, hsize_t& current_append_index)

--- a/src/io/hdf/hdf_dataproxy.h
+++ b/src/io/hdf/hdf_dataproxy.h
@@ -48,6 +48,20 @@ struct h5data_proxy : public h5_space_type<T, 0>
   {
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(&ref), xfer_plist);
   }
+
+  inline bool append(const data_type& ref,
+                     hid_t grp,
+                     const std::string& aname,
+                     hsize_t& current_leading_index,
+                     hid_t xfer_plist = H5P_DEFAULT) const
+  {
+    std::vector<hsize_t> my_dims;
+    hsize_t rank = dims.size() + 1;
+    my_dims.resize(rank, 1);
+    std::copy(dims.begin(), dims.end(), my_dims.begin() + 1);
+    return h5d_append(grp, aname.c_str(), current_leading_index, FileSpace::rank, my_dims.data(), get_address(&ref),
+                      xfer_plist);
+  }
 };
 
 /** specialization for bool, convert to int

--- a/src/io/hdf/hdf_pete.h
+++ b/src/io/hdf/hdf_pete.h
@@ -17,6 +17,7 @@
 #include "OhmmsPETE/OhmmsVector.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "OhmmsPETE/OhmmsArray.h"
+#include "type_traits/container_traits_ohmms.h"
 
 namespace qmcplusplus
 {
@@ -44,6 +45,17 @@ struct h5data_proxy<Vector<T>> : public h5_space_type<T, 1>
   inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(ref.data()), xfer_plist);
+  }
+
+  inline bool append(const data_type& ref,
+                     hid_t grp,
+                     const std::string& aname,
+                     hsize_t& current_append_index,
+                     hid_t xfer_plist = H5P_DEFAULT)
+  {
+    std::array<hsize_t, 2> my_dims{1, dims[0]};
+    return h5d_append(grp, aname.c_str(), current_append_index, 2, my_dims.data(), get_address(ref.data()), 1,
+                      xfer_plist);
   }
 };
 

--- a/src/io/hdf/hdf_pete.h
+++ b/src/io/hdf/hdf_pete.h
@@ -17,7 +17,6 @@
 #include "OhmmsPETE/OhmmsVector.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "OhmmsPETE/OhmmsArray.h"
-#include "type_traits/container_traits_ohmms.h"
 
 namespace qmcplusplus
 {

--- a/src/io/hdf/hdf_wrapper_functions.h
+++ b/src/io/hdf/hdf_wrapper_functions.h
@@ -226,16 +226,16 @@ bool h5d_read(hid_t grp,
   hid_t dataspace = H5Dget_space(h1);
   hid_t memspace  = H5Screate_simple(ndims, counts, NULL);
   // According to the HDF5 manual (https://support.hdfgroup.org/HDF5/doc/RM/H5S/H5Sselect_hyperslab.htm)
-  // , the fifth argument (count) means the number of hyper-slabs to select along each dimensions 
+  // , the fifth argument (count) means the number of hyper-slabs to select along each dimensions
   // while the sixth argument (block) is the size of each hyper-slab.
   // To write a single hyper-slab of size counts in a dataset, we call
   // H5Sselect_hyperslab(dataspace, H5S_SELECT_SET, offsets, NULL, ones.data(), counts);
   // The vector "ones" means we want to write one hyper-slab (block) along each dimensions.
-  // The result is equivalent to calling 
+  // The result is equivalent to calling
   // H5Sselect_hyperslab(dataspace, H5S_SELECT_SET, offsets, NULL, counts, NULL);
   // , but it implies writing count hyper-slabs along each dimension and each hyper-slab is of size one.
   const std::vector<hsize_t> ones(ndims, 1);
-  herr_t ret      = H5Sselect_hyperslab(dataspace, H5S_SELECT_SET, offsets, NULL, ones.data(), counts);
+  herr_t ret = H5Sselect_hyperslab(dataspace, H5S_SELECT_SET, offsets, NULL, ones.data(), counts);
 
   hid_t h5d_type_id = get_h5_datatype(*first);
   ret               = H5Dread(h1, h5d_type_id, memspace, dataspace, xfer_plist, first);
@@ -395,6 +395,20 @@ inline bool h5d_write(hid_t grp,
   return ret != -1;
 }
 
+/** Append to a hdf5 dataset
+ *  @param[in]      grp         an invalid grp id will result in
+ *                              a noop returning true
+ *  @param[in]      aname       string identifier of dataset
+ *  @param[in,out]  current     position in dataset, input is ignored if
+ *                              dataset at aname doesn't exist
+ *  @param[in]      ndims       number of dimensions
+ *  @param[in]      dims        ptr to dims
+ *  @param[in]      first       ptr to start of data
+ *  @param[in]      chunk_size  chunk size
+ *  @param[in]      xfer_plist  hid to hd5 plist
+ *
+ *  Assumption: we are appending slices in the first index.
+ */
 template<typename T>
 inline bool h5d_append(hid_t grp,
                        const std::string& aname,

--- a/src/io/hdf/tests/test_hdf_archive.cpp
+++ b/src/io/hdf/tests/test_hdf_archive.cpp
@@ -14,11 +14,10 @@
 #include "catch.hpp"
 
 #include "hdf/hdf_archive.h"
-#include <H5Fpublic.h>
 #include <vector>
 #include <string>
 #include <sstream>
-
+#include "type_traits/container_traits_ohmms.h"
 
 using std::string;
 using std::vector;

--- a/src/io/hdf/tests/test_hdf_archive.cpp
+++ b/src/io/hdf/tests/test_hdf_archive.cpp
@@ -205,7 +205,7 @@ TEST_CASE("hdf_archive_append_pete", "[hdf]")
 {
   using qmcplusplus::Vector;
   hdf_archive hd;
-  bool okay = hd.create("test_append_pete.hdf", H5F_ACC_TRUNC);
+  bool okay = hd.create("test_append_pete.hdf");
   REQUIRE(okay);
 
   Vector<double> v1{2.3, 3.4, 5.6};
@@ -219,7 +219,8 @@ TEST_CASE("hdf_archive_append_pete", "[hdf]")
   append_index = hd.append(v2, name, append_index);
   hd.close();
   hdf_archive read_hd;
-  okay = read_hd.open("test_append_pete.hdf", H5F_ACC_RDONLY);
+  // For hdf5@1.14.6+cxx+mpi api=v114
+  okay = read_hd.open("test_append_pete.hdf");
   REQUIRE(okay);
 
   Vector<double> v_read;
@@ -229,6 +230,7 @@ TEST_CASE("hdf_archive_append_pete", "[hdf]")
   CHECK(v_read.size() == 3);
   CHECK(v1 == v_read);
 
+  // Select the second row in the hyperslab
   select_one_vector = {1, -1};
   read_hd.readSlabSelection(v_read, select_one_vector, name);
 

--- a/src/io/hdf/tests/test_hdf_archive.cpp
+++ b/src/io/hdf/tests/test_hdf_archive.cpp
@@ -14,6 +14,7 @@
 #include "catch.hpp"
 
 #include "hdf/hdf_archive.h"
+#include <H5Fpublic.h>
 #include <vector>
 #include <string>
 #include <sstream>
@@ -200,13 +201,49 @@ TEST_CASE("hdf_archive_vector", "[hdf]")
     CHECK(v_const[i] == v2_for_const[i]);
 }
 
+TEST_CASE("hdf_archive_append_pete", "[hdf]")
+{
+  using qmcplusplus::Vector;
+  hdf_archive hd;
+  bool okay = hd.create("test_append_pete.hdf", H5F_ACC_TRUNC);
+  REQUIRE(okay);
+
+  Vector<double> v1{2.3, 3.4, 5.6};
+  hsize_t append_index = 0;
+
+  std::string name = "pete_vector_series";
+  append_index     = hd.append(v1, name, append_index);
+
+  Vector<double> v2{4.0, 5.0, 6.0};
+
+  append_index = hd.append(v2, name, append_index);
+  hd.close();
+  hdf_archive read_hd;
+  okay = read_hd.open("test_append_pete.hdf", H5F_ACC_RDONLY);
+  REQUIRE(okay);
+
+  Vector<double> v_read;
+  std::array<int, 2> select_one_vector{0, -1};
+  read_hd.readSlabSelection(v_read, select_one_vector, name);
+
+  CHECK(v_read.size() == 3);
+  CHECK(v1 == v_read);
+
+  select_one_vector = {1, -1};
+  read_hd.readSlabSelection(v_read, select_one_vector, name);
+
+  CHECK(v_read.size() == 3);
+  CHECK(v2 == v_read);
+}
+
 TEST_CASE("hdf_archive_group", "[hdf]")
 {
   hdf_archive hd;
-  hd.create("test_group.hdf");
+  bool okay = hd.create("test_group.hdf");
+  REQUIRE(okay);
 
-  int i     = 3;
-  bool okay = hd.writeEntry(i, "int");
+  int i = 3;
+  okay  = hd.writeEntry(i, "int");
   REQUIRE(okay);
 
   CHECK(hd.group_path_as_string() == "");
@@ -486,5 +523,4 @@ TEST_CASE("hdf_std_vec_bool", "[hdf]")
   REQUIRE(v2_for_const.size() == 3);
   for (int i = 0; i < v_const.size(); i++)
     CHECK(v_const[i] == v2_for_const[i]);
-
 }


### PR DESCRIPTION
## Proposed changes

hdf5 archive lacks support for appending to hdf5 datasets which is present in the hdf_wrappers.  This PR extends this functionality to the hdf_archive level allowing new modules to append to hdf5 datasets without resorting to using Observable helper.  New estimators should use this functionality instread of observable helper. Revives some code from #4540.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature
- Code style update (formatting, renaming)
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation or build script changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
sdgx2

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
