### PR TITLE
Remove target input entry from PairCorrelationEstimator.

### DIFF
--- a/docs/hamiltonianobservable.rst
+++ b/docs/hamiltonianobservable.rst
@@ -1081,8 +1081,6 @@ attributes:
   +-------------------------------+--------------+----------------------+------------------------+-------------------------+
   | ``debug``:math:`^o`           | boolean      | yes/no               | no                     | *No current function*   |
   +-------------------------------+--------------+----------------------+------------------------+-------------------------+
-  | ``target``:math:`^o`          | text         | ``particleset.name`` |   ``"e"``              | Quantum particles       |
-  +-------------------------------+--------------+----------------------+------------------------+-------------------------+
   | ``sources``:math:`^o`         | text array   | ``particleset.name`` |   ``"e"``              | Classical particles     |
   +-------------------------------+--------------+----------------------+------------------------+-------------------------+
 
@@ -1106,9 +1104,6 @@ Additional information:
    measured. Typically there is only one classical particleset (e.g.,
    ``sources="ion0"``), but there can be several in principle (e.g.,
    ``sources="ion0 ion1 ion2"``).
-
--  ``target:`` The default value is the preferred usage (i.e.,
-   ``target`` does not need to be provided).
 
 -  Data is output to the ``stat.h5`` for each QMC subrun. It appears in an hdf group
    determined by the name attribute.

--- a/src/Estimators/EstimatorManagerNew.h
+++ b/src/Estimators/EstimatorManagerNew.h
@@ -90,7 +90,7 @@ public:
                            const ParticleSet& pset_primary,
                            const TrialWaveFunction& twf_primary,
                            const QMCHamiltonian& H,
-                           PSPool& pset_pool);
+                           const PSPool& pset_pool);
 
   /** Start the manager at the beginning of a driver run().
    * Open files. Setting zeros.

--- a/src/Estimators/PairCorrelationEstimator.cpp
+++ b/src/Estimators/PairCorrelationEstimator.cpp
@@ -17,12 +17,12 @@ namespace qmcplusplus
 {
 
 PairCorrelationEstimator::PairCorrelationEstimator(const PairCorrelationInput& pci,
-                                                   PSPool& pset_pool,
+                                                   const PSPool& pset_pool,
+                                                   ParticleSet& elecs,
                                                    DataLocality data_locality)
     : OperatorEstBase(data_locality, pci.get_name(), pci.get_type()), input_(pci)
 {
-  ParticleSet& elecs = getParticleSet(pset_pool, pci.get_target());
-  num_species_       = elecs.groups();
+  num_species_ = elecs.groups();
   n_vec_.resize(num_species_, 0);
   for (int i = 0; i < num_species_; i++)
     n_vec_[i] = elecs.last(i) - elecs.first(i);

--- a/src/Estimators/PairCorrelationEstimator.h
+++ b/src/Estimators/PairCorrelationEstimator.h
@@ -43,7 +43,8 @@ public:
    *
    */
   PairCorrelationEstimator(const PairCorrelationInput& pci,
-                           PSPool& psp,
+                           const PSPool& pset_pool,
+                           ParticleSet& elecs,
                            DataLocality data_locality = DataLocality::crowd);
 
   PairCorrelationEstimator(const PairCorrelationEstimator& pce, DataLocality dl);

--- a/src/Estimators/PairCorrelationInput.cpp
+++ b/src/Estimators/PairCorrelationInput.cpp
@@ -26,7 +26,6 @@ PairCorrelationInput::PairCorrelationInput(xmlNodePtr cur)
   explicit_set_delta_ = setIfInInput(delta_, "dr");
   setIfInInput(debug_, "debug");
   setIfInInput(sources_, "sources");
-  setIfInInput(target_, "target");
 }
 
 } // namespace qmcplusplus

--- a/src/Estimators/PairCorrelationInput.h
+++ b/src/Estimators/PairCorrelationInput.h
@@ -32,8 +32,8 @@ public:
     {
       section_name            = type_tag;
       section_name_alternates = {"gofr"};
-      attributes              = {"type", "name", "num_bin", "rmax", "dr", "debug", "sources", "target"};
-      strings                 = {"type", "name", "target"};
+      attributes              = {"type", "name", "num_bin", "rmax", "dr", "debug", "sources"};
+      strings                 = {"type", "name"};
       multi_strings           = {"sources"};
       reals                   = {"dr", "rmax"};
       integers                = {"num_bin"};
@@ -48,7 +48,6 @@ private:
 
   std::string name_{type_tag};
   std::string type_{type_tag};
-  std::string target_{"e"};
   std::vector<std::string> sources_{"e"};
   Real rmax_{10};
   bool explicit_set_rmax_{false};
@@ -62,7 +61,6 @@ public:
   std::string get_name() const { return name_; }
   std::string get_type() const { return type_; }
   const std::vector<std::string>& get_sources() const { return sources_; }
-  const std::string& get_target() const { return target_; }
   Real get_rmax() const { return rmax_; }
   Real get_delta() const { return delta_; }
   int get_nbins() const { return nbins_; }

--- a/src/Particle/ParticleSetPool.h
+++ b/src/Particle/ParticleSetPool.h
@@ -89,7 +89,7 @@ public:
 
   /** get the Pool object
    */
-  inline PoolType& getPool() { return myPool; }
+  inline const PoolType& getPool() const { return myPool; }
 
   /// get simulation cell
   const auto& getSimulationCell() const { return *simulation_cell_; }

--- a/tests/heg/heg_14_gamma/batch/deter-heg-SJ-batch.xml
+++ b/tests/heg/heg_14_gamma/batch/deter-heg-SJ-batch.xml
@@ -52,7 +52,7 @@
    </qmcsystem>
    <qmc method="vmc" move="pbyp">
      <estimators>
-       <estimator name="gofr" type="PairCorrelation" sources="e" target="e"/>
+       <estimator name="gofr" type="PairCorrelation" sources="e"/>
      </estimators>
       <parameter name="warmupsteps"         >    2             </parameter>
       <parameter name="blocks"              >    3             </parameter>


### PR DESCRIPTION
## Proposed changes
The target particleset of an estimator should be inherited from estimator manager originally from driver section.
Thus the estimator level target selection is unnecessary and causes confusion.
For this reason, it is removed in this PR.

## What type(s) of changes does this code introduce?
- Bugfix
- Refactoring (no functional changes, no api changes)
- Documentation or build script changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
