### PR TITLE
[Nexus] Update handling of numeric arrays in `qmcpack_input.py`

### DIFF
--- a/nexus/lib/qmcpack_input.py
+++ b/nexus/lib/qmcpack_input.py
@@ -1575,13 +1575,17 @@ class Param(Names):
         #end if
         if 'text' in xml:
             try:
-                #try: # Try to make int array
-                #    val = loadtxt(StringIO(xml.text),int,converters=int)
-                #except ValueError:
-                #    val = loadtxt(StringIO(xml.text),float)
-                #    #end try
-                ##end try
-                val = loadtxt(StringIO(xml.text),float)
+                try: # Try to make int array
+                    # NumPy >= 1.23.0 uses int(float(value)) here, must specify int converter
+                    if np.lib.NumpyVersion(np.__version__) >= '1.23.0':
+                        val = loadtxt(StringIO(xml.text),int,converters=int)
+                    else:
+                        # int converter however will break NumPy <1.23.0
+                        val = loadtxt(StringIO(xml.text),int)
+                except:
+                    val = loadtxt(StringIO(xml.text),float)
+                    #end try
+                #end try
             except:
                 try: # Try to make int array
                     val = array(xml.text.split(),dtype=int)


### PR DESCRIPTION
## Proposed changes

Updated `qmcpack_input.py` to more robustly handle numeric array parsing

Closes #5626 pending testing.

The previous method for handling the parsing of a string to an array involved checking the type of the first string in the array, however as pointed out in Issue #5626 there was a possibility that the type of the potential array of strings was not homogeneous, and therefore even if the first value would be properly parsed as say, an `int`, an error would be raised when trying to parse the entire string as an array as type `int`.

The new method replaces that code with a series of `try... except:` statements that both circumvent the need for explicitly defined `is_int()`, `is_float()`, and `is_array()` functions, the latter of which introduced an ambiguity in namespace in the function `Param.write()`. The original and updated functions are shown below:

### Original
```python
if 'text' in xml:
    token = xml.text.split('\n',1)[0].split(None,1)[0]
    try:
        if is_int(token):
            val = loadtxt(StringIO(xml.text),int)
        elif is_float(token):
            val = loadtxt(StringIO(xml.text),float)
        else:
            val = array(xml.text.split())
        #end if
    except:
        if is_int(token):
            val = array(xml.text.split(),dtype=int)
        elif is_float(token):
            val = array(xml.text.split(),dtype=float)
        else:
            val = array(xml.text.split())
        #end if
    #end try
    if val.size==1:
        val = val.ravel()[0]
    #end if
#end if
```

### Updated
```python
if 'text' in xml:
    try:
        try: # Try to make int array
            val = loadtxt(StringIO(xml.text),int)
        except ValueError:
            try: # Try to make float array
                val = loadtxt(StringIO(xml.text),float)
            except ValueError:
                pass
            #end try
        #end try
    except:
        try: # Try to make int array
            val = array(xml.text.split(),dtype=int)
        except ValueError:
            try: # Try to make float array
                val = array(xml.text.split(),dtype=float)
            except ValueError:
                val = array(xml.text.split())
            #end try
        #end try
    #end try
    if val.size==1:
        val = val.ravel()[0]
    #end if
#end if
```


In addition to this, the function `attribute_to_value()` was redefined to facilitate the removal of the `is_int()`, `is_float()`, and `is_array()` functions, and to remove the possibility of an error arising in the same way as described earlier. The original and updated functions are shown below:

### Original
```python
def attribute_to_value(attr):
    if is_int(attr):
        val = int(attr)
    elif is_float(attr):
        val = float(attr)
    elif is_array(attr,int):
        val = array(attr.split(),int)
        if val.size==9:
            val.shape = 3,3
        #end if
    elif is_array(attr,float):
        val = array(attr.split(),float)
    else:
        val = attr
    #end if
    return val
#end def attribute_to_value
```

### Updated
```python
def attribute_to_value(attr):
    try:
        return int(attr)
    except ValueError:
        try:
            return float(attr)
        except ValueError:
            pass
        #end try
    #end try

    try:
        val = np.array(attr.split(),int)
        if val.size==9:
            val.shape = 3,3
        #end if
        return val
    except ValueError:
        try:
            return np.array(attr.split(),float)
        except ValueError:
            return attr
        #end try
    #end try

#end def attribute_to_value
```

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Checked with Python 3.13.1 & NumPy 2.2.2

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
