### PR TITLE
Align SYCL `batched_gemv` to CUDA's

### DIFF
--- a/src/Platforms/SYCL/syclBLAS.cpp
+++ b/src/Platforms/SYCL/syclBLAS.cpp
@@ -93,7 +93,7 @@ template sycl::event gemv(sycl::queue& handle,
 
 /** gemv trans = 'T' case. COLS refers to columns of the m x n column-major Fortran matrix A.
  */
-template<typename T, unsigned COLBS>
+template<typename T, unsigned ROWBS, unsigned COLBS>
 sycl::event gemvT_batched_impl(sycl::queue& handle,
                                const int m,
                                const int n,
@@ -111,8 +111,7 @@ sycl::event gemvT_batched_impl(sycl::queue& handle,
   if (m == 0 || n == 0 || batch_count == 0)
     return sycl::event();
 
-  // TODO: templatize?
-  static constexpr int ROWBS = 4;
+  static_assert(ROWBS <= COLBS, "Row block size must not be larger than column block size!");
 
   constexpr int SUM_SIZE = ROWBS * COLBS;
   const int num_row_blocks = (n + ROWBS - 1) / ROWBS;
@@ -252,7 +251,7 @@ sycl::event gemv_batched<float>(sycl::queue& handle,
   if (trans == 'N' || trans == 'n')
     return gemvN_batched_impl<float, 64>(handle, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
   else if (trans == 'T' || trans == 't')
-    return gemvT_batched_impl<float, 64>(handle, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
+    return gemvT_batched_impl<float, 4, 64>(handle, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
   else
     throw std::runtime_error("syclBLAS::gemv_batched only supports 'N', 'T', 'C', 'n'. Input value is " +
                              std::string(1, trans));
@@ -277,7 +276,7 @@ sycl::event gemv_batched<double>(sycl::queue& handle,
   if (trans == 'N' || trans == 'n')
     return gemvN_batched_impl<double, 64>(handle, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
   else if (trans == 'T' || trans == 't')
-    return gemvT_batched_impl<double, 64>(handle, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
+    return gemvT_batched_impl<double, 4, 64>(handle, m, n, alpha, A, lda, x, incx, beta, y, incy, batch_count);
   else
     throw std::runtime_error("syclBLAS::gemv_batched only supports 'N', 'T', 'C', 'n'. Input value is " +
                              std::string(1, trans));
@@ -303,7 +302,7 @@ sycl::event gemv_batched<std::complex<float>>(sycl::queue& handle,
     return gemvN_batched_impl<std::complex<float>, 64>(handle, m, n, alpha, A, lda, x, incx, beta, y, incy,
                                                        batch_count);
   else if (trans == 'T' || trans == 't')
-    return gemvT_batched_impl<std::complex<float>, 64>(handle, m, n, alpha, A, lda, x, incx, beta, y, incy,
+    return gemvT_batched_impl<std::complex<float>, 4, 64>(handle, m, n, alpha, A, lda, x, incx, beta, y, incy,
                                                        batch_count);
   else
     throw std::runtime_error("syclBLAS::gemv_batched only supports 'N', 'T', 'C', 'n'. Input value is " +
@@ -330,7 +329,7 @@ sycl::event gemv_batched<std::complex<double>>(sycl::queue& handle,
     return gemvN_batched_impl<std::complex<double>, 64>(handle, m, n, alpha, A, lda, x, incx, beta, y, incy,
                                                         batch_count);
   else if (trans == 'T' || trans == 't')
-    return gemvT_batched_impl<std::complex<double>, 64>(handle, m, n, alpha, A, lda, x, incx, beta, y, incy,
+    return gemvT_batched_impl<std::complex<double>, 4, 64>(handle, m, n, alpha, A, lda, x, incx, beta, y, incy,
                                                         batch_count);
   else
     throw std::runtime_error("syclBLAS::gemv_batched only supports 'N', 'T', 'C', 'n'. Input value is " +

--- a/src/Platforms/SYCL/syclBLAS.cpp
+++ b/src/Platforms/SYCL/syclBLAS.cpp
@@ -219,6 +219,7 @@ sycl::event gemvN_batched_impl(sycl::queue& handle,
       {
         T sum = T(0);
 
+        #pragma unroll
         for (int col_id = 0; col_id < n; ++col_id)
           sum += A_iw[col_id * lda + row_begin + tid] * x_iw[col_id * incx];
 

--- a/src/Platforms/SYCL/syclBLAS.cpp
+++ b/src/Platforms/SYCL/syclBLAS.cpp
@@ -199,6 +199,9 @@ sycl::event gemvN_batched_impl(sycl::queue& handle,
   const sycl::range<2> global{batch_count, static_cast<size_t>(ROWBS * num_row_blocks)};
 
   return handle.submit([&](sycl::handler& h) {
+    if (!events.empty())
+      h.depends_on(events);
+
     h.parallel_for(sycl::nd_range<2>(global, local), [=](sycl::nd_item<2> item) {
       const int bx  = static_cast<int>(item.get_group(0));    // blockIdx.x
       const int by  = static_cast<int>(item.get_group(1));    // blockIdx.y

--- a/src/Platforms/SYCL/syclBLAS.cpp
+++ b/src/Platforms/SYCL/syclBLAS.cpp
@@ -198,35 +198,20 @@ sycl::event gemvN_batched_impl(sycl::queue& handle,
   const sycl::range<2> local{1, ROWBS};
   const sycl::range<2> global{batch_count, static_cast<size_t>(ROWBS * num_row_blocks)};
 
-  return handle.submit([&](sycl::handler& h) {
-    if (!events.empty())
-      h.depends_on(events);
-
-    h.parallel_for(sycl::nd_range<2>(global, local), [=](sycl::nd_item<2> item) {
-      const int bx  = static_cast<int>(item.get_group(0));    // blockIdx.x
-      const int by  = static_cast<int>(item.get_group(1));    // blockIdx.y
-      const int tid = static_cast<int>(item.get_local_id(1)); // threadIdx.x
-
-      const T* __restrict__ A_iw = A[bx];
-      const T* __restrict__ x_iw = x[bx];
-      T* __restrict__ y_iw       = y[bx];
-
-      const int row_begin = by * ROWBS;
-
-      if (row_begin + tid < m)
-      {
-        T sum = T(0);
-
+  return handle.parallel_for(sycl::nd_range<2>(global, local), [=](sycl::nd_item<2> item) {
+    const unsigned batch = item.get_group(0);
+    const int row        = item.get_global_id(1);
+    if (row < m)
+    {
+      T sum(0);
 #pragma unroll
-        for (int col_id = 0; col_id < n; ++col_id)
-          sum += A_iw[col_id * lda + row_begin + tid] * x_iw[col_id * incx];
-
-        if (beta[bx] == T(0))
-          y_iw[(row_begin + tid) * incy] = alpha[bx] * sum; // protecting NaN from y_iw
-        else
-          y_iw[(row_begin + tid) * incy] = alpha[bx] * sum + beta[bx] * y_iw[(row_begin + tid) * incy];
-      }
-    });
+      for (int col = 0; col < n; col++)
+        sum += A[batch][col * lda + row] * x[batch][col * incx];
+      if (beta[batch] == T(0))
+        y[batch][row * incy] = alpha[batch] * sum; // protecting NaN from y_iw
+      else
+        y[batch][row * incy] = alpha[batch] * sum + beta[batch] * y[batch][row * incy];
+    }
   });
 }
 


### PR DESCRIPTION
## Proposed changes

Align SYCL `batched_gemv[NT]` kernels to the CUDA variants. Resulted in ~3x faster performance overall in benchmark testing: `src/Platforms/tests/benchmark_accelBLAS "AccelBLAS gemv_batched benchmark"` on Aurora.

- Before:
    ```
    -------------------------------------------------------------------------------
    AccelBLAS gemv_batched benchmark
      gemv_batched<PlatformKind::SYCL>
    -------------------------------------------------------------------------------
    /home/leey/project/qmcpack/src/Platforms/tests/benchmark_AccelBLAS.cpp:407
    ...............................................................................

    benchmark name                       samples       iterations    estimated
                                         mean          low mean      high mean
                                         std dev       low std dev   high std dev
    -------------------------------------------------------------------------------
    [SYCL/f32]
    gemv_batched_137x79_N_bs64                     100             1    983.312 ms
                                            9.83662 ms    9.83348 ms    9.84051 ms
                                            17.7988 us    14.3506 us    24.5974 us

    [SYCL/f64]
    gemv_batched_137x79_N_bs64                     100             1     11.0358 s
                                            9.90384 ms    9.89675 ms    9.91111 ms
                                            36.7607 us    32.4087 us    44.3481 us

    [SYCL/f32]
    gemv_batched_137x79_T_bs64                     100             1    561.906 ms
                                            5.62591 ms    5.62261 ms    5.62947 ms
                                            17.4847 us    15.4053 us    22.1497 us

    [SYCL/f64]
    gemv_batched_137x79_T_bs64                     100             1    630.543 ms
                                            6.32057 ms    6.31739 ms    6.32379 ms
                                            16.3545 us    14.3819 us    20.5412 us
    ```
- After:
    ```
    -------------------------------------------------------------------------------
    AccelBLAS gemv_batched benchmark
      gemv_batched<PlatformKind::SYCL>
    -------------------------------------------------------------------------------
    /home/leey/project/qmcpack/src/Platforms/tests/benchmark_AccelBLAS.cpp:407
    ...............................................................................

    benchmark name                       samples       iterations    estimated
                                         mean          low mean      high mean
                                         std dev       low std dev   high std dev
    -------------------------------------------------------------------------------
    [SYCL/f32]
    gemv_batched_137x79_N_bs64                     100             1     12.1795 s
                                            2.65468 ms    2.65155 ms    2.65817 ms
                                            16.8654 us    14.4431 us    20.3502 us

    [SYCL/f64]
    gemv_batched_137x79_N_bs64                     100             1     14.8434 s
                                            3.16175 ms    3.15747 ms    3.16659 ms
                                              23.09 us    19.1353 us    32.2427 us

    [SYCL/f32]
    gemv_batched_137x79_T_bs64                     100             1    214.568 ms
                                            2.13945 ms    2.13535 ms    2.14369 ms
                                            21.1288 us    19.0325 us    23.9365 us

    [SYCL/f64]
    gemv_batched_137x79_T_bs64                     100             1    293.858 ms
                                             2.9381 ms    2.93492 ms    2.94142 ms
                                            16.6514 us      14.71 us    19.2061 us
    ```

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Aurora

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
