### PR TITLE
Change from per NonLocalECPComponent VP to a single NonLocalECPotential VP

### DIFF
--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -22,6 +22,7 @@
 #include "QMCHamiltonians/L2Potential.h"
 #include "OhmmsData/AttributeSet.h"
 #include "Numerics/OneDimNumGridFunctor.h"
+#include "Message/UniformCommunicateError.h"
 
 namespace qmcplusplus
 {
@@ -111,30 +112,26 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
         app_log() << "  Will compute forces in CoulombPBCAB.\n" << std::endl;
       std::unique_ptr<CoulombPBCAB> apot = std::make_unique<CoulombPBCAB>(IonConfig, targetPtcl, doForces);
       for (int i = 0; i < localPot.size(); i++)
-      {
         if (localPot[i])
           apot->add(i, std::move(localPot[i]));
-      }
       targetH.addOperator(std::move(apot), "LocalECP");
     }
   }
   if (hasNonLocalPot)
   {
     std::unique_ptr<NonLocalECPotential> apot =
-        std::make_unique<NonLocalECPotential>(IonConfig, targetPtcl, targetPsi, use_DLA == "yes");
+        std::make_unique<NonLocalECPotential>(IonConfig, targetPtcl, targetPsi, use_DLA == "yes",
+                                              NLPP_algo == "batched");
 
     int nknot_max = 0;
     // These are actually NonLocalECPComponents
     for (int i = 0; i < nonLocalPot.size(); i++)
-    {
       if (nonLocalPot[i])
       {
         nknot_max = std::max(nknot_max, nonLocalPot[i]->getNknot());
-        if (NLPP_algo == "batched")
-          nonLocalPot[i]->initVirtualParticle(targetPtcl);
         apot->addComponent(i, std::move(nonLocalPot[i]));
       }
-    }
+
     app_log() << "\n  Using NonLocalECP potential \n"
               << "    Maximum grid on a sphere for NonLocalECPotential: " << nknot_max << std::endl;
     if (NLPP_algo == "batched")
@@ -145,29 +142,30 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
   if (hasSOPot)
   {
 #ifndef QMC_COMPLEX
-    APP_ABORT("SOECPotential evaluations require complex build. Rebuild with -D QMC_COMPLEX=1\n");
+    throw UniformCommunicateError("SOECPotential evaluations require complex build. Rebuild with -D QMC_COMPLEX=1\n");
 #endif
     if (physicalSO == "yes")
       app_log() << "    Spin-Orbit potential included in local energy" << std::endl;
     else if (physicalSO == "no")
       app_log() << "    Spin-Orbit potential is not included in local energy" << std::endl;
     else
-      APP_ABORT("physicalSO must be set to yes/no. Unknown option given\n");
+      throw UniformCommunicateError("physicalSO must be set to yes/no. Unknown option given\n");
 
-    std::unique_ptr<SOECPotential> apot = std::make_unique<SOECPotential>(IonConfig, targetPtcl, targetPsi, use_exact_spin);
-    int nknot_max                       = 0;
-    int sknot_max                       = 0;
+    if (use_exact_spin && NLPP_algo != "batched")
+      throw UniformCommunicateError("spin_integrator=\"exact\" requires algorithm=\"batched\".\n");
+
+    std::unique_ptr<SOECPotential> apot =
+        std::make_unique<SOECPotential>(IonConfig, targetPtcl, targetPsi, use_exact_spin, NLPP_algo == "batched");
+    int nknot_max = 0;
+    int sknot_max = 0;
     for (int i = 0; i < soPot.size(); i++)
-    {
       if (soPot[i])
       {
         nknot_max = std::max(nknot_max, soPot[i]->getNknot());
         sknot_max = std::max(sknot_max, soPot[i]->getSknot());
-        if (NLPP_algo == "batched")
-          soPot[i]->initVirtualParticle(targetPtcl);
         apot->addComponent(i, std::move(soPot[i]));
       }
-    }
+
     app_log() << "\n  Using SOECP potential \n"
               << "    Maximum grid on a sphere for SOECPotential: " << nknot_max << std::endl;
     if (use_exact_spin)

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -115,9 +115,6 @@ private:
   ///The gradient of the wave function w.r.t. the ion position
   ParticleSet::ParticleGradient Gion;
 
-  ///virtual particle set: delayed initialization
-  VirtualParticleSet* VP;
-
   /// Can disable grid randomization for testing
   bool do_randomize_grid_;
 
@@ -177,6 +174,7 @@ public:
    * @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
    */
   RealType evaluateOne(ParticleSet& W,
+                       const OptionalRef<VirtualParticleSet> vp,
                        int iat,
                        TrialWaveFunction& Psi,
                        int iel,
@@ -201,6 +199,7 @@ public:
    */
   static void mw_evaluateOne(const RefVectorWithLeader<NonLocalECPComponent>& ecp_component_list,
                              const RefVectorWithLeader<ParticleSet>& p_list,
+                             const std::optional<const RefVectorWithLeader<VirtualParticleSet>> vp_list,
                              const RefVectorWithLeader<TrialWaveFunction>& psi_list,
                              const RefVector<const NLPPJob<RealType>>& joblist,
                              std::vector<RealType>& pairpots,
@@ -222,6 +221,7 @@ public:
    * @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
    */
   RealType evaluateOneWithForces(ParticleSet& W,
+                                 const OptionalRef<VirtualParticleSet> vp,
                                  int iat,
                                  TrialWaveFunction& Psi,
                                  int iel,
@@ -245,6 +245,7 @@ public:
    * @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
    */
   RealType evaluateOneWithForces(ParticleSet& W,
+                                 const OptionalRef<VirtualParticleSet> vp,
                                  ParticleSet& ions,
                                  int iat,
                                  TrialWaveFunction& Psi,
@@ -256,6 +257,7 @@ public:
 
   // This function needs to be updated to SoA. myTableIndex is introduced temporarily.
   RealType evaluateValueAndDerivatives(ParticleSet& P,
+                                       const OptionalRef<VirtualParticleSet> vp,
                                        int iat,
                                        TrialWaveFunction& psi,
                                        int iel,
@@ -313,15 +315,11 @@ public:
 
   void print(std::ostream& os);
 
-  void initVirtualParticle(const ParticleSet& qp);
-  void deleteVirtualParticle();
-
   inline void setRmax(int rmax) { Rmax = rmax; }
   inline RealType getRmax() const { return Rmax; }
   inline int getNknot() const { return nknot; }
   inline void setLmax(int Lmax) { lmax = Lmax; }
   inline int getLmax() const { return lmax; }
-  const VirtualParticleSet* getVP() const { return VP; };
 
   // copy sgridxyz_m to rrotsgrid_m without rotation. For testing only.
   friend void copyGridUnrotatedForTest(NonLocalECPComponent& nlpp);

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -44,7 +44,8 @@ class NonLocalECPotential : public OperatorBase, public ForceBase
   struct NonLocalECPotentialMultiWalkerResource;
 
 public:
-  NonLocalECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi, bool enable_DLA);
+  NonLocalECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi, bool enable_DLA, bool use_VP);
+  NonLocalECPotential(const NonLocalECPotential& nlpp, ParticleSet& els, TrialWaveFunction& psi);
   ~NonLocalECPotential() override;
 
   bool dependsOnWaveFunction() const override { return true; }
@@ -167,6 +168,8 @@ protected:
   bool use_DLA;
 
 private:
+  ///virtual particle set
+  const std::unique_ptr<VirtualParticleSet> vp_;
   ///number of ions
   int NumIons;
   ///index of distance table for the ion-el pair

--- a/src/QMCHamiltonians/SOECPComponent.h
+++ b/src/QMCHamiltonians/SOECPComponent.h
@@ -78,7 +78,6 @@ private:
   //scratch spaces used by evaluateValueAndDerivative
   Matrix<ValueType> dratio_;
   Vector<ValueType> dlogpsi_vp_;
-  VirtualParticleSet* vp_;
   std::pair<SPOSet::ValueVector, SPOSet::ValueVector> spinor_multiplier_;
 
   //This builds the full quadrature grid for the Simpsons rule used for spin integrals as well as
@@ -115,7 +114,13 @@ public:
    *
    * @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
    */
-  RealType evaluateOne(ParticleSet& W, int iat, TrialWaveFunction& Psi, int iel, RealType r, const PosType& dr);
+  RealType evaluateOne(ParticleSet& W,
+                       const OptionalRef<VirtualParticleSet> vp,
+                       int iat,
+                       TrialWaveFunction& Psi,
+                       int iel,
+                       RealType r,
+                       const PosType& dr);
 
   RealType calculateProjector(RealType r, const PosType& dr, RealType sold);
 
@@ -123,6 +128,7 @@ public:
   void setupExactSpinProjector(RealType r, const PosType& dr, RealType sold);
 
   RealType evaluateOneExactSpinIntegration(ParticleSet& W,
+                                           VirtualParticleSet& vp,
                                            const int iat,
                                            const TrialWaveFunction& psi,
                                            const int iel,
@@ -131,6 +137,7 @@ public:
 
   static void mw_evaluateOne(const RefVectorWithLeader<SOECPComponent>& soecp_component_list,
                              const RefVectorWithLeader<ParticleSet>& p_list,
+                             const std::optional<const RefVectorWithLeader<VirtualParticleSet>> vp_list,
                              const RefVectorWithLeader<TrialWaveFunction>& psi_list,
                              const RefVector<const NLPPJob<RealType>>& joblist,
                              std::vector<RealType>& pairpots,
@@ -138,12 +145,14 @@ public:
 
   static void mw_evaluateOneExactSpinIntegration(const RefVectorWithLeader<SOECPComponent>& soecp_component_list,
                                                  const RefVectorWithLeader<ParticleSet>& p_list,
+                                                 const RefVectorWithLeader<VirtualParticleSet>& vp_list,
                                                  const RefVectorWithLeader<TrialWaveFunction>& psi_list,
                                                  const RefVector<const NLPPJob<RealType>>& joblist,
                                                  std::vector<RealType>& pairpots,
                                                  ResourceCollection& collection);
 
   RealType evaluateValueAndDerivatives(ParticleSet& P,
+                                       const OptionalRef<VirtualParticleSet> vp,
                                        int iat,
                                        TrialWaveFunction& psi,
                                        int iel,
@@ -154,6 +163,7 @@ public:
                                        Vector<ValueType>& dhpsioverpsi);
 
   RealType evaluateValueAndDerivativesExactSpinIntegration(ParticleSet& P,
+                                                           VirtualParticleSet& vp,
                                                            int iat,
                                                            TrialWaveFunction& psi,
                                                            int iel,
@@ -165,17 +175,12 @@ public:
 
   void print(std::ostream& os);
 
-  void initVirtualParticle(const ParticleSet& qp);
-  void deleteVirtualParticle();
-
   inline void setRmax(RealType rmax) { rmax_ = rmax; }
   inline RealType getRmax() const { return rmax_; }
   inline void setLmax(int lmax) { lmax_ = lmax; }
   inline int getLmax() const { return lmax_; }
   inline int getNknot() const { return nknot_; }
   inline int getSknot() const { return sknot_; }
-
-  const VirtualParticleSet* getVP() const { return vp_; };
 
   friend struct ECPComponentBuilder;
   friend void copyGridUnrotatedForTest(SOECPComponent& nlpp);

--- a/src/QMCHamiltonians/SOECPotential.h
+++ b/src/QMCHamiltonians/SOECPotential.h
@@ -31,7 +31,8 @@ class SOECPotential : public OperatorBase
   using Real = QMCTraits::RealType;
 
 public:
-  SOECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi, bool use_exact_spin);
+  SOECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi, bool use_exact_spin, bool use_VP);
+  SOECPotential(const SOECPotential& sopp, ParticleSet& els, TrialWaveFunction& psi);
   ~SOECPotential() override;
 
   bool dependsOnWaveFunction() const override { return true; }
@@ -92,6 +93,8 @@ protected:
                               bool keep_grid = false);
 
 private:
+  ///virtual particle set
+  const std::unique_ptr<VirtualParticleSet> vp_;
   ///number of ions
   int num_ions_;
   ///index of distance table for ion-el pair

--- a/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
@@ -131,7 +131,7 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
   TrialWaveFunction psi2(runtime_options);
   RefVectorWithLeader<TrialWaveFunction> twf_list(psi, {psi, psi2});
 
-  NonLocalECPotential nl_ecp(ions, elec, psi, false /*use_DLA*/);
+  NonLocalECPotential nl_ecp(ions, elec, psi, false /*use_DLA*/, false /*use_VP*/);
 
   int num_walkers = 2;
   int max_values  = 10;

--- a/src/type_traits/RefVectorWithLeader.h
+++ b/src/type_traits/RefVectorWithLeader.h
@@ -23,17 +23,21 @@ template<typename T>
 class RefVectorWithLeader : public std::vector<std::reference_wrapper<T>>
 {
 public:
+  using BaseVec = std::vector<std::reference_wrapper<T>>;
+
   RefVectorWithLeader(T& leader) : leader_(leader) {}
 
-  RefVectorWithLeader(T& leader, const std::vector<std::reference_wrapper<T>>& vec) : leader_(leader)
+  RefVectorWithLeader(T& leader, const BaseVec& vec) : leader_(leader)
   {
     for (T& element : vec)
       this->push_back(element);
   }
 
+  RefVectorWithLeader(T& leader, BaseVec&& vec) : BaseVec(std::move(vec)), leader_(leader) {}
+
   T& getLeader() const { return leader_; }
 
-  T& operator[](size_t i) const { return std::vector<std::reference_wrapper<T>>::operator[](i).get(); }
+  T& operator[](size_t i) const { return BaseVec::operator[](i).get(); }
 
   template<typename CASTTYPE>
   CASTTYPE& getCastedLeader() const


### PR DESCRIPTION
## Proposed changes
Review after #5637
The new ownership arrangement removes a lot of weird pointer operations. 

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted