### PR TITLE
[Nexus] Remove deprecated Matplotlib keyword `warn` from `plotting.py`

### DIFF
--- a/nexus/lib/plotting.py
+++ b/nexus/lib/plotting.py
@@ -18,7 +18,7 @@ try:
     gui_envs = ['GTKAgg','TKAgg','Qt4Agg','WXAgg']
     for gui in gui_envs:
         try:
-            matplotlib.use(gui,warn=False, force=True)
+            matplotlib.use(gui, force=True)
             from matplotlib import pyplot
             success = True
             break

--- a/nexus/lib/pwscf_analyzer.py
+++ b/nexus/lib/pwscf_analyzer.py
@@ -859,7 +859,7 @@ class PwscfAnalyzer(SimulationAnalyzer):
                 gui_envs = ['GTKAgg','TKAgg','agg','Qt4Agg','WXAgg']
                 for gui in gui_envs:
                     try:
-                        matplotlib.use(gui,warn=False, force=True)
+                        matplotlib.use(gui, force=True)
                         from matplotlib import pyplot
                         success = True
                         break


### PR DESCRIPTION
## Proposed changes

The module `plotting.py` contained a series of `try... except` statements to test for matplotlib, however in the innermost nested `try... except` the command `matplotlib.use()` was invoked with a keyword `warn=False` that has been deprecated since at least the release of matplotlib 3.3, and has been defaulted to `False` since matplotlib 3.0. Given that matplotlib <3.0 is for Python 2 mostly, and since Nexus does not support Python 2 anymore, this should be removed.

Previously, this was throwing an exception that was not caught because of the `try... except` statement it was contained in that caught all exceptions, in this case a `TypeError`, even though it should only be catching the correct exception of `ValueError`.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Perlmutter with Python 3.9.18 using Matplotlib 3.8.2, and Python 3.13.2 and Matplotlib 3.10.1

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
