### PR TITLE
running unit tests with asan on broken for openmpi

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -159,6 +159,12 @@ function(
                    ENVIRONMENT
                    OMP_NUM_THREADS=${THREADS})
       set(TEST_ADDED_TEMP TRUE)
+      if("asan" IN_LIST ENABLE_SANITIZER)
+        set_property(
+          TEST ${TESTNAME}
+          APPEND
+          PROPERTY ENVIRONMENT LSAN_OPTIONS=${LSAN_OPTIONS})
+      endif()
     endif()
   else()
     if((${PROCS} STREQUAL "1"))

--- a/CMake/unit_test.cmake
+++ b/CMake/unit_test.cmake
@@ -1,7 +1,5 @@
 include(test_labels)
 
-include(CMakePrintHelpers)
-
 # Runs unit tests
 function(ADD_UNIT_TEST TESTNAME PROCS THREADS TEST_BINARY)
   message(VERBOSE "Adding test ${TESTNAME}")
@@ -20,13 +18,14 @@ function(ADD_UNIT_TEST TESTNAME PROCS THREADS TEST_BINARY)
   endif()
 
   if(TEST_ADDED)
-    set(TEST_ADDITIONAL_ENV
-        $<$<STREQUAL:${ENABLE_SANITIZER},asan>:LSAN_OPTIONS=suppressions=${PROJECT_SOURCE_DIR}/config/sanitizers/lsan.supp>
-    )
-    set_tests_properties(
-      ${TESTNAME} PROPERTIES PROCESSORS ${TOT_PROCS} ENVIRONMENT "OMP_NUM_THREADS=${THREADS};${TEST_ADDITIONAL_ENV}"
-                             PROCESSOR_AFFINITY TRUE)
-    cmake_print_properties(TESTS ${TESTNAME} PROPERTIES ENVIRONMENT)
+    set_tests_properties(${TESTNAME} PROPERTIES PROCESSORS ${TOT_PROCS} ENVIRONMENT OMP_NUM_THREADS=${THREADS}
+                                                PROCESSOR_AFFINITY TRUE)
+    if("asan" IN_LIST ENABLE_SANITIZER)
+      set_property(
+        TEST ${TESTNAME}
+        APPEND
+        PROPERTY ENVIRONMENT LSAN_OPTIONS=${LSAN_OPTIONS})
+    endif()
 
     if(ENABLE_CUDA
        OR ENABLE_ROCM

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ set(VALID_SANITIZERS "asan" "ubsan" "tsan" "msan" "typesan")
 set(ENABLE_SANITIZER "" CACHE STRING "asan,ubsan,tsan,msan,typesan")
 set_property(CACHE ENABLE_SANITIZER PROPERTY STRINGS ${VALID_SANITIZERS})
 
-set(LSAN_OPTIONS "suppressions=${PROJECT_SOURCE_DIR}/config/sanitizers/lsan.supp" CACHE string "cached value of environment variable LSAN_OPTIONS used by ctest")
+set(LSAN_OPTIONS "suppressions=${PROJECT_SOURCE_DIR}/config/sanitizers/lsan.supp" CACHE STRING "cached value of environment variable LSAN_OPTIONS used by ctest")
 
 if(ENABLE_SANITIZER)
   # Perform sanitizer option check, only works in debug mode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 ######################################################################
 project(
   qmcpack
-  VERSION 4.1.9 
+  VERSION 4.1.9
   LANGUAGES C CXX)
 
 #--------------------------------------------------------------------
@@ -168,9 +168,11 @@ mark_as_advanced(QMC_EXP_THREADING)
 #--------------------------------------------------------------------
 
 # Add optional sanitizers ASAN, UBSAN, MSAN, TYPESAN
-set(VALID_SANITIZERS "asan" "ubsan" "tsan" "msan" "typesan")
+set(VALID_SANITIZERS "" "asan" "ubsan" "tsan" "msan" "typesan")
 set(ENABLE_SANITIZER "" CACHE STRING "asan,ubsan,tsan,msan,typesan")
 set_property(CACHE ENABLE_SANITIZER PROPERTY STRINGS ${VALID_SANITIZERS})
+
+set(LSAN_OPTIONS "suppressions=${PROJECT_SOURCE_DIR}/config/sanitizers/lsan.supp" CACHE string "cached value of environment variable LSAN_OPTIONS used by ctest")
 
 if(ENABLE_SANITIZER)
   # Perform sanitizer option check, only works in debug mode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ mark_as_advanced(QMC_EXP_THREADING)
 #--------------------------------------------------------------------
 
 # Add optional sanitizers ASAN, UBSAN, MSAN, TYPESAN
-set(VALID_SANITIZERS "" "asan" "ubsan" "tsan" "msan" "typesan")
+set(VALID_SANITIZERS "asan" "ubsan" "tsan" "msan" "typesan")
 set(ENABLE_SANITIZER "" CACHE STRING "asan,ubsan,tsan,msan,typesan")
 set_property(CACHE ENABLE_SANITIZER PROPERTY STRINGS ${VALID_SANITIZERS})
 

--- a/config/sanitizers/lsan.supp
+++ b/config/sanitizers/lsan.supp
@@ -5,3 +5,5 @@ leak:malloc
 leak:opal_hash_table_init2
 leak:strdup
 leak:calloc
+leak:ompi*
+leak:pmix*


### PR DESCRIPTION
## Proposed changes

In my development environment every unit test fails asan for a mpi build. This fixes that. It also makes it possible to use the lsan suppression file at all with ctest.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- New feature
- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation or build script changes
- Other (please describe):

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
sdgx2

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
