### PR TITLE
Select the reduction algorithm using SLM when using icpx.

### DIFF
--- a/CMake/IntelCompilers.cmake
+++ b/CMake/IntelCompilers.cmake
@@ -36,6 +36,8 @@ if(QMC_OMP)
             CACHE STRING "Offload target architecture")
         set(OPENMP_OFFLOAD_COMPILE_OPTIONS "-fopenmp-targets=${OFFLOAD_TARGET}")
       endif()
+      # Select the intra-team reduction implementation using shared local memory.
+      set(OPENMP_OFFLOAD_COMPILE_OPTIONS "${OPENMP_OFFLOAD_COMPILE_OPTIONS} -mllvm -vpo-paropt-atomic-free-reduction-slm=true" )
     endif(ENABLE_OFFLOAD)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fiopenmp")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fiopenmp")

--- a/config/build_alcf_aurora_icpx.sh
+++ b/config/build_alcf_aurora_icpx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This recipe is intended for ALCF Aurora https://www.alcf.anl.gov/support-center/aurora-sunspot
-# last revision: Apr 25th 2025
+# last revision: Jul 11th 2025
 #
 # How to invoke this script?
 # build_alcf_aurora_icpx.sh # build all the variants assuming the current directory is the source directory.
@@ -52,7 +52,6 @@ for name in gpu_real_MP gpu_real gpu_cplx_MP gpu_cplx \
 do
 
 CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=$TYPE -DMPIEXEC_PREFLAGS='--cpu-bind;depth;-d;8'"
-unset CMAKE_CXX_FLAGS
 
 if [[ $name == *"cplx"* ]]; then
   CMAKE_FLAGS="$CMAKE_FLAGS -DQMC_COMPLEX=ON"
@@ -64,7 +63,6 @@ fi
 
 if [[ $name == *"gpu"* ]]; then
   CMAKE_FLAGS="$CMAKE_FLAGS -DQMC_GPU_ARCHS=intel_gpu_pvc"
-  CMAKE_CXX_FLAGS="-mllvm -vpo-paropt-atomic-free-reduction-slm=true"
 fi
 
 folder=build_${Machine}_${Compiler}_${name}
@@ -76,15 +74,14 @@ fi
 echo "**********************************"
 echo "folder $folder"
 echo "CMAKE_FLAGS: $CMAKE_FLAGS"
-echo "CMAKE_CXX_FLAGS: $CMAKE_CXX_FLAGS"
 echo "**********************************"
 
 mkdir $folder
 cd $folder
 
 if [ ! -f CMakeCache.txt ] ; then
-cmake $CMAKE_FLAGS -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
-      -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpicxx $source_folder
+cmake -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpicxx \
+      $CMAKE_FLAGS $source_folder
 fi
 
 if [[ -v install_folder ]]; then


### PR DESCRIPTION
## Proposed changes
Promote the current setting from Aurora build script to Intel compiler settings.
I found intel_gpu_bmg (battlemage, lunar lake) requires it to add the failing unit test https://cdash.qmcpack.org/tests/28817264

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
