### PR TITLE
Small optimization for `cuBLAS_MFs::gemvT_batched_kernel`

### DIFF
--- a/src/Platforms/CUDA/cuBLAS_missing_functions.cu
+++ b/src/Platforms/CUDA/cuBLAS_missing_functions.cu
@@ -50,7 +50,6 @@ __global__ void gemvT_batched_kernel(const int m, // number of columns in row ma
 
   constexpr int SUM_SIZE = ROWBS * COLBS;
   __shared__ uninitialized_array<T, SUM_SIZE> sum;
-  __shared__ uninitialized_array<T, COLBS> x_part;
 
   const int tid = threadIdx.x;
   for (int i = 0; i < ROWBS; i++)
@@ -67,10 +66,11 @@ __global__ void gemvT_batched_kernel(const int m, // number of columns in row ma
   {
     const int col_id = ib * COLBS + tid;
     if (col_id < m)
-      x_part[tid] = x_iw[col_id * incx];
-    for (int row_id = row_begin; row_id < row_begin + row_max; row_id++)
-      if (col_id < m)
-        sum[(row_id - row_begin) * COLBS + tid] += x_part[tid] * A_iw[row_id * lda + col_id];
+    {
+      const T x = x_iw[col_id * incx];
+      for (int row_id = row_begin; row_id < row_begin + row_max; row_id++)
+        sum[(row_id - row_begin) * COLBS + tid] += x * A_iw[row_id * lda + col_id];
+    }
   }
 
   for (int iend = COLBS / 2; iend > 0; iend /= 2)


### PR DESCRIPTION
## Proposed changes

A small optimization for `cuBLAS_MFs::gemvT_batched_kernel` by replacing a shared memory with a direct register load. This wins ~10% speed up, observed during the `NiO` benchmark tests:

- Original (shared memory):
    ```sh
     Time (%)  Total Time (ns)  Instances   Avg (ns)     Med (ns)    Min (ns)   Max (ns)   StdDev (ns)                                                  Name
     --------  ---------------  ---------  -----------  -----------  ---------  ---------  -----------  ----------------------------------------------------------------------------------------------------
         ...
         11.1      145,699,371     35,712      4,079.8      4,256.0      1,856     17,856        886.6  void qmcplusplus::cuBLAS_MFs::gemvT_batched_kernel<float, (int)4, (int)64>(int, int, const T1 *, co…
         ...
    ```
- This PR (register load):
    ```sh
     Time (%)  Total Time (ns)  Instances   Avg (ns)     Med (ns)    Min (ns)   Max (ns)   StdDev (ns)                                                  Name
     --------  ---------------  ---------  -----------  -----------  ---------  ---------  -----------  ----------------------------------------------------------------------------------------------------
         ...
         10.3      132,179,913     35,712      3,701.3      3,872.0      1,856     15,808        780.9  void qmcplusplus::cuBLAS_MFs::gemvT_batched_kernel<float, (int)4, (int)64>(int, int, const T1 *, co…
         ...
    ```


## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Personal desktop with CUDA 12.9, LLVM 20.1.0

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
