### PR TITLE
WalkerLogXXX should provide move constructors

### DIFF
--- a/src/QMCDrivers/WalkerLogBuffer.h
+++ b/src/QMCDrivers/WalkerLogBuffer.h
@@ -151,6 +151,9 @@ private:
 
 public:
   WalkerLogBuffer();
+  WalkerLogBuffer(const WalkerLogBuffer& other)       = default;
+  WalkerLogBuffer(WalkerLogBuffer&& other)            = default;
+  WalkerLogBuffer& operator=(WalkerLogBuffer&& other) = default;
 
   /// current number of rows in the data buffer
   inline size_t nrows() { return buffer.size(0); }

--- a/src/QMCDrivers/WalkerLogCollector.h
+++ b/src/QMCDrivers/WalkerLogCollector.h
@@ -96,13 +96,20 @@ private:
   Array<WLog::PsiVal, 2> Gtmp;
   /// tmp storage for walker wavefunciton laplacians
   Array<WLog::PsiVal, 1> Ltmp;
-  /// state data set by WalkerLogManager
-  const WalkerLogState& state_;
+  /** This is just a bundle of constructor arguments, if the intention
+   * was dynamic manipulation of object state through a reference
+   * back door. Since it wasn't used this way I turned it to the by
+   * value.
+   * If you want to do a state transform write a function to do it
+   * and document it.
+   */
+  WalkerLogState state_;
 
 public:
   /// constructor. The state should be given by the manager.
   WalkerLogCollector(const WalkerLogState& state);
-
+  WalkerLogCollector(WalkerLogCollector&& other)            = default;
+  WalkerLogCollector& operator=(WalkerLogCollector&& other) = default;
   /// resize buffers to zero rows at beginning of each MC block
   void startBlock();
 

--- a/src/QMCDrivers/WalkerLogCollector.h
+++ b/src/QMCDrivers/WalkerLogCollector.h
@@ -96,12 +96,14 @@ private:
   Array<WLog::PsiVal, 2> Gtmp;
   /// tmp storage for walker wavefunciton laplacians
   Array<WLog::PsiVal, 1> Ltmp;
-  /** This is just a bundle of constructor arguments, if the intention
-   * was dynamic manipulation of object state through a reference
-   * back door. Since it wasn't used this way I turned it to the by
-   * value.
-   * If you want to do a state transform write a function to do it
-   * and document it.
+  /** Hopefully This is just a bundle of constructor arguments.
+   *  It was a reference, so perhaps, the intention was dynamic
+   *  manipulation of a group of objects state from afar.
+   *  Since it hadn't yet been used this way its just a private member
+   *  now. _reviewers_ do not allow it to be made a reference again.
+   *
+   *  If you want to do a state transform write a function, document
+   *  it, call it from a sensible and obvious scope.
    */
   WalkerLogState state_;
 

--- a/src/QMCDrivers/WalkerLogManager.cpp
+++ b/src/QMCDrivers/WalkerLogManager.cpp
@@ -77,9 +77,6 @@ WalkerLogManager::WalkerLogManager(WalkerLogInput& inp, bool allow_logs, std::st
   registered_hdf = false;
 }
 
-// WalkerLogManager::WalkerLogManager(WalkerLogManager&& other) :
-// {}
-
 std::unique_ptr<WalkerLogCollector> WalkerLogManager::makeCollector() const
 {
   if (state.verbose)

--- a/src/QMCDrivers/WalkerLogManager.cpp
+++ b/src/QMCDrivers/WalkerLogManager.cpp
@@ -77,6 +77,8 @@ WalkerLogManager::WalkerLogManager(WalkerLogInput& inp, bool allow_logs, std::st
   registered_hdf = false;
 }
 
+// WalkerLogManager::WalkerLogManager(WalkerLogManager&& other) :
+// {}
 
 std::unique_ptr<WalkerLogCollector> WalkerLogManager::makeCollector() const
 {

--- a/src/QMCDrivers/WalkerLogManager.h
+++ b/src/QMCDrivers/WalkerLogManager.h
@@ -31,14 +31,14 @@ struct WalkerLogInput;
  *    to the HDF file at the end of each MC block.
  *
  *    Just prior to the write, this class examines the distribution of walker
- *    energies on its rank for each MC step in the MC block, identifies the 
- *    minimum/maximum/median energy walkers and buffers their full data 
+ *    energies on its rank for each MC step in the MC block, identifies the
+ *    minimum/maximum/median energy walkers and buffers their full data
  *    (including per-particle information) for the write.
- *    This data corresponds to walker information at specific quantiles of the 
+ *    This data corresponds to walker information at specific quantiles of the
  *    energy distribution.
  *    See WalkerLogManager::writeBuffers()
  *
- *    Writing per-particle information for all walkers is optional, as is 
+ *    Writing per-particle information for all walkers is optional, as is
  *    writing data for the minimum/maximum/median energy walkers.
  *    Scalar "property" data for each walker is always written.
  */
@@ -104,7 +104,8 @@ private:
 
 public:
   WalkerLogManager(WalkerLogInput& inp, bool allow_logs, std::string series_root, Communicate* comm = 0);
-
+  WalkerLogManager& operator=(WalkerLogManager&& other) = default;
+  WalkerLogManager(WalkerLogManager&& other)            = default;
   /// create a WalkerLogCollector
   std::unique_ptr<WalkerLogCollector> makeCollector() const;
 

--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -34,7 +34,8 @@ set(DRIVER_TEST_SRC
     test_vmc_driver.cpp
     test_dmc_driver.cpp
     test_SimpleFixedNodeBranch.cpp
-    test_QMCDriverFactory.cpp)
+    test_QMCDriverFactory.cpp
+    test_WalkerLogManager.cpp)
 
 # legacy driver mpi, not tested in a meaningful way since the standard unit test is
 # just one rank with mpi.

--- a/src/QMCDrivers/tests/ValidWalkerLogInput.h
+++ b/src/QMCDrivers/tests/ValidWalkerLogInput.h
@@ -1,0 +1,38 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2025 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_VALIDWALKERLOGINPUT_H
+#define QMCPLUSPLUS_VALIDWALKERLOGINPUT_H
+
+#include <array>
+#include <string_view>
+namespace qmcplusplus::testing
+{
+class WalkerLogInputSections
+{
+public:
+  enum class valid
+  {
+    DEFAULT = 0
+  };
+
+  static std::string_view getXml(valid val) { return xml[static_cast<std::size_t>(val)]; }
+  auto begin() { return xml.begin(); }
+  auto end() { return xml.end(); }
+
+private:
+  static constexpr std::array<std::string_view, 1> xml{
+      R"XML(
+<walkerlogs/>
+)XML"};
+};
+
+} // namespace qmcplusplus::testing
+
+#endif

--- a/src/QMCDrivers/tests/test_WalkerLogManager.cpp
+++ b/src/QMCDrivers/tests/test_WalkerLogManager.cpp
@@ -1,0 +1,69 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source
+// License. See LICENSE file in top directory for details.
+//
+// Copyright (c) 2025 QMCPACK developers.
+//
+// File developed by: Peter W. Doak, doakpw@ornl.gov, Oak Ridge National
+// Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "OhmmsData/Libxml2Doc.h"
+#include "QMCDrivers/WalkerLogManager.h"
+#include "catch.hpp"
+
+#include "Message/Communicate.h"
+#include <MockGoldWalkerElements.h>
+
+#include "ValidWalkerLogInput.h"
+#include "WalkerLogInput.h"
+
+namespace qmcplusplus
+{
+class CollectorHolder
+{
+public:
+  void setWalkerLogCollector(UPtr<WalkerLogCollector>&& wlc) { walker_collector_ = std::move(wlc); }
+  void startBlock() { walker_collector_->startBlock(); }
+
+private:
+  UPtr<WalkerLogCollector> walker_collector_;
+};
+
+struct LogAndStuff
+{
+  WalkerLogManager wlm;
+  CollectorHolder ch;
+};
+
+TEST_CASE("WalkerLogManager::move", "[drivers]")
+{
+  Communicate* comm = OHMMS::Controller;
+  RuntimeOptions run_time_options;
+
+  auto mgwe     = testing::makeGoldWalkerElementsWithEEEI(comm, run_time_options);
+  using WLInput = testing::WalkerLogInputSections;
+  Libxml2Document doc;
+  bool okay = doc.parseFromString(WLInput::getXml(WLInput::valid::DEFAULT));
+  REQUIRE(okay);
+  xmlNodePtr node = doc.getRoot();
+  WalkerLogInput walker_log_input{node};
+  auto make_stuff = [comm](WalkerLogInput& walker_log_input) -> LogAndStuff {
+    WalkerLogManager wlm{walker_log_input, true, "root_name", comm};
+    CollectorHolder ch;
+    ch.setWalkerLogCollector(wlm.makeCollector());
+    return {std::move(wlm), std::move(ch)};
+  };
+  auto l_and_s = make_stuff(walker_log_input);
+
+  // In the past this has resulted in a AddressSanitizer:
+  // stack-use-after-return
+  // due to access to a dead reference to
+  // a state object made back in moved from WalkerLogManager in
+  // the factory function.  Seemed to work in release, caught by llvm
+  // asan.
+  l_and_s.ch.startBlock();
+}
+
+
+} // namespace qmcplusplus

--- a/src/QMCDrivers/tests/test_WalkerLogManager.cpp
+++ b/src/QMCDrivers/tests/test_WalkerLogManager.cpp
@@ -13,8 +13,6 @@
 #include "catch.hpp"
 
 #include "Message/Communicate.h"
-#include <MockGoldWalkerElements.h>
-
 #include "ValidWalkerLogInput.h"
 #include "WalkerLogInput.h"
 
@@ -39,9 +37,7 @@ struct LogAndStuff
 TEST_CASE("WalkerLogManager::move", "[drivers]")
 {
   Communicate* comm = OHMMS::Controller;
-  RuntimeOptions run_time_options;
 
-  auto mgwe     = testing::makeGoldWalkerElementsWithEEEI(comm, run_time_options);
   using WLInput = testing::WalkerLogInputSections;
   Libxml2Document doc;
   bool okay = doc.parseFromString(WLInput::getXml(WLInput::valid::DEFAULT));


### PR DESCRIPTION
## Proposed changes

I see no documented reason for why move constructors or the rule of five in general should be broken for `WalkerLog*` classes.  And it became a subtle use after return asan issue when refactoring batched drivers. I have addressed this sufficiently to address work needed for testing of variable estimator measurements to be sound and testable. I have also added the the beginning of actual unit testing for WalkerLogManager and a testing data class for WalkerLogInput.

There was a nasty shared state reference which so far looks to have been unused.  This will all get more coverage int he variable esimator measurement period PR.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- New feature
- Documentation or build script changes
- Other (please describe):

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
