### PR TITLE
Start stop block consistency

### DIFF
--- a/src/Estimators/EstimatorManagerCrowd.cpp
+++ b/src/Estimators/EstimatorManagerCrowd.cpp
@@ -56,7 +56,8 @@ void EstimatorManagerCrowd::startBlock(int steps)
 
 void EstimatorManagerCrowd::stopBlock()
 {
-  // the main estimator does more here.
+  for (auto& uope : operator_ests_)
+    uope->startBlock(steps);
 }
 
 

--- a/src/Estimators/EstimatorManagerCrowd.cpp
+++ b/src/Estimators/EstimatorManagerCrowd.cpp
@@ -57,7 +57,7 @@ void EstimatorManagerCrowd::startBlock(int steps)
 void EstimatorManagerCrowd::stopBlock()
 {
   for (auto& uope : operator_ests_)
-    uope->startBlock(steps);
+    uope->stopBlock();
 }
 
 

--- a/src/Estimators/EstimatorManagerNew.cpp
+++ b/src/Estimators/EstimatorManagerNew.cpp
@@ -245,7 +245,12 @@ void EstimatorManagerNew::startDriverRun()
 
 void EstimatorManagerNew::stopDriverRun() { h_file.reset(); }
 
-void EstimatorManagerNew::startBlock(int steps) { block_timer_.restart(); }
+void EstimatorManagerNew::startBlock(int steps)
+{
+  block_timer_.restart();
+  for (auto& op_est : operator_ests_)
+    op_est->startBlock(steps);
+}
 
 void EstimatorManagerNew::stopBlock(unsigned long accept, unsigned long reject, FullPrecRealType block_weight)
 {

--- a/src/Estimators/OperatorEstBase.h
+++ b/src/Estimators/OperatorEstBase.h
@@ -103,12 +103,21 @@ public:
 
   virtual void normalize(QMCT::RealType invToWgt);
 
+  /** Entry point for an estimator  to do something at the start of each block.
+   *
+   *  Called on rank scope estimator from
+   *  EstimatorManagerNew::startBlock()
+   *  Called on crowd scope estimators from
+   *  Crowd::startBlock())
+   */
   virtual void startBlock(int steps) = 0;
 
-  /** One more entry point incase an estimator has something it needs
-   *  to do at the end of each block.
+  /** Entry point for estimator to do something at the end of each block.
    *
-   *  Only called on rank scope estimator from EstimatorManagerNew::stopBlock())
+   *  Called on rank scope estimator from
+   *  EstimatorManagerNew::stopBlock()
+   *  Called on crowd scope estimators from
+   *  Crowd::stopBlock())
    */
   virtual void stopBlock() {};
 

--- a/src/Estimators/SpinDensityNew.cpp
+++ b/src/Estimators/SpinDensityNew.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<OperatorEstBase> SpinDensityNew::spawnCrowdClone() const
 
 void SpinDensityNew::startBlock(int steps)
 {
-  if (data_locality_ == DataLocality::rank)
+  if (data_locality_ == DataLocality::queue)
   {
     int num_particles = std::accumulate(species_size_.begin(), species_size_.end(), 0);
     size_t data_size  = num_particles * steps * 2;

--- a/src/QMCDrivers/DMC/DMCContextForSteps.h
+++ b/src/QMCDrivers/DMC/DMCContextForSteps.h
@@ -8,7 +8,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 #include <NonLocalTOperator.h>
-#include <QMCDriverNew.h>
+
 namespace qmcplusplus
 {
 class DMCBatched::DMCContextForSteps : public ContextForSteps


### PR DESCRIPTION
## Proposed changes
Consistently call startBlock and stopBlock for all estimators.
While these "hooks" are not much used at the moment by estimators they are needed for to implement various memory reduction and testing strategies and currently are called inconsistently.  startBlock gets called crowd scope estimators and stopBlock for rank scope estimators.  This PR connects the missing calls.

Currently I believe SpinDensityNew with memory saving in the actual application will have less than optimal performance due to crowd scope estimators reserving only 10 particle steps worth of memory.

With this fix SpinDensityNew::startBlock also needs a fix.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Documentation or build script changes
- Other (please describe):

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
sdgx2
## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
