### PR TITLE
[Nexus] Remove Deprecated NumPy Aliases `numpy.string_` and `numpy.float_`

### DIFF
--- a/nexus/lib/rmg_input.py
+++ b/nexus/lib/rmg_input.py
@@ -2414,10 +2414,10 @@ def write_double_array(v):
 
 
 rmg_value_types = obj({
-    'string'        : (str  , np.string_),
+    'string'        : (str  , np.bytes_),
     'boolean'       : (bool , np.bool_  ),
     'integer'       : (int  , np.int_   ),
-    'double'        : (float, np.float_ ),
+    'double'        : (float, np.float64 ),
     'integer array' : (tuple,list,np.ndarray),
     'double array'  : (tuple,list,np.ndarray),
     })
@@ -3142,7 +3142,7 @@ class RmgInput(SimulationInput):
         unrecognized = []
         for k,v in values.items():
             if k in input_spec.keywords:
-                if isinstance(v,(str,np.string_)):
+                if isinstance(v,(str,np.bytes_)):
                     self[k] = input_spec.keywords[k].read(v)
                 else:
                     self[k] = input_spec.keywords[k].assign(v)

--- a/nexus/lib/testing.py
+++ b/nexus/lib/testing.py
@@ -1,16 +1,7 @@
-# Workaround numpy2 changes
-def portable_numpy(np):
-    if np.lib.NumpyVersion(np.__version__) >= '2.0.0b1':
-        np.set_printoptions(legacy="1.25")
-        np.string_ = np.bytes_
-        np.float_  = np.float64
-    #end if
-#end def portable_numpy
-
-
 try:
     import numpy as np
-    portable_numpy(np)
+    if np.lib.NumpyVersion(np.__version__) >= '2.0.0b1':
+        np.set_printoptions(legacy="1.25")
     numpy_available = True
 except:
     numpy_available = False
@@ -34,10 +25,10 @@ def value_diff(v1,v2,atol=def_atol,rtol=def_rtol,int_as_float=False):
     v2_bool  = isinstance(v2,(bool,np.bool_))
     v1_int   = isinstance(v1,(int,np.int_)) and not v1_bool
     v2_int   = isinstance(v2,(int,np.int_)) and not v2_bool
-    v1_float = isinstance(v1,(float,np.float_))
-    v2_float = isinstance(v2,(float,np.float_))
-    v1_str   = isinstance(v1,(str,np.string_))
-    v2_str   = isinstance(v2,(str,np.string_))
+    v1_float = isinstance(v1,(float,np.float64))
+    v2_float = isinstance(v2,(float,np.float64))
+    v1_str   = isinstance(v1,(str,np.bytes_))
+    v2_str   = isinstance(v2,(str,np.bytes_))
     if id(v1)==id(v2):
         None
     elif int_as_float and (v1_int or v1_float) and (v2_int or v2_float):

--- a/nexus/tests/unit/test_qmcpack_input.py
+++ b/nexus/tests/unit/test_qmcpack_input.py
@@ -30,8 +30,8 @@ def format_value(v):
             s = s[:-2]
         #end if
         s += '])'
-    elif isinstance(v,(str,np.string_)):
-        s = "'"+v+"'"
+    elif isinstance(v,(str,np.bytes_)):
+        s = "'"+str(v)+"'"
     else:
         s = str(v)
     #end if

--- a/nexus/tests/unit/test_quantum_package_input.py
+++ b/nexus/tests/unit/test_quantum_package_input.py
@@ -22,8 +22,8 @@ def format_value(v):
             s = s[:-2]
         #end if
         s += '])'
-    elif isinstance(v,(str,np.string_)):
-        s = "'"+v+"'"
+    elif isinstance(v,(str,np.bytes_)):
+        s = "'"+str(v)+"'"
     else:
         s = str(v)
     #end if

--- a/nexus/tests/unit/test_vasp_input.py
+++ b/nexus/tests/unit/test_vasp_input.py
@@ -31,8 +31,8 @@ def format_value(v):
             s = s[:-2]
         #end if
         s += '])'
-    elif isinstance(v,(str,np.string_)):
-        s = "'"+v+"'"
+    elif isinstance(v,(str,np.bytes_)):
+        s = "'"+str(v)+"'"
     else:
         s = str(v)
     #end if


### PR DESCRIPTION
## Proposed changes

The NumPy aliases `numpy.string_` and `numpy.float_` were removed in NumPy 2.0.0. The correct aliases `numpy.bytes_` and `numpy.float64` have been available since at least NumPy 1.13, and therefore can replace the deprecated aliases. 

Further, the function for NumPy compatibility in `testing.py` was removed and the command for altering print settings was placed in the try-except statement to retain desired print formatting but remove the unnecessary function. 

All instances where `numpy.bytes_` were added to strings were altered so the `numpy.bytes_` object was first converted to string to ensure compatibility.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Checked compatibility with default python environment on Perlmutter, Python 3.6.15, NumPy 1.17.3, as well as the most recent python environment on Perlmutter, Python 3.13.2, NumPy 2.1.3. Found `numpy.bytes_` and `numpy.string_` are equivalent and produce no errors. Also found that `numpy.float_` and `numpy.float64` are equivalent and produce no errors.

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
