### PR TITLE
[Nexus] Change Structure.center_molecule() to behave more robustly

### DIFF
--- a/nexus/lib/structure.py
+++ b/nexus/lib/structure.py
@@ -1206,7 +1206,31 @@ class Structure(Sobj):
 
 
     def center_molecule(self):
-        self.slide(self.center-self.pos.mean(0),recenter=False)
+        """Center a molecule in a unit cell, ensuring equal padding on all sides
+        
+        Note
+        ----
+        Only works in orthorhombic, tetragonal, and cubic unit cells!
+        """
+
+        # Find smallest X, Y, and Z coordinate
+        min_xyz = np.min(self.pos, 0)
+
+        # Shift molecule to be in the corner of the +x, +y, +z octant (think first quadrant but in 3D)
+        for i in range(3):
+            self.pos[:, i] = self.pos[:, i] - min_xyz[i]
+
+        # Find the minimum distance between the molecule's new xyz coordinates 
+        # and the maximum xyz extent of the unit cell
+        max_xyz = [np.min(self.axes[i, i] - self.pos[:, i], 0) for i in range(3)]
+
+        # Divide each by two to ensure equal spacing on each side of new positions
+        translate_xyz = [i/2 for i in max_xyz]
+
+        # Shift the molecule by the translated amounts, placing it equally
+        # far away from the edges of the unit cell
+        for i in range(3):
+            self.pos[:, i] += translate_xyz[i]
     #end def center_molecule
 
 


### PR DESCRIPTION
## Proposed changes

A function in `structure.py`, `Structure.center_molecule()`, previously shifted the average atomic coordinates to the 1/2 point in the unit cell, however this could introduce unexpected behavior when working with molecular systems with a large spatial extent. If a molecule had a large number of atoms in a small cluster and also had a long tail (e.g. an indole with a long alkane tail), the center of atomic coordinates would be localized largely in the cluster, while the tail would be significantly further away from that center. Should the molecule be shifted then so that that center is in the center of the unit cell, it is possible that some of the atoms in the tail of the molecule would be in an adjacent unit cell, which in the case of isolated molecular species would alter the properties of the molecule, such as the molecular dipole moment (see [Figure 1 in this paper](https://doi.org/10.1103/PhysRevB.51.4014)).

To fix this, the proposed algorithm now shifts the molecule to the (+x, +y, +z) corner of the unit cell closest to the origin, calculates the smallest gap between the edge of the spatial extent of the molecule and the unit cell edges, and shifts the molecule so that it is equally far away from each side of the unit cell in every direction. 

An example of a modified form of an adamantane core with an alkene tail is shown below, old centering first, then new centering:

<img width="1624" height="992" alt="old_centering" src="https://github.com/user-attachments/assets/8a9ae110-dd30-44f7-9a44-cdfc30877e4e" />

<img width="1624" height="992" alt="new_centering" src="https://github.com/user-attachments/assets/6d965998-3307-400a-96cd-cf2dd459318c" />

As is clear here, the previous centering method allows for the molecule to exceed the edges of the unit cell, but the new method contains the entire molecule. It should be noted that these were generated using identical inputs, with identically sized unit cells, the only change was the algorithm used.

This is an exaggerated situation, often the differences would be more subtle, however this will catch situations that may occur for the common user, such as modeling a polymer with an elongated functional group that contains a significant number of atoms.

One possible issue with this method is that it is only applicable for orthorhombic, tetragonal, and cubic unit cells. While this does seem to be a significant issue, the vast majority of molecular calculations in periodic code are done in these types of unit cells. If need be, a fix for the remaining types of cell is possible, however this should suffice for essentially every user case.

## What type(s) of changes does this code introduce?

- Bugfix
- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Tested to work on Perlmutter, Python 3.13.2, NumPy 2.1.3.

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
