### PR TITLE
Modify resizeAndPreserve to use std::get

### DIFF
--- a/src/QMCTools/ppconvert/src/common/Blitz.h
+++ b/src/QMCTools/ppconvert/src/common/Blitz.h
@@ -145,7 +145,7 @@ struct Array<T, 1, base_type> : base_type
   using sizes_type = decltype(std::declval<base_type const&>().sizes());
   sizes_type shape() const { return base_type::sizes(); }
   void resize(sizes_type sizes) { resizeAndPreserve(sizes); }
-  void resizeAndPreserve(sizes_type sizes) { using std::get; base_type::reextent({get<0>(sizes), get<1>(sizes)}); }
+  void resizeAndPreserve(sizes_type sizes) { using std::get; base_type::reextent({get<0>(sizes)}); }
   std::ptrdiff_t extent(int d) const
   {
     switch (d)


### PR DESCRIPTION
to conform to Multi interface

## Proposed changes

Stop using deprecated Multi interface based on tuple for resizing

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 24.04

## Checklist

* * [x ] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
