### PR TITLE
Update Lab5 Excited States Tutorial for Python 3 Compatibility

### DIFF
--- a/labs/lab5_excited_states/band.py
+++ b/labs/lab5_excited_states/band.py
@@ -72,10 +72,10 @@ run_project()
 
 p = band.load_analyzer_image()
 p.plot_bandstructure()
-print "VBM:\n{0}".format(p.bands.vbm) 
-print "CBM:\n{0}".format(p.bands.cbm)
+print("VBM:\n{0}".format(p.bands.vbm)) 
+print("CBM:\n{0}".format(p.bands.cbm))
 
-#print 'CBM, Delta'
-#print p.bands.up[51]
-#print 'Delta prime'
-#print p.bands.up[46]
+#print("CBM, Delta")
+#print(p.bands.up[51])
+#print("Delta prime")
+#print(p.bands.up[46])


### PR DESCRIPTION
## Proposed changes
This PR updates the Lab5 excited states tutorial (labs/lab5_excited_states/optical.py and band.py) to be compatible with Python 3 and adds helpful documentation comments to clarify the usage of different determinant formats.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* [ ] I have read the pull request guidance and develop docs
* [x] This PR is up to date with the current state of 'develop'
* [ ] Code added or changed in the PR has been clang-formatted
* [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* [ ] Documentation has been added (if appropriate)
