### PR TITLE
Orbital Rotation for SplineC2COMPTarget

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
@@ -18,6 +18,7 @@
 
 
 #include "EinsplineSpinorSetBuilder.h"
+#include <PlatformSelector.hpp>
 #include "QMCWaveFunctions/SpinorSet.h"
 #include "OhmmsData/AttributeSet.h"
 #include "Message/CommOperators.h"
@@ -50,6 +51,7 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
   std::string truncate("no");
   std::string hybrid_rep("no");
   std::string spo_object_name;
+  std::string useGPU;
 
   ScopedTimer spo_timer_scope(createGlobalTimer("einspline::CreateSpinorSetFromXML", timer_level_medium));
 
@@ -68,6 +70,7 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
     a.add(spo_prec, "precision");
     a.add(truncate, "truncate");
     a.add(myName, "tag");
+    a.add(useGPU, "gpu", CPUOMPTargetSelector::candidate_values);
 
     a.put(XMLRoot);
     a.add(numOrbs, "size");
@@ -176,7 +179,6 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
     myComm->barrier_and_abort(
         "The 'truncate' feature of spline SPO has been removed. Please use hybrid orbital representation.");
 
-  std::string useGPU("no");
 #if !defined(QMC_COMPLEX)
   if (use_real_splines_)
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
@@ -157,6 +157,8 @@ void SplineC2C<ST>::applyRotation(const ValueMatrix& rot_mat, bool use_stored_co
         spl_coefs[cur_elem + 1] = newval_i;
       }
   }
+  // update coefficients on GPU from host
+  SplineInst->finalize();
 }
 
 template<typename ST>

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -116,12 +116,8 @@ void SplineC2COMPTarget<ST>::applyRotation(const ValueMatrix& rot_mat, bool use_
         spl_coefs[cur_elem + 1] = newval_i;
       }
   }
-
-  PRAGMA_OFFLOAD("omp target update to (spl_coefs[0:spline_ptr->coefs_size])")
-  {
-    spline_ptr->coefs = spl_coefs;
-  }
-
+  // update coefficients on GPU from host
+  SplineInst->finalize();
 }
 
 template<typename ST>

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -17,6 +17,7 @@
 #include "Platforms/OMPTarget/ompReductionComplex.hpp"
 #include "ApplyPhaseC2C.hpp"
 #include "Concurrency/OpenMP.h"
+#include "CPU/BLAS.hpp"
 
 namespace qmcplusplus
 {
@@ -50,6 +51,77 @@ bool SplineC2COMPTarget<ST>::write_splines(hdf_archive& h5f)
   o << "spline_" << MyIndex;
   einspline_engine<SplineType> bigtable(SplineInst->getSplinePtr());
   return h5f.writeEntry(bigtable, o.str().c_str()); //"spline_0");
+}
+
+template<typename ST>
+void SplineC2COMPTarget<ST>::storeParamsBeforeRotation()
+{
+  const auto spline_ptr = SplineInst->getSplinePtr();
+  const auto coefs_tot_size = spline_ptr->coefs_size;
+  coef_copy_ = std::make_shared<std::vector<ST>>(coefs_tot_size);
+  std::copy_n(spline_ptr->coefs, coefs_tot_size, coef_copy_->begin());
+}
+
+
+template<typename ST>
+void SplineC2COMPTarget<ST>::applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy)
+{
+  const auto spline_ptr = SplineInst->getSplinePtr();
+  assert(spline_ptr != nullptr);
+  const auto spl_coefs      = spline_ptr->coefs;
+  const auto Nsplines       = spline_ptr->num_splines; // May include padding
+  const auto coefs_tot_size = spline_ptr->coefs_size;
+  const auto basis_set_size = coefs_tot_size / Nsplines;
+  assert(OrbitalSetSize == rot_mat.rows());
+  assert(OrbitalSetSize == rot_mat.cols());
+
+  if (!use_stored_copy)
+  {
+    assert(coef_copy_ != nullptr);
+    std::copy_n(spl_coefs, coefs_tot_size, coef_copy_->begin());
+  }
+
+  if constexpr (std::is_same_v<ST, RealType>)
+  {
+    //if ST is double, go ahead and use blas to make things faster
+    //Note that Nsplines needs to be divided by 2 since spl_coefs and coef_copy_ are stored as reals.
+    //Also casting them as ValueType so they are complex to do the correct gemm
+    BLAS::gemm('N', 'N', OrbitalSetSize, basis_set_size, OrbitalSetSize, ValueType(1.0, 0.0), rot_mat.data(),
+               OrbitalSetSize, (ValueType*)coef_copy_->data(), Nsplines / 2, ValueType(0.0, 0.0),
+               (ValueType*)spl_coefs, Nsplines / 2);
+  }
+  else
+  {
+    // if ST is float, RealType is double and ValueType is std::complex<double> for C2C
+    // Just use naive matrix multiplication in order to avoid losing precision on rotation matrix
+    for (IndexType i = 0; i < basis_set_size; i++)
+      for (IndexType j = 0; j < OrbitalSetSize; j++)
+      {
+        // cur_elem points to the real componend of the coefficient.
+        // Imag component is adjacent in memory.
+        const auto cur_elem = Nsplines * i + 2 * j;
+        ST newval_r{0.};
+        ST newval_i{0.};
+        for (IndexType k = 0; k < OrbitalSetSize; k++)
+        {
+          const auto index = Nsplines * i + 2 * k;
+          ST zr            = (*coef_copy_)[index];
+          ST zi            = (*coef_copy_)[index + 1];
+          ST wr            = rot_mat[k][j].real();
+          ST wi            = rot_mat[k][j].imag();
+          newval_r += zr * wr - zi * wi;
+          newval_i += zr * wi + zi * wr;
+        }
+        spl_coefs[cur_elem]     = newval_r;
+        spl_coefs[cur_elem + 1] = newval_i;
+      }
+  }
+
+  PRAGMA_OFFLOAD("omp target update to (spline_ptr[0:1], spl_coefs[0:spline_ptr->coefs_size])")
+  {
+    spline_ptr->coefs = spl_coefs;
+  }
+
 }
 
 template<typename ST>

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -117,7 +117,7 @@ void SplineC2COMPTarget<ST>::applyRotation(const ValueMatrix& rot_mat, bool use_
       }
   }
 
-  PRAGMA_OFFLOAD("omp target update to (spline_ptr[0:1], spl_coefs[0:spline_ptr->coefs_size])")
+  PRAGMA_OFFLOAD("omp target update to (spl_coefs[0:spline_ptr->coefs_size])")
   {
     spline_ptr->coefs = spl_coefs;
   }

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -73,6 +73,9 @@ private:
   ///multi bspline set
   std::shared_ptr<MultiBsplineBase<ST>> SplineInst;
 
+  ///Copy of original splines for orbital rotation. Only need these on host
+  std::shared_ptr<std::vector<ST>> coef_copy_;
+
   std::shared_ptr<OffloadVector<ST>> mKK;
   std::shared_ptr<OffloadPosVector<ST>> myKcart;
   std::shared_ptr<OffloadVector<ST>> GGt_offload;
@@ -141,6 +144,13 @@ public:
   }
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<SplineC2COMPTarget>(*this); }
+
+  bool isRotationSupported() const override { return true; }
+
+  ///store copy of spline coefficients for obrital rotation
+  void storeParamsBeforeRotation() override;
+
+  void applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy) override;
 
   inline void resizeStorage(size_t n) override
   {

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -596,7 +596,7 @@ TEST_CASE("RotatedSPOs hcpBe", "[wavefunction]")
   // spline file for use in eval_bspline_spo.py
 
   const char* particles = R"(<tmp>
-<sposet_builder type="bspline" href="hcpBe.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" meshfactor="1.0" precision="double" gpu="no">
+<sposet_builder type="bspline" href="hcpBe.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" meshfactor="1.0" precision="double">
       <sposet type="bspline" name="spo_ud" spindataset="0" size="2"/>
 </sposet_builder>
 </tmp>)";

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -746,44 +746,41 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
     CHECK(ratios_list[1][0] == ComplexApprox(refRatio2));
   }
 
-  if (!spo->isOMPoffload())
+  //Need to remember that the electrons are distored from initial positions
+  //Move them back for rotation test
+  Rnew    = elec_.R - dR;
+  elec_.R = Rnew;
+  elec_.update();
+
+  //Let's also test orbital rotation
+  //random unitary
+  SPOSet::ValueVector row0 = {ValueType(0.47586834, 0.07134236), ValueType(-0.35882226, -0.6570473),
+                              ValueType(-0.30699602, -0.3372662)};
+  SPOSet::ValueVector row1 = {ValueType(-0.09062269, -0.23061815), ValueType(0.52931815, 0.07182243),
+                              ValueType(-0.79260564, -0.15825018)};
+  SPOSet::ValueVector row2 = {ValueType(0.3187019, -0.7781333), ValueType(0.315927, -0.23321542),
+                              ValueType(0.36577135, 0.07035348)};
+  SPOSet::ValueMatrix rot_mat(3, 3);
+  for (int iorb = 0; iorb < 3; iorb++)
   {
-    //Need to remember that the electrons are distored from initial positions
-    //Move them back for rotation test
-    Rnew    = elec_.R - dR;
-    elec_.R = Rnew;
-    elec_.update();
-
-    //Let's also test orbital rotation
-    //random unitary
-    SPOSet::ValueVector row0 = {ValueType(0.47586834, 0.07134236), ValueType(-0.35882226, -0.6570473),
-                                ValueType(-0.30699602, -0.3372662)};
-    SPOSet::ValueVector row1 = {ValueType(-0.09062269, -0.23061815), ValueType(0.52931815, 0.07182243),
-                                ValueType(-0.79260564, -0.15825018)};
-    SPOSet::ValueVector row2 = {ValueType(0.3187019, -0.7781333), ValueType(0.315927, -0.23321542),
-                                ValueType(0.36577135, 0.07035348)};
-    SPOSet::ValueMatrix rot_mat(3, 3);
-    for (int iorb = 0; iorb < 3; iorb++)
-    {
-      rot_mat(0, iorb) = row0[iorb];
-      rot_mat(1, iorb) = row1[iorb];
-      rot_mat(2, iorb) = row2[iorb];
-    }
-    SPOSet::ValueMatrix psiM_rot_manual(elec_.R.size(), spo->size());
-    for (int i = 0; i < elec_.R.size(); i++)
-      for (int j = 0; j < spo->size(); j++)
-      {
-        psiM_rot_manual[i][j] = 0.;
-        for (int k = 0; k < spo->size(); k++)
-          psiM_rot_manual[i][j] += psiM_ref[i][k] * rot_mat[k][j];
-      }
-
-    spo->storeParamsBeforeRotation();
-    spo->applyRotation(rot_mat, false);
-    spo->evaluate_notranspose(elec_, 0, elec_.R.size(), psiM, dpsiM, d2psiM);
-    auto check = checkMatrix(psiM_rot_manual, psiM, true);
-    CHECKED_ELSE(check.result) { FAIL(check.result_message); }
+    rot_mat(0, iorb) = row0[iorb];
+    rot_mat(1, iorb) = row1[iorb];
+    rot_mat(2, iorb) = row2[iorb];
   }
+  SPOSet::ValueMatrix psiM_rot_manual(elec_.R.size(), spo->size());
+  for (int i = 0; i < elec_.R.size(); i++)
+    for (int j = 0; j < spo->size(); j++)
+    {
+      psiM_rot_manual[i][j] = 0.;
+      for (int k = 0; k < spo->size(); k++)
+        psiM_rot_manual[i][j] += psiM_ref[i][k] * rot_mat[k][j];
+    }
+
+  spo->storeParamsBeforeRotation();
+  spo->applyRotation(rot_mat, false);
+  spo->evaluate_notranspose(elec_, 0, elec_.R.size(), psiM, dpsiM, d2psiM);
+  auto check = checkMatrix(psiM_rot_manual, psiM, true);
+  CHECKED_ELSE(check.result) { FAIL(check.result_message); }
 }
 
 #endif //QMC_COMPLEX

--- a/src/QMCWaveFunctions/tests/test_spline_applyrotation.cpp
+++ b/src/QMCWaveFunctions/tests/test_spline_applyrotation.cpp
@@ -65,7 +65,7 @@ TEST_CASE("Spline applyRotation zero rotation", "[wavefunction]")
   // Load diamondC_1x1x1 wfn and explicitly construct a SplineC2C object with 7 orbitals
   // This results in padding of the spline coefs table and thus is a more stringent test.
   const char* particles = R"(
-<sposet_collection type="einspline" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" gpu="no" precision="double">
+<sposet_collection type="einspline" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" precision="double">
   <sposet name="updet" size="7"/>
 </sposet_collection>)";
 
@@ -201,7 +201,7 @@ TEST_CASE("Spline applyRotation one rotation", "[wavefunction]")
   // Load diamondC_1x1x1 wfn and explicitly construct a SplineC2C object with 7 orbitals
   // This results in padding of the spline coefs table and thus is a more stringent test.
   const char* particles = R"(
-<sposet_collection type="einspline" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" gpu="no" precision="double">
+<sposet_collection type="einspline" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" precision="double">
   <sposet name="updet" size="7"/>
 </sposet_collection>)";
 
@@ -410,7 +410,7 @@ TEST_CASE("Spline applyRotation two rotations", "[wavefunction]")
   // Load diamondC_1x1x1 wfn and explicitly construct a SplineC2C object with 7 orbitals
   // This results in padding of the spline coefs table and thus is a more stringent test.
   const char* particles = R"(
-<sposet_collection type="einspline" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" gpu="no" precision="double">
+<sposet_collection type="einspline" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" precision="double">
   <sposet name="updet" size="7"/>
 </sposet_collection>)";
 
@@ -714,7 +714,7 @@ TEST_CASE("Spline applyRotation complex rotation", "[wavefunction]")
   // Load diamondC_1x1x1 wfn and explicitly construct a SplineC2C object with 7 orbitals
   // This results in padding of the spline coefs table and thus is a more stringent test.
   const char* particles = R"(
-<sposet_collection type="einspline" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" gpu="no" precision="double">
+<sposet_collection type="einspline" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" precision="double">
   <sposet name="updet" size="7"/>
 </sposet_collection>)";
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

Please also follow the [GitHub Pull Request guidance](https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance). As much as possible, try to avoid the ["Don't"s](https://qmcpack.readthedocs.io/en/develop/developing.html#don-t) to help maintain a high development velocity.

## Proposed changes
Implements orbital rotations for SplineC2COMPTarget. Basically, it keeps a copy of the spline coeffs on the host, and whenever the splines are rotated, it does the rotation on the CPU and offloads the new spline coeffs to the GPU for later use. This is the simplest approach, and should be fine for production calcualtions. For optimizations, where we will do many transfers from the host to device of the new coefficients, this may not be ideal. But it is at least something to build off of. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
El Dorado

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)

**NOTE** it doesn't add a new test, it uncomments a previous guard so that applyRotation can be tested
