### PR TITLE
Replace deprecated hipBLAS complex types for ROCm 6.0+ and 7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -745,39 +745,21 @@ if(ENABLE_ROCM)
         "Rerun cmake with -DROCM_ROOT=<your ROCm installation root directory> added.")
   endif()
 
-  # Detect ROCm version detected via hipconfig
-  execute_process(
-    COMMAND hipconfig --version
-    OUTPUT_VARIABLE HIPCONFIG_VERSION_OUTPUT
-    RESULT_VARIABLE HIPCONFIG_RESULT
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-  )
-  if(HIPCONFIG_RESULT EQUAL 0)
-    string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+" ROCM_VERSION "${HIPCONFIG_VERSION_OUTPUT}")
-    if(ROCM_VERSION)
-      message(STATUS "ROCm version detected via hipconfig: ${ROCM_VERSION}")
-    else()
-      message(FATAL_ERROR "Could not parse ROCm version from hipconfig output:\n${HIPCONFIG_VERSION_OUTPUT}")
-    endif()
-  else()
-    message(FATAL_ERROR "Failed to execute hipconfig to get ROCm version.")
-  endif()
-
-  # Check for minimum required ROCm version
-  if(ROCM_VERSION VERSION_LESS "6.0.0")
-    message(FATAL_ERROR "QMCPACK requires ROCm 6.0.0 or newer. Detected ${ROCM_VERSION}")
-  endif()
-
-  # Add HIPBLAS_V2 for ROCm < 7.0
-  if(ROCM_VERSION VERSION_LESS "7.0.0")
-    add_definitions(-DHIPBLAS_V2)
-    message(STATUS "Defining HIPBLAS_V2 for compatibility with ROCm < 7.0 (Detected ${ROCM_VERSION})")
-  endif()
-
   find_package(hipblas CONFIG REQUIRED)
+  find_package(rocblas CONFIG REQUIRED)
   find_package(rocsolver CONFIG REQUIRED)
   find_package(rocthrust CONFIG REQUIRED)
+
+  # Check for minimum required rocBLAS version
+  if(rocblas_VERSION VERSION_LESS "4.0.0")
+    message(FATAL_ERROR "QMCPACK requires rocBLAS 4.0.0 or newer. Detected ${rocblas_VERSION}")
+  endif()
+
+  # Add HIPBLAS_V2 for rocBLAS < 5.0.0
+  if(rocblas_VERSION VERSION_LESS "5.0.0")
+    add_definitions(-DHIPBLAS_V2)
+    message(STATUS "Defining HIPBLAS_V2 for compatibility with rocBLAS < 5.0.0 (Detected ${rocblas_VERSION})")
+  endif()
 
   # architecture flags
   if(DEFINED HIP_ARCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -744,6 +744,37 @@ if(ENABLE_ROCM)
         "This happens when the ROCm installation cannot be found by CMake. "
         "Rerun cmake with -DROCM_ROOT=<your ROCm installation root directory> added.")
   endif()
+
+  # Detect ROCm version detected via hipconfig
+  execute_process(
+    COMMAND hipconfig --version
+    OUTPUT_VARIABLE HIPCONFIG_VERSION_OUTPUT
+    RESULT_VARIABLE HIPCONFIG_RESULT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  if(HIPCONFIG_RESULT EQUAL 0)
+    string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+" ROCM_VERSION "${HIPCONFIG_VERSION_OUTPUT}")
+    if(ROCM_VERSION)
+      message(STATUS "ROCm version detected via hipconfig: ${ROCM_VERSION}")
+    else()
+      message(FATAL_ERROR "Could not parse ROCm version from hipconfig output:\n${HIPCONFIG_VERSION_OUTPUT}")
+    endif()
+  else()
+    message(FATAL_ERROR "Failed to execute hipconfig to get ROCm version.")
+  endif()
+
+  # Check for minimum required ROCm version
+  if(ROCM_VERSION VERSION_LESS "6.0.0")
+    message(FATAL_ERROR "QMCPACK requires ROCm 6.0.0 or newer. Detected ${ROCM_VERSION}")
+  endif()
+
+  # Add HIPBLAS_V2 for ROCm < 7.0
+  if(ROCM_VERSION VERSION_LESS "7.0.0")
+    add_definitions(-DHIPBLAS_V2)
+    message(STATUS "Defining HIPBLAS_V2 for compatibility with ROCm < 7.0 (Detected ${ROCM_VERSION})")
+  endif()
+
   find_package(hipblas CONFIG REQUIRED)
   find_package(rocsolver CONFIG REQUIRED)
   find_package(rocthrust CONFIG REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,20 +746,13 @@ if(ENABLE_ROCM)
   endif()
 
   find_package(hipblas CONFIG REQUIRED)
-  find_package(rocblas CONFIG REQUIRED)
+  # Check for minimum required rocBLAS version
+  if(hipblas_VERSION VERSION_LESS "2.0.0")
+    message(FATAL_ERROR "QMCPACK requires hipBLAS minimum version 2.0.0 from ROCm 6.0. Detected ${hipblas_VERSION}.")
+  endif()
+
   find_package(rocsolver CONFIG REQUIRED)
   find_package(rocthrust CONFIG REQUIRED)
-
-  # Check for minimum required rocBLAS version
-  if(rocblas_VERSION VERSION_LESS "4.0.0")
-    message(FATAL_ERROR "QMCPACK requires rocBLAS 4.0.0 or newer. Detected ${rocblas_VERSION}")
-  endif()
-
-  # Add HIPBLAS_V2 for rocBLAS < 5.0.0
-  if(rocblas_VERSION VERSION_LESS "5.0.0")
-    add_definitions(-DHIPBLAS_V2)
-    message(STATUS "Defining HIPBLAS_V2 for compatibility with rocBLAS < 5.0.0 (Detected ${rocblas_VERSION})")
-  endif()
 
   # architecture flags
   if(DEFINED HIP_ARCH)

--- a/external_codes/boost_multi/multi/include/boost/multi/adaptors/cuda/cublas/context.hpp
+++ b/external_codes/boost_multi/multi/include/boost/multi/adaptors/cuda/cublas/context.hpp
@@ -111,8 +111,8 @@ using std::is_convertible_v;
 // }
 
 #if defined(__HIP_PLATFORM_NVIDIA__) || defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-	using Complex = hipblasComplex;
-	using DoubleComplex = hipblasDoubleComplex;
+	using Complex = hipFloatComplex;
+	using DoubleComplex = hipDoubleComplex;
 #else  //  __CUDA__  __NVCC__  or clang cuda
 	using Complex = cuComplex;
 	using DoubleComplex = cuDoubleComplex;

--- a/external_codes/boost_multi/multi/include/boost/multi/adaptors/cuda/cublas/context.hpp
+++ b/external_codes/boost_multi/multi/include/boost/multi/adaptors/cuda/cublas/context.hpp
@@ -111,8 +111,8 @@ using std::is_convertible_v;
 // }
 
 #if defined(__HIP_PLATFORM_NVIDIA__) || defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-	using Complex = hipFloatComplex;
-	using DoubleComplex = hipDoubleComplex;
+	using Complex = hipblasComplex;
+	using DoubleComplex = hipblasDoubleComplex;
 #else  //  __CUDA__  __NVCC__  or clang cuda
 	using Complex = cuComplex;
 	using DoubleComplex = cuDoubleComplex;

--- a/src/AFQMC/Numerics/detail/HIP/hipblas_wrapper.hpp
+++ b/src/AFQMC/Numerics/detail/HIP/hipblas_wrapper.hpp
@@ -45,7 +45,7 @@ inline hipblasStatus_t hipblas_copy(hipblasHandle_t handle,
                                     int incy)
 {
   hipblasStatus_t success =
-      hipblasCcopy(handle, n, reinterpret_cast<hipblasComplex*>(x), incx, reinterpret_cast<hipblasComplex*>(y), incy);
+      hipblasCcopy(handle, n, reinterpret_cast<hipFloatComplex*>(x), incx, reinterpret_cast<hipFloatComplex*>(y), incy);
   hipDeviceSynchronize();
   return success;
 }
@@ -57,8 +57,8 @@ inline hipblasStatus_t hipblas_copy(hipblasHandle_t handle,
                                     std::complex<double>* y,
                                     int incy)
 {
-  hipblasStatus_t success = hipblasZcopy(handle, n, reinterpret_cast<hipblasDoubleComplex*>(x), incx,
-                                         reinterpret_cast<hipblasDoubleComplex*>(y), incy);
+  hipblasStatus_t success = hipblasZcopy(handle, n, reinterpret_cast<hipDoubleComplex*>(x), incx,
+                                         reinterpret_cast<hipDoubleComplex*>(y), incy);
   hipDeviceSynchronize();
   return success;
 }
@@ -83,8 +83,8 @@ inline hipblasStatus_t hipblas_scal(hipblasHandle_t handle,
                                     std::complex<float>* x,
                                     int incx)
 {
-  hipblasStatus_t success = hipblasCscal(handle, n, reinterpret_cast<hipblasComplex const*>(&alpha),
-                                         reinterpret_cast<hipblasComplex*>(x), incx);
+  hipblasStatus_t success = hipblasCscal(handle, n, reinterpret_cast<hipFloatComplex const*>(&alpha),
+                                         reinterpret_cast<hipFloatComplex*>(x), incx);
   hipDeviceSynchronize();
   return success;
 }
@@ -95,8 +95,8 @@ inline hipblasStatus_t hipblas_scal(hipblasHandle_t handle,
                                     std::complex<double>* x,
                                     int incx)
 {
-  hipblasStatus_t success = hipblasZscal(handle, n, reinterpret_cast<hipblasDoubleComplex const*>(&alpha),
-                                         reinterpret_cast<hipblasDoubleComplex*>(x), incx);
+  hipblasStatus_t success = hipblasZscal(handle, n, reinterpret_cast<hipDoubleComplex const*>(&alpha),
+                                         reinterpret_cast<hipDoubleComplex*>(x), incx);
   hipDeviceSynchronize();
   return success;
 }
@@ -130,8 +130,8 @@ inline std::complex<float> hipblas_dot(hipblasHandle_t handle,
 {
   std::complex<float> result;
   hipblasStatus_t success =
-      hipblasCdotu(handle, n, reinterpret_cast<hipblasComplex const*>(x), incx,
-                   reinterpret_cast<hipblasComplex const*>(y), incy, reinterpret_cast<hipblasComplex*>(&result));
+      hipblasCdotu(handle, n, reinterpret_cast<hipFloatComplex const*>(x), incx,
+                   reinterpret_cast<hipFloatComplex const*>(y), incy, reinterpret_cast<hipFloatComplex*>(&result));
   hipDeviceSynchronize();
   if (HIPBLAS_STATUS_SUCCESS != success)
     throw std::runtime_error("Error: hipblas_dot returned error code.");
@@ -146,9 +146,9 @@ inline std::complex<double> hipblas_dot(hipblasHandle_t handle,
                                         int incy)
 {
   std::complex<double> result;
-  hipblasStatus_t success = hipblasZdotu(handle, n, reinterpret_cast<hipblasDoubleComplex const*>(x), incx,
-                                         reinterpret_cast<hipblasDoubleComplex const*>(y), incy,
-                                         reinterpret_cast<hipblasDoubleComplex*>(&result));
+  hipblasStatus_t success = hipblasZdotu(handle, n, reinterpret_cast<hipDoubleComplex const*>(x), incx,
+                                         reinterpret_cast<hipDoubleComplex const*>(y), incy,
+                                         reinterpret_cast<hipDoubleComplex*>(&result));
   hipDeviceSynchronize();
   if (HIPBLAS_STATUS_SUCCESS != success)
     throw std::runtime_error("Error: hipblas_dot returned error code.");
@@ -234,8 +234,8 @@ inline hipblasStatus_t hipblas_axpy(hipblasHandle_t handle,
                                     int incy)
 {
   hipblasStatus_t success =
-      hipblasCaxpy(handle, n, reinterpret_cast<hipblasComplex const*>(&alpha),
-                   reinterpret_cast<hipblasComplex const*>(x), incx, reinterpret_cast<hipblasComplex*>(y), incy);
+      hipblasCaxpy(handle, n, reinterpret_cast<hipFloatComplex const*>(&alpha),
+                   reinterpret_cast<hipFloatComplex const*>(x), incx, reinterpret_cast<hipFloatComplex*>(y), incy);
   hipDeviceSynchronize();
   return success;
 }
@@ -248,9 +248,9 @@ inline hipblasStatus_t hipblas_axpy(hipblasHandle_t handle,
                                     std::complex<double>* y,
                                     int incy)
 {
-  hipblasStatus_t success = hipblasZaxpy(handle, n, reinterpret_cast<hipblasDoubleComplex const*>(&alpha),
-                                         reinterpret_cast<hipblasDoubleComplex const*>(x), incx,
-                                         reinterpret_cast<hipblasDoubleComplex*>(y), incy);
+  hipblasStatus_t success = hipblasZaxpy(handle, n, reinterpret_cast<hipDoubleComplex const*>(&alpha),
+                                         reinterpret_cast<hipDoubleComplex const*>(x), incx,
+                                         reinterpret_cast<hipDoubleComplex*>(y), incy);
   hipDeviceSynchronize();
   return success;
 }
@@ -308,9 +308,9 @@ inline hipblasStatus_t hipblas_gemv(hipblasHandle_t handle,
                                     int incy)
 {
   hipblasStatus_t success =
-      hipblasCgemv(handle, hipblasOperation(Atrans), M, N, reinterpret_cast<hipblasComplex const*>(&alpha),
-                   reinterpret_cast<hipblasComplex const*>(A), lda, reinterpret_cast<hipblasComplex const*>(x), incx,
-                   reinterpret_cast<hipblasComplex const*>(&beta), reinterpret_cast<hipblasComplex*>(y), incy);
+      hipblasCgemv(handle, hipblasOperation(Atrans), M, N, reinterpret_cast<hipFloatComplex const*>(&alpha),
+                   reinterpret_cast<hipFloatComplex const*>(A), lda, reinterpret_cast<hipFloatComplex const*>(x), incx,
+                   reinterpret_cast<hipFloatComplex const*>(&beta), reinterpret_cast<hipFloatComplex*>(y), incy);
   hipDeviceSynchronize();
   return success;
 }
@@ -329,10 +329,10 @@ inline hipblasStatus_t hipblas_gemv(hipblasHandle_t handle,
                                     int incy)
 {
   hipblasStatus_t success =
-      hipblasZgemv(handle, hipblasOperation(Atrans), M, N, reinterpret_cast<hipblasDoubleComplex const*>(&alpha),
-                   reinterpret_cast<hipblasDoubleComplex const*>(A), lda,
-                   reinterpret_cast<hipblasDoubleComplex const*>(x), incx,
-                   reinterpret_cast<hipblasDoubleComplex const*>(&beta), reinterpret_cast<hipblasDoubleComplex*>(y),
+      hipblasZgemv(handle, hipblasOperation(Atrans), M, N, reinterpret_cast<hipDoubleComplex const*>(&alpha),
+                   reinterpret_cast<hipDoubleComplex const*>(A), lda,
+                   reinterpret_cast<hipDoubleComplex const*>(x), incx,
+                   reinterpret_cast<hipDoubleComplex const*>(&beta), reinterpret_cast<hipDoubleComplex*>(y),
                    incy);
   hipDeviceSynchronize();
   return success;
@@ -459,9 +459,9 @@ inline hipblasStatus_t hipblas_gemm(hipblasHandle_t handle,
 {
   hipblasStatus_t success =
       hipblasCgemm(handle, hipblasOperation(Atrans), hipblasOperation(Btrans), M, N, K,
-                   reinterpret_cast<hipblasComplex const*>(&alpha), reinterpret_cast<hipblasComplex const*>(A), lda,
-                   reinterpret_cast<hipblasComplex const*>(B), ldb, reinterpret_cast<hipblasComplex const*>(&beta),
-                   reinterpret_cast<hipblasComplex*>(C), ldc);
+                   reinterpret_cast<hipFloatComplex const*>(&alpha), reinterpret_cast<hipFloatComplex const*>(A), lda,
+                   reinterpret_cast<hipFloatComplex const*>(B), ldb, reinterpret_cast<hipFloatComplex const*>(&beta),
+                   reinterpret_cast<hipFloatComplex*>(C), ldc);
   hipDeviceSynchronize();
   return success;
 }
@@ -482,11 +482,11 @@ inline hipblasStatus_t hipblas_gemm(hipblasHandle_t handle,
                                     int ldc)
 {
   hipblasStatus_t success = hipblasZgemm(handle, hipblasOperation(Atrans), hipblasOperation(Btrans), M, N, K,
-                                         reinterpret_cast<hipblasDoubleComplex const*>(&alpha),
-                                         reinterpret_cast<hipblasDoubleComplex const*>(A), lda,
-                                         reinterpret_cast<hipblasDoubleComplex const*>(B), ldb,
-                                         reinterpret_cast<hipblasDoubleComplex const*>(&beta),
-                                         reinterpret_cast<hipblasDoubleComplex*>(C), ldc);
+                                         reinterpret_cast<hipDoubleComplex const*>(&alpha),
+                                         reinterpret_cast<hipDoubleComplex const*>(A), lda,
+                                         reinterpret_cast<hipDoubleComplex const*>(B), ldb,
+                                         reinterpret_cast<hipDoubleComplex const*>(&beta),
+                                         reinterpret_cast<hipDoubleComplex*>(C), ldc);
   hipDeviceSynchronize();
   return success;
 }
@@ -543,13 +543,13 @@ inline hipblasStatus_t hipblas_gemm(hipblasHandle_t handle,
                                     int M,
                                     int N,
                                     int K,
-                                    const hipblasDoubleComplex alpha,
-                                    const hipblasDoubleComplex* A,
+                                    const hipDoubleComplex alpha,
+                                    const hipDoubleComplex* A,
                                     int lda,
-                                    const hipblasDoubleComplex* B,
+                                    const hipDoubleComplex* B,
                                     int ldb,
-                                    const hipblasDoubleComplex beta,
-                                    hipblasDoubleComplex* C,
+                                    const hipDoubleComplex beta,
+                                    hipDoubleComplex* C,
                                     int ldc)
 {
   hipblasStatus_t success = hipblasZgemm(handle, hipblasOperation(Atrans), hipblasOperation(Btrans), M, N, K, &alpha, A,
@@ -596,7 +596,7 @@ inline hipblasStatus_t hipblas_getrfBatched(hipblasHandle_t handle,
                                             int* infoArray,
                                             int batchSize)
 {
-  hipblasStatus_t success = hipblasZgetrfBatched(handle, n, reinterpret_cast<hipblasDoubleComplex* const*>(Aarray), lda,
+  hipblasStatus_t success = hipblasZgetrfBatched(handle, n, reinterpret_cast<hipDoubleComplex* const*>(Aarray), lda,
                                                  PivotArray, infoArray, batchSize);
   hipDeviceSynchronize();
   return success;
@@ -610,7 +610,7 @@ inline hipblasStatus_t hipblas_getrfBatched(hipblasHandle_t handle,
                                             int* infoArray,
                                             int batchSize)
 {
-  hipblasStatus_t success = hipblasCgetrfBatched(handle, n, reinterpret_cast<hipblasComplex* const*>(Aarray), lda,
+  hipblasStatus_t success = hipblasCgetrfBatched(handle, n, reinterpret_cast<hipFloatComplex* const*>(Aarray), lda,
                                                  PivotArray, infoArray, batchSize);
   hipDeviceSynchronize();
   return success;
@@ -665,8 +665,8 @@ inline hipblasStatus_t hipblas_getriBatched(hipblasHandle_t handle,
                                             int batchSize)
 {
   hipblasStatus_t success =
-      hipblasZgetrsBatched(handle, op, n, n, reinterpret_cast<hipblasDoubleComplex* const*>(Aarray), lda, PivotArray,
-                           reinterpret_cast<hipblasDoubleComplex* const*>(Carray), ldc, infoArray, batchSize);
+      hipblasZgetrsBatched(handle, op, n, n, reinterpret_cast<hipDoubleComplex* const*>(Aarray), lda, PivotArray,
+                           reinterpret_cast<hipDoubleComplex* const*>(Carray), ldc, infoArray, batchSize);
   hipDeviceSynchronize();
   return success;
 }
@@ -684,8 +684,8 @@ inline hipblasStatus_t hipblas_getriBatched(hipblasHandle_t handle,
                                             int batchSize)
 {
   hipblasStatus_t success =
-      hipblasCgetrsBatched(handle, op, n, n, reinterpret_cast<hipblasComplex* const*>(Aarray), lda, PivotArray,
-                           reinterpret_cast<hipblasComplex* const*>(Carray), ldc, infoArray, batchSize);
+      hipblasCgetrsBatched(handle, op, n, n, reinterpret_cast<hipFloatComplex* const*>(Aarray), lda, PivotArray,
+                           reinterpret_cast<hipFloatComplex* const*>(Carray), ldc, infoArray, batchSize);
   hipDeviceSynchronize();
   return success;
 }
@@ -736,8 +736,8 @@ inline hipblasStatus_t hipblas_matinvBatched(hipblasHandle_t handle,
 {
   //hipblasStatus_t success =
   //hipblasCmatinvBatched(handle,n,
-  //reinterpret_cast<const hipblasComplex * const*>(Aarray),lda,
-  //reinterpret_cast<hipblasComplex **>(Carray),ldc,
+  //reinterpret_cast<const hipFloatComplex * const*>(Aarray),lda,
+  //reinterpret_cast<hipFloatComplex **>(Carray),ldc,
   //infoArray,batchSize);
   throw std::runtime_error("Error: matinvBatched doesn't exist.");
   hipDeviceSynchronize();
@@ -756,8 +756,8 @@ inline hipblasStatus_t hipblas_matinvBatched(hipblasHandle_t handle,
 {
   //hipblasStatus_t success =
   //hipblasZmatinvBatched(handle,n,
-  //reinterpret_cast<const hipblasDoubleComplex *const*>(Aarray),lda,
-  //reinterpret_cast<hipblasDoubleComplex **>(Carray),ldc,
+  //reinterpret_cast<const hipDoubleComplex *const*>(Aarray),lda,
+  //reinterpret_cast<hipDoubleComplex **>(Carray),ldc,
   //infoArray,batchSize);
   throw std::runtime_error("Error: matinvBatched doesn't exist.");
   hipDeviceSynchronize();
@@ -821,9 +821,9 @@ inline hipblasStatus_t hipblas_geam(hipblasHandle_t handle,
 {
   hipblasStatus_t success =
       hipblasCgeam(handle, hipblasOperation(Atrans), hipblasOperation(Btrans), M, N,
-                   reinterpret_cast<hipblasComplex const*>(&alpha), reinterpret_cast<hipblasComplex const*>(A), lda,
-                   reinterpret_cast<hipblasComplex const*>(&beta), reinterpret_cast<hipblasComplex const*>(B), ldb,
-                   reinterpret_cast<hipblasComplex*>(C), ldc);
+                   reinterpret_cast<hipFloatComplex const*>(&alpha), reinterpret_cast<hipFloatComplex const*>(A), lda,
+                   reinterpret_cast<hipFloatComplex const*>(&beta), reinterpret_cast<hipFloatComplex const*>(B), ldb,
+                   reinterpret_cast<hipFloatComplex*>(C), ldc);
   hipDeviceSynchronize();
   return success;
 }
@@ -843,11 +843,11 @@ inline hipblasStatus_t hipblas_geam(hipblasHandle_t handle,
                                     int ldc)
 {
   hipblasStatus_t success = hipblasZgeam(handle, hipblasOperation(Atrans), hipblasOperation(Btrans), M, N,
-                                         reinterpret_cast<hipblasDoubleComplex const*>(&alpha),
-                                         reinterpret_cast<hipblasDoubleComplex const*>(A), lda,
-                                         reinterpret_cast<hipblasDoubleComplex const*>(&beta),
-                                         reinterpret_cast<hipblasDoubleComplex const*>(B), ldb,
-                                         reinterpret_cast<hipblasDoubleComplex*>(C), ldc);
+                                         reinterpret_cast<hipDoubleComplex const*>(&alpha),
+                                         reinterpret_cast<hipDoubleComplex const*>(A), lda,
+                                         reinterpret_cast<hipDoubleComplex const*>(&beta),
+                                         reinterpret_cast<hipDoubleComplex const*>(B), ldb,
+                                         reinterpret_cast<hipDoubleComplex*>(C), ldc);
   hipDeviceSynchronize();
   return success;
 }
@@ -924,11 +924,11 @@ inline hipblasStatus_t hipblas_gemmStridedBatched(hipblasHandle_t handle,
                                                   int batchSize)
 {
   hipblasStatus_t success = hipblasCgemmStridedBatched(handle, hipblasOperation(Atrans), hipblasOperation(Btrans), M, N,
-                                                       K, reinterpret_cast<hipblasComplex const*>(&alpha),
-                                                       reinterpret_cast<hipblasComplex const*>(A), lda, strideA,
-                                                       reinterpret_cast<hipblasComplex const*>(B), ldb, strideB,
-                                                       reinterpret_cast<hipblasComplex const*>(&beta),
-                                                       reinterpret_cast<hipblasComplex*>(C), ldc, strideC, batchSize);
+                                                       K, reinterpret_cast<hipFloatComplex const*>(&alpha),
+                                                       reinterpret_cast<hipFloatComplex const*>(A), lda, strideA,
+                                                       reinterpret_cast<hipFloatComplex const*>(B), ldb, strideB,
+                                                       reinterpret_cast<hipFloatComplex const*>(&beta),
+                                                       reinterpret_cast<hipFloatComplex*>(C), ldc, strideC, batchSize);
   hipDeviceSynchronize();
   return success;
 }
@@ -954,11 +954,11 @@ inline hipblasStatus_t hipblas_gemmStridedBatched(hipblasHandle_t handle,
 {
   hipblasStatus_t success =
       hipblasZgemmStridedBatched(handle, hipblasOperation(Atrans), hipblasOperation(Btrans), M, N, K,
-                                 reinterpret_cast<hipblasDoubleComplex const*>(&alpha),
-                                 reinterpret_cast<hipblasDoubleComplex const*>(A), lda, strideA,
-                                 reinterpret_cast<hipblasDoubleComplex const*>(B), ldb, strideB,
-                                 reinterpret_cast<hipblasDoubleComplex const*>(&beta),
-                                 reinterpret_cast<hipblasDoubleComplex*>(C), ldc, strideC, batchSize);
+                                 reinterpret_cast<hipDoubleComplex const*>(&alpha),
+                                 reinterpret_cast<hipDoubleComplex const*>(A), lda, strideA,
+                                 reinterpret_cast<hipDoubleComplex const*>(B), ldb, strideB,
+                                 reinterpret_cast<hipDoubleComplex const*>(&beta),
+                                 reinterpret_cast<hipDoubleComplex*>(C), ldc, strideC, batchSize);
   hipDeviceSynchronize();
   return success;
 }
@@ -1025,9 +1025,9 @@ inline hipblasStatus_t hipblas_gemmBatched(hipblasHandle_t handle,
 {
   hipblasStatus_t success =
       hipblasCgemmBatched(handle, hipblasOperation(Atrans), hipblasOperation(Btrans), M, N, K,
-                          reinterpret_cast<hipblasComplex*>(&alpha), reinterpret_cast<hipblasComplex**>(A), lda,
-                          reinterpret_cast<hipblasComplex**>(B), ldb, reinterpret_cast<hipblasComplex*>(&beta),
-                          reinterpret_cast<hipblasComplex**>(C), ldc, batchSize);
+                          reinterpret_cast<hipFloatComplex*>(&alpha), reinterpret_cast<hipFloatComplex**>(A), lda,
+                          reinterpret_cast<hipFloatComplex**>(B), ldb, reinterpret_cast<hipFloatComplex*>(&beta),
+                          reinterpret_cast<hipFloatComplex**>(C), ldc, batchSize);
   hipDeviceSynchronize();
   return success;
 }
@@ -1050,9 +1050,9 @@ inline hipblasStatus_t hipblas_gemmBatched(hipblasHandle_t handle,
 {
   hipblasStatus_t success =
       hipblasZgemmBatched(handle, hipblasOperation(Atrans), hipblasOperation(Btrans), M, N, K,
-                          reinterpret_cast<hipblasDoubleComplex*>(&alpha), reinterpret_cast<hipblasDoubleComplex**>(A),
-                          lda, reinterpret_cast<hipblasDoubleComplex**>(B), ldb,
-                          reinterpret_cast<hipblasDoubleComplex*>(&beta), reinterpret_cast<hipblasDoubleComplex**>(C),
+                          reinterpret_cast<hipDoubleComplex*>(&alpha), reinterpret_cast<hipDoubleComplex**>(A),
+                          lda, reinterpret_cast<hipDoubleComplex**>(B), ldb,
+                          reinterpret_cast<hipDoubleComplex*>(&beta), reinterpret_cast<hipDoubleComplex**>(C),
                           ldc, batchSize);
   hipDeviceSynchronize();
   return success;

--- a/src/Platforms/ROCm/CMakeLists.txt
+++ b/src/Platforms/ROCm/CMakeLists.txt
@@ -2,7 +2,7 @@
 #// This file is distributed under the University of Illinois/NCSA Open Source License.
 #// See LICENSE file in top directory for details.
 #//
-#// Copyright (c) 2021 QMCPACK developers.
+#// Copyright (c) 2025 QMCPACK developers.
 #//
 #// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 #//
@@ -16,3 +16,9 @@ set(ROCM_LA_SRCS hipBLAS.cpp)
 add_library(platform_rocm_LA ${ROCM_LA_SRCS})
 target_link_libraries(platform_rocm_LA PUBLIC roc::hipblas roc::rocsolver)
 target_link_libraries(platform_rocm_LA PRIVATE platform_rocm_runtime)
+
+# Add HIPBLAS_V2 for hipBLAS < 3.0.0
+if(hipblas_VERSION VERSION_LESS "3.0.0")
+  target_compile_definitions(platform_rocm_LA PUBLIC -DHIPBLAS_V2)
+  message(STATUS "Defining HIPBLAS_V2 for compatibility with hipBLAS < 3.0.0 (Detected ${hipblas_VERSION})")
+endif()

--- a/src/Platforms/ROCm/cuda2hip.h
+++ b/src/Platforms/ROCm/cuda2hip.h
@@ -30,8 +30,8 @@
 #define CUBLAS_STATUS_NOT_SUPPORTED     HIPBLAS_STATUS_NOT_SUPPORTED
 #define CUBLAS_STATUS_SUCCESS           HIPBLAS_STATUS_SUCCESS
 
-#define cublasComplex           hipblasComplex
-#define cublasDoubleComplex     hipblasDoubleComplex
+#define cublasComplex           hipFloatComplex
+#define cublasDoubleComplex     hipDoubleComplex
 #define cublasHandle_t          hipblasHandle_t
 #define cublasStatus_t          hipblasStatus_t
 #define cublasCreate            hipblasCreate

--- a/src/Platforms/ROCm/hipBLAS.cpp
+++ b/src/Platforms/ROCm/hipBLAS.cpp
@@ -17,50 +17,6 @@
 #include <rocsolver/rocsolver.h>
 
 //------------------------------------------------------------------------------
-hipblasStatus_t hipblasCgemmBatched(hipblasHandle_t handle,
-                                    hipblasOperation_t transa,
-                                    hipblasOperation_t transb,
-                                    int m,
-                                    int n,
-                                    int k,
-                                    const hipComplex* alpha,
-                                    const hipComplex* const Aarray[],
-                                    int lda,
-                                    const hipComplex* const Barray[],
-                                    int ldb,
-                                    const hipComplex* beta,
-                                    hipComplex* const Carray[],
-                                    int ldc,
-                                    int batchCount)
-{
-  return hipblasCgemmBatched(handle, transa, transb, m, n, k, (const hipFloatComplex*)alpha,
-                             (const hipFloatComplex* const*)Aarray, lda, (const hipFloatComplex* const*)Barray, ldb,
-                             (const hipFloatComplex*)beta, (hipFloatComplex* const*)Carray, ldc, batchCount);
-}
-
-hipblasStatus_t hipblasZgemmBatched(hipblasHandle_t handle,
-                                    hipblasOperation_t transa,
-                                    hipblasOperation_t transb,
-                                    int m,
-                                    int n,
-                                    int k,
-                                    const hipDoubleComplex* alpha,
-                                    const hipDoubleComplex* const Aarray[],
-                                    int lda,
-                                    const hipDoubleComplex* const Barray[],
-                                    int ldb,
-                                    const hipDoubleComplex* beta,
-                                    hipDoubleComplex* const Carray[],
-                                    int ldc,
-                                    int batchCount)
-{
-  return hipblasZgemmBatched(handle, transa, transb, m, n, k, (const hipDoubleComplex*)alpha,
-                             (const hipDoubleComplex* const*)Aarray, lda,
-                             (const hipDoubleComplex* const*)Barray, ldb, (const hipDoubleComplex*)beta,
-                             (hipDoubleComplex* const*)Carray, ldc, batchCount);
-}
-
-//------------------------------------------------------------------------------
 hipblasStatus_t hipblasSgetrfBatched_(hipblasHandle_t handle,
                                       int n,
                                       float* const A[],

--- a/src/Platforms/ROCm/hipBLAS.cpp
+++ b/src/Platforms/ROCm/hipBLAS.cpp
@@ -33,9 +33,9 @@ hipblasStatus_t hipblasCgemmBatched(hipblasHandle_t handle,
                                     int ldc,
                                     int batchCount)
 {
-  return hipblasCgemmBatched(handle, transa, transb, m, n, k, (const hipblasComplex*)alpha,
-                             (const hipblasComplex* const*)Aarray, lda, (const hipblasComplex* const*)Barray, ldb,
-                             (const hipblasComplex*)beta, (hipblasComplex* const*)Carray, ldc, batchCount);
+  return hipblasCgemmBatched(handle, transa, transb, m, n, k, (const hipFloatComplex*)alpha,
+                             (const hipFloatComplex* const*)Aarray, lda, (const hipFloatComplex* const*)Barray, ldb,
+                             (const hipFloatComplex*)beta, (hipFloatComplex* const*)Carray, ldc, batchCount);
 }
 
 hipblasStatus_t hipblasZgemmBatched(hipblasHandle_t handle,
@@ -54,10 +54,10 @@ hipblasStatus_t hipblasZgemmBatched(hipblasHandle_t handle,
                                     int ldc,
                                     int batchCount)
 {
-  return hipblasZgemmBatched(handle, transa, transb, m, n, k, (const hipblasDoubleComplex*)alpha,
-                             (const hipblasDoubleComplex* const*)Aarray, lda,
-                             (const hipblasDoubleComplex* const*)Barray, ldb, (const hipblasDoubleComplex*)beta,
-                             (hipblasDoubleComplex* const*)Carray, ldc, batchCount);
+  return hipblasZgemmBatched(handle, transa, transb, m, n, k, (const hipDoubleComplex*)alpha,
+                             (const hipDoubleComplex* const*)Aarray, lda,
+                             (const hipDoubleComplex* const*)Barray, ldb, (const hipDoubleComplex*)beta,
+                             (hipDoubleComplex* const*)Carray, ldc, batchCount);
 }
 
 //------------------------------------------------------------------------------
@@ -168,7 +168,7 @@ hipblasStatus_t hipblasCgetriBatched_(hipblasHandle_t handle,
 {
   if (!P)
     throw std::runtime_error("hipblasXgetriBatched_ pivot array cannot be a null pointer!");
-  return hipblasCgetriBatched(handle, n, (hipblasComplex* const*)A, lda, (int*)P, (hipblasComplex* const*)C, ldc, info,
+  return hipblasCgetriBatched(handle, n, (hipFloatComplex* const*)A, lda, (int*)P, (hipFloatComplex* const*)C, ldc, info,
                               batchSize);
 }
 
@@ -184,6 +184,6 @@ hipblasStatus_t hipblasZgetriBatched_(hipblasHandle_t handle,
 {
   if (!P)
     throw std::runtime_error("hipblasXgetriBatched_ pivot array cannot be a null pointer!");
-  return hipblasZgetriBatched(handle, n, (hipblasDoubleComplex* const*)A, lda, (int*)P, (hipblasDoubleComplex* const*)C,
+  return hipblasZgetriBatched(handle, n, (hipDoubleComplex* const*)A, lda, (int*)P, (hipDoubleComplex* const*)C,
                               ldc, info, batchSize);
 }

--- a/src/Platforms/ROCm/hipBLAS.hpp
+++ b/src/Platforms/ROCm/hipBLAS.hpp
@@ -20,41 +20,6 @@
 
 //------------------------------------------------------------------------------
 hipblasStatus_t
-hipblasCgemmBatched(hipblasHandle_t handle,
-                    hipblasOperation_t transa,
-                    hipblasOperation_t transb,
-                    int m,
-                    int n,
-                    int k,
-                    const hipComplex *alpha,
-                    const hipComplex *const Aarray[],
-                    int lda,
-                    const hipComplex *const Barray[],
-                    int ldb,
-                    const hipComplex *beta,
-                    hipComplex *const Carray[],
-                    int ldc,
-                    int batchCount);
-
-hipblasStatus_t
-hipblasZgemmBatched(hipblasHandle_t handle,
-                    hipblasOperation_t transa,
-                    hipblasOperation_t transb,
-                    int m,
-                    int n,
-                    int k,
-                    const hipDoubleComplex *alpha,
-                    const hipDoubleComplex *const Aarray[],
-                    int lda,
-                    const hipDoubleComplex *const Barray[],
-                    int ldb,
-                    const hipDoubleComplex *beta,
-                    hipDoubleComplex *const Carray[],
-                    int ldc,
-                    int batchCount);
-
-//------------------------------------------------------------------------------
-hipblasStatus_t
 hipblasSgetrfBatched_(hipblasHandle_t handle,
                       int n,
                       float *const A[],

--- a/src/Platforms/ROCm/hipblasTypeMapping.hpp
+++ b/src/Platforms/ROCm/hipblasTypeMapping.hpp
@@ -21,7 +21,7 @@
 namespace qmcplusplus
 {
 
-// This saves us writing specific overloads with reinterpret casts for different std::complex to hipblasComplex types.
+// This saves us writing specific overloads with reinterpret casts for different std::complex to hipFloatComplex types.
 template<typename T>
 using hipblasTypeMap =
     typename std::disjunction<OnTypesEqual<T, float, float>,
@@ -30,18 +30,18 @@ using hipblasTypeMap =
                               OnTypesEqual<T, double*, double*>,
                               OnTypesEqual<T, float**, float**>,
                               OnTypesEqual<T, double**, double**>,
-                              OnTypesEqual<T, std::complex<double>, hipblasDoubleComplex>,
-                              OnTypesEqual<T, std::complex<float>, hipblasComplex>,
-                              OnTypesEqual<T, std::complex<double>*, hipblasDoubleComplex*>,
-                              OnTypesEqual<T, std::complex<float>**, hipblasComplex**>,
-                              OnTypesEqual<T, std::complex<double>**, hipblasDoubleComplex**>,
-                              OnTypesEqual<T, std::complex<float>*, hipblasComplex*>,
-                              OnTypesEqual<T, const std::complex<double>*, const hipblasDoubleComplex*>,
-                              OnTypesEqual<T, const std::complex<float>*, const hipblasComplex*>,
-                              OnTypesEqual<T, const std::complex<float>**, const hipblasComplex**>,
-                              OnTypesEqual<T, const std::complex<double>**, const hipblasDoubleComplex**>,
-                              OnTypesEqual<T, const std::complex<float>* const*, const hipblasComplex* const*>,
-                              OnTypesEqual<T, const std::complex<double>* const*, const hipblasDoubleComplex* const*>,
+                              OnTypesEqual<T, std::complex<double>, hipDoubleComplex>,
+                              OnTypesEqual<T, std::complex<float>, hipFloatComplex>,
+                              OnTypesEqual<T, std::complex<double>*, hipDoubleComplex*>,
+                              OnTypesEqual<T, std::complex<float>**, hipFloatComplex**>,
+                              OnTypesEqual<T, std::complex<double>**, hipDoubleComplex**>,
+                              OnTypesEqual<T, std::complex<float>*, hipFloatComplex*>,
+                              OnTypesEqual<T, const std::complex<double>*, const hipDoubleComplex*>,
+                              OnTypesEqual<T, const std::complex<float>*, const hipFloatComplex*>,
+                              OnTypesEqual<T, const std::complex<float>**, const hipFloatComplex**>,
+                              OnTypesEqual<T, const std::complex<double>**, const hipDoubleComplex**>,
+                              OnTypesEqual<T, const std::complex<float>* const*, const hipFloatComplex* const*>,
+                              OnTypesEqual<T, const std::complex<double>* const*, const hipDoubleComplex* const*>,
                               default_type<void>>::type;
 
 template<typename T>


### PR DESCRIPTION
- Replaced `hipblasComplex` with `hipFloatComplex` and `hipblasDoubleComplex` with
  `hipDoubleComplex` to reflect changes in ROCm 6.0+ and support ROCm 7.0,
  where the old types have been removed.
- Added support for building with ROCm 6.x by using `-DHIPBLAS_V2`.

Verified builds with both ROCm 6.0 and 7.0.
