### PR TITLE
Add email support to Perlmutter Jobs through Nexus

### DIFF
--- a/nexus/lib/machines.py
+++ b/nexus/lib/machines.py
@@ -2475,6 +2475,10 @@ class Perlmutter(NerscMachine):
         c+='#SBATCH -o '+job.outfile+'\n'
         c+='#SBATCH -e '+job.errfile+'\n'
 
+        if job.email is not None:
+            c+='#SBATCH --mail-type=ALL\n'
+            c+='#SBATCH --mail-user={0}\n'.format(job.email)
+
         if 'gpu' in job.constraint:
             gpus_per_task = int(floor(float(self.gpus_per_node)/job.processes_per_node))
             c+='#SBATCH --gpus-per-task={0}\n'.format(gpus_per_task)


### PR DESCRIPTION
## Proposed changes

Some supercomputers supported by Nexus have the ability to include an email in the job's `sbatch` file, however this feature was lacking for Perlmutter. This PR adds in the code required to both add the email into the job header, and also set `--mail-type=ALL` to make sure the user receives emails regarding their job. This is consistent with the other supercomputers that already have support for job emails.

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

This has been tested on Perlmutter using a simple python script to call Nexus and create a job for a Quantum ESPRESSO calculation.

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
