### PR TITLE
Add 2dxy option on qmc-get-supercell tool

### DIFF
--- a/src/QMCTools/getSupercell.cpp
+++ b/src/QMCTools/getSupercell.cpp
@@ -245,7 +245,7 @@ void getBestTile(double* primcell, int target, int* tilemat, double& radius, int
 }
 
 
-void getBestTile2D(double* primcell, int target, int* tilemat, double& radius, int range = 7)
+void getBestTileXY2D(double* primcell, int target, int* tilemat, double& radius, int range = 7)
 {
   double largest          = 0.0;
   double bestScore        = 0.0;
@@ -354,7 +354,7 @@ int main(int argc, char* argv[])
 
   if (xy_2d == 1)
   {
-    getBestTile2D(prim, target, besttile, radius, maxentry);
+    getBestTileXY2D(prim, target, besttile, radius, maxentry);
   }
   else
   {

--- a/src/QMCTools/getSupercell.cpp
+++ b/src/QMCTools/getSupercell.cpp
@@ -245,6 +245,67 @@ void getBestTile(double* primcell, int target, int* tilemat, double& radius, int
 }
 
 
+void getBestTile2D(double* primcell, int target, int* tilemat, double& radius, int range = 7)
+{
+  double largest          = 0.0;
+  double bestScore        = 0.0;
+  static const double tol = 0.0000001;
+  double detPrim          = getDet(primcell);
+
+  if (detPrim < 0)
+  {
+    target *= -1;
+  }
+#pragma omp parallel
+  {
+    double my_largest = 0.0;
+    int my_besttile[9];
+    double localBestScore = 0.0;
+#pragma omp for
+    for (int i = -range; i <= range; i++)
+    { 
+     int d[9];
+     double super[9];
+     for (int j = -range; j <= range; j++) 
+     for (int k = -range; k <= range; k++) 
+     for (int l = -range; l <= range; l++)  
+     {
+      int det_tile = i*l - j*k;
+      if (det_tile != target) continue;
+
+      d[0] = i; d[1] = j; d[2] = 0;
+      d[3] = k; d[4] = l; d[5] = 0;
+      d[6] = 0; d[7] = 0; d[8] = 1;
+
+      getSupercell(primcell, d, super);
+      double score = getScore(super);
+      double rad = SimCellRad(super);
+
+      if (rad > my_largest + tol || (rad > my_largest - tol && score > localBestScore))
+      {
+        my_largest     = rad;
+        localBestScore = score;
+        std::memcpy(my_besttile, d, 9 * sizeof(int));
+      } 
+     } 
+    }
+    if (my_largest > largest + tol || (my_largest > largest - tol && localBestScore > bestScore))
+    {    
+#pragma omp critical
+      {
+        if (my_largest > largest + tol || (my_largest > largest - tol && localBestScore > bestScore))
+        {
+          largest   = my_largest;
+          bestScore = localBestScore;
+          std::memcpy(tilemat, my_besttile, 9 * sizeof(int));
+        }
+      }
+     }
+  }
+  radius = largest;
+}
+
+
 int main(int argc, char* argv[])
 {
   double prim[9];
@@ -252,6 +313,8 @@ int main(int argc, char* argv[])
   char* pend;
   int verbose  = 0;
   int maxentry = 4;
+  int xy_2d = 0;
+
   for (int i = 1; i < argc; i++)
   {
     if (i <= argc)
@@ -278,13 +341,25 @@ int main(int argc, char* argv[])
         maxentry = strtol(argv[i + 1], &pend, 10);
         i++;
       }
-    }
+      if (!std::strcmp(argv[i], "--2dxy"))
+      {
+        xy_2d = 1;
+      }
+    } 
   }
 
   int besttile[9];
   double super[9];
   double radius;
-  getBestTile(prim, target, besttile, radius, maxentry);
+
+  if (xy_2d == 1)
+  {
+    getBestTile2D(prim, target, besttile, radius, maxentry);
+  }
+  else
+  {
+    getBestTile(prim, target, besttile, radius, maxentry);
+  }
   getSupercell(prim, besttile, super);
   if (verbose)
   {

--- a/src/QMCTools/tests/CMakeLists.txt
+++ b/src/QMCTools/tests/CMakeLists.txt
@@ -101,6 +101,27 @@ set_tests_properties(
              PROCESSOR_AFFINITY
              TRUE)
 
+if(HAVE_MPI)
+  add_test(NAME get-supercell_2dxy_terse COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS}
+                                                 $<TARGET_FILE:qmc-get-supercell> --ptvs 1 0 0 0 1 0 0 0 1 --target 8 --2dxy)
+else()
+  add_test(NAME get-supercell_2dxy_terse COMMAND $<TARGET_FILE:qmc-get-supercell> --ptvs 1 0 0 0 1 0 0 0 1 --target 8 --2dxy)
+endif()
+set_tests_properties(
+  get-supercell_2dxy_terse
+  PROPERTIES TIMEOUT
+             120
+             LABELS
+             "deterministic"
+             PASS_REGULAR_EXPRESSION
+             "0.5   2   0   0   0   4   0   0   0   1   2   0   0   0   4   0   0   0   1"
+             PROCESSORS
+             1
+             ENVIRONMENT
+             OMP_NUM_THREADS=3
+             PROCESSOR_AFFINITY
+             TRUE)
+     
 # Check qmc-extract-eshdf-kvectors
 set(KTEST_HDF_INPUT1 ${qmcpack_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp/pwscf.pwscf.h5)
 set(KTEST_HDF_INPUT2 ${qmcpack_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp/pwscf.pwscf.h5)


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

qmc-get-supercell tool is to get the best tiling matrix possessing the largest Wigner-Seitz radius within the given cell size, but it is not easy to guess the tiling matrix of 2D system for the large cell. This PR is to add option --2dxy where only xy component is allowed to expand.

## What type(s) of changes does this code introduce?

- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Polaris, Aurora

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [ ] I have read the pull request guidance and develop docs
* * [ ] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
