### PR TITLE
Remove resetTargetParticleSet thoughout the code base

### DIFF
--- a/src/Estimators/EstimatorManagerBase.cpp
+++ b/src/Estimators/EstimatorManagerBase.cpp
@@ -136,8 +136,6 @@ void EstimatorManagerBase::reset()
     Collectables->add2Record(BlockAverages);
 }
 
-void EstimatorManagerBase::resetTargetParticleSet(ParticleSet& p) {}
-
 void EstimatorManagerBase::addHeader(std::ostream& o)
 {
   o.setf(std::ios::scientific, std::ios::floatfield);

--- a/src/Estimators/EstimatorManagerBase.h
+++ b/src/Estimators/EstimatorManagerBase.h
@@ -125,8 +125,6 @@ public:
   //bool put(xmlNodePtr cur);
   bool put(QMCHamiltonian& H, xmlNodePtr cur);
 
-  void resetTargetParticleSet(ParticleSet& p);
-
   /** reset the estimator
    */
   void reset();

--- a/src/Particle/LongRange/EwaldHandler2D.h
+++ b/src/Particle/LongRange/EwaldHandler2D.h
@@ -53,7 +53,6 @@ public:
   }
   void initBreakup(ParticleSet& ref) override {}
   void Breakup(ParticleSet& ref, mRealType rs_in) override { initBreakup(ref); }
-  void resetTargetParticleSet(ParticleSet& ref) override {}
   // overrides end
 private:
   mRealType alpha;

--- a/src/Particle/LongRange/EwaldHandler3D.h
+++ b/src/Particle/LongRange/EwaldHandler3D.h
@@ -61,8 +61,6 @@ public:
 
   void Breakup(ParticleSet& ref, mRealType rs_in) override { initBreakup(ref); }
 
-  void resetTargetParticleSet(ParticleSet& ref) override {}
-
   inline mRealType evaluate(mRealType r, mRealType rinv) const override { return erfc(r * Sigma) * rinv; }
 
   /** evaluate the contribution from the long-range part for for spline

--- a/src/Particle/LongRange/EwaldHandlerQuasi2D.h
+++ b/src/Particle/LongRange/EwaldHandlerQuasi2D.h
@@ -61,7 +61,6 @@ public:
   }
   void initBreakup(ParticleSet& ref) override {}
   void Breakup(ParticleSet& ref, mRealType rs_in) override { initBreakup(ref); }
-  void resetTargetParticleSet(ParticleSet& ref) override {}
   // overrides end
 private:
   mRealType alpha;

--- a/src/Particle/LongRange/LRHandlerBase.h
+++ b/src/Particle/LongRange/LRHandlerBase.h
@@ -185,7 +185,6 @@ struct LRHandlerBase
 
   virtual void initBreakup(ParticleSet& ref)              = 0;
   virtual void Breakup(ParticleSet& ref, mRealType rs_in) = 0;
-  virtual void resetTargetParticleSet(ParticleSet& ref)   = 0;
 
   virtual mRealType evaluate(mRealType r, mRealType rinv) const = 0;
   virtual mRealType evaluateLR(mRealType r) const               = 0;
@@ -250,7 +249,6 @@ struct DummyLRHandler : public LRHandlerBase
   mRealType evaluateLR(mRealType r) const override { return 0.0; }
   mRealType srDf(mRealType r, mRealType rinv) const override { return 0.0; }
   void Breakup(ParticleSet& ref, mRealType rs_in) override {}
-  void resetTargetParticleSet(ParticleSet& ref) override {}
   LRHandlerBase* makeClone(ParticleSet& ref) const override { return new DummyLRHandler<Func>(LR_kc); }
 };
 

--- a/src/Particle/LongRange/LRHandlerSRCoulomb.h
+++ b/src/Particle/LongRange/LRHandlerSRCoulomb.h
@@ -107,10 +107,6 @@ public:
     LR_rc = Basis.get_rc();
   }
 
-  void resetTargetParticleSet(ParticleSet& ref) override { myFunc.reset(ref); }
-
-  void resetTargetParticleSet(ParticleSet& ref, mRealType rs) { myFunc.reset(ref, rs); }
-
   inline mRealType evaluate(mRealType r, mRealType rinv) const override
   {
     //Right now LRHandlerSRCoulomb is the force only handler.  This is why the gcoefs are used for evaluate.

--- a/src/Particle/LongRange/LRHandlerTemp.h
+++ b/src/Particle/LongRange/LRHandlerTemp.h
@@ -97,10 +97,6 @@ public:
     LR_rc = Basis.get_rc();
   }
 
-  void resetTargetParticleSet(ParticleSet& ref) override { myFunc.reset(ref); }
-
-  void resetTargetParticleSet(ParticleSet& ref, mRealType rs) { myFunc.reset(ref, rs); }
-
   inline mRealType evaluate(mRealType r, mRealType rinv) const override
   {
     mRealType v = 0.0;

--- a/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
@@ -96,10 +96,6 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
     LR_rc = Basis.get_rc();
   }
 
-  void resetTargetParticleSet(ParticleSet& ref) override { myFunc.reset(ref); }
-
-  void resetTargetParticleSet(ParticleSet& ref, mRealType rs) { myFunc.reset(ref, rs); }
-
   inline mRealType evaluate(mRealType r, mRealType rinv) const override
   {
     mRealType v = 0.0;

--- a/src/Particle/LongRange/LRRPAHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPAHandlerTemp.h
@@ -99,10 +99,6 @@ struct LRRPAHandlerTemp : public LRHandlerBase
     LR_rc = Basis.get_rc();
   }
 
-  void resetTargetParticleSet(ParticleSet& ref) override { myFunc.reset(ref); }
-
-  void resetTargetParticleSet(ParticleSet& ref, mRealType rs) { myFunc.reset(ref, rs); }
-
   inline mRealType evaluate(mRealType r, mRealType rinv) const override
   {
     mRealType v = 0.0;

--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
@@ -241,7 +241,6 @@ void CSVMC::resetRun()
     for (int ip = 0; ip < NumThreads; ++ip)
     {
       std::ostringstream os;
-      estimatorClones[ip]->resetTargetParticleSet(*wClones[ip]);
       estimatorClones[ip]->setCollectionMode(false);
 #if !defined(REMOVE_TRACEMANAGER)
       traceClones[ip] = Traces->makeClone();

--- a/src/QMCDrivers/RMC/RMC.cpp
+++ b/src/QMCDrivers/RMC/RMC.cpp
@@ -221,7 +221,6 @@ void RMC::resetRun()
     for (int ip = 0; ip < NumThreads; ++ip)
     {
       std::ostringstream os;
-      estimatorClones[ip]->resetTargetParticleSet(*wClones[ip]);
       estimatorClones[ip]->setCollectionMode(false);
       Rng[ip] = RandomNumberControl::Children[ip]->makeClone();
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCDrivers/VMC/VMC.cpp
+++ b/src/QMCDrivers/VMC/VMC.cpp
@@ -174,7 +174,6 @@ void VMC::resetRun()
     for (int ip = 0; ip < NumThreads; ++ip)
     {
       std::ostringstream os;
-      estimatorClones[ip]->resetTargetParticleSet(*wClones[ip]);
       estimatorClones[ip]->setCollectionMode(false);
 #if !defined(REMOVE_TRACEMANAGER)
       traceClones[ip] = Traces->makeClone();

--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -135,8 +135,6 @@ ACForce::Return_t ACForce::evaluate(TrialWaveFunction& psi, ParticleSet& P)
   return 0.0;
 };
 
-void ACForce::resetTargetParticleSet(ParticleSet& P) {}
-
 void ACForce::addObservables(PropertySetType& plist, BufferType& collectables)
 {
   if (first_force_index_ < 0)

--- a/src/QMCHamiltonians/ACForce.h
+++ b/src/QMCHamiltonians/ACForce.h
@@ -49,9 +49,6 @@ public:
   //Not derived from base class.  But we need it to properly set the Hamiltonian reference.
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& H);
 
-  /** Initialization/assignment **/
-  void resetTargetParticleSet(ParticleSet& P) final;
-
   void addObservables(PropertySetType& plist, BufferType& collectables) final;
 
   void setObservables(PropertySetType& plist) final;

--- a/src/QMCHamiltonians/BareForce.cpp
+++ b/src/QMCHamiltonians/BareForce.cpp
@@ -29,8 +29,6 @@ BareForce::BareForce(ParticleSet& ions, ParticleSet& elns) : ForceBase(ions, eln
 
 std::string BareForce::getClassName() const { return "BareForce"; }
 
-void BareForce::resetTargetParticleSet(ParticleSet& P) {}
-
 std::unique_ptr<OperatorBase> BareForce::makeClone(ParticleSet& qp)
 {
   return std::make_unique<BareForce>(*this);

--- a/src/QMCHamiltonians/BareForce.h
+++ b/src/QMCHamiltonians/BareForce.h
@@ -27,7 +27,6 @@ struct BareForce : public OperatorDependsOnlyOnParticleSet, public ForceBase
 public:
   BareForce(ParticleSet& ions, ParticleSet& elns);
   std::string getClassName() const override;
-  void resetTargetParticleSet(ParticleSet& P) override;
 
   Return_t evaluate(ParticleSet& P) override;
 

--- a/src/QMCHamiltonians/BareKineticEnergy.cpp
+++ b/src/QMCHamiltonians/BareKineticEnergy.cpp
@@ -69,8 +69,6 @@ bool BareKineticEnergy::dependsOnWaveFunction() const { return true; }
 
 std::string BareKineticEnergy::getClassName() const { return "BareKineticEnergy"; }
 
-void BareKineticEnergy::resetTargetParticleSet(ParticleSet& p) {}
-
 #if !defined(REMOVE_TRACEMANAGER)
 void BareKineticEnergy::contributeParticleQuantities()
 {

--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -55,7 +55,6 @@ public:
 
   bool dependsOnWaveFunction() const override;
   std::string getClassName() const override;
-  void resetTargetParticleSet(ParticleSet& p) override;
 
 #if !defined(REMOVE_TRACEMANAGER)
   void contributeParticleQuantities() override;

--- a/src/QMCHamiltonians/ChiesaCorrection.cpp
+++ b/src/QMCHamiltonians/ChiesaCorrection.cpp
@@ -21,8 +21,6 @@ ChiesaCorrection::ChiesaCorrection(ParticleSet& ptcl, const TrialWaveFunction& p
 
 std::string ChiesaCorrection::getClassName() const { return "ChiesaCorrection"; }
 
-void ChiesaCorrection::resetTargetParticleSet(ParticleSet& P) {}
-
 bool ChiesaCorrection::put(xmlNodePtr cur) { return true; }
 
 bool ChiesaCorrection::get(std::ostream& os) const

--- a/src/QMCHamiltonians/ChiesaCorrection.h
+++ b/src/QMCHamiltonians/ChiesaCorrection.h
@@ -26,8 +26,6 @@ public:
 
   std::string getClassName() const override;
 
-  void resetTargetParticleSet(ParticleSet& P) override;
-
   Return_t evaluate(TrialWaveFunction& psi, ParticleSet& P) override;
 
   bool put(xmlNodePtr cur) override;

--- a/src/QMCHamiltonians/ConservedEnergy.h
+++ b/src/QMCHamiltonians/ConservedEnergy.h
@@ -71,8 +71,6 @@ struct ConservedEnergy : public OperatorDependsOnlyOnParticleSet
   ConservedEnergy() {}
   ~ConservedEnergy() override {}
 
-  void resetTargetParticleSet(ParticleSet& P) override {}
-
   std::string getClassName() const override { return "ConservedEnergy"; }
 
   Return_t evaluate(ParticleSet& P) override

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -161,15 +161,6 @@ void CoulombPBCAA::updateSource(ParticleSet& s)
   new_value_ = value_ = eL + eS + myConst;
 }
 
-void CoulombPBCAA::resetTargetParticleSet(ParticleSet& P)
-{
-  if (is_active)
-  {
-    PtclRefName = P.getDistTable(d_aa_ID).getName();
-    lr_aa_->resetTargetParticleSet(P);
-  }
-}
-
 #if !defined(REMOVE_TRACEMANAGER)
 void CoulombPBCAA::contributeParticleQuantities() { request_.contribute_array(name_); }
 

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -41,8 +41,8 @@ struct CoulombPBCAA : public OperatorDependsOnlyOnParticleSet, public ForceBase
   using mRealType      = LRHandlerType::mRealType;
   using OffloadSpline  = OneDimCubicSplineLinearGrid<LRCoulombSingleton::pRealType>;
 
-  /// energy-optimized long range handle. Should be const LRHandlerType eventually
-  std::shared_ptr<LRHandlerType> lr_aa_;
+  /// energy-optimized long range handle
+  std::shared_ptr<const LRHandlerType> lr_aa_;
   /// energy-optimized short range pair potential
   std::shared_ptr<const RadFunctorType> rVs;
   /// the same as rVs but can be used inside OpenMP offload regions
@@ -113,8 +113,6 @@ struct CoulombPBCAA : public OperatorDependsOnlyOnParticleSet, public ForceBase
   ~CoulombPBCAA() override;
 
   std::string getClassName() const override { return "CoulombPBCAA"; }
-
-  void resetTargetParticleSet(ParticleSet& P) override;
 
   /** evaluate just one walker
    *

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -67,16 +67,6 @@ std::unique_ptr<OperatorBase> CoulombPBCAB::makeClone(ParticleSet& qp)
 
 CoulombPBCAB::~CoulombPBCAB() = default;
 
-void CoulombPBCAB::resetTargetParticleSet(ParticleSet& P)
-{
-  int tid = P.addTable(pset_ions_);
-  if (tid != myTableIndex)
-  {
-    APP_ABORT("CoulombPBCAB::resetTargetParticleSet found inconsistent table index");
-  }
-  AB->resetTargetParticleSet(P);
-}
-
 void CoulombPBCAB::addObservables(PropertySetType& plist, BufferType& collectables)
 {
   my_index_ = plist.add(name_.c_str());

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -43,8 +43,8 @@ public:
   using RadFunctorType = LRCoulombSingleton::RadFunctorType;
   using mRealType      = LRHandlerType::mRealType;
 
-  ///long-range Handler. Should be const LRHandlerType eventually
-  std::shared_ptr<LRHandlerType> AB;
+  ///long-range Handler
+  std::shared_ptr<const LRHandlerType> AB;
   ///long-range derivative handler
   std::shared_ptr<const LRHandlerType> dAB;
   ///locator of the distance table
@@ -128,8 +128,6 @@ public:
   //CoulombPBCAB(const CoulombPBCAB& c);
 
   ~CoulombPBCAB() override;
-
-  void resetTargetParticleSet(ParticleSet& P) override;
 
   std::string getClassName() const override { return "CoulombPBCAB"; }
 

--- a/src/QMCHamiltonians/CoulombPotential.cpp
+++ b/src/QMCHamiltonians/CoulombPotential.cpp
@@ -352,12 +352,6 @@ Return_t CoulombPotential::evaluate_spAB(const DistanceTableAB& d,
 }
 #endif
 
-
-void CoulombPotential::resetTargetParticleSet(ParticleSet& P)
-{
-  //myTableIndex is the same
-}
-
 void CoulombPotential::updateSource(ParticleSet& s)
 {
   if (is_AA)

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -117,7 +117,6 @@ public:
                          const ParticleScalar* restrict Za,
                          const ParticleScalar* restrict Zb);
 #endif
-  void resetTargetParticleSet(ParticleSet& P) override;
   ~CoulombPotential() override {};
 
   void updateSource(ParticleSet& s) override;

--- a/src/QMCHamiltonians/DensityEstimator.cpp
+++ b/src/QMCHamiltonians/DensityEstimator.cpp
@@ -44,8 +44,6 @@ DensityEstimator::DensityEstimator(ParticleSet& elns)
 
 std::string DensityEstimator::getClassName() const { return "DensityEstimator"; }
 
-void DensityEstimator::resetTargetParticleSet(ParticleSet& P) {}
-
 DensityEstimator::Return_t DensityEstimator::evaluate(ParticleSet& P)
 {
   if (t_walker_ == nullptr)

--- a/src/QMCHamiltonians/DensityEstimator.h
+++ b/src/QMCHamiltonians/DensityEstimator.h
@@ -31,7 +31,6 @@ public:
   DensityEstimator(ParticleSet& elns);
 
   std::string getClassName() const override;
-  void resetTargetParticleSet(ParticleSet& P) override;
 
   Return_t evaluate(ParticleSet& P) override;
 

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -164,7 +164,6 @@ public:
   void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
 
   //should be empty for Collectables interface
-  void resetTargetParticleSet(ParticleSet& P) override {}
   void setObservables(PropertySetType& plist) override {}
   void setParticlePropertyList(PropertySetType& plist, int offset) override {}
   void contributeScalarQuantities() override {}

--- a/src/QMCHamiltonians/EnergyDensityEstimator.cpp
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.cpp
@@ -246,12 +246,6 @@ bool EnergyDensityEstimator::get(std::ostream& os) const
 }
 
 
-void EnergyDensityEstimator::resetTargetParticleSet(ParticleSet& P)
-{
-  //remains empty
-}
-
-
 //#define ENERGYDENSITY_CHECK
 
 EnergyDensityEstimator::Return_t EnergyDensityEstimator::evaluate(ParticleSet& P)

--- a/src/QMCHamiltonians/EnergyDensityEstimator.h
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.h
@@ -32,7 +32,6 @@ public:
   ~EnergyDensityEstimator() override;
 
   std::string getClassName() const override { return "EnergyDensityEstimator"; }
-  void resetTargetParticleSet(ParticleSet& P) override;
   Return_t evaluate(ParticleSet& P) override;
   void addObservables(PropertySetType& plist) {}
   void addObservables(PropertySetType& plist, BufferType& olist) override;

--- a/src/QMCHamiltonians/ForceCeperley.h
+++ b/src/QMCHamiltonians/ForceCeperley.h
@@ -57,8 +57,6 @@ public:
 
   void setObservables(PropertySetType& plist) override { setObservablesF(plist); }
 
-  void resetTargetParticleSet(ParticleSet& P) override {}
-
   // Compute ion-ion forces at construction to include in the total forces
   void evaluate_IonIon(ParticleSet::ParticlePos& forces) const;
 

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
@@ -221,8 +221,6 @@ bool ForceChiesaPBCAA::put(xmlNodePtr cur)
   return true;
 }
 
-void ForceChiesaPBCAA::resetTargetParticleSet(ParticleSet& P) { dAB->resetTargetParticleSet(P); }
-
 void ForceChiesaPBCAA::addObservables(PropertySetType& plist, BufferType& collectables)
 {
   my_index_ = plist.add(name_.c_str());
@@ -231,19 +229,6 @@ void ForceChiesaPBCAA::addObservables(PropertySetType& plist, BufferType& collec
 
 std::unique_ptr<OperatorBase> ForceChiesaPBCAA::makeClone(ParticleSet& qp)
 {
-  std::unique_ptr<ForceChiesaPBCAA> tmp = std::make_unique<ForceChiesaPBCAA>(PtclA, qp, false);
-  tmp->Rcut                             = Rcut;    // parameter: radial distance within which estimator is used
-  tmp->m_exp                            = m_exp;   // parameter: exponent in polynomial fit
-  tmp->N_basis                          = N_basis; // parameter: size of polynomial basis set
-  tmp->Sinv.resize(N_basis, N_basis);
-  tmp->Sinv = Sinv; // terms in fitting polynomial
-  tmp->h.resize(N_basis);
-  tmp->h = h; // terms in fitting polynomial
-  tmp->c.resize(N_basis);
-  tmp->c               = c; // polynomial coefficients
-  tmp->add_ion_ion_    = add_ion_ion_;
-  tmp->forces_ion_ion_ = forces_ion_ion_;
-  tmp->initBreakup(qp);
-  return tmp;
+  return std::make_unique<ForceChiesaPBCAA>(*this);
 }
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.h
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.h
@@ -39,7 +39,7 @@ struct ForceChiesaPBCAA : public OperatorDependsOnlyOnParticleSet, public ForceB
   ///source particle set
   ParticleSet& PtclA;
   ///long-range Handler
-  std::unique_ptr<LRHandlerType> dAB;
+  std::shared_ptr<const LRHandlerType> dAB;
   ///number of species of A particle set
   int NumSpeciesA;
   ///number of species of B particle set
@@ -95,10 +95,6 @@ struct ForceChiesaPBCAA : public OperatorDependsOnlyOnParticleSet, public ForceB
     OperatorBase::setParticlePropertyList(plist, offset);
     setParticleSetF(plist, offset);
   }
-
-
-  void resetTargetParticleSet(ParticleSet& P) override;
-
 
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp) final;
 

--- a/src/QMCHamiltonians/GridExternalPotential.h
+++ b/src/QMCHamiltonians/GridExternalPotential.h
@@ -31,8 +31,6 @@ public:
 
   std::string getClassName() const override { return "GridExternalPotential"; }
 
-  void resetTargetParticleSet(ParticleSet& P) override {}
-
   //standard interface functions
   bool put(xmlNodePtr cur) override;
   bool get(std::ostream& os) const override;

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -348,7 +348,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur)
       {
         if (estType == "coulomb")
         {
-          std::unique_ptr<Pressure> BP = std::make_unique<Pressure>(targetPtcl);
+          std::unique_ptr<Pressure> BP = std::make_unique<Pressure>();
           BP->put(element);
           targetH->addOperator(std::move(BP), "Pressure", false);
           int nlen(100);

--- a/src/QMCHamiltonians/HarmonicExternalPotential.h
+++ b/src/QMCHamiltonians/HarmonicExternalPotential.h
@@ -43,9 +43,6 @@ struct HarmonicExternalPotential : public OperatorDependsOnlyOnParticleSet
   ~HarmonicExternalPotential() override {}
 
   std::string getClassName() const override { return "HarmonicExternalPotential"; }
-  //unneeded interface functions
-  void resetTargetParticleSet(ParticleSet& P) override {}
-
   //standard interface functions
   bool put(xmlNodePtr cur) override;
   bool get(std::ostream& os) const override;

--- a/src/QMCHamiltonians/L2Potential.cpp
+++ b/src/QMCHamiltonians/L2Potential.cpp
@@ -29,16 +29,6 @@ L2Potential::L2Potential(const ParticleSet& ions, ParticleSet& els, TrialWaveFun
   psi_ref = &psi;
 }
 
-void L2Potential::resetTargetParticleSet(ParticleSet& P)
-{
-  int tid = P.addTable(IonConfig);
-  if (tid != myTableIndex)
-  {
-    APP_ABORT("  L2Potential::resetTargetParticleSet found a different distance table index.");
-  }
-}
-
-
 void L2Potential::add(int groupID, std::unique_ptr<L2RadialPotential>&& ppot)
 {
   for (int iat = 0; iat < PP.size(); iat++)

--- a/src/QMCHamiltonians/L2Potential.h
+++ b/src/QMCHamiltonians/L2Potential.h
@@ -74,8 +74,6 @@ struct L2Potential : public OperatorBase
   bool dependsOnWaveFunction() const override { return true; }
   std::string getClassName() const override { return "L2Potential"; }
 
-  void resetTargetParticleSet(ParticleSet& P) override;
-
   Return_t evaluate(TrialWaveFunction& psi, ParticleSet& P) override;
 
   void evaluateDK(ParticleSet& P, int iel, TensorType& D, PosType& K);

--- a/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
@@ -213,8 +213,6 @@ void LatticeDeviationEstimator::setObservables(PropertySetType& plist)
   }
 }
 
-void LatticeDeviationEstimator::resetTargetParticleSet(ParticleSet& P) {}
-
 std::unique_ptr<OperatorBase> LatticeDeviationEstimator::makeClone(ParticleSet& qp)
 {
   // default constructor does not work with threads

--- a/src/QMCHamiltonians/LatticeDeviationEstimator.h
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.h
@@ -58,7 +58,6 @@ public:
   //void addObservables(PropertySetType& plist, BufferType& collectables); // also used for multiple scalars
 
   // pure virtual functions require overrider
-  void resetTargetParticleSet(ParticleSet& P) override;                                   // required
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& P) final; // required
 
 private:

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -71,15 +71,6 @@ void LocalECPotential::releaseResource(ResourceCollection& collection,
   collection.takebackResource(O_leader.mw_res_handle_);
 }
 
-void LocalECPotential::resetTargetParticleSet(ParticleSet& P)
-{
-  int tid = P.addTable(IonConfig);
-  if (tid != myTableIndex)
-  {
-    APP_ABORT("  LocalECPotential::resetTargetParticleSet found a different distance table index.");
-  }
-}
-
 void LocalECPotential::add(int groupID, std::unique_ptr<RadialPotentialType>&& ppot, RealType z)
 {
   for (int iat = 0; iat < PP.size(); iat++)

--- a/src/QMCHamiltonians/LocalECPotential.h
+++ b/src/QMCHamiltonians/LocalECPotential.h
@@ -79,7 +79,6 @@ struct LocalECPotential : public OperatorDependsOnlyOnParticleSet
   void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const override;
 
   std::string getClassName() const override { return "LocalECPotential"; }
-  void resetTargetParticleSet(ParticleSet& P) override;
 
 #if !defined(REMOVE_TRACEMANAGER)
   void contributeParticleQuantities() override;

--- a/src/QMCHamiltonians/MPC.cpp
+++ b/src/QMCHamiltonians/MPC.cpp
@@ -30,8 +30,6 @@
 
 namespace qmcplusplus
 {
-void MPC::resetTargetParticleSet(ParticleSet& ptcl) {}
-
 MPC::MPC(ParticleSet& ptcl, double cutoff)
     : Ecut(cutoff), d_aa_ID(ptcl.addTable(ptcl, DTModes::NEED_FULL_TABLE_ON_HOST_AFTER_DONEPBYP)), FirstTime(true)
 {

--- a/src/QMCHamiltonians/MPC.h
+++ b/src/QMCHamiltonians/MPC.h
@@ -78,7 +78,6 @@ public:
   ~MPC() override;
 
   std::string getClassName() const override { return "MPC"; }
-  void resetTargetParticleSet(ParticleSet& P) override;
 
   Return_t evaluate(ParticleSet& P) override;
 

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -36,8 +36,6 @@ MomentumEstimator::MomentumEstimator(ParticleSet& elns, TrialWaveFunction& psi)
   twist = elns.getTwist();
 }
 
-void MomentumEstimator::resetTargetParticleSet(ParticleSet& P) {}
-
 MomentumEstimator::Return_t MomentumEstimator::evaluate(TrialWaveFunction& psi, ParticleSet& P)
 {
   const int np = P.getTotalNum();

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -23,7 +23,6 @@ public:
   MomentumEstimator(ParticleSet& elns, TrialWaveFunction& psi);
   bool dependsOnWaveFunction() const override { return true; }
   std::string getClassName() const override { return "MomentumEstimator"; }
-  void resetTargetParticleSet(ParticleSet& P) override;
 
   Return_t evaluate(TrialWaveFunction& psi, ParticleSet& P) override;
 

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -44,8 +44,6 @@ struct NonLocalECPotential::NonLocalECPotentialMultiWalkerResource : public Reso
   Matrix<Real> vi_samples;
 };
 
-void NonLocalECPotential::resetTargetParticleSet(ParticleSet& P) {}
-
 /** constructor
  *\param ions the positions of the ions
  *\param els the positions of the electrons

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -50,7 +50,6 @@ public:
 
   bool dependsOnWaveFunction() const override { return true; }
   std::string getClassName() const override { return "NonLocalECPotential"; }
-  void resetTargetParticleSet(ParticleSet& P) override;
 
 #if !defined(REMOVE_TRACEMANAGER)
   void contributeParticleQuantities() override;

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -173,12 +173,6 @@ public:
 
   //////// PURELY VIRTUAL FUNCTIONS ////////////////
   /** 
-   * @brief Reset the data with the target ParticleSet
-   * @param P new target ParticleSet
-   */
-  virtual void resetTargetParticleSet(ParticleSet& P) = 0;
-
-  /** 
    * @brief Evaluate the local energy contribution of this component
    * @param P input configuration containing N particles
    * @return the value of the Hamiltonian component

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -236,7 +236,6 @@ public:
   void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override {}
 
   //should be empty for Collectables interface
-  void resetTargetParticleSet(ParticleSet& P) override {}
   void setObservables(PropertySetType& plist) override {}
   void setParticlePropertyList(PropertySetType& plist, int offset) override {}
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCHamiltonians/PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/PairCorrEstimator.cpp
@@ -103,8 +103,6 @@ PairCorrEstimator::PairCorrEstimator(ParticleSet& elns, std::string& sources)
   }
 }
 
-void PairCorrEstimator::resetTargetParticleSet(ParticleSet& P) {}
-
 // The value should match the index to norm_factor in set_norm_factor
 int PairCorrEstimator::gen_pair_id(const int ig, const int jg, const int ns)
 {

--- a/src/QMCHamiltonians/PairCorrEstimator.h
+++ b/src/QMCHamiltonians/PairCorrEstimator.h
@@ -36,7 +36,6 @@ public:
   PairCorrEstimator(ParticleSet& elns, std::string& sources);
 
   std::string getClassName() const override { return "PairCorrEstimator"; }
-  void resetTargetParticleSet(ParticleSet& P) override;
 
   /* evaluate the pair correlation functions */
   Return_t evaluate(ParticleSet& P) override;

--- a/src/QMCHamiltonians/Pressure.h
+++ b/src/QMCHamiltonians/Pressure.h
@@ -29,33 +29,32 @@ namespace qmcplusplus
  where d is the dimension of space and /Omega is the volume.
 **/
 
-struct Pressure : public OperatorDependsOnlyOnParticleSet
+class Pressure : public OperatorDependsOnlyOnParticleSet
 {
   using WP = WalkerProperties::Indexes;
-  double pNorm;
   //     bool ZV;
   //     bool ZB;
 
+public:
   /** constructor
    *
    * Pressure operators need to be re-evaluated during optimization.
    */
-  Pressure(ParticleSet& P)
+  Pressure()
   {
     update_mode_.set(OPTIMIZABLE, 1);
-    pNorm = 1.0 / (P.getLattice().DIM * P.getLattice().Volume);
   }
   ///destructor
   ~Pressure() override {}
 
   bool dependsOnWaveFunction() const override { return true; }
   std::string getClassName() const override { return "Pressure"; }
-  void resetTargetParticleSet(ParticleSet& P) override { pNorm = 1.0 / (P.getLattice().DIM * P.getLattice().Volume); }
 
   inline Return_t evaluate(ParticleSet& P) override
   {
+    const double pNorm = 1.0 / (P.getLattice().DIM * P.getLattice().Volume);
     value_ = 2.0 * P.PropertyList[WP::LOCALENERGY] - P.PropertyList[WP::LOCALPOTENTIAL];
-    value_ *= pNorm;
+    value_ *= 1.0 / (P.getLattice().DIM * P.getLattice().Volume);;
     return 0.0;
   }
 
@@ -132,7 +131,7 @@ struct Pressure : public OperatorDependsOnlyOnParticleSet
 
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp) final
   {
-    return std::make_unique<Pressure>(qp);
+    return std::make_unique<Pressure>();
   }
 };
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -949,14 +949,6 @@ RefVector<OperatorBase> QMCHamiltonian::getTWFDependentComponents()
   return components;
 }
 
-void QMCHamiltonian::resetTargetParticleSet(ParticleSet& P)
-{
-  for (int i = 0; i < H.size(); i++)
-    H[i]->resetTargetParticleSet(P);
-  for (int i = 0; i < auxH.size(); i++)
-    auxH[i]->resetTargetParticleSet(P);
-}
-
 void QMCHamiltonian::setRandomGenerator(RandomBase<FullPrecRealType>* rng)
 {
   for (int i = 0; i < H.size(); i++)

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -381,8 +381,6 @@ public:
    */
   FullPrecRealType getEnsembleAverage();
 
-  void resetTargetParticleSet(ParticleSet& P);
-
   const std::string& getName() const { return myName; }
 
   bool get(std::ostream& os) const;

--- a/src/QMCHamiltonians/SOECPotential.cpp
+++ b/src/QMCHamiltonians/SOECPotential.cpp
@@ -83,8 +83,6 @@ SOECPotential::SOECPotential(const SOECPotential& sopp, ParticleSet& els, TrialW
 
 SOECPotential::~SOECPotential() = default;
 
-void SOECPotential::resetTargetParticleSet(ParticleSet& P) {}
-
 SOECPotential::Return_t SOECPotential::evaluate(TrialWaveFunction& psi, ParticleSet& P)
 {
   evaluateImpl(psi, P, false);

--- a/src/QMCHamiltonians/SOECPotential.h
+++ b/src/QMCHamiltonians/SOECPotential.h
@@ -37,7 +37,6 @@ public:
 
   bool dependsOnWaveFunction() const override { return true; }
   std::string getClassName() const override { return "SOECPotential"; }
-  void resetTargetParticleSet(ParticleSet& P) override;
 
   Return_t evaluate(TrialWaveFunction& psi, ParticleSet& P) override;
   Return_t evaluateDeterministic(TrialWaveFunction& psi, ParticleSet& P) override;

--- a/src/QMCHamiltonians/SelfHealingOverlapLegacy.h
+++ b/src/QMCHamiltonians/SelfHealingOverlapLegacy.h
@@ -48,7 +48,6 @@ public:
   void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
 
   //should be empty for Collectables interface
-  void resetTargetParticleSet(ParticleSet& P) override {}
   void setObservables(PropertySetType& plist) override {}
   void setParticlePropertyList(PropertySetType& plist, int offset) override {}
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCHamiltonians/SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/SkAllEstimator.cpp
@@ -52,9 +52,6 @@ SkAllEstimator::SkAllEstimator(ParticleSet& source, ParticleSet& target)
   hdf5_out = false;
 }
 
-void SkAllEstimator::resetTargetParticleSet(ParticleSet& P) { elns = &P; }
-
-
 void SkAllEstimator::evaluateIonIon()
 {
   std::stringstream ss;

--- a/src/QMCHamiltonians/SkAllEstimator.h
+++ b/src/QMCHamiltonians/SkAllEstimator.h
@@ -32,7 +32,6 @@ public:
   SkAllEstimator(ParticleSet& ions, ParticleSet& elns);
 
   std::string getClassName() const override { return "SkAllEstimator"; }
-  void resetTargetParticleSet(ParticleSet& P) override;
 
   Return_t evaluate(ParticleSet& P) override;
 

--- a/src/QMCHamiltonians/SkEstimator.cpp
+++ b/src/QMCHamiltonians/SkEstimator.cpp
@@ -42,8 +42,6 @@ SkEstimator::SkEstimator(ParticleSet& source)
   hdf5_out = true;
 }
 
-void SkEstimator::resetTargetParticleSet(ParticleSet& P) { sourcePtcl = &P; }
-
 SkEstimator::Return_t SkEstimator::evaluate(ParticleSet& P)
 {
   //sum over species

--- a/src/QMCHamiltonians/SkEstimator.h
+++ b/src/QMCHamiltonians/SkEstimator.h
@@ -31,7 +31,6 @@ public:
   SkEstimator(ParticleSet& elns);
 
   std::string getClassName() const override { return "SkEstimator"; }
-  void resetTargetParticleSet(ParticleSet& P) override;
 
   Return_t evaluate(ParticleSet& P) override;
 

--- a/src/QMCHamiltonians/SkPot.cpp
+++ b/src/QMCHamiltonians/SkPot.cpp
@@ -37,8 +37,6 @@ SkPot::SkPot(ParticleSet& source)
   }
 }
 
-void SkPot::resetTargetParticleSet(ParticleSet& P) { sourcePtcl = &P; }
-
 SkPot::Return_t SkPot::evaluate(ParticleSet& P)
 {
   throw std::runtime_error("SkPot::evaluate not implemented. There was an implementation with"

--- a/src/QMCHamiltonians/SkPot.h
+++ b/src/QMCHamiltonians/SkPot.h
@@ -30,7 +30,6 @@ public:
   SkPot(ParticleSet& elns);
 
   std::string getClassName() const override { return "SkPot"; }
-  void resetTargetParticleSet(ParticleSet& P) override;
 
   [[noreturn]] Return_t evaluate(ParticleSet& P) override;
 

--- a/src/QMCHamiltonians/SpeciesKineticEnergy.h
+++ b/src/QMCHamiltonians/SpeciesKineticEnergy.h
@@ -35,7 +35,6 @@ public:
   Return_t evaluate(ParticleSet& P) override;
 
   // pure virtual functions require overrider
-  void resetTargetParticleSet(ParticleSet& P) override {}                                 // required
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp) final; // required
 
   // allocate multiple columns in scalar.dat

--- a/src/QMCHamiltonians/SpinDensity.h
+++ b/src/QMCHamiltonians/SpinDensity.h
@@ -53,7 +53,6 @@ public:
   void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
 
   //should be empty for Collectables interface
-  void resetTargetParticleSet(ParticleSet& P) override {}
   void setObservables(PropertySetType& plist) override {}
   void setParticlePropertyList(PropertySetType& plist, int offset) override {}
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCHamiltonians/StaticStructureFactor.h
+++ b/src/QMCHamiltonians/StaticStructureFactor.h
@@ -47,7 +47,6 @@ public:
   void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
 
   //should be empty for Collectables interface
-  void resetTargetParticleSet(ParticleSet& P) override {}
   void setObservables(PropertySetType& plist) override {}
   void setParticlePropertyList(PropertySetType& plist, int offset) override {}
 

--- a/src/QMCHamiltonians/StressPBC.h
+++ b/src/QMCHamiltonians/StressPBC.h
@@ -90,8 +90,6 @@ struct StressPBC : public OperatorBase, public ForceBase
 
   void setObservables(PropertySetType& plist) override { setObservablesStress(plist); }
 
-  void resetTargetParticleSet(ParticleSet& P) override {}
-
   void setParticlePropertyList(PropertySetType& plist, int offset) override { setParticleSetStress(plist, offset); }
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
   bool put(xmlNodePtr cur) override;

--- a/src/QMCHamiltonians/tests/test_density_estimator.cpp
+++ b/src/QMCHamiltonians/tests/test_density_estimator.cpp
@@ -59,8 +59,6 @@ TEST_CASE("Density Estimator evaluate exception", "[hamiltonian]")
   ParticleSet elec(simulation_cell);
   DensityEstimator density_estimator(elec);
   REQUIRE(density_estimator.getClassName() == "DensityEstimator");
-  // empty function
-  density_estimator.resetTargetParticleSet(elec);
   // check exception is thrown when weights are not defined
   CHECK_THROWS_AS(density_estimator.evaluate(elec), std::invalid_argument);
 }

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -468,7 +468,6 @@ TEST_CASE("AC Force", "[hamiltonian]")
   force_new.put(newh1);
   const auto vold = force_old.evaluate(psi, elec);
   const auto vnew = force_new.evaluate(psi, elec);
-  force_old.resetTargetParticleSet(elec); // does nothing?
 
   CHECK(vold == Approx(0));
   CHECK(vnew == Approx(0));


### PR DESCRIPTION
~~Review after merging #5671~~
## Proposed changes
Closes #3239
Finally here. With proper shared_ptr. No more awful copy+reset.

## What type(s) of changes does this code introduce?
- Other (please describe): House keeping.

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
