### PR TITLE
Restrict asan suppression to only the MPI case.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,8 +172,6 @@ set(VALID_SANITIZERS "asan" "ubsan" "tsan" "msan" "typesan")
 set(ENABLE_SANITIZER "" CACHE STRING "asan,ubsan,tsan,msan,typesan")
 set_property(CACHE ENABLE_SANITIZER PROPERTY STRINGS ${VALID_SANITIZERS})
 
-set(LSAN_OPTIONS "suppressions=${PROJECT_SOURCE_DIR}/config/sanitizers/lsan.supp" CACHE STRING "cached value of environment variable LSAN_OPTIONS used by ctest")
-
 if(ENABLE_SANITIZER)
   # Perform sanitizer option check, only works in debug mode
   if(NOT ENABLE_SANITIZER IN_LIST VALID_SANITIZERS)
@@ -269,6 +267,13 @@ if(ENABLE_SANITIZER)
     set(CMAKE_CXX_FLAGS_SAN
         "-fsanitize=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer"
         CACHE STRING "AddressSanitizer C++ compiler builds." FORCE)
+    if(NOT DEFINED LSAN_OPTIONS)
+      if(QMC_MPI)
+        set(LSAN_OPTIONS "suppressions=${PROJECT_SOURCE_DIR}/config/sanitizers/lsan_mpi.supp")
+      else()
+        set(LSAN_OPTIONS "")
+      endif()
+    endif()
   elseif("${ENABLE_SANITIZER}" STREQUAL "ubsan")
     set(CMAKE_CXX_FLAGS_SAN
         "-fsanitize=undefined"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,23 +163,9 @@ set(HAVE_EINSPLINE 1) # to be removed
 option(QMC_EXP_THREADING "Experimental non openmp threading models" OFF)
 mark_as_advanced(QMC_EXP_THREADING)
 
-#--------------------------------------------------------------------
-# Sanitizer options
-#--------------------------------------------------------------------
-
 # Add optional sanitizers ASAN, UBSAN, MSAN, TYPESAN
 set(VALID_SANITIZERS "asan" "ubsan" "tsan" "msan" "typesan")
-set(ENABLE_SANITIZER "" CACHE STRING "asan,ubsan,tsan,msan,typesan")
-set_property(CACHE ENABLE_SANITIZER PROPERTY STRINGS ${VALID_SANITIZERS})
-
-if(ENABLE_SANITIZER)
-  # Perform sanitizer option check, only works in debug mode
-  if(NOT ENABLE_SANITIZER IN_LIST VALID_SANITIZERS)
-    message(FATAL_ERROR "Invalid -DENABLE_SANITIZER=${ENABLE_SANITIZER}, value must be one of ${VALID_SANITIZERS}")
-  else()
-    message(STATUS "Enable sanitizer ENABLE_SANITIZER=${ENABLE_SANITIZER}")
-  endif()
-endif()
+set(ENABLE_SANITIZER "" CACHE STRING "Valid input: ${VALID_SANITIZERS} or left empty")
 
 #--------------------------------------------------------------------
 # INSTALL_NEXUS install Nexus alongside QMCPACK
@@ -259,6 +245,12 @@ include(TestCxx17Library)
 # SETUP SANITIZERS FLAGS
 #-----------------------------------------------------------------------
 if(ENABLE_SANITIZER)
+  message(STATUS "Enable sanitizer ENABLE_SANITIZER=${ENABLE_SANITIZER}")
+  # Perform sanitizer option check
+  if(NOT ENABLE_SANITIZER IN_LIST VALID_SANITIZERS)
+    message(FATAL_ERROR "Invalid ENABLE_SANITIZER input, value must be one of ${VALID_SANITIZERS}")
+  endif()
+
   if(NOT ${COMPILER} MATCHES "GNU" AND NOT ${COMPILER} MATCHES "Clang")
     message(FATAL_ERROR "-DENABLE_SANITIZER=${ENABLE_SANITIZER} only works with GNU or Clang compilers")
   endif()
@@ -273,6 +265,9 @@ if(ENABLE_SANITIZER)
       else()
         set(LSAN_OPTIONS "")
       endif()
+    endif()
+    if(LSAN_OPTIONS)
+      message(STATUS "Set environment variable LSAN_OPTIONS for CTest: ${LSAN_OPTIONS}")
     endif()
   elseif("${ENABLE_SANITIZER}" STREQUAL "ubsan")
     set(CMAKE_CXX_FLAGS_SAN

--- a/config/sanitizers/lsan.supp
+++ b/config/sanitizers/lsan.supp
@@ -1,9 +1,0 @@
-
-
-leak:opal_free_list_grow_st
-leak:malloc
-leak:opal_hash_table_init2
-leak:strdup
-leak:calloc
-leak:ompi*
-leak:pmix*

--- a/config/sanitizers/lsan_mpi.supp
+++ b/config/sanitizers/lsan_mpi.supp
@@ -1,0 +1,8 @@
+leak:calloc
+leak:malloc
+leak:operator new
+leak:strdup
+leak:opal_free_list_grow_st
+leak:opal_hash_table_init2
+leak:ompi*
+leak:pmix*


### PR DESCRIPTION
## Proposed changes
a https://github.com/QMCPACK/qmcpack/pull/5566 follow-up

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
