### PR TITLE
Switch to "estimator_period" keyword and add Nexus support

### DIFF
--- a/nexus/lib/qmcpack_input.py
+++ b/nexus/lib/qmcpack_input.py
@@ -2565,7 +2565,7 @@ class vmc(QIxml):
                   'blocks','steps','substeps','timestep','maxcpusecs','rewind',
                   'storeconfigs','checkproperties','recordconfigs','current',
                   'stepsbetweensamples','samplesperthread','samples','usedrift',
-                  'spin_mass',
+                  'spin_mass','estimator_period',
                   'walkers','nonlocalpp','tau','walkersperthread','reconfiguration', # legacy - batched
                   'dmcwalkersperthread','current','ratio','firststep',
                   'minimumtargetwalkers','max_seconds']
@@ -2588,7 +2588,7 @@ class dmc(QIxml):
                   'stepsbetweensamples','samplesperthread','samples','reconfiguration',
                   'nonlocalmoves','maxage','alpha','gamma','reserve','use_nonblocking',
                   'branching_cutoff_scheme','feedback','sigmabound',
-                  'spin_mass',
+                  'spin_mass','estimator_period',
                   'walkers','nonlocalmove','pop_control','targetwalkers',               # legacy - batched
                   'minimumtargetwalkers','energybound','feedback','recordwalkers',
                   'fastgrad','popcontrol','branchinterval','usedrift','storeconfigs',
@@ -7437,7 +7437,8 @@ gen_basic_input_defaults = obj(
     interactions     = 'all',            
     corrections      = 'default',        
     observables      = None,             
-    estimators       = None,             
+    estimators       = None,
+    estimator_period = None,
     traces           = None,             
     calculations     = None,             
     det_format       = 'new',            
@@ -7820,6 +7821,13 @@ def generate_basic_input(**kwargs):
         ests_elem = estimators()
         ests_elem.estimators = ests
         sim.qmcsystem.estimators = ests_elem
+    #end if
+    if kw.estimator_period is not None:
+        for c in kw.calculations:
+            if isinstance(c,(vmc,dmc)):
+                c.estimator_period = kw.estimator_period
+            #end if
+        #end for
     #end if
     sim.calculations = make_collection(kw.calculations).copy()
 

--- a/src/QMCDrivers/QMCDriverInput.cpp
+++ b/src/QMCDrivers/QMCDriverInput.cpp
@@ -62,7 +62,7 @@ void QMCDriverInput::readXML(xmlNodePtr cur)
   parameter_set.add(total_walkers_, "total_walkers");
   parameter_set.add(dummy_int, "stepsbetweensamples", {}, TagStatus::UNSUPPORTED);
   parameter_set.add(dummy_int, "samplesperthread", {}, TagStatus::UNSUPPORTED);
-  parameter_set.add(estimator_measurement_period_, "estimator_measurement_period");
+  parameter_set.add(estimator_measurement_period_, "estimator_period");
   parameter_set.add(requested_samples_, "samples");
   parameter_set.add(tau_, "timestep");
   parameter_set.add(tau_, "time_step");


### PR DESCRIPTION
## Proposed changes

Changes input keyword "estimator_measurement_period" to "estimator_period" as discussed in #5576.  Also add support for the new keyword in Nexus.


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop

## Checklist

* * [x] This PR is up to date with the current state of 'develop'

