### PR TITLE
Bump up CUDA version in CI and fix test_afqmc_numerics

### DIFF
--- a/src/AFQMC/Memory/CUDA/cuda_arch.cpp
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.cpp
@@ -112,6 +112,7 @@ void free(void* p, const std::string& message)
       std::cerr << " Error from: " << message << std::endl;
     }
     std::cerr << " Error from calling cudaFree: " << cudaGetErrorString(status) << std::endl;
+    throw std::runtime_error("Error: cudaFree returned error code.");
   }
 }
 

--- a/src/AFQMC/Memory/HIP/hip_arch.cpp
+++ b/src/AFQMC/Memory/HIP/hip_arch.cpp
@@ -118,6 +118,7 @@ void free(void* p, const std::string& message)
       std::cerr << " Error from : " << message << std::endl;
     }
     std::cerr << " Error when calling hipFree: " << hipGetErrorString(status) << std::endl;
+    throw std::runtime_error("Error: hipFree returned error code.");
   }
 }
 

--- a/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
@@ -620,7 +620,7 @@ void test_dense_gerf_gqr_strided_device(Allocator& alloc)
     array<int, 1, IAllocator> info(iextensions<1u>{2}, IAllocator{alloc});
     array<T, 2, Allocator> TAU({2, 4}, alloc);
 
-    geqrfStrided(4, 3, A.origin(), 4, 12, TAU.origin(), sz, info.origin(), 2);
+    geqrfStrided(4, 3, A.origin(), 4, 12, TAU.origin(), 4, info.origin(), 2);
     gqrStrided(4, 3, 3, A.origin(), 4, 12, TAU.origin(), 4, WORK.origin(), sz, info.origin(), 2);
     for (int i = 0; i < 2; i++)
     {
@@ -764,7 +764,6 @@ TEST_CASE("dense_ma_operations_device_complex", "[matrix_operations]")
     test_dense_mat_mul_device<Alloc>(alloc);
     test_dense_gerf_gqr_device<Alloc>(alloc);
     test_dense_gerf_gqr_strided_device<Alloc>(alloc);
-    test_dense_geqrf_getri_batched_device<Alloc>(alloc);
     test_dense_geqrf_getri_batched_device<Alloc>(alloc);
     test_dense_batched_gemm<Alloc>(alloc);
   }


### PR DESCRIPTION
## Proposed changes
Due to recent change on sulfur, CUDA version on the offload CI case needs to be updated.
Fix a wrong stride used in test_afqmc_numerics.

## What type(s) of changes does this code introduce?
- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted