### PR TITLE
Printout correction "Accelerators per rank"

### DIFF
--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -99,7 +99,7 @@ QMCMain::QMCMain(Communicate* c)
       << "\n  Number of ranks in group  = " << myComm->size()
       << "\n  MPI ranks per node        = " << node_comm.size()
 #if defined(ENABLE_OFFLOAD) || defined(ENABLE_CUDA) || defined(ENABLE_ROCM) || defined(ENABLE_SYCL)
-      << "\n  Accelerators per node     = " << DeviceManager::getGlobal().getNumDevices()
+      << "\n  Accelerators per rank     = " << DeviceManager::getGlobal().getNumDevices()
 #endif
       << std::endl;
   // clang-format on


### PR DESCRIPTION
## Proposed changes
When using a script or mpi launcher exposing one GPU per MPI rank, the code prints out
```
Accelerators per node = 1
```
which caused confusion on multi-GPU nodes.
What the code print is actually the number of visible GPUs by rank 0.
Thus change the printout to
```
Accelerators per rank = 1
```

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Aurora

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
