### PR TITLE
Consolidate multi-walker APIs of OperatorDependsOnlyOnParticleSet

### DIFF
--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -214,7 +214,6 @@ CoulombPBCAA::Return_t CoulombPBCAA::evaluate(ParticleSet& P)
 }
 
 void CoulombPBCAA::mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
-                               const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                const RefVectorWithLeader<ParticleSet>& p_list) const
 {
   auto& o_leader = o_list.getCastedLeader<CoulombPBCAA>();
@@ -238,11 +237,10 @@ void CoulombPBCAA::mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
     }
   }
   else
-    OperatorBase::mw_evaluate(o_list, wf_list, p_list);
+    OperatorDependsOnlyOnParticleSet::mw_evaluate(o_list, p_list);
 }
 
 void CoulombPBCAA::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
-                                          const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                           const RefVectorWithLeader<ParticleSet>& p_list,
                                           const std::vector<ListenerVector<RealType>>& listeners,
                                           const std::vector<ListenerVector<RealType>>& listeners_ions) const
@@ -361,17 +359,6 @@ void CoulombPBCAA::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase
         listener.report(iw, name, v_sample);
   }
 }
-
-void CoulombPBCAA::mw_evaluatePerParticleWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
-                                                       const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                                       const RefVectorWithLeader<ParticleSet>& p_list,
-                                                       const std::vector<ListenerVector<RealType>>& listeners,
-                                                       const std::vector<ListenerVector<RealType>>& ion_listeners) const
-
-{
-  mw_evaluatePerParticle(o_list, wf_list, p_list, listeners, ion_listeners);
-}
-
 
 void CoulombPBCAA::evaluateIonDerivs(ParticleSet& P,
                                      ParticleSet& ions,
@@ -876,8 +863,5 @@ void CoulombPBCAA::releaseResource(ResourceCollection& collection,
   collection.takebackResource(o_leader.mw_res_handle_);
 }
 
-std::unique_ptr<OperatorBase> CoulombPBCAA::makeClone(ParticleSet& qp)
-{
-  return std::make_unique<CoulombPBCAA>(*this);
-}
+std::unique_ptr<OperatorBase> CoulombPBCAA::makeClone(ParticleSet& qp) { return std::make_unique<CoulombPBCAA>(*this); }
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -126,7 +126,6 @@ struct CoulombPBCAA : public OperatorDependsOnlyOnParticleSet, public ForceBase
   Return_t evaluate(ParticleSet& P) override;
 
   void mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
-                   const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                    const RefVectorWithLeader<ParticleSet>& p_list) const override;
 
   /**
@@ -134,16 +133,9 @@ struct CoulombPBCAA : public OperatorDependsOnlyOnParticleSet, public ForceBase
    * to registered listeners from Estimators.
    */
   void mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
-                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                               const RefVectorWithLeader<ParticleSet>& p_list,
                               const std::vector<ListenerVector<RealType>>& listeners,
                               const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
-
-  void mw_evaluatePerParticleWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
-                                           const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                           const RefVectorWithLeader<ParticleSet>& p_list,
-                                           const std::vector<ListenerVector<RealType>>& listeners,
-                                           const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
   void evaluateIonDerivs(ParticleSet& P,
                          ParticleSet& ions,

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -60,10 +60,7 @@ CoulombPBCAB::CoulombPBCAB(ParticleSet& ions, ParticleSet& elns, bool computeFor
   app_log() << "  Number of k vectors " << AB->Fk.size() << std::endl;
 }
 
-std::unique_ptr<OperatorBase> CoulombPBCAB::makeClone(ParticleSet& qp)
-{
-  return std::make_unique<CoulombPBCAB>(*this);
-}
+std::unique_ptr<OperatorBase> CoulombPBCAB::makeClone(ParticleSet& qp) { return std::make_unique<CoulombPBCAB>(*this); }
 
 CoulombPBCAB::~CoulombPBCAB() = default;
 
@@ -212,8 +209,8 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
         v1 = 0.0;
         for (int s = 0; s < NumSpeciesB; s++)
           v1 += Qspec[s] * q *
-              AB->evaluate(P.getSimulationCell().getKLists().getKShell(), RhoKB.rhok_r[s], RhoKB.rhok_i[s], RhoKA.eikr_r[i],
-                           RhoKA.eikr_i[i]);
+              AB->evaluate(P.getSimulationCell().getKLists().getKShell(), RhoKB.rhok_r[s], RhoKB.rhok_i[s],
+                           RhoKA.eikr_r[i], RhoKA.eikr_i[i]);
         Vi_samp(i) += v1;
         Vlr += v1;
       }
@@ -268,7 +265,6 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
 #endif
 
 void CoulombPBCAB::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
-                                          const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                           const RefVectorWithLeader<ParticleSet>& p_list,
                                           const std::vector<ListenerVector<RealType>>& listeners,
                                           const std::vector<ListenerVector<RealType>>& ion_listeners) const
@@ -377,16 +373,6 @@ void CoulombPBCAB::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase
     auto& coulomb_ab  = o_list.getCastedElement<CoulombPBCAB>(iw);
     coulomb_ab.value_ = evaluate_walker(iw, coulomb_ab, p_list[iw], listeners, ion_listeners);
   }
-}
-
-void CoulombPBCAB::mw_evaluatePerParticleWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
-                                                       const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                                       const RefVectorWithLeader<ParticleSet>& p_list,
-                                                       const std::vector<ListenerVector<RealType>>& listeners,
-                                                       const std::vector<ListenerVector<RealType>>& ion_listeners) const
-
-{
-  mw_evaluatePerParticle(o_list, wf_list, p_list, listeners, ion_listeners);
 }
 
 /** Evaluate the background term. Other constants are handled by AA potentials.

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -147,17 +147,10 @@ public:
    *  to registered listeners from Estimators.
    */
   void mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
-                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                               const RefVectorWithLeader<ParticleSet>& p_list,
                               const std::vector<ListenerVector<RealType>>& listeners,
                               const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
-
-  void mw_evaluatePerParticleWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
-                                           const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                           const RefVectorWithLeader<ParticleSet>& p_list,
-                                           const std::vector<ListenerVector<RealType>>& listeners,
-                                           const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
   void evaluateIonDerivs(ParticleSet& P,
                          ParticleSet& ions,

--- a/src/QMCHamiltonians/CoulombPotential.cpp
+++ b/src/QMCHamiltonians/CoulombPotential.cpp
@@ -379,7 +379,6 @@ Return_t CoulombPotential::evaluate(ParticleSet& P)
 }
 
 void CoulombPotential::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
-                                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                               const RefVectorWithLeader<ParticleSet>& p_list,
                                               const std::vector<ListenerVector<RealType>>& listeners,
                                               const std::vector<ListenerVector<RealType>>& ion_listeners) const
@@ -395,24 +394,23 @@ void CoulombPotential::mw_evaluatePerParticle(const RefVectorWithLeader<Operator
   auto myTableIndex           = o_leader.myTableIndex;
   auto nCenters               = o_leader.nCenters;
 
-  auto evaluate_walker = [&va_sample, &vb_sample, myTableIndex,
-                          is_AA, is_active](int walker_index, const ParticleSet& pset, const ParticleSet& pset_ions,
-                                 const std::vector<ListenerVector<RealType>>& listeners,
-                                 const std::vector<ListenerVector<RealType>>& ion_listeners) -> Return_t {
+  auto evaluate_walker = [&va_sample, &vb_sample, myTableIndex, is_AA,
+                          is_active](int walker_index, const ParticleSet& pset, const ParticleSet& pset_ions,
+                                     const std::vector<ListenerVector<RealType>>& listeners,
+                                     const std::vector<ListenerVector<RealType>>& ion_listeners) -> Return_t {
     Return_t value = 0;
     if (is_AA)
       if (is_active)
-	value =
-          evaluate_spAA(pset.getDistTableAA(myTableIndex), pset.Z.first_address(), va_sample, listeners);
+        value = evaluate_spAA(pset.getDistTableAA(myTableIndex), pset.Z.first_address(), va_sample, listeners);
       else
-	value =
-          evaluate_spAA(pset.getDistTableAA(myTableIndex), pset.Z.first_address(), va_sample, ion_listeners);
+        value = evaluate_spAA(pset.getDistTableAA(myTableIndex), pset.Z.first_address(), va_sample, ion_listeners);
     else
-      value = evaluate_spAB(pset.getDistTableAB(myTableIndex), pset_ions.Z.first_address(), pset.Z.first_address(), va_sample, vb_sample, listeners, ion_listeners);
+      value = evaluate_spAB(pset.getDistTableAB(myTableIndex), pset_ions.Z.first_address(), pset.Z.first_address(),
+                            va_sample, vb_sample, listeners, ion_listeners);
     return value;
   };
 
-  auto name                   = o_leader.name_;
+  auto name = o_leader.name_;
   for (int iw = 0; iw < o_list.size(); ++iw)
   {
     auto& coulomb_pot = o_list.getCastedElement<CoulombPotential>(iw);
@@ -439,16 +437,6 @@ void CoulombPotential::mw_evaluatePerParticle(const RefVectorWithLeader<Operator
       for (const ListenerVector<RealType>& ion_listener : ion_listeners)
         ion_listener.report(iw, name, va_sample);
   }
-}
-
-void CoulombPotential::mw_evaluatePerParticleWithToperator(
-    const RefVectorWithLeader<OperatorBase>& o_list,
-    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-    const RefVectorWithLeader<ParticleSet>& p_list,
-    const std::vector<ListenerVector<RealType>>& listeners,
-    const std::vector<ListenerVector<RealType>>& ion_listeners) const
-{
-  mw_evaluatePerParticle(o_list, wf_list, p_list, listeners, ion_listeners);
 }
 
 void CoulombPotential::evaluateIonDerivs(ParticleSet& P,

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -100,15 +100,16 @@ public:
   Return_t evaluateAB(const DistanceTableAB& d, const ParticleScalar* restrict Za, const ParticleScalar* restrict Zb);
 
   static Return_t evaluate_spAA(const DistanceTableAA& d,
-                                const ParticleScalar* restrict Z, Vector<RealType>& ve_samples,
+                                const ParticleScalar* restrict Z,
+                                Vector<RealType>& ve_samples,
                                 const std::vector<ListenerVector<RealType>>& listeners);
   static Return_t evaluate_spAB(const DistanceTableAB& d,
                                 const ParticleScalar* restrict Za,
                                 const ParticleScalar* restrict Zb,
-				Vector<RealType>& ve_samples,
-				Vector<RealType>& vi_samples,
-				const std::vector<ListenerVector<RealType>>& listeners,
-				const std::vector<ListenerVector<RealType>>& ion_listeners);
+                                Vector<RealType>& ve_samples,
+                                Vector<RealType>& vi_samples,
+                                const std::vector<ListenerVector<RealType>>& listeners,
+                                const std::vector<ListenerVector<RealType>>& ion_listeners);
 
 #if !defined(REMOVE_TRACEMANAGER)
   /** evaluate AA-type interactions */
@@ -124,16 +125,9 @@ public:
   Return_t evaluate(ParticleSet& P) override;
 
   void mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
-                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                               const RefVectorWithLeader<ParticleSet>& p_list,
                               const std::vector<ListenerVector<RealType>>& listeners,
                               const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
-
-  void mw_evaluatePerParticleWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
-                                           const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                           const RefVectorWithLeader<ParticleSet>& p_list,
-                                           const std::vector<ListenerVector<RealType>>& listeners,
-                                           const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
   void evaluateIonDerivs(ParticleSet& P,
                          ParticleSet& ions,
@@ -150,6 +144,7 @@ public:
   void setParticlePropertyList(PropertySetType& plist, int offset) override;
 
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp) override;
+
 private:
   ResourceHandle<CoulombPotentialMultiWalkerResource> mw_res_handle_;
 };

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -143,7 +143,6 @@ LocalECPotential::Return_t LocalECPotential::evaluate(ParticleSet& P)
 }
 
 void LocalECPotential::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
-                                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                               const RefVectorWithLeader<ParticleSet>& p_list,
                                               const std::vector<ListenerVector<RealType>>& listeners,
                                               const std::vector<ListenerVector<RealType>>& ion_listeners) const
@@ -199,16 +198,6 @@ void LocalECPotential::mw_evaluatePerParticle(const RefVectorWithLeader<Operator
     auto& local_ecp  = o_list.getCastedElement<LocalECPotential>(iw);
     local_ecp.value_ = evaluate_walker(iw, p_list[iw], PP, listeners, ion_listeners);
   }
-}
-
-void LocalECPotential::mw_evaluatePerParticleWithToperator(
-    const RefVectorWithLeader<OperatorBase>& o_list,
-    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-    const RefVectorWithLeader<ParticleSet>& p_list,
-    const std::vector<ListenerVector<RealType>>& listeners,
-    const std::vector<ListenerVector<RealType>>& ion_listeners) const
-{
-  mw_evaluatePerParticle(o_list, wf_list, p_list, listeners, ion_listeners);
 }
 
 void LocalECPotential::evaluateIonDerivs(ParticleSet& P,

--- a/src/QMCHamiltonians/LocalECPotential.h
+++ b/src/QMCHamiltonians/LocalECPotential.h
@@ -90,16 +90,9 @@ struct LocalECPotential : public OperatorDependsOnlyOnParticleSet
 
   Return_t evaluate(ParticleSet& P) override;
   void mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
-                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                               const RefVectorWithLeader<ParticleSet>& p_list,
                               const std::vector<ListenerVector<RealType>>& listeners,
                               const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
-
-  void mw_evaluatePerParticleWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
-                                           const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                           const RefVectorWithLeader<ParticleSet>& p_list,
-                                           const std::vector<ListenerVector<RealType>>& listeners,
-                                           const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
 
   void evaluateIonDerivs(ParticleSet& P,
                          ParticleSet& ions,

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -86,31 +86,6 @@ void OperatorBase::mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
                                const RefVectorWithLeader<ParticleSet>& p_list) const
 {
   assert(this == &o_list.getLeader());
-/**  Temporary raw omp pragma for simple thread parallelism
-   *   ignoring the driver level concurrency
-   *   
-   *  TODO: replace this with a proper abstraction. It should adequately describe the behavior
-   *  and strictly limit the activation of this level concurrency to when it is intended.
-   *  It is unlikely to belong in this function.
-   *  
-   *  This implicitly depends on openmp work division logic. Essentially adhoc runtime
-   *  crowds over which we have given up control of thread/global scope.
-   *  How many walkers per thread? How to handle their data movement if any of these
-   *  hamiltonians should be accelerated? We can neither reason about or describe it in C++
-   *
-   *  As I understand it it should only be required for as long as the AMD openmp offload 
-   *  compliler is incapable of running multiple threads. They should/must fix their compiler
-   *  before delivery of frontier and it should be removed at that point at latest
-   *
-   *  If you want 16 threads of 1 walker that should be 16 crowds of 1
-   *  not one crowd of 16 with openmp thrown in at hamiltonian level.
-   *  If this must be different from the other crowd batching. Make this a reasoned about
-   *  and controlled level of concurency blocking at the driver level.
-   *
-   *  This is only thread safe only if each walker has a complete
-   *  set of anything involved in an Operator.evaluate.
-   */
-#pragma omp parallel for
   for (int iw = 0; iw < o_list.size(); iw++)
     o_list[iw].evaluate(wf_list[iw], p_list[iw]);
 }
@@ -121,6 +96,7 @@ void OperatorBase::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase
                                           const std::vector<ListenerVector<RealType>>& listeners,
                                           const std::vector<ListenerVector<RealType>>& listeners_ions) const
 {
+  assert(this == &o_list.getLeader());
   mw_evaluate(o_list, wf_list, p_list);
 }
 

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -621,18 +621,68 @@ private:
 
 /** @ingroup hamiltonian
  * A base class for both for Hamiltonian operator components and non-Hamiltonian operators that depends solely on ParticleSet
+ * Due to lack of TWF dependency, there is no response to T operator.
  */
 class OperatorDependsOnlyOnParticleSet : public OperatorBase
 {
 public:
-  virtual Return_t evaluate(ParticleSet& pset) = 0;
+  virtual Return_t evaluate(ParticleSet& pset)                       = 0;
   virtual std::unique_ptr<OperatorBase> makeClone(ParticleSet& pset) = 0;
+
+  virtual void mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
+                           const RefVectorWithLeader<ParticleSet>& p_list) const
+  {
+    assert(this == &o_list.getLeader());
+    for (int iw = 0; iw < o_list.size(); iw++)
+      o_list.getCastedElement<OperatorDependsOnlyOnParticleSet>(iw).evaluate(p_list[iw]);
+  }
+
+  virtual void mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
+                                      const RefVectorWithLeader<ParticleSet>& p_list,
+                                      const std::vector<ListenerVector<RealType>>& listeners,
+                                      const std::vector<ListenerVector<RealType>>& listeners_ions) const
+  {
+    mw_evaluate(o_list, p_list);
+  }
 
 private:
   inline Return_t evaluate(TrialWaveFunction& psi, ParticleSet& pset) final { return evaluate(pset); }
   inline std::unique_ptr<OperatorBase> makeClone(ParticleSet& pset, TrialWaveFunction& psi) final
   {
     return makeClone(pset);
+  }
+
+  inline void mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
+                          const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                          const RefVectorWithLeader<ParticleSet>& p_list) const final
+  {
+    mw_evaluate(o_list, p_list);
+  }
+
+  inline void mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
+                                     const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                     const RefVectorWithLeader<ParticleSet>& p_list,
+                                     const std::vector<ListenerVector<RealType>>& listeners,
+                                     const std::vector<ListenerVector<RealType>>& listeners_ions) const final
+  {
+    mw_evaluatePerParticle(o_list, p_list, listeners, listeners_ions);
+  }
+
+  inline void mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                       const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                       const RefVectorWithLeader<ParticleSet>& p_list) const final
+  {
+    mw_evaluate(o_list, p_list);
+  }
+
+  inline void mw_evaluatePerParticleWithToperator(
+      const RefVectorWithLeader<OperatorBase>& o_list,
+      const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+      const RefVectorWithLeader<ParticleSet>& p_list,
+      const std::vector<ListenerVector<RealType>>& listeners,
+      const std::vector<ListenerVector<RealType>>& listeners_ions) const final
+  {
+    mw_evaluatePerParticle(o_list, p_list, listeners, listeners_ions);
   }
 };
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -245,17 +245,11 @@ void test_CoulombPBCAA_3p(DynamicCoordinateKind kind)
   RefVectorWithLeader<ParticleSet> p_ref_list(elec, {elec, elec_clone});
   RefVectorWithLeader<OperatorBase> caa_ref_list(caa, {caa, caa_clone});
 
-  // dummy psi
-  RuntimeOptions runtime_options;
-  TrialWaveFunction psi(runtime_options);
-  TrialWaveFunction psi_clone(runtime_options);
-  RefVectorWithLeader<TrialWaveFunction> psi_ref_list(psi, {psi, psi_clone});
-
   ResourceCollectionTeamLock<ParticleSet> mw_pset_lock(pset_res, p_ref_list);
   ResourceCollectionTeamLock<OperatorBase> mw_caa_lock(caa_res, caa_ref_list);
 
   ParticleSet::mw_update(p_ref_list);
-  caa.mw_evaluate(caa_ref_list, psi_ref_list, p_ref_list);
+  caa.mw_evaluate(caa_ref_list, p_ref_list);
 
   CHECK(caa.getValue() == Approx(-5.4954533536));
   CHECK(caa_clone.getValue() == Approx(-6.329373489));
@@ -307,10 +301,6 @@ TEST_CASE("CoulombAA::mw_evaluatePerParticle", "[hamiltonian]")
   // golden CoulombPBCAA
   CoulombPBCAA caa(elec, true, false, kind == DynamicCoordinateKind::DC_POS_OFFLOAD);
 
-  // mock golden wavefunction, only needed to satisfy APIs
-  RuntimeOptions runtime_options;
-  TrialWaveFunction psi(runtime_options);
-
   // informOfPerParticleListener should be called on the golden instance of this operator if there
   // are listeners present for it.  This would normally be done by QMCHamiltonian but this is a unit test.
   caa.informOfPerParticleListener();
@@ -325,9 +315,6 @@ TEST_CASE("CoulombAA::mw_evaluatePerParticle", "[hamiltonian]")
   CoulombPBCAA caa2(elec2, true, false, kind == DynamicCoordinateKind::DC_POS_OFFLOAD);
   RefVector<OperatorBase> caas{caa, caa2};
   RefVectorWithLeader<OperatorBase> o_list(caa, caas);
-
-  TrialWaveFunction psi_clone(runtime_options);
-  RefVectorWithLeader<TrialWaveFunction> twf_list(psi, {psi, psi_clone});
 
   // Self-energy correction, no background charge for e-e interaction
   double consts = caa.myConst;
@@ -356,7 +343,7 @@ TEST_CASE("CoulombAA::mw_evaluatePerParticle", "[hamiltonian]")
 
   ParticleSet::mw_update(p_list);
 
-  caa.mw_evaluatePerParticle(o_list, twf_list, p_list, listeners, ion_listeners);
+  caa.mw_evaluatePerParticle(o_list, p_list, listeners, ion_listeners);
   CHECK(caa.getValue() == Approx(-2.9332312765));
   CHECK(caa2.getValue() == Approx(-3.4537460926));
   // Check that the sum of the particle energies == the total

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
@@ -245,7 +245,7 @@ TEST_CASE("CoulombAB::Listener", "[hamiltonian]")
   ion_listeners.emplace_back("localpotential", getParticularListener(ion_pots2));
 
   ParticleSet::mw_update(p_list);
-  cab.mw_evaluatePerParticle(o_list, twf_list, p_list, listeners, ion_listeners);
+  cab.mw_evaluatePerParticle(o_list, p_list, listeners, ion_listeners);
   CHECK(cab.getValue() == Approx(-2.219665062 + 0.0267892759 * 4));
   CHECK(cab2.getValue() == Approx(-1.7222343352));
   // Check that the sum of the particle energies == the total


### PR DESCRIPTION
~~Review after merging #5671~~

## Proposed changes
Consolidate multi-walker APIs of OperatorDependsOnlyOnParticleSet.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
