### PR TITLE
Remove hamiltonian from test_twf_fastderiv_raii

### DIFF
--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -186,7 +186,6 @@ foreach(CATEGORY common trialwf sposet jastrow determinant)
     ${UTEST_EXE}
     catch_main
     qmcwfs
-    qmcham
     platform_LA
     platform_runtime
     sposets_for_testing


### PR DESCRIPTION
## Proposed changes
Unit tests of wavefunction are not allowed to have dependency beyond wavefunction.
Thus the dependency on qmcham needs to be removed. This PR reverts part of the change from #5599
For Hamiltonian related tests, the APIs consumed by Hamiltonian should be tested directly without relying on Hamiltonian objects.

## What type(s) of changes does this code introduce?
- Other (please describe): revert changes.

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'