### PR TITLE
Resize VirtualParticleSet at makeMoves instead of constructor

### DIFF
--- a/src/Estimators/MagnetizationDensity.cpp
+++ b/src/Estimators/MagnetizationDensity.cpp
@@ -146,7 +146,7 @@ void MagnetizationDensity::generateSpinIntegrand(ParticleSet& pset_target,
   for (int samp = 0; samp < nsamples_; samp++)
     ds[samp] = sgrid[samp] - pset_target.spins[iat];
 
-  VirtualParticleSet vp(pset_target, nsamples_);
+  VirtualParticleSet vp(pset_target);
   std::vector<Position> dV(nsamples_, 0);
   vp.makeMovesWithSpin(pset_target, iat, dV, ds);
   psi_target.evaluateRatios(vp, ratios);

--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -62,7 +62,7 @@ VirtualParticleSet::VirtualParticleSet(const ParticleSet& p, size_t dt_count_lim
   }
 }
 
-void VirtualParticleSet::resizeVP(const size_t nptcl)
+void VirtualParticleSet::resize(const size_t nptcl)
 {
   TotalNum = nptcl;
   R.resize(nptcl);
@@ -150,7 +150,7 @@ void VirtualParticleSet::makeMoves(const ParticleSet& refp,
   refPtcl       = jel;
   refSourcePtcl = iat;
 
-  resizeVP(deltaV.size());
+  resize(deltaV.size());
   for (size_t ivp = 0; ivp < R.size(); ivp++)
     R[ivp] = refp.R[jel] + deltaV[ivp];
   if (refp.isSpinor())
@@ -176,7 +176,7 @@ void VirtualParticleSet::makeMovesWithSpin(const ParticleSet& refp,
   refPtcl       = jel;
   refSourcePtcl = iat;
 
-  resizeVP(deltaV.size());
+  resize(deltaV.size());
   assert(deltaV.size() == deltaS.size());
   for (size_t ivp = 0; ivp < R.size(); ivp++)
   {
@@ -217,7 +217,7 @@ void VirtualParticleSet::mw_makeMoves(const RefVectorWithLeader<VirtualParticleS
     vp.refPtcl       = job.electron_id;
     vp.refSourcePtcl = job.ion_id;
 
-    vp.resizeVP(deltaV.size());
+    vp.resize(deltaV.size());
     for (size_t k = 0; k < vp.R.size(); k++, ivp++)
     {
       vp.R[k] = refp_list[iw].R[vp.refPtcl] + deltaV[k];
@@ -269,7 +269,7 @@ void VirtualParticleSet::mw_makeMovesWithSpin(const RefVectorWithLeader<VirtualP
     vp.refPtcl       = job.electron_id;
     vp.refSourcePtcl = job.ion_id;
 
-    vp.resizeVP(deltaV.size());
+    vp.resize(deltaV.size());
     assert(deltaV.size() == deltaS.size());
     for (size_t k = 0; k < vp.R.size(); k++, ivp++)
     {

--- a/src/Particle/VirtualParticleSet.h
+++ b/src/Particle/VirtualParticleSet.h
@@ -50,7 +50,7 @@ private:
   OptionalRef<const ParticleSet> refPS;
 
   // resize internal storage
-  void resizeVP(const size_t nptcl);
+  void resize(const size_t nptcl);
 
 public:
   /// Reference particle

--- a/src/Particle/VirtualParticleSet.h
+++ b/src/Particle/VirtualParticleSet.h
@@ -49,6 +49,9 @@ private:
   /// ParticleSet this object refers to after makeMoves
   OptionalRef<const ParticleSet> refPS;
 
+  // resize internal storage
+  void resizeVP(const size_t nptcl);
+
 public:
   /// Reference particle
   int refPtcl;
@@ -67,7 +70,7 @@ public:
      * @param nptcl number of virtual particles
      * @param dt_count_limit distance tables corresepond to [0, dt_count_limit) of the reference particle set are created
      */
-  VirtualParticleSet(const ParticleSet& p, int nptcl, size_t dt_count_limit = 0);
+  VirtualParticleSet(const ParticleSet& p, size_t dt_count_limit = 0);
 
   ~VirtualParticleSet();
 

--- a/src/Particle/tests/test_VirtualParticleSet.cpp
+++ b/src/Particle/tests/test_VirtualParticleSet.cpp
@@ -41,11 +41,11 @@ TEST_CASE("VirtualParticleSet", "[particle]")
   ParticleSet elecs_clone(elecs);
   elecs_clone.update();
 
-  VirtualParticleSet vp_Ni(elecs, 3);
-  VirtualParticleSet vp_O(elecs, 5);
+  VirtualParticleSet vp_Ni(elecs);
+  VirtualParticleSet vp_O(elecs);
 
-  VirtualParticleSet vp_Ni_clone(elecs_clone, 3);
-  VirtualParticleSet vp_O_clone(elecs_clone, 5);
+  VirtualParticleSet vp_Ni_clone(elecs_clone);
+  VirtualParticleSet vp_O_clone(elecs_clone);
 
   vp_Ni_clone.makeMoves(elecs_clone, 3, {{0.1, 0.2, 0.3}, {0.2, 0.1, 0.3}, {0.3, 0.1, 0.2}});
   const DistanceTableAB& dt_vp_ion = vp_Ni_clone.getDistTableAB(0);

--- a/src/QMCDrivers/WaveFunctionTester.cpp
+++ b/src/QMCDrivers/WaveFunctionTester.cpp
@@ -1380,7 +1380,7 @@ void WaveFunctionTester::runRatioV()
   Tau=0.025;
 
   //create a VP with 8 virtual moves
-  VirtualParticleSet vp(&W,8);
+  VirtualParticleSet vp(W);
   W.enableVirtualMoves();
 
   //cheating

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -34,7 +34,7 @@ NonLocalECPComponent::NonLocalECPComponent(const NonLocalECPComponent& nl_ecpc, 
   for (int i = 0; i < nl_ecpc.nlpp_m.size(); ++i)
     nlpp_m[i] = nl_ecpc.nlpp_m[i]->makeClone();
   if (nl_ecpc.VP)
-    VP = new VirtualParticleSet(pset, nknot, nl_ecpc.VP->getNumDistTables());
+    VP = new VirtualParticleSet(pset, nl_ecpc.VP->getNumDistTables());
 }
 
 NonLocalECPComponent::~NonLocalECPComponent()
@@ -51,7 +51,7 @@ void NonLocalECPComponent::initVirtualParticle(const ParticleSet& qp)
 {
   assert(VP == 0);
   outputManager.pause();
-  VP = new VirtualParticleSet(qp, nknot);
+  VP = new VirtualParticleSet(qp);
   outputManager.resume();
 }
 

--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -37,7 +37,7 @@ void SOECPComponent::initVirtualParticle(const ParticleSet& qp)
 {
   assert(vp_ == nullptr);
   outputManager.pause();
-  vp_ = new VirtualParticleSet(qp, total_knots_);
+  vp_ = new VirtualParticleSet(qp);
   outputManager.resume();
 }
 
@@ -60,7 +60,7 @@ SOECPComponent* SOECPComponent::makeClone(const ParticleSet& qp)
   for (int i = 0; i < sopp_m_.size(); i++)
     myclone->sopp_m_[i] = sopp_m_[i]->makeClone();
   if (vp_)
-    myclone->vp_ = new VirtualParticleSet(qp, total_knots_);
+    myclone->vp_ = new VirtualParticleSet(qp);
   return myclone;
 }
 

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -118,7 +118,7 @@ void test_DiracDeterminant_first(const DetMatInvertor inverter_kind)
 
   CHECK(std::real(ratio_0) == Approx(-0.5343861437));
 
-  VirtualParticleSet VP(elec, 2);
+  VirtualParticleSet VP(elec);
   std::vector<Pos> newpos2(2);
   std::vector<Value> ratios2(2);
   newpos2[0] = newpos - elec.R[1];

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -103,7 +103,7 @@ void test_DiracDeterminantBatched_first()
 
   CHECK(std::real(ratio_0) == Approx(-0.5343861437));
 
-  VirtualParticleSet VP(elec, 2);
+  VirtualParticleSet VP(elec);
   std::vector<Pos> newpos2(2);
   std::vector<Value> ratios2(2);
   newpos2[0] = newpos - elec.R[1];

--- a/src/QMCWaveFunctions/tests/test_J1_bspline.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1_bspline.cpp
@@ -402,7 +402,7 @@ void test_J1_spline(const DynamicCoordinateKind kind_selected)
 
   // test NLPP related APIs
   const int nknot = 3;
-  VirtualParticleSet vp(elec_, nknot), vp_clone(elec_clone, nknot);
+  VirtualParticleSet vp(elec_), vp_clone(elec_clone);
   RefVectorWithLeader<VirtualParticleSet> vp_list(vp, {vp, vp_clone});
   ResourceCollection vp_res("test_vp_res");
   vp.createResource(vp_res);

--- a/src/QMCWaveFunctions/tests/test_J2_bspline.cpp
+++ b/src/QMCWaveFunctions/tests/test_J2_bspline.cpp
@@ -226,7 +226,7 @@ TEST_CASE("BSpline builder Jastrow J2", "[wavefunction]")
 
   CHECK(std::real(ratio_0) == Approx(0.9522052017));
 
-  VirtualParticleSet VP(elec_, 2);
+  VirtualParticleSet VP(elec_);
   std::vector<PosType> newpos2(2);
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec_.R[1];

--- a/src/QMCWaveFunctions/tests/test_LCAO_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_LCAO_diamondC_2x1x1.cpp
@@ -334,8 +334,8 @@ void test_LCAO_DiamondC_2x1x1_real(const bool useOffload)
     const size_t nvp_                  = 4;
     const size_t nvp_2                 = 3;
     const std::vector<size_t> nvp_list = {nvp_, nvp_2};
-    VirtualParticleSet VP_(elec_, nvp_);
-    VirtualParticleSet VP_2(elec_2, nvp_2);
+    VirtualParticleSet VP_(elec_);
+    VirtualParticleSet VP_2(elec_2);
 
     // move VPs
     std::vector<ParticleSet::SingleParticlePos> newpos_vp_(nvp_);
@@ -783,8 +783,8 @@ void test_LCAO_DiamondC_2x1x1_cplx(const bool useOffload)
     const size_t nvp_                  = 4;
     const size_t nvp_2                 = 3;
     const std::vector<size_t> nvp_list = {nvp_, nvp_2};
-    VirtualParticleSet VP_(elec_, nvp_);
-    VirtualParticleSet VP_2(elec_2, nvp_2);
+    VirtualParticleSet VP_(elec_);
+    VirtualParticleSet VP_2(elec_2);
 
     // move VPs
     std::vector<ParticleSet::SingleParticlePos> newpos_vp_(nvp_);

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -575,7 +575,7 @@ void test_Ne(bool transform)
     // when a determinant only contains a single particle.
     SPOSet::ValueVector phi(1), phiinv(1);
     phiinv[0] = 100;
-    VirtualParticleSet VP(elec, 2);
+    VirtualParticleSet VP(elec);
     std::vector<ParticleSet::SingleParticlePos> newpos2(2);
     std::vector<SPOSet::ValueType> ratios2(2);
     newpos2[0] = disp;

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -535,7 +535,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
 
   // test NLPP related APIs
   const int nknot = 3;
-  VirtualParticleSet vp(elec_, nknot), vp_clone(elec_clone, nknot);
+  VirtualParticleSet vp(elec_), vp_clone(elec_clone);
   RefVectorWithLeader<VirtualParticleSet> vp_list(vp, {vp, vp_clone});
   ResourceCollection vp_res("test_vp_res");
   vp.createResource(vp_res);

--- a/src/QMCWaveFunctions/tests/test_einset_LiH.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_LiH.cpp
@@ -231,8 +231,8 @@ void test_einset_LiH_x(bool use_offload)
     const size_t nvp_                  = 4;
     const size_t nvp_2                 = 3;
     const std::vector<size_t> nvp_list = {nvp_, nvp_2};
-    VirtualParticleSet VP_(elec_, nvp_);
-    VirtualParticleSet VP_2(elec_2, nvp_2);
+    VirtualParticleSet VP_(elec_);
+    VirtualParticleSet VP_2(elec_2);
 
     // move VPs
     std::vector<ParticleSet::SingleParticlePos> newpos_vp_(nvp_);

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -359,7 +359,7 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
   elec_.update();
 
   //Now we test evaluateValue()
-  VirtualParticleSet vp(elec_, 1);
+  VirtualParticleSet vp(elec_);
   for (unsigned int iat = 0; iat < 3; iat++)
   {
     std::vector<ParticleSet::PosType> delta_v(1);
@@ -666,7 +666,7 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
   }
 
   //test mw_evaluateDetRatios
-  VirtualParticleSet vp1(elec_, 1), vp2(elec_2, 1);
+  VirtualParticleSet vp1(elec_), vp2(elec_2);
   RefVectorWithLeader<VirtualParticleSet> vp_list(vp1, {vp1, vp2});
   ResourceCollection vp_res("vp_res");
   vp.createResource(vp_res);

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -180,7 +180,7 @@ void test_LiH_msd(const std::string& spo_xml_string,
 
     CHECK(std::real(ratio_0) == Approx(2.350046921));
 
-    VirtualParticleSet VP(elec_, 2);
+    VirtualParticleSet VP(elec_);
     std::vector<PosType> newpos2(2);
     std::vector<ValueType> ratios2(2);
     newpos2[0] = newpos - elec_.R[1];

--- a/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
@@ -318,7 +318,7 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
   for (int i = 0; i < NumOptimizables; i++)
     CHECK(dlogpsi[i] == ValueApprox(dlogpsiWF[i]));
 
-  VirtualParticleSet VP(elec_, 2);
+  VirtualParticleSet VP(elec_);
   std::vector<PosType> newpos2(2);
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec_.R[1];
@@ -361,7 +361,7 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
 
   // test NLPP related APIs
   const int nknot = 3;
-  VirtualParticleSet vp(elec_, nknot), vp_clone(elec_clone, nknot);
+  VirtualParticleSet vp(elec_), vp_clone(elec_clone);
   RefVectorWithLeader<VirtualParticleSet> vp_list(vp, {vp, vp_clone});
   ResourceCollection vp_res("test_vp_res");
   vp.createResource(vp_res);


### PR DESCRIPTION
## Proposed changes

~~Review after https://github.com/QMCPACK/qmcpack/pull/5636~~
With this change, `VirtualParticleSet` size is no longer fixed at construction. One `VirtualParticleSet` object can be used to serve different quadrature point counts. My next PR will move `VirtualParticleSet` object ownership from `NonLocalECPComponent` to `NonLocalECPotential` and clean up the pointer mess.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted