### PR TITLE
Postpone resizing distance tables from construction to evaluation

### DIFF
--- a/src/Particle/DistanceTable.h
+++ b/src/Particle/DistanceTable.h
@@ -65,12 +65,8 @@ protected:
 
 public:
   ///constructor using source and target ParticleSet
-  DistanceTable(const ParticleSet& source, const size_t target_size, const std::string& target_name, DTModes modes)
-      : origin_(source),
-        num_sources_(source.getTotalNum()),
-        num_targets_(0),
-        name_(source.getName() + "_" + target_name),
-        modes_(modes)
+  DistanceTable(const ParticleSet& source, const std::string& target_name, DTModes modes)
+      : origin_(source), num_sources_(source.getTotalNum()), name_(source.getName() + "_" + target_name), modes_(modes)
   {}
 
   /// copy constructor. deleted
@@ -270,9 +266,7 @@ protected:
 
 public:
   ///constructor using source and target ParticleSet
-  DistanceTableAA(const ParticleSet& target, DTModes modes)
-      : DistanceTable(target, target.getTotalNum(), target.getName(), modes)
-  {}
+  DistanceTableAA(const ParticleSet& target, DTModes modes) : DistanceTable(target, target.getName(), modes) {}
 
   /** return full table distances
    */
@@ -345,8 +339,8 @@ protected:
 
 public:
   ///constructor using source and target ParticleSet
-  DistanceTableAB(const ParticleSet& source, const size_t target_size, const std::string& target_name, DTModes modes)
-      : DistanceTable(source, target_size, target_name, modes)
+  DistanceTableAB(const ParticleSet& source, const std::string& target_name, DTModes modes)
+      : DistanceTable(source, target_name, modes)
   {}
 
   /** return full table distances

--- a/src/Particle/DistanceTable.h
+++ b/src/Particle/DistanceTable.h
@@ -315,6 +315,47 @@ public:
   {
     return nullptr;
   }
+
+  int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const final
+  {
+    //ensure there are neighbors
+    assert(num_targets_ > 1);
+    RealType min_dist = std::numeric_limits<RealType>::max();
+    int index         = -1;
+    if (newpos)
+    {
+      for (int jat = 0; jat < num_targets_; ++jat)
+        if (temp_r_[jat] < min_dist && jat != iat)
+        {
+          min_dist = temp_r_[jat];
+          index    = jat;
+        }
+      assert(index >= 0);
+      dr = temp_dr_[index];
+    }
+    else
+    {
+      for (int jat = 0; jat < iat; ++jat)
+        if (distances_[iat][jat] < min_dist)
+        {
+          min_dist = distances_[iat][jat];
+          index    = jat;
+        }
+      for (int jat = iat + 1; jat < num_targets_; ++jat)
+        if (distances_[jat][iat] < min_dist)
+        {
+          min_dist = distances_[jat][iat];
+          index    = jat;
+        }
+      assert(index != iat && index >= 0);
+      if (index < iat)
+        dr = displacements_[iat][index];
+      else
+        dr = displacements_[index][iat];
+    }
+    r = min_dist;
+    return index;
+  }
 };
 
 /** AB type of DistanceTable containing storage. 'source' and 'target' are different sets of particles. */

--- a/src/Particle/DistanceTable.h
+++ b/src/Particle/DistanceTable.h
@@ -46,12 +46,16 @@ public:
   using DistRow   = Vector<RealType, aligned_allocator<RealType>>;
   using DisplRow  = VectorSoaContainer<RealType, DIM>;
 
+private:
+  /// resize based on number of target particles
+  virtual void resize(const size_t num_targets) = 0;
+
 protected:
   /// source particleset
   const ParticleSet& origin_;
 
   const size_t num_sources_;
-  const size_t num_targets_;
+  size_t num_targets_ = 0;
 
   ///name of the table
   const std::string name_;
@@ -64,7 +68,7 @@ public:
   DistanceTable(const ParticleSet& source, const size_t target_size, const std::string& target_name, DTModes modes)
       : origin_(source),
         num_sources_(source.getTotalNum()),
-        num_targets_(target_size),
+        num_targets_(0),
         name_(source.getName() + "_" + target_name),
         modes_(modes)
   {}

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -314,7 +314,7 @@ int ParticleSet::addTable(const ParticleSet& psrc, DTModes modes)
     if (myName == psrc.getName())
       DistTables.push_back(createDistanceTable(*this, description));
     else
-      DistTables.push_back(createDistanceTableAB(psrc, TotalNum, myName, description));
+      DistTables.push_back(createDistanceTableAB(psrc, myName, description));
     distTableDescriptions.push_back(description.str());
     myDistTableMap[psrc.getName()] = tid;
     app_debug() << "  ... ParticleSet::addTable Create Table #" << tid << " " << DistTables[tid]->getName()

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -58,8 +58,6 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableAA
   inline void move(const ParticleSet& P, const PosType& rnew, const IndexType iat, bool prepare_old) override
   {
     ScopedTimer local_timer(move_timer_);
-    if (num_targets_ != P.getTotalNum())
-      resize(P.getTotalNum());
 
 #if !defined(NDEBUG)
     old_prepared_elec_id_ = prepare_old ? iat : -1;

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -74,47 +74,6 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableAA
     }
   }
 
-  int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const override
-  {
-    //ensure there are neighbors
-    assert(num_targets_ > 1);
-    RealType min_dist = std::numeric_limits<RealType>::max();
-    int index         = -1;
-    if (newpos)
-    {
-      for (int jat = 0; jat < num_targets_; ++jat)
-        if (temp_r_[jat] < min_dist && jat != iat)
-        {
-          min_dist = temp_r_[jat];
-          index    = jat;
-        }
-      assert(index >= 0);
-      dr = temp_dr_[index];
-    }
-    else
-    {
-      for (int jat = 0; jat < iat; ++jat)
-        if (distances_[iat][jat] < min_dist)
-        {
-          min_dist = distances_[iat][jat];
-          index    = jat;
-        }
-      for (int jat = iat + 1; jat < num_targets_; ++jat)
-        if (distances_[jat][iat] < min_dist)
-        {
-          min_dist = distances_[jat][iat];
-          index    = jat;
-        }
-      assert(index != iat && index >= 0);
-      if (index < iat)
-        dr = displacements_[iat][index];
-      else
-        dr = displacements_[index][iat];
-    }
-    r = min_dist;
-    return index;
-  }
-
   /** After accepting the iat-th particle, update the iat-th row of distances_ and displacements_.
    * Upper triangle is not needed in the later computation and thus not updated
    */

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -57,6 +57,7 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableAA
   ///evaluate the temporary pair relations
   inline void move(const ParticleSet& P, const PosType& rnew, const IndexType iat, bool prepare_old) override
   {
+    assert(num_targets_ > 0);
     ScopedTimer local_timer(move_timer_);
 
 #if !defined(NDEBUG)

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -233,8 +233,6 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   inline void move(const ParticleSet& P, const PosType& rnew, const IndexType iat, bool prepare_old) override
   {
     ScopedTimer local_timer(move_timer_);
-    if (num_targets_ != P.getTotalNum())
-      resize(P.getTotalNum());
 
 #if !defined(NDEBUG)
     old_prepared_elec_id_ = prepare_old ? iat : -1;
@@ -281,8 +279,6 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     for (int iw = 0; iw < nw; iw++)
     {
       auto& dt = dt_list.getCastedElement<SoaDistanceTableAAOMPTarget>(iw);
-      if (dt.num_targets_ != p_list[iw].getTotalNum())
-        dt.resize(p_list[iw].getTotalNum());
 #if !defined(NDEBUG)
       dt.old_prepared_elec_id_ = prepare_old ? iat : -1;
 #endif

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -347,47 +347,6 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     }
   }
 
-  int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const override
-  {
-    //ensure there are neighbors
-    assert(num_targets_ > 1);
-    RealType min_dist = std::numeric_limits<RealType>::max();
-    int index         = -1;
-    if (newpos)
-    {
-      for (int jat = 0; jat < num_targets_; ++jat)
-        if (temp_r_[jat] < min_dist && jat != iat)
-        {
-          min_dist = temp_r_[jat];
-          index    = jat;
-        }
-      assert(index >= 0);
-      dr = temp_dr_[index];
-    }
-    else
-    {
-      for (int jat = 0; jat < iat; ++jat)
-        if (distances_[iat][jat] < min_dist)
-        {
-          min_dist = distances_[iat][jat];
-          index    = jat;
-        }
-      for (int jat = iat + 1; jat < num_targets_; ++jat)
-        if (distances_[jat][iat] < min_dist)
-        {
-          min_dist = distances_[jat][iat];
-          index    = jat;
-        }
-      assert(index != iat && index >= 0);
-      if (index < iat)
-        dr = displacements_[iat][index];
-      else
-        dr = displacements_[index][iat];
-    }
-    r = min_dist;
-    return index;
-  }
-
   /** After accepting the iat-th particle, update the iat-th row of distances_ and displacements_.
    * Upper triangle is not needed in the later computation and thus not updated
    */

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -232,6 +232,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   ///evaluate the temporary pair relations
   inline void move(const ParticleSet& P, const PosType& rnew, const IndexType iat, bool prepare_old) override
   {
+    assert(num_targets_ > 0);
     ScopedTimer local_timer(move_timer_);
 
 #if !defined(NDEBUG)
@@ -282,6 +283,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
 #if !defined(NDEBUG)
       dt.old_prepared_elec_id_ = prepare_old ? iat : -1;
 #endif
+      assert(dt.num_targets_ > 0);
     }
 
     const int ChunkSizePerTeam = 512;

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -25,9 +25,9 @@ namespace qmcplusplus
 template<typename T, unsigned D, int SC>
 struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableAB
 {
-  SoaDistanceTableAB(const ParticleSet& source, const size_t target_size, const std::string& target_name)
+  SoaDistanceTableAB(const ParticleSet& source, const std::string& target_name)
       : DTD_BConds<T, D, SC>(source.getLattice()),
-        DistanceTableAB(source, target_size, target_name, DTModes::ALL_OFF),
+        DistanceTableAB(source, target_name, DTModes::ALL_OFF),
         evaluate_timer_(createGlobalTimer("DTAB::evaluate_" + name_, timer_level_fine)),
         move_timer_(createGlobalTimer("DTAB::move_" + name_, timer_level_fine)),
         update_timer_(createGlobalTimer("DTAB::update_" + name_, timer_level_fine))

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -59,8 +59,6 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableAB
   inline void move(const ParticleSet& P, const PosType& rnew, const IndexType iat, bool prepare_old) override
   {
     ScopedTimer local_timer(move_timer_);
-    if (num_targets_ != P.getTotalNum())
-      resize(P.getTotalNum());
 
     DTD_BConds<T, D, SC>::computeDistances(rnew, origin_.getCoordinates().getAllParticlePos(), temp_r_.data(), temp_dr_,
                                            0, num_sources_);

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -96,9 +96,9 @@ private:
   }
 
 public:
-  SoaDistanceTableABOMPTarget(const ParticleSet& source, const size_t target_size, const std::string& target_name)
+  SoaDistanceTableABOMPTarget(const ParticleSet& source, const std::string& target_name)
       : DTD_BConds<T, D, SC>(source.getLattice()),
-        DistanceTableAB(source, target_size, target_name, DTModes::ALL_OFF),
+        DistanceTableAB(source, target_name, DTModes::ALL_OFF),
         offload_timer_(createGlobalTimer("DTABOMPTarget::offload_" + name_, timer_level_fine)),
         evaluate_timer_(createGlobalTimer("DTABOMPTarget::evaluate_" + name_, timer_level_fine))
 

--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -59,8 +59,8 @@ VirtualParticleSet::VirtualParticleSet(const ParticleSet& p, int nptcl, size_t d
   for (int i = 0; i < dt_count_limit; ++i)
   {
     size_t tid = DistTables.size();
-    auto& dt = p.getDistTable(i);
-    DistTables.push_back(createDistanceTable(dt.get_origin(), TotalNum, myName, null_out));
+    auto& dt   = p.getDistTable(i);
+    DistTables.push_back(createDistanceTable(dt.get_origin(), myName, null_out));
     if (!(dt.getModes() & DTModes::NEED_VP_FULL_TABLE_ON_HOST))
       DistTables[tid]->setModes(DTModes::MW_EVALUATE_RESULT_NO_TRANSFER_TO_HOST);
     app_debug() << "  ... VirtualParticleSet::VirtualParticleSet Create Table #" << tid << " "

--- a/src/Particle/createDistanceTable.h
+++ b/src/Particle/createDistanceTable.h
@@ -53,16 +53,13 @@ inline std::unique_ptr<DistanceTableAA> createDistanceTable(const ParticleSet& s
 
 ///free function create a distable table of s-t
 std::unique_ptr<DistanceTableAB> createDistanceTableAB(const ParticleSet& s,
-                                                       const size_t t_size,
                                                        const std::string& t_name,
                                                        std::ostream& description);
 std::unique_ptr<DistanceTableAB> createDistanceTableABOMPTarget(const ParticleSet& s,
-                                                                const size_t t_size,
                                                                 const std::string& t_name,
                                                                 std::ostream& description);
 
 inline std::unique_ptr<DistanceTableAB> createDistanceTable(const ParticleSet& s,
-                                                            const size_t t_size,
                                                             const std::string& t_name,
                                                             std::ostream& description)
 {
@@ -70,9 +67,9 @@ inline std::unique_ptr<DistanceTableAB> createDistanceTable(const ParticleSet& s
   // is determined by the number of source particles.
   // Thus the implementation selection is determined by the source particle set.
   if (s.getCoordinates().getKind() == DynamicCoordinateKind::DC_POS_OFFLOAD)
-    return createDistanceTableABOMPTarget(s, t_size, t_name, description);
+    return createDistanceTableABOMPTarget(s, t_name, description);
   else
-    return createDistanceTableAB(s, t_size, t_name, description);
+    return createDistanceTableAB(s, t_name, description);
 }
 
 } // namespace qmcplusplus

--- a/src/Particle/createDistanceTableAB.cpp
+++ b/src/Particle/createDistanceTableAB.cpp
@@ -25,7 +25,6 @@ namespace qmcplusplus
  *\return index of the distance table with the name
  */
 std::unique_ptr<DistanceTableAB> createDistanceTableAB(const ParticleSet& s,
-                                                       const size_t t_size,
                                                        const std::string& t_name,
                                                        std::ostream& description)
 {
@@ -46,19 +45,19 @@ std::unique_ptr<DistanceTableAB> createDistanceTableAB(const ParticleSet& s,
     if (s.getLattice().DiagonalOnly)
     {
       o << "    Distance computations use orthorhombic periodic cell in 3D." << std::endl;
-      dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, PPPO + SOA_OFFSET>>(s, t_size, t_name);
+      dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, PPPO + SOA_OFFSET>>(s, t_name);
     }
     else
     {
       if (s.getLattice().WignerSeitzRadius > s.getLattice().SimulationCellRadius)
       {
         o << "    Distance computations use general periodic cell in 3D with corner image checks." << std::endl;
-        dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, PPPG + SOA_OFFSET>>(s, t_size, t_name);
+        dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, PPPG + SOA_OFFSET>>(s, t_name);
       }
       else
       {
         o << "    Distance computations use general periodic cell in 3D without corner image checks." << std::endl;
-        dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, PPPS + SOA_OFFSET>>(s, t_size, t_name);
+        dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, PPPS + SOA_OFFSET>>(s, t_name);
       }
     }
   }
@@ -67,31 +66,31 @@ std::unique_ptr<DistanceTableAB> createDistanceTableAB(const ParticleSet& s,
     if (s.getLattice().DiagonalOnly)
     {
       o << "    Distance computations use orthorhombic code for periodic cell in 2D." << std::endl;
-      dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, PPNO + SOA_OFFSET>>(s, t_size, t_name);
+      dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, PPNO + SOA_OFFSET>>(s, t_name);
     }
     else
     {
       if (s.getLattice().WignerSeitzRadius > s.getLattice().SimulationCellRadius)
       {
         o << "    Distance computations use general periodic cell in 2D with corner image checks." << std::endl;
-        dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, PPNG + SOA_OFFSET>>(s, t_size, t_name);
+        dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, PPNG + SOA_OFFSET>>(s, t_name);
       }
       else
       {
         o << "    Distance computations use general periodic cell in 2D without corner image checks." << std::endl;
-        dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, PPNS + SOA_OFFSET>>(s, t_size, t_name);
+        dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, PPNS + SOA_OFFSET>>(s, t_name);
       }
     }
   }
   else if (sc == SUPERCELL_WIRE)
   {
     o << "    Distance computations use periodic cell in one dimension." << std::endl;
-    dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, SUPERCELL_WIRE + SOA_OFFSET>>(s, t_size, t_name);
+    dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, SUPERCELL_WIRE + SOA_OFFSET>>(s, t_name);
   }
   else //open boundary condition
   {
     o << "    Distance computations use open boundary conditions in 3D." << std::endl;
-    dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, SUPERCELL_OPEN + SOA_OFFSET>>(s, t_size, t_name);
+    dt = std::make_unique<SoaDistanceTableAB<RealType, DIM, SUPERCELL_OPEN + SOA_OFFSET>>(s, t_name);
   }
 
   description << o.str() << std::endl;

--- a/src/Particle/createDistanceTableABOMPTarget.cpp
+++ b/src/Particle/createDistanceTableABOMPTarget.cpp
@@ -25,7 +25,6 @@ namespace qmcplusplus
  *\return index of the distance table with the name
  */
 std::unique_ptr<DistanceTableAB> createDistanceTableABOMPTarget(const ParticleSet& s,
-                                                                const size_t t_size,
                                                                 const std::string& t_name,
                                                                 std::ostream& description)
 {
@@ -46,19 +45,19 @@ std::unique_ptr<DistanceTableAB> createDistanceTableABOMPTarget(const ParticleSe
     if (s.getLattice().DiagonalOnly)
     {
       o << "    Distance computations use orthorhombic periodic cell in 3D." << std::endl;
-      dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, PPPO + SOA_OFFSET>>(s, t_size, t_name);
+      dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, PPPO + SOA_OFFSET>>(s, t_name);
     }
     else
     {
       if (s.getLattice().WignerSeitzRadius > s.getLattice().SimulationCellRadius)
       {
         o << "    Distance computations use general periodic cell in 3D with corner image checks." << std::endl;
-        dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, PPPG + SOA_OFFSET>>(s, t_size, t_name);
+        dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, PPPG + SOA_OFFSET>>(s, t_name);
       }
       else
       {
         o << "    Distance computations use general periodic cell in 3D without corner image checks." << std::endl;
-        dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, PPPS + SOA_OFFSET>>(s, t_size, t_name);
+        dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, PPPS + SOA_OFFSET>>(s, t_name);
       }
     }
   }
@@ -67,31 +66,31 @@ std::unique_ptr<DistanceTableAB> createDistanceTableABOMPTarget(const ParticleSe
     if (s.getLattice().DiagonalOnly)
     {
       o << "    Distance computations use orthorhombic code for periodic cell in 2D." << std::endl;
-      dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, PPNO + SOA_OFFSET>>(s, t_size, t_name);
+      dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, PPNO + SOA_OFFSET>>(s, t_name);
     }
     else
     {
       if (s.getLattice().WignerSeitzRadius > s.getLattice().SimulationCellRadius)
       {
         o << "    Distance computations use general periodic cell in 2D with corner image checks." << std::endl;
-        dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, PPNG + SOA_OFFSET>>(s, t_size, t_name);
+        dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, PPNG + SOA_OFFSET>>(s, t_name);
       }
       else
       {
         o << "    Distance computations use general periodic cell in 2D without corner image checks." << std::endl;
-        dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, PPNS + SOA_OFFSET>>(s, t_size, t_name);
+        dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, PPNS + SOA_OFFSET>>(s, t_name);
       }
     }
   }
   else if (sc == SUPERCELL_WIRE)
   {
     o << "    Distance computations use periodic cell in one dimension." << std::endl;
-    dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, SUPERCELL_WIRE + SOA_OFFSET>>(s, t_size, t_name);
+    dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, SUPERCELL_WIRE + SOA_OFFSET>>(s, t_name);
   }
   else //open boundary condition
   {
     o << "    Distance computations use open boundary conditions in 3D." << std::endl;
-    dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, SUPERCELL_OPEN + SOA_OFFSET>>(s, t_size, t_name);
+    dt = std::make_unique<SoaDistanceTableABOMPTarget<RealType, DIM, SUPERCELL_OPEN + SOA_OFFSET>>(s, t_name);
   }
 
   description << o.str() << std::endl;

--- a/src/Particle/tests/test_distance_table.cpp
+++ b/src/Particle/tests/test_distance_table.cpp
@@ -597,6 +597,7 @@ void test_distance_pbc_z_batched_APIs(DynamicCoordinateKind test_kind)
 
   std::vector<ParticleSet::SingleParticlePos> disp{{0.2, 0.1, 0.3}, {0.2, 0.1, 0.3}};
 
+  ParticleSet::mw_update(p_list);
   ParticleSet::mw_makeMove(p_list, 0, disp);
   ParticleSet::mw_accept_rejectMove(p_list, 0, {true, true}, true);
   ParticleSet::mw_makeMove(p_list, 1, disp);
@@ -643,6 +644,7 @@ void test_distance_fcc_pbc_z_batched_APIs(DynamicCoordinateKind test_kind)
 
   std::vector<ParticleSet::SingleParticlePos> disp{{0.2, 0.1, 0.3}, {0.2, 0.1, 0.3}};
 
+  ParticleSet::mw_update(p_list);
   ParticleSet::mw_makeMove(p_list, 0, disp);
   ParticleSet::mw_accept_rejectMove(p_list, 0, {true, true}, true);
   ParticleSet::mw_makeMove(p_list, 1, disp);
@@ -697,6 +699,7 @@ void test_distance_pbc_z_batched_APIs_ee_NEED_TEMP_DATA_ON_HOST(DynamicCoordinat
 
   std::vector<ParticleSet::SingleParticlePos> disp{{0.2, 0.1, 0.3}, {0.2, 0.1, 0.3}};
 
+  ParticleSet::mw_update(p_list);
   ParticleSet::mw_makeMove(p_list, 0, disp);
   CHECK(ee_dtable.getTempDists()[1] == Approx(2.7239676944));
   CHECK(ee_dtable.getTempDispls()[1][0] == Approx(2.7));

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -67,19 +67,17 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces, bo
   setEnergyDomain(POTENTIAL);
   twoBodyQuantumDomain(ref);
   PtclRefName = ref.getDistTable(d_aa_ID).getName();
+
   if (ComputeForces || quasi2d)
-  {
     ref.turnOnPerParticleSK();
-  }
+
   initBreakup(ref);
+
   if (ComputeForces)
-  {
     updateSource(ref);
-  }
 
   if (!is_active)
   {
-    ref.update();
     updateSource(ref);
 
     ewaldref::RealMat A;
@@ -145,6 +143,7 @@ void CoulombPBCAA::addObservables(PropertySetType& plist, BufferType& collectabl
 
 void CoulombPBCAA::updateSource(ParticleSet& s)
 {
+  s.update();
   mRealType eL(0.0), eS(0.0);
   if (ComputeForces)
   {

--- a/src/QMCHamiltonians/StressPBC.cpp
+++ b/src/QMCHamiltonians/StressPBC.cpp
@@ -36,7 +36,7 @@ StressPBC::StressPBC(ParticleSet& ions, ParticleSet& elns, TrialWaveFunction& Ps
       firstTimeStress(true)
 {
   ReportEngine PRE("StressPBC", "StressPBC");
-  name_  = "StressPBC";
+  name_   = "StressPBC";
   prefix_ = "StressPBC";
   //This sets up the long range breakups.
   initBreakup(PtclTarg);
@@ -44,6 +44,7 @@ StressPBC::StressPBC(ParticleSet& ions, ParticleSet& elns, TrialWaveFunction& Ps
   stress_ee_const = 0.0;
   if (firstTimeStress)
   { // calculate constants
+    ions.update();
     CalculateIonIonStress();
     firstTimeStress = false;
   }
@@ -173,13 +174,13 @@ SymTensor<StressPBC::RealType, OHMMS_DIM> StressPBC::evaluateLR_AA(ParticleSet& 
     for (int spec2 = spec1; spec2 < NumSpecies; spec2++)
     {
       SymTensor<RealType, OHMMS_DIM> temp =
-          AA->evaluateStress(P.getSimulationCell().getKLists().getKShell(), PtclRhoK.rhok_r[spec1], PtclRhoK.rhok_i[spec1],
-                             PtclRhoK.rhok_r[spec2], PtclRhoK.rhok_i[spec2]);
+          AA->evaluateStress(P.getSimulationCell().getKLists().getKShell(), PtclRhoK.rhok_r[spec1],
+                             PtclRhoK.rhok_i[spec1], PtclRhoK.rhok_r[spec2], PtclRhoK.rhok_i[spec2]);
       if (spec2 == spec1)
         temp *= 0.5;
       stress_aa += Z1 * Zmyspec[spec2] * temp;
     } //spec2
-  }   //spec1
+  } //spec1
 
   return stress_aa;
 }

--- a/src/QMCWaveFunctions/LCAO/CuspCorrectionConstruction.cpp
+++ b/src/QMCWaveFunctions/LCAO/CuspCorrectionConstruction.cpp
@@ -734,6 +734,8 @@ void generateCuspInfo(Matrix<CuspCorrectionParameters>& info,
 
       if (corrO)
       {
+        localTargetPtcl.update();
+
         OneMolecularOrbital etaMO(&localTargetPtcl, &localSourcePtcl, &local_eta);
         etaMO.changeOrbital(center_idx, mo_idx);
 

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
@@ -541,6 +541,7 @@ std::unique_ptr<SPOSet> LCAOrbitalBuilder::createSPOSetFromXML(xmlNodePtr cur)
     // The random particle placement step executes after this part of the code, overwriting
     // the leftover positions from the cusp initialization.
     ParticleSet tmp_targetPtcl(targetPtcl);
+    tmp_targetPtcl.update();
 
     const int num_centers = sourcePtcl.getTotalNum();
     auto& lcwc            = dynamic_cast<LCAOrbitalSetWithCorrection&>(*sposet);

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -727,6 +727,7 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   //Check initial values for both walkers
   RefVector<ParticleGradient> G_list  = {G, G2};
   RefVector<ParticleLaplacian> L_list = {L, L2};
+  ParticleSet::mw_update(p_ref_list);
   sd.mw_evaluateLog(sd_ref_list, p_ref_list, G_list, L_list);
   for (int iw = 0; iw < sd_ref_list.size(); iw++)
   {
@@ -750,7 +751,7 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   MCCoords<CoordsType::POS_SPIN> displs(2);
   displs.positions = {dr, dr};
   displs.spins     = {ds, ds};
-  elec_.mw_makeMove(p_ref_list, 1, displs);
+  ParticleSet::mw_makeMove(p_ref_list, 1, displs);
 
   //Check ratios and grads for both walkers for proposed move
   std::vector<PsiValue> ratios(2);
@@ -779,7 +780,7 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
 
   //reject move and check for initial values for mw_evalGrad
   std::fill(grads.begin(), grads.end(), 0);
-  elec_.mw_accept_rejectMove<CoordsType::POS_SPIN>(p_ref_list, 1, {false, false});
+  ParticleSet::mw_accept_rejectMove<CoordsType::POS_SPIN>(p_ref_list, 1, {false, false});
   sd.mw_evalGrad(sd_ref_list, p_ref_list, 1, grads);
   for (int iw = 0; iw < grads.size(); iw++)
   {
@@ -800,8 +801,8 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   }
 
   //now make and accept move, checking new values
-  elec_.mw_makeMove(p_ref_list, 1, displs);
-  elec_.mw_accept_rejectMove<CoordsType::POS_SPIN>(p_ref_list, 1, {true, true});
+  ParticleSet::mw_makeMove(p_ref_list, 1, displs);
+  ParticleSet::mw_accept_rejectMove<CoordsType::POS_SPIN>(p_ref_list, 1, {true, true});
 
   G  = 0;
   L  = 0;


### PR DESCRIPTION
## Proposed changes
distance tables had fixed sizes of target particles. This PR moves the resizing of internal storage to evaluate/mw_evaluate allowing more flexible use of DTs.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted