### PR TITLE
Remove useless DiracDeterminant::mw_evaluateRatios

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -138,10 +138,6 @@ public:
                             const std::pair<ValueVector, ValueVector>& spinor_multipler,
                             std::vector<ValueType>& ratios) override;
 
-  void mw_evaluateRatios(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                         const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
-                         std::vector<std::vector<ValueType>>& ratios) const override;
-
   void evaluateDerivRatios(const VirtualParticleSet& VP,
                            const opt_variables_type& optvars,
                            std::vector<ValueType>& ratios,

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -792,15 +792,9 @@ void DiracDeterminantBatched<PL, VT, FPVT>::mw_calcRatio(const RefVectorWithLead
 template<PlatformKind PL, typename VT, typename FPVT>
 void DiracDeterminantBatched<PL, VT, FPVT>::evaluateRatios(const VirtualParticleSet& VP, std::vector<Value>& ratios)
 {
-  {
-    ScopedTimer local_timer(RatioTimer);
-    const int WorkingIndex = VP.refPtcl - FirstIndex;
-    std::copy_n(psiMinv_[WorkingIndex], d2psiV.size(), d2psiV.data());
-  }
-  {
-    ScopedTimer local_timer(SPOVTimer);
-    phi_.evaluateDetRatios(VP, psiV_host_view, d2psiV_host_view, ratios);
-  }
+  ScopedTimer local_timer(SPOVTimer);
+  Vector<ValueType> inv_row(psiMinv_[VP.refPtcl - FirstIndex], psiV.size());
+  phi_.evaluateDetRatios(VP, psiV_host_view, inv_row, ratios);
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>
@@ -809,15 +803,9 @@ void DiracDeterminantBatched<PL, VT, FPVT>::evaluateSpinorRatios(
     const std::pair<ValueVector, ValueVector>& spinor_multiplier,
     std::vector<Value>& ratios)
 {
-  {
-    ScopedTimer local_timer(RatioTimer);
-    const int WorkingIndex = VP.refPtcl - FirstIndex;
-    std::copy_n(psiMinv_[WorkingIndex], d2psiV.size(), d2psiV.data());
-  }
-  {
-    ScopedTimer local_timer(SPOVTimer);
-    phi_.evaluateDetSpinorRatios(VP, psiV_host_view, spinor_multiplier, d2psiV_host_view, ratios);
-  }
+  ScopedTimer local_timer(SPOVTimer);
+  Vector<ValueType> inv_row(psiMinv_[VP.refPtcl - FirstIndex], psiV.size());
+  phi_.evaluateDetSpinorRatios(VP, psiV_host_view, spinor_multiplier, inv_row, ratios);
 }
 
 template<PlatformKind PL, typename VT, typename FPVT>


### PR DESCRIPTION
## Proposed changes
mw_evaluateRatios was implemented forcing serialization when SPOSet is offload.
When SPOSet isn't offload, phi->mw_evalauteDetRatios fallback implementation still does serialization.
Then the overriding `mw_evaluateRatios` is useless since the default fallback achieves the same results.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
