### PR TITLE
Add spinor detratios

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
@@ -18,6 +18,7 @@
 
 
 #include "EinsplineSpinorSetBuilder.h"
+#include <PlatformSelector.hpp>
 #include "QMCWaveFunctions/SpinorSet.h"
 #include "OhmmsData/AttributeSet.h"
 #include "Message/CommOperators.h"
@@ -50,6 +51,7 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
   std::string truncate("no");
   std::string hybrid_rep("no");
   std::string spo_object_name;
+  std::string useGPU; 
 
   ScopedTimer spo_timer_scope(createGlobalTimer("einspline::CreateSpinorSetFromXML", timer_level_medium));
 
@@ -68,6 +70,7 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
     a.add(spo_prec, "precision");
     a.add(truncate, "truncate");
     a.add(myName, "tag");
+    a.add(useGPU, "gpu", CPUOMPTargetSelector::candidate_values);
 
     a.put(XMLRoot);
     a.add(numOrbs, "size");
@@ -176,7 +179,6 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
     myComm->barrier_and_abort(
         "The 'truncate' feature of spline SPO has been removed. Please use hybrid orbital representation.");
 
-  std::string useGPU("no");
 #if !defined(QMC_COMPLEX)
   if (use_real_splines_)
   {

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -134,6 +134,11 @@ public:
                          const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
                          std::vector<std::vector<Value>>& ratios) const override;
 
+  void mw_evaluateSpinorRatios(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                               const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+                               const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+                               std::vector<std::vector<Value>>& ratios) const override;
+
   void evaluateDerivRatios(const VirtualParticleSet& VP,
                            const opt_variables_type& optvars,
                            std::vector<ValueType>& ratios,

--- a/src/QMCWaveFunctions/SPOSet.cpp
+++ b/src/QMCWaveFunctions/SPOSet.cpp
@@ -88,6 +88,22 @@ void SPOSetT<T>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOSetT>& spo_li
 }
 
 template<typename T>
+void SPOSetT<T>::mw_evaluateDetSpinorRatios(const RefVectorWithLeader<SPOSetT>& spo_list,
+                                            const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+                                            const RefVector<ValueVector>& psi_list,
+                                            const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+                                            const std::vector<const ValueType*>& invRow_ptr_list,
+                                            std::vector<std::vector<ValueType>>& ratios_list) const
+{
+  assert(this == &spo_list.getLeader());
+  for (int iw = 0; iw < spo_list.size(); iw++)
+  {
+    Vector<ValueType> invRow(const_cast<ValueType*>(invRow_ptr_list[iw]), psi_list[iw].get().size());
+    spo_list[iw].evaluateDetSpinorRatios(vp_list[iw], psi_list[iw], spinor_multiplier_list[iw], invRow, ratios_list[iw]);
+  }
+}
+
+template<typename T>
 void SPOSetT<T>::evaluateVGL_spin(const ParticleSet& P,
                                   int iat,
                                   ValueVector& psi,

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -267,6 +267,13 @@ public:
                                     const std::vector<const ValueType*>& invRow_ptr_list,
                                     std::vector<std::vector<ValueType>>& ratios_list) const;
 
+  virtual void mw_evaluateDetSpinorRatios(const RefVectorWithLeader<SPOSetT>& spo_list,
+                                          const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+                                          const RefVector<ValueVector>& psi_list,
+                                          const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+                                          const std::vector<const ValueType*>& invRow_ptr_list,
+                                          std::vector<std::vector<ValueType>>& ratios_list) const;
+
   /** evaluate the values, gradients and laplacians of this single-particle orbital set
    * @param P current ParticleSet
    * @param iat active particle

--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -121,6 +121,7 @@ void SpinorSet::mw_evaluateDetRatios(const RefVectorWithLeader<SPOSet>& spo_list
 {
   auto& spo_leader = spo_list.getCastedLeader<SpinorSet>();
   auto& vp_leader  = vp_list.getLeader();
+  IndexType nat = vp_leader.getTotalNum();
   assert(this == &spo_leader);
 
   IndexType nw                    = spo_list.size();
@@ -143,7 +144,7 @@ void SpinorSet::mw_evaluateDetRatios(const RefVectorWithLeader<SPOSet>& spo_list
     up_psi_v_list.push_back(spo.psi_work_up);
     dn_psi_v_list.push_back(spo.psi_work_down);
 
-    std::vector<ValueType> tmp(norb_requested);
+    std::vector<ValueType> tmp(nat);
     upratios_list.push_back(tmp);
     dnratios_list.push_back(tmp);
   }
@@ -156,10 +157,9 @@ void SpinorSet::mw_evaluateDetRatios(const RefVectorWithLeader<SPOSet>& spo_list
   //up/dn ratios_list is on host, so just do it here on host
   for (int iw = 0; iw < nw; iw++)
   {
-    auto& vp = vp_list[iw];
-    for (size_t iat = 0.0; iat < vp.getTotalNum(); iat++)
+    for (size_t iat = 0.0; iat < nat; iat++)
     {
-      ParticleSet::Scalar_t s = vp.activeSpin(iat);
+      ParticleSet::Scalar_t s = vp_list[iw].activeSpin(iat);
       RealType coss           = std::cos(s);
       RealType sins           = std::sin(s);
 

--- a/src/QMCWaveFunctions/SpinorSet.h
+++ b/src/QMCWaveFunctions/SpinorSet.h
@@ -54,6 +54,11 @@ public:
    */
   void evaluateValue(const ParticleSet& P, int iat, ValueVector& psi) override;
 
+  void evaluateDetRatios(const VirtualParticleSet& VP,
+                         ValueVector& psi,
+                         const ValueVector& invrow,
+                         std::vector<ValueType>& ratios) override;
+
   void evaluateDetSpinorRatios(const VirtualParticleSet& VP,
                                ValueVector& psi,
                                const std::pair<ValueVector, ValueVector>& spinor_multipler,

--- a/src/QMCWaveFunctions/SpinorSet.h
+++ b/src/QMCWaveFunctions/SpinorSet.h
@@ -59,6 +59,12 @@ public:
                          const ValueVector& invrow,
                          std::vector<ValueType>& ratios) override;
 
+  void mw_evaluateDetRatios(const RefVectorWithLeader<SPOSet>& spo_list,
+                            const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+                            const RefVector<ValueVector>& psi_list,
+                            const std::vector<const ValueType*>& invRow_ptr_list,
+                            std::vector<std::vector<ValueType>>& ratios_list) const override;
+
   void evaluateDetSpinorRatios(const VirtualParticleSet& VP,
                                ValueVector& psi,
                                const std::pair<ValueVector, ValueVector>& spinor_multipler,

--- a/src/QMCWaveFunctions/SpinorSet.h
+++ b/src/QMCWaveFunctions/SpinorSet.h
@@ -14,6 +14,7 @@
 #define QMCPLUSPLUS_SPINORSET_H
 
 #include "QMCWaveFunctions/SPOSet.h"
+#include "VirtualParticleSet.h"
 #include <ResourceHandle.h>
 
 namespace qmcplusplus
@@ -70,6 +71,13 @@ public:
                                const std::pair<ValueVector, ValueVector>& spinor_multipler,
                                const ValueVector& invrow,
                                std::vector<ValueType>& ratios) override;
+
+  void mw_evaluateDetSpinorRatios(const RefVectorWithLeader<SPOSet>& spo_list, 
+                                  const RefVectorWithLeader<const VirtualParticleSet>& vp_list, 
+                                  const RefVector<ValueVector>& psi_list, 
+                                  const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list, 
+                                  const std::vector<const ValueType*>& invRow_ptr_list, 
+                                  std::vector<std::vector<ValueType>>& ratios_list) const override;
 
   /** evaluate the values, gradients and laplacians of this single-particle orbital set
    * @param P current ParticleSet

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -396,6 +396,14 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
           (eis * static_cast<ValueType>(5.2) * psiM_up[iat][iorb] +
            emis * static_cast<ValueType>(-0.3) * psiM_down[iat][iorb]);
     CHECK(ratios[0] == ComplexApprox(refVal));
+
+    //now just check evaluateDetRatios
+    refVal = 0.0;
+    for (int iorb = 0; iorb < OrbitalSetSize; iorb++)
+      refVal += static_cast<ValueType>(2.1) * (eis * psiM_up[iat][iorb] + emis * psiM_down[iat][iorb]);
+    spo->evaluateDetRatios(vp, psi, psiinv, ratios);
+    CHECK(ratios[0] == ComplexApprox(refVal));
+
     elec_.rejectMove(iat);
   }
 

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -22,6 +22,8 @@
 #include "QMCWaveFunctions/SpinorSet.h"
 #include "Utilities/for_testing/checkMatrix.hpp"
 #include "Particle/VirtualParticleSet.h"
+#include "QMCHamiltonians/NLPPJob.h"
+#include "DistanceTable.h"
 
 #include <stdio.h>
 #include <string>
@@ -33,6 +35,9 @@ namespace qmcplusplus
 {
 //Now we test the spinor set with Einspline orbitals from HDF.
 #ifdef QMC_COMPLEX
+
+using OffloadVector = Vector<SPOSet::ValueType, OffloadPinnedAllocator<SPOSet::ValueType>>;
+
 TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
 {
   app_log() << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
@@ -658,6 +663,51 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
 
     std::vector<bool> accept = {false, false};
     elec_.mw_accept_rejectMove<CoordsType::POS_SPIN>(p_list, iat, accept);
+  }
+
+  //test mw_evaluateDetRatios
+  VirtualParticleSet vp1(elec_, 1), vp2(elec_2, 1);
+  RefVectorWithLeader<VirtualParticleSet> vp_list(vp1, {vp1, vp2});
+  ResourceCollection vp_res("vp_res");
+  vp.createResource(vp_res);
+  ResourceCollectionTeamLock<VirtualParticleSet> mw_vp_lock(vp_res, vp_list);
+
+  OffloadVector inv_row(3);
+  inv_row = {0.1, 0.2, 0.3};
+  inv_row.updateTo();
+  std::vector<const SPOSet::ValueType*> inv_row_ptr(2,  spo->isOMPoffload() ? inv_row.device_data() : inv_row.data());
+  for (int iat = 0; iat < 3; iat++)
+  {
+    const int ei_table_index = elec_.addTable(ions_);
+    const auto& ei_table1 = elec_.getDistTableAB(ei_table_index);
+    NLPPJob<RealType> job1(0, iat, ei_table1.getDistances()[iat][0], -ei_table1.getDisplacements()[iat][0]);
+    const int ei_table_index2 = elec_2.addTable(ions_);
+    const auto& ei_table2 = elec_2.getDistTableAB(ei_table_index2);
+    NLPPJob<RealType> job2(0, iat, ei_table2.getDistances()[iat][0], -ei_table2.getDisplacements()[iat][0]);
+
+    std::vector<ParticleSet::PosType> deltaV1 {{-dR[iat][0], -dR[iat][1], -dR[iat][2]}};
+    std::vector<ParticleSet::PosType> deltaV2 {{-dR[iat][0], -dR[iat][1], -dR[iat][2]}};
+
+    VirtualParticleSet::mw_makeMoves(vp_list, p_list, {deltaV1, deltaV2}, {job1, job2}, false);
+
+    RealType s1 = elec_.spins[iat];
+    RealType s2 = elec_2.spins[iat];
+    ValueType eis1(std::cos(s1), std::sin(s1));
+    ValueType emis1(std::cos(s1), -std::sin(s1));
+    ValueType eis2(std::cos(s2), std::sin(s2));
+    ValueType emis2(std::cos(s2), -std::sin(s2));
+
+    ValueType refRatio1, refRatio2;
+    for (int iorb = 0; iorb < OrbitalSetSize; iorb++)
+    {
+      refRatio1 += inv_row[iorb] * (eis1 * psiM_up[iat][iorb] + emis1 * psiM_down[iat][iorb]);
+      refRatio2 += inv_row[iorb] * (eis2 * psiM_up[(iat+ 1) % 3][iorb] + emis2 * psiM_down[(iat+1) % 3][iorb]);
+    }
+
+    std::vector<std::vector<ValueType>> ratios_list(2, std::vector<ValueType>(1));
+    spo->mw_evaluateDetRatios(spo_list, RefVectorWithLeader<const VirtualParticleSet>(vp1, {vp1,vp2}), psi_v_list, inv_row_ptr, ratios_list);
+    CHECK(ratios_list[0][0] == ComplexApprox(refRatio1));
+    CHECK(ratios_list[1][0] == ComplexApprox(refRatio2));
   }
 
   //Need to remember that the electrons are distored from initial positions


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

Please also follow the [GitHub Pull Request guidance](https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance). As much as possible, try to avoid the ["Don't"s](https://qmcpack.readthedocs.io/en/develop/developing.html#don-t) to help maintain a high development velocity.

## Proposed changes

This PR implements some missing features in SpinorSet, namely evaluateDetRatios and evaluateDetSpinorRatios which and the appropriate mw_ implementations which allows for offloaded determinant ratios evaluations  in NonLocalECPComponent and SOECPComponents. 

After doing some test runs of SOC on a new machine, I noticed I was basically getting constant throughput for SOC as I increased the walkers_per_rank. After looking at the timers, it was clear that basically everything in the hamiltonian evaluation was falling back to CPU implementation, so we were getting basically no performance. Part of the problem was that we hardcoded the SpinorSetBuilder with useGPU="no" as a guard and never removed it. The rest was that we should be using mw_ evaluateDetRatios and mw_evaluateDetSpinorRatios, which didn't exist in SpinorSet. This is all now fixed, along with unit tests. 

Below is a figure showing relative throughput on the GPUs compared to the nonSOC case. Just from the change in determinant size alone in going from an up and down determinant of size (N/2) to a single larger determinant of size N, you expect a factor of 4 slowdown from the standard N^3 scaling. Around 300 walkers/rank is around where the throughput peaks, so we are giving enough work to the GPU and not being dominated by transfers, and with the fix we see about a 2.5 slowdown relative to the nonSOC, which is in the right ballpark. 

![image](https://github.com/user-attachments/assets/41acc886-94a5-4880-bfeb-39835eeeaa18)

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
AMD MI-300A APUs

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
