### PR TITLE
Remove Hamiltonian component internal TWF references

### DIFF
--- a/src/QMCHamiltonians/ACForce.h
+++ b/src/QMCHamiltonians/ACForce.h
@@ -23,6 +23,12 @@
 
 namespace qmcplusplus
 {
+/** Assaraf-Caffarel force operator
+ * Unlike most OperatorBase derived classes, it requires call Hamiltonian functions.
+ * To workaround the limitation of OperatorBase, it captures a QMCHamiltonian object reference via the constructor
+ * or add2Hamiltonian which wraps the usual makeClone function with a QMCHamiltonian object reference added.
+ * This is quite ungly but that is how things currently work.
+ */
 class ACForce : public OperatorBase
 {
 public:
@@ -34,7 +40,6 @@ public:
   /** Destructor, "final" triggers a clang warning **/
   ~ACForce() override = default;
 
-  bool dependsOnWaveFunction() const override { return true; }
   std::string getClassName() const override { return "ACForce"; }
 
   /** I/O Routines */
@@ -75,11 +80,9 @@ private:
   RealType delta_;
 
   //** Internal variables **/
-  //  I'm assuming that psi, ions, elns, and the hamiltonian are bound to this
+  //  I'm assuming that ions and the hamiltonian are bound to this
   //  instantiation.  Making sure no crosstalk happens is the job of whatever clones this.
-  ParticleSet& ions_;
-  ParticleSet& elns_;
-  TrialWaveFunction& psi_;
+  ParticleSet& ions_; // can ions_ make const?
   QMCHamiltonian& ham_;
 
   ///For indexing observables

--- a/src/QMCHamiltonians/BareKineticEnergy.cpp
+++ b/src/QMCHamiltonians/BareKineticEnergy.cpp
@@ -44,7 +44,7 @@ struct BareKineticEnergy::MultiWalkerResource : public Resource
    * Store mass per species and use SameMass to choose the methods.
    * if SameMass, probably faster and easy to vectorize but no impact on the performance.
    */
-BareKineticEnergy::BareKineticEnergy(ParticleSet& p, TrialWaveFunction& psi) : ps_(p), psi_(psi)
+BareKineticEnergy::BareKineticEnergy(ParticleSet& p, TrialWaveFunction& psi) : ps_(p)
 {
   setEnergyDomain(KINETIC);
   oneBodyQuantumDomain(p);
@@ -64,8 +64,6 @@ BareKineticEnergy::BareKineticEnergy(ParticleSet& p, TrialWaveFunction& psi) : p
 
 ///destructor
 BareKineticEnergy::~BareKineticEnergy() = default;
-
-bool BareKineticEnergy::dependsOnWaveFunction() const { return true; }
 
 std::string BareKineticEnergy::getClassName() const { return "BareKineticEnergy"; }
 
@@ -142,7 +140,7 @@ Return_t BareKineticEnergy::evaluateValueAndDerivatives(TrialWaveFunction& psi,
 {
   // const_cast is needed because TWF::evaluateDerivatives calculates dlogpsi.
   // KineticEnergy must be the first element in the hamiltonian array.
-  psi_.evaluateDerivatives(P, optvars, const_cast<Vector<ValueType>&>(dlogpsi), dhpsioverpsi);
+  psi.evaluateDerivatives(P, optvars, const_cast<Vector<ValueType>&>(dlogpsi), dhpsioverpsi);
   return evaluate(psi, P);
 }
 

--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -53,7 +53,6 @@ public:
   ///destructor
   ~BareKineticEnergy() override;
 
-  bool dependsOnWaveFunction() const override;
   std::string getClassName() const override;
 
 #if !defined(REMOVE_TRACEMANAGER)
@@ -177,8 +176,6 @@ private:
 
   struct MultiWalkerResource;
   ResourceHandle<MultiWalkerResource> mw_res_;
-
-  TrialWaveFunction& psi_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -13,6 +13,7 @@
 
 #include "DensityMatrices1B.h"
 #include "OhmmsData/AttributeSet.h"
+#include "ParticleSet.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "Numerics/MatrixOperators.h"
 #include "Utilities/IteratorUtility.h"
@@ -49,7 +50,7 @@ DensityMatrices1B::DensityMatrices1B(ParticleSet& P, TrialWaveFunction& psi, Par
     : timers(getGlobalTimerManager(), DMTimerNames, timer_level_fine),
       basis_functions("DensityMatrices1B::basis"),
       lattice_(P.getLattice()),
-      Psi(psi),
+      spomap(psi.getSPOMap()),
       Pq(P),
       Pc(Pcl)
 {
@@ -61,7 +62,7 @@ DensityMatrices1B::DensityMatrices1B(DensityMatrices1B& master, ParticleSet& P, 
       timers(getGlobalTimerManager(), DMTimerNames, timer_level_fine),
       basis_functions(master.basis_functions),
       lattice_(P.getLattice()),
-      Psi(psi),
+      spomap(psi.getSPOMap()),
       Pq(P),
       Pc(master.Pc)
 {
@@ -279,8 +280,7 @@ void DensityMatrices1B::set_state(xmlNodePtr cur)
 
   for (int i = 0; i < sposets.size(); ++i)
   {
-    auto& spomap = Psi.getSPOMap();
-    auto spo_it  = spomap.find(sposets[i]);
+    auto spo_it = spomap.find(sposets[i]);
     if (spo_it == spomap.end())
       throw std::runtime_error("DensityMatrices1B::put  sposet " + sposets[i] + " does not exist.");
     basis_functions.add(spo_it->second->makeClone());
@@ -603,9 +603,9 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate(TrialWaveFunction& psi, 
     if (check_derivatives)
       test_derivatives();
     if (evaluator == loop)
-      evaluate_loop(P);
+      evaluate_loop(psi, P);
     else if (evaluator == matrix)
-      evaluate_matrix(P);
+      evaluate_matrix(psi, P);
     else
       APP_ABORT("DensityMatrices1B::evaluate  invalid evaluator");
   }
@@ -613,7 +613,7 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate(TrialWaveFunction& psi, 
 }
 
 
-DensityMatrices1B::Return_t DensityMatrices1B::evaluate_matrix(ParticleSet& P)
+DensityMatrices1B::Return_t DensityMatrices1B::evaluate_matrix(TrialWaveFunction& psi, ParticleSet& P)
 {
   //perform warmup sampling the first time
   if (!warmed_up)
@@ -630,9 +630,9 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate_matrix(ParticleSet& P)
   // compute sample positions (monte carlo or deterministic)
   generate_samples(weight);
   // compute basis and wavefunction ratio values in matrix form
-  generate_sample_basis(Phi_MB);      // basis           : samples   x basis_size
-  generate_sample_ratios(Psi_NM);     // conj(Psi ratio) : particles x samples
-  generate_particle_basis(P, Phi_NB); // conj(basis)     : particles x basis_size
+  generate_sample_basis(Phi_MB);          // basis           : samples   x basis_size
+  generate_sample_ratios(psi, P, Psi_NM); // conj(Psi ratio) : particles x samples
+  generate_particle_basis(P, Phi_NB);     // conj(basis)     : particles x basis_size
   // perform integration via matrix products
   {
     ScopedTimer local_timer(timers[DM_matrix_products]);
@@ -766,7 +766,7 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate_matrix(ParticleSet& P)
 }
 
 
-DensityMatrices1B::Return_t DensityMatrices1B::evaluate_check(ParticleSet& P)
+DensityMatrices1B::Return_t DensityMatrices1B::evaluate_check(TrialWaveFunction& psi, ParticleSet& P)
 {
 #ifdef DMCHECK
   APP_ABORT("DensityMatrices1B::evaluate_check  use of E_trace in this function needs to be replaces with "
@@ -841,7 +841,7 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate_check(ParticleSet& P)
 }
 
 
-DensityMatrices1B::Return_t DensityMatrices1B::evaluate_loop(ParticleSet& P)
+DensityMatrices1B::Return_t DensityMatrices1B::evaluate_loop(TrialWaveFunction& psi, ParticleSet& P)
 {
   const int basis_size2 = basis_size * basis_size;
   if (!warmed_up)
@@ -858,7 +858,7 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate_loop(ParticleSet& P)
   {
     for (int ns = 0; ns < species_size[s]; ++ns, ++n)
     {
-      integrate(P, n);
+      integrate(psi, P, n);
       update_basis(P.R[n]);
       int ij = nindex + s * basis_size2;
       for (int i = 0; i < basis_size; ++i)
@@ -1168,14 +1168,16 @@ void DensityMatrices1B::generate_sample_basis(Matrix_t& Phi_mb)
 }
 
 
-void DensityMatrices1B::generate_sample_ratios(std::vector<Matrix_t*> Psi_nm)
+void DensityMatrices1B::generate_sample_ratios(TrialWaveFunction& psi,
+                                               ParticleSet& elecs,
+                                               std::vector<Matrix_t*> Psi_nm)
 {
   ScopedTimer t(timers[DM_gen_sample_ratios]);
   for (int m = 0; m < samples; ++m)
   {
     // get N ratios for the current sample point
-    Pq.makeVirtualMoves(rsamples[m]);
-    Psi.evaluateRatiosAlltoOne(Pq, psi_ratios);
+    elecs.makeVirtualMoves(rsamples[m]);
+    psi.evaluateRatiosAlltoOne(Pq, psi_ratios);
 
     // collect ratios into per-species matrices
     int p = 0;
@@ -1209,16 +1211,16 @@ void DensityMatrices1B::generate_particle_basis(ParticleSet& P, std::vector<Matr
 }
 
 
-inline void DensityMatrices1B::integrate(ParticleSet& P, int n)
+inline void DensityMatrices1B::integrate(TrialWaveFunction& psi, ParticleSet& elecs, int n)
 {
   std::fill(integrated_values.begin(), integrated_values.end(), 0.0);
   for (int s = 0; s < samples; ++s)
   {
     PosType& rsamp = rsamples[s];
     update_basis(rsamp);
-    P.makeMove(n, rsamp - P.R[n]);
-    Value_t ratio = sample_weights[s] * qmcplusplus::conj(Psi.calcRatio(P, n));
-    P.rejectMove(n);
+    elecs.makeMove(n, rsamp - elecs.R[n]);
+    Value_t ratio = sample_weights[s] * qmcplusplus::conj(psi.calcRatio(elecs, n));
+    elecs.rejectMove(n);
     for (int i = 0; i < basis_size; ++i)
       integrated_values[i] += ratio * basis_values[i];
   }

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -80,7 +80,7 @@ public:
   int nindex;
   int eindex;
   const Lattice_t& lattice_;
-  TrialWaveFunction& Psi;
+  const SPOSet::SPOMap& spomap;
   ParticleSet& Pq;
   const ParticleSet* Pc;
   TraceSample<TraceReal>* w_trace;
@@ -148,7 +148,6 @@ public:
   DensityMatrices1B(DensityMatrices1B& master, ParticleSet& P, TrialWaveFunction& psi);
   ~DensityMatrices1B() override;
 
-  bool dependsOnWaveFunction() const override { return true; }
   std::string getClassName() const override { return "DensityMatrices1B"; }
   //standard interface
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
@@ -196,7 +195,7 @@ public:
   //  basis & wavefunction ratio matrix construction
   void get_energies(std::vector<Vector_t*>& E_n);
   void generate_sample_basis(Matrix_t& Phi_mb);
-  void generate_sample_ratios(std::vector<Matrix_t*> Psi_nm);
+  void generate_sample_ratios(TrialWaveFunction& psi, ParticleSet& elecs, std::vector<Matrix_t*> Psi_nm);
   void generate_particle_basis(ParticleSet& P, std::vector<Matrix_t*>& Phi_nb);
   //  basis set updates
   void update_basis(const PosType& r);
@@ -205,11 +204,11 @@ public:
   void test_overlap();
   void test_derivatives();
   //  original loop implementation
-  void integrate(ParticleSet& P, int n);
-  Return_t evaluate_loop(ParticleSet& P);
+  void integrate(TrialWaveFunction& psi, ParticleSet& elecs, int n);
+  Return_t evaluate_loop(TrialWaveFunction& psi, ParticleSet& P);
   //  matrix implementation
-  Return_t evaluate_check(ParticleSet& P);
-  Return_t evaluate_matrix(ParticleSet& P);
+  Return_t evaluate_check(TrialWaveFunction& psi, ParticleSet& P);
+  Return_t evaluate_matrix(TrialWaveFunction& psi, ParticleSet& P);
 
 
   bool match(Value_t e1, Value_t e2, RealType tol = 1e-12);

--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -120,8 +120,7 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
   if (hasNonLocalPot)
   {
     std::unique_ptr<NonLocalECPotential> apot =
-        std::make_unique<NonLocalECPotential>(IonConfig, targetPtcl, targetPsi, use_DLA == "yes",
-                                              NLPP_algo == "batched");
+        std::make_unique<NonLocalECPotential>(IonConfig, targetPtcl, use_DLA == "yes", NLPP_algo == "batched");
 
     int nknot_max = 0;
     // These are actually NonLocalECPComponents

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -370,7 +370,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur)
         {
           APP_ABORT("Unknown psi \"" + PsiName + "\" for momentum.");
         }
-        std::unique_ptr<MomentumEstimator> ME = std::make_unique<MomentumEstimator>(targetPtcl, *psi_it->second);
+        std::unique_ptr<MomentumEstimator> ME = std::make_unique<MomentumEstimator>(targetPtcl);
         bool rt(myComm->rank() == 0);
         ME->putSpecial(element, targetPtcl, rt);
         targetH->addOperator(std::move(ME), "MomentumEstimator", false);

--- a/src/QMCHamiltonians/L2Potential.cpp
+++ b/src/QMCHamiltonians/L2Potential.cpp
@@ -26,7 +26,6 @@ L2Potential::L2Potential(const ParticleSet& ions, ParticleSet& els, TrialWaveFun
   size_t ns    = ions.getSpeciesSet().getTotalNum();
   PPset.resize(ns);
   PP.resize(NumIons, nullptr);
-  psi_ref = &psi;
 }
 
 void L2Potential::add(int groupID, std::unique_ptr<L2RadialPotential>&& ppot)
@@ -43,7 +42,7 @@ L2Potential::Return_t L2Potential::evaluate(TrialWaveFunction& psi, ParticleSet&
   // compute the Hessian
   TrialWaveFunction::HessVector D2;
   // evaluateHessian gives the Hessian(log(Psi))
-  psi_ref->evaluateHessian(P, D2);
+  psi.evaluateHessian(P, D2);
   // add gradient terms to get (Hessian(Psi))/Psi instead
   const size_t N = P.getTotalNum();
   for (size_t n = 0; n < N; n++)

--- a/src/QMCHamiltonians/L2Potential.h
+++ b/src/QMCHamiltonians/L2Potential.h
@@ -66,12 +66,9 @@ struct L2Potential : public OperatorBase
   std::vector<std::unique_ptr<L2RadialPotential>> PPset;
   ///PP[iat] is the L2 potential for the iat-th particle
   std::vector<L2RadialPotential*> PP;
-  ///Associated trial wavefunction
-  TrialWaveFunction* psi_ref;
 
   L2Potential(const ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi);
 
-  bool dependsOnWaveFunction() const override { return true; }
   std::string getClassName() const override { return "L2Potential"; }
 
   Return_t evaluate(TrialWaveFunction& psi, ParticleSet& P) override;

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -28,8 +28,8 @@
 
 namespace qmcplusplus
 {
-MomentumEstimator::MomentumEstimator(ParticleSet& elns, TrialWaveFunction& psi)
-    : M(40), refPsi(psi), lattice_(elns.getLattice()), norm_nofK(1), hdf5_out(false)
+MomentumEstimator::MomentumEstimator(ParticleSet& elns)
+    : M(40), lattice_(elns.getLattice()), norm_nofK(1), hdf5_out(false)
 {
   update_mode_.set(COLLECTABLE, 1);
   psi_ratios.resize(elns.getTotalNum());
@@ -48,7 +48,7 @@ MomentumEstimator::Return_t MomentumEstimator::evaluate(TrialWaveFunction& psi, 
     //make it cartesian
     vPos[s] = lattice_.toCart(newpos);
     P.makeVirtualMoves(vPos[s]);
-    refPsi.evaluateRatiosAlltoOne(P, psi_ratios);
+    psi.evaluateRatiosAlltoOne(P, psi_ratios);
     for (int i = 0; i < np; ++i)
       psi_ratios_all[s][i] = psi_ratios[i];
 
@@ -423,7 +423,7 @@ bool MomentumEstimator::get(std::ostream& os) const { return true; }
 
 std::unique_ptr<OperatorBase> MomentumEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  std::unique_ptr<MomentumEstimator> myclone = std::make_unique<MomentumEstimator>(qp, psi);
+  std::unique_ptr<MomentumEstimator> myclone = std::make_unique<MomentumEstimator>(qp);
   myclone->resize(kPoints, M);
   myclone->my_index_ = my_index_;
   myclone->norm_nofK = norm_nofK;

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -20,8 +20,7 @@ namespace qmcplusplus
 class MomentumEstimator : public OperatorBase
 {
 public:
-  MomentumEstimator(ParticleSet& elns, TrialWaveFunction& psi);
-  bool dependsOnWaveFunction() const override { return true; }
+  MomentumEstimator(ParticleSet& elns);
   std::string getClassName() const override { return "MomentumEstimator"; }
 
   Return_t evaluate(TrialWaveFunction& psi, ParticleSet& P) override;
@@ -40,8 +39,6 @@ public:
   void resize(const std::vector<PosType>& kin, const int Min);
   ///number of samples
   int M;
-  ///reference to the trial wavefunction for ratio evaluations
-  TrialWaveFunction& refPsi;
   ///lattice vector
   const Lattice& lattice_;
   ///normalization factor for n(k)

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -49,15 +49,10 @@ struct NonLocalECPotential::NonLocalECPotentialMultiWalkerResource : public Reso
  *\param els the positions of the electrons
  *\param psi trial wavefunction
  */
-NonLocalECPotential::NonLocalECPotential(ParticleSet& ions,
-                                         ParticleSet& els,
-                                         TrialWaveFunction& psi,
-                                         bool enable_DLA,
-                                         bool use_VP)
+NonLocalECPotential::NonLocalECPotential(ParticleSet& ions, ParticleSet& els, bool enable_DLA, bool use_VP)
     : ForceBase(ions, els),
       myRNG(nullptr),
       IonConfig(ions),
-      Psi(psi),
       use_DLA(enable_DLA),
       vp_(use_VP ? std::make_unique<VirtualParticleSet>(els) : nullptr),
       Peln(els),
@@ -80,11 +75,10 @@ NonLocalECPotential::NonLocalECPotential(ParticleSet& ions,
   }
 }
 
-NonLocalECPotential::NonLocalECPotential(const NonLocalECPotential& nlpp, ParticleSet& els, TrialWaveFunction& psi)
+NonLocalECPotential::NonLocalECPotential(const NonLocalECPotential& nlpp, ParticleSet& els)
     : ForceBase(nlpp.IonConfig, els),
       myRNG(nullptr),
       IonConfig(nlpp.IonConfig),
-      Psi(psi),
       use_DLA(nlpp.use_DLA),
       vp_(nlpp.vp_ ? std::make_unique<VirtualParticleSet>(els, nlpp.vp_->getNumDistTables()) : nullptr),
       Peln(els),
@@ -213,7 +207,7 @@ void NonLocalECPotential::evaluateImpl(TrialWaveFunction& psi, ParticleSet& P, b
   const auto& myTable = P.getDistTableAB(myTableIndex);
   for (int ig = 0; ig < P.groups(); ++ig) //loop over species
   {
-    Psi.prepareGroup(P, ig);
+    psi.prepareGroup(P, ig);
     for (int jel = P.first(ig); jel < P.last(ig); ++jel)
     {
       const auto& dist  = myTable.getDistRow(jel);
@@ -222,7 +216,7 @@ void NonLocalECPotential::evaluateImpl(TrialWaveFunction& psi, ParticleSet& P, b
         if (PP[iat] != nullptr && dist[iat] < PP[iat]->getRmax())
         {
           Real pairpot =
-              PP[iat]->evaluateOne(P, vp_ ? makeOptionalRef<VirtualParticleSet>(*vp_) : std::nullopt, iat, Psi, jel,
+              PP[iat]->evaluateOne(P, vp_ ? makeOptionalRef<VirtualParticleSet>(*vp_) : std::nullopt, iat, psi, jel,
                                    dist[iat], -displ[iat],
                                    compute_txy_all ? makeOptionalRef<std::vector<NonLocalData>>(tmove_xy_all_)
                                                    : std::nullopt,
@@ -326,11 +320,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
   RefVector<NonLocalECPotential> ecp_potential_list;
   RefVectorWithLeader<NonLocalECPComponent> ecp_component_list(**pp_component);
   RefVectorWithLeader<ParticleSet> pset_list(pset_leader);
-  RefVectorWithLeader<TrialWaveFunction> psi_list(O_leader.Psi);
-  // we are moving away from internally stored Psi, double check before Psi gets finally removed.
-  assert(&O_leader.Psi == &wf_list.getLeader());
-  for (size_t iw = 0; iw < nw; iw++)
-    assert(&o_list.getCastedElement<NonLocalECPotential>(iw).Psi == &wf_list[iw]);
+  RefVectorWithLeader<TrialWaveFunction> psi_list(wf_list.getLeader());
 
   RefVector<const NLPPJob<Real>> batch_list;
   RefVector<VirtualParticleSet> vp_list;
@@ -464,8 +454,6 @@ void NonLocalECPotential::evaluateIonDerivs(ParticleSet& P,
                                             ParticleSet::ParticlePos& hf_terms,
                                             ParticleSet::ParticlePos& pulay_terms)
 {
-  //We're going to ignore psi and use the internal Psi.
-
   value_    = 0.0;
   forces_   = 0;
   PulayTerm = 0;
@@ -473,7 +461,7 @@ void NonLocalECPotential::evaluateIonDerivs(ParticleSet& P,
   const auto& myTable = P.getDistTableAB(myTableIndex);
   for (int ig = 0; ig < P.groups(); ++ig) //loop over species
   {
-    Psi.prepareGroup(P, ig);
+    psi.prepareGroup(P, ig);
     for (int jel = P.first(ig); jel < P.last(ig); ++jel)
     {
       const auto& dist  = myTable.getDistRow(jel);
@@ -482,7 +470,7 @@ void NonLocalECPotential::evaluateIonDerivs(ParticleSet& P,
         if (PP[iat] != nullptr && dist[iat] < PP[iat]->getRmax())
           value_ +=
               PP[iat]->evaluateOneWithForces(P, vp_ ? makeOptionalRef<VirtualParticleSet>(*vp_) : std::nullopt, ions,
-                                             iat, Psi, jel, dist[iat], -displ[iat], forces_[iat], PulayTerm);
+                                             iat, psi, jel, dist[iat], -displ[iat], forces_[iat], PulayTerm);
     }
   }
 
@@ -490,14 +478,17 @@ void NonLocalECPotential::evaluateIonDerivs(ParticleSet& P,
   pulay_terms -= PulayTerm;
 }
 
-void NonLocalECPotential::computeOneElectronTxy(ParticleSet& P, const int ref_elec, std::vector<NonLocalData>& tmove_xy)
+void NonLocalECPotential::computeOneElectronTxy(TrialWaveFunction& psi,
+                                                ParticleSet& P,
+                                                const int ref_elec,
+                                                std::vector<NonLocalData>& tmove_xy)
 {
   tmove_xy.clear();
   const auto& myTable = P.getDistTableAB(myTableIndex);
   const auto& dist    = myTable.getDistRow(ref_elec);
   const auto& displ   = myTable.getDisplRow(ref_elec);
   for (const int iat : neighbor_lists.getNeighboringIons(ref_elec))
-    PP[iat]->evaluateOne(P, vp_ ? makeOptionalRef<VirtualParticleSet>(*vp_) : std::nullopt, iat, Psi, ref_elec,
+    PP[iat]->evaluateOne(P, vp_ ? makeOptionalRef<VirtualParticleSet>(*vp_) : std::nullopt, iat, psi, ref_elec,
                          dist[iat], -displ[iat], tmove_xy, use_DLA);
 }
 
@@ -552,7 +543,7 @@ void NonLocalECPotential::evaluateOneBodyOpMatrixForceDeriv(ParticleSet& P,
   }
 }
 
-int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P, NonLocalTOperator& move_op)
+int NonLocalECPotential::makeNonLocalMovesPbyP(TrialWaveFunction& psi, ParticleSet& P, NonLocalTOperator& move_op)
 {
   auto& RandomGen(*myRNG);
   auto& nonLocalOps = move_op;
@@ -565,11 +556,11 @@ int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P, NonLocalTOperator
     if (oneTMove)
     {
       const int iat = oneTMove->PID;
-      Psi.prepareGroup(P, P.getGroupID(iat));
+      psi.prepareGroup(P, P.getGroupID(iat));
       GradType grad_iat;
-      if (P.makeMoveAndCheck(iat, oneTMove->Delta) && Psi.calcRatioGrad(P, iat, grad_iat) != ValueType(0))
+      if (P.makeMoveAndCheck(iat, oneTMove->Delta) && psi.calcRatioGrad(P, iat, grad_iat) != ValueType(0))
       {
-        Psi.acceptMove(P, iat, true);
+        psi.acceptMove(P, iat, true);
         P.acceptMove(iat);
         NonLocalMoveAccepted++;
       }
@@ -582,16 +573,16 @@ int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P, NonLocalTOperator
     //make a non-local move per particle
     for (int ig = 0; ig < P.groups(); ++ig) //loop over species
     {
-      Psi.prepareGroup(P, ig);
+      psi.prepareGroup(P, ig);
       for (int iat = P.first(ig); iat < P.last(ig); ++iat)
       {
-        computeOneElectronTxy(P, iat, tmove_xy);
+        computeOneElectronTxy(psi, P, iat, tmove_xy);
         const NonLocalData* oneTMove = nonLocalOps.selectMove(RandomGen(), tmove_xy);
         if (oneTMove)
         {
-          if (P.makeMoveAndCheck(iat, oneTMove->Delta) && Psi.calcRatioGrad(P, iat, grad_iat) != ValueType(0))
+          if (P.makeMoveAndCheck(iat, oneTMove->Delta) && psi.calcRatioGrad(P, iat, grad_iat) != ValueType(0))
           {
-            Psi.acceptMove(P, iat, true);
+            psi.acceptMove(P, iat, true);
             P.acceptMove(iat);
             NonLocalMoveAccepted++;
           }
@@ -608,23 +599,23 @@ int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P, NonLocalTOperator
     //make a non-local move per particle
     for (int ig = 0; ig < P.groups(); ++ig) //loop over species
     {
-      Psi.prepareGroup(P, ig);
+      psi.prepareGroup(P, ig);
       for (int iat = P.first(ig); iat < P.last(ig); ++iat)
       {
         const NonLocalData* oneTMove;
         if (elecTMAffected[iat])
         {
           // recompute Txy for the given electron effected by T-moves
-          computeOneElectronTxy(P, iat, tmove_xy);
+          computeOneElectronTxy(psi, P, iat, tmove_xy);
           oneTMove = nonLocalOps.selectMove(RandomGen(), tmove_xy);
         }
         else
           oneTMove = nonLocalOps.selectMove(RandomGen(), iat);
         if (oneTMove)
         {
-          if (P.makeMoveAndCheck(iat, oneTMove->Delta) && Psi.calcRatioGrad(P, iat, grad_iat) != ValueType(0))
+          if (P.makeMoveAndCheck(iat, oneTMove->Delta) && psi.calcRatioGrad(P, iat, grad_iat) != ValueType(0))
           {
-            Psi.acceptMove(P, iat, true);
+            psi.acceptMove(P, iat, true);
             // mark all affected electrons
             neighbor_lists.markAffectedElecs(P.getDistTableAB(myTableIndex), iat, elecTMAffected);
             P.acceptMove(iat);
@@ -637,7 +628,7 @@ int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P, NonLocalTOperator
 
   if (NonLocalMoveAccepted > 0)
   {
-    Psi.completeUpdates();
+    psi.completeUpdates();
     // this step also updates electron positions on the device.
     P.donePbyP(true);
   }
@@ -677,7 +668,7 @@ void NonLocalECPotential::releaseResource(ResourceCollection& collection,
 
 std::unique_ptr<OperatorBase> NonLocalECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  return std::make_unique<NonLocalECPotential>(*this, qp, psi);
+  return std::make_unique<NonLocalECPotential>(*this, qp);
 }
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
@@ -44,7 +44,7 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluateValueAndDerivatives(T
         value_ +=
             PP[iat]->evaluateValueAndDerivatives(P, vp_ ? makeOptionalRef<VirtualParticleSet>(*vp_) : std::nullopt,
 
-                                                 iat, Psi, jel, dist[iat], -displ[iat], optvars, dlogpsi, dhpsioverpsi);
+                                                 iat, psi, jel, dist[iat], -displ[iat], optvars, dlogpsi, dhpsioverpsi);
   }
   return value_;
 }

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -44,11 +44,10 @@ class NonLocalECPotential : public OperatorBase, public ForceBase
   struct NonLocalECPotentialMultiWalkerResource;
 
 public:
-  NonLocalECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi, bool enable_DLA, bool use_VP);
-  NonLocalECPotential(const NonLocalECPotential& nlpp, ParticleSet& els, TrialWaveFunction& psi);
+  NonLocalECPotential(ParticleSet& ions, ParticleSet& els, bool enable_DLA, bool use_VP);
+  NonLocalECPotential(const NonLocalECPotential& nlpp, ParticleSet& els);
   ~NonLocalECPotential() override;
 
-  bool dependsOnWaveFunction() const override { return true; }
   std::string getClassName() const override { return "NonLocalECPotential"; }
 
 #if !defined(REMOVE_TRACEMANAGER)
@@ -97,10 +96,11 @@ public:
 
 
   /** make non local moves with particle-by-particle moves
+   * @param psi trial wavefunction
    * @param P particle set
    * @return the number of accepted moves
    */
-  int makeNonLocalMovesPbyP(ParticleSet& P, NonLocalTOperator& move_op) override;
+  int makeNonLocalMovesPbyP(TrialWaveFunction& psi, ParticleSet& P, NonLocalTOperator& move_op) override;
 
   Return_t evaluateValueAndDerivatives(TrialWaveFunction& psi,
                                        ParticleSet& P,
@@ -162,8 +162,6 @@ protected:
   std::vector<std::unique_ptr<NonLocalECPComponent>> PPset;
   ///reference to the center ion
   ParticleSet& IonConfig;
-  ///target TrialWaveFunction
-  TrialWaveFunction& Psi;
   ///true, determinant localization approximation(DLA) is enabled
   bool use_DLA;
 
@@ -202,11 +200,15 @@ private:
 
   /** compute the T move transition probability for a given electron
    * member variable nonLocalOps.Txy is updated
+   * @param psi trial wavefunction
    * @param P particle set
    * @param ref_elec reference electron id
    * @param tmove_xy off-diagonal terms for one electron.
    */
-  void computeOneElectronTxy(ParticleSet& P, const int ref_elec, std::vector<NonLocalData>& tmove_xy);
+  void computeOneElectronTxy(TrialWaveFunction& psi,
+                             ParticleSet& P,
+                             const int ref_elec,
+                             std::vector<NonLocalData>& tmove_xy);
 
   friend class testing::TestNonLocalECPotential;
 };

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -127,7 +127,7 @@ public:
   virtual ~OperatorBase() = default;
 
   /// return true if this operator depends on a wavefunction
-  virtual bool dependsOnWaveFunction() const { return false; }
+  virtual bool dependsOnWaveFunction() const { return true; }
 
   //////// GETTER AND SETTER FUNCTIONS ////////////////
 
@@ -392,10 +392,11 @@ public:
   {}
 
   /** make non local moves with particle-by-particle moves
+   * @param psi trial wavefunction
    * @param P particle set
    * @return the number of accepted moves
    */
-  virtual int makeNonLocalMovesPbyP(ParticleSet& P, NonLocalTOperator& move_op) { return 0; }
+  virtual int makeNonLocalMovesPbyP(TrialWaveFunction& psi, ParticleSet& P, NonLocalTOperator& move_op) { return 0; }
 
   /** 
    * @brief Update data associated with a particleset.
@@ -621,6 +622,7 @@ class OperatorDependsOnlyOnParticleSet : public OperatorBase
 public:
   virtual Return_t evaluate(ParticleSet& pset) = 0;
   virtual std::unique_ptr<OperatorBase> makeClone(ParticleSet& pset) = 0;
+  bool dependsOnWaveFunction() const final { return false; }
 
 private:
   inline Return_t evaluate(TrialWaveFunction& psi, ParticleSet& pset) final { return evaluate(pset); }

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -961,7 +961,7 @@ int QMCHamiltonian::makeNonLocalMoves(TrialWaveFunction& psi, ParticleSet& P, No
 {
   int num_moves = 0;
   for (int i = 0; i < H.size(); ++i)
-    num_moves += H[i]->makeNonLocalMovesPbyP(P, move_op);
+    num_moves += H[i]->makeNonLocalMovesPbyP(psi, P, move_op);
   return num_moves;
 }
 

--- a/src/QMCHamiltonians/SOECPotential.cpp
+++ b/src/QMCHamiltonians/SOECPotential.cpp
@@ -47,7 +47,6 @@ SOECPotential::SOECPotential(ParticleSet& ions,
                              bool use_VP)
     : my_rng_(nullptr),
       ion_config_(ions),
-      psi_(psi),
       vp_(use_VP ? std::make_unique<VirtualParticleSet>(els) : nullptr),
       use_exact_spin_(use_exact_spin)
 {
@@ -64,7 +63,6 @@ SOECPotential::SOECPotential(ParticleSet& ions,
 SOECPotential::SOECPotential(const SOECPotential& sopp, ParticleSet& els, TrialWaveFunction& psi)
     : my_rng_(nullptr),
       ion_config_(sopp.ion_config_),
-      psi_(psi),
       vp_(sopp.vp_ ? std::make_unique<VirtualParticleSet>(els, sopp.vp_->getNumDistTables()) : nullptr),
       use_exact_spin_(sopp.use_exact_spin_)
 {
@@ -112,8 +110,8 @@ void SOECPotential::evaluateImpl(TrialWaveFunction& psi, ParticleSet& P, bool ke
     for (int iat = 0; iat < pp_.size(); iat++)
       if (pp_[iat] != nullptr && dist[iat] < pp_[iat]->getRmax())
         value_ += use_exact_spin_
-            ? pp_[iat]->evaluateOneExactSpinIntegration(P, *vp_, iat, psi_, jel, dist[iat], -displ[iat])
-            : pp_[iat]->evaluateOne(P, vp_ ? makeOptionalRef<VirtualParticleSet>(*vp_) : std::nullopt, iat, psi_, jel,
+            ? pp_[iat]->evaluateOneExactSpinIntegration(P, *vp_, iat, psi, jel, dist[iat], -displ[iat])
+            : pp_[iat]->evaluateOne(P, vp_ ? makeOptionalRef<VirtualParticleSet>(*vp_) : std::nullopt, iat, psi, jel,
                                     dist[iat], -displ[iat]);
   }
 }
@@ -139,13 +137,13 @@ SOECPotential::Return_t SOECPotential::evaluateValueAndDerivatives(TrialWaveFunc
       {
         if (use_exact_spin_)
           value_ +=
-              pp_[iat]->evaluateValueAndDerivativesExactSpinIntegration(P, *vp_, iat, psi_, jel, dist[iat], -displ[iat],
+              pp_[iat]->evaluateValueAndDerivativesExactSpinIntegration(P, *vp_, iat, psi, jel, dist[iat], -displ[iat],
                                                                         optvars, dlogpsi, dhpsioverpsi);
 
         else
           value_ +=
               pp_[iat]->evaluateValueAndDerivatives(P, vp_ ? makeOptionalRef<VirtualParticleSet>(*vp_) : std::nullopt,
-                                                    iat, psi_, jel, dist[iat], -displ[iat], optvars, dlogpsi,
+                                                    iat, psi, jel, dist[iat], -displ[iat], optvars, dlogpsi,
                                                     dhpsioverpsi);
       }
   }
@@ -223,10 +221,7 @@ void SOECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase>& o_l
   RefVector<SOECPotential> soecp_potential_list;
   RefVectorWithLeader<SOECPComponent> soecp_component_list(**pp_component);
   RefVectorWithLeader<ParticleSet> pset_list(pset_leader);
-  RefVectorWithLeader<TrialWaveFunction> psi_list(O_leader.psi_);
-  assert(&O_leader.psi_ == &wf_list.getLeader());
-  for (size_t iw = 0; iw < nw; iw++)
-    assert(&o_list.getCastedElement<SOECPotential>(iw).psi_ == &wf_list[iw]);
+  RefVectorWithLeader<TrialWaveFunction> psi_list(wf_list.getLeader());
 
   RefVector<const NLPPJob<RealType>> batch_list;
   RefVector<VirtualParticleSet> vp_list;

--- a/src/QMCHamiltonians/SOECPotential.h
+++ b/src/QMCHamiltonians/SOECPotential.h
@@ -35,7 +35,6 @@ public:
   SOECPotential(const SOECPotential& sopp, ParticleSet& els, TrialWaveFunction& psi);
   ~SOECPotential() override;
 
-  bool dependsOnWaveFunction() const override { return true; }
   std::string getClassName() const override { return "SOECPotential"; }
 
   Return_t evaluate(TrialWaveFunction& psi, ParticleSet& P) override;
@@ -85,7 +84,6 @@ protected:
   std::vector<SOECPComponent*> pp_;
   std::vector<std::unique_ptr<SOECPComponent>> ppset_;
   ParticleSet& ion_config_;
-  TrialWaveFunction& psi_;
   static void mw_evaluateImpl(const RefVectorWithLeader<OperatorBase>& o_list,
                               const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                               const RefVectorWithLeader<ParticleSet>& p_list,

--- a/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
@@ -135,7 +135,7 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
   TrialWaveFunction psi2(runtime_options);
   RefVectorWithLeader<TrialWaveFunction> twf_list(psi, {psi, psi2});
 
-  NonLocalECPotential nl_ecp(ions, elec, psi, false /*use_DLA*/, false /*use_VP*/);
+  NonLocalECPotential nl_ecp(ions, elec, false /*use_DLA*/, false /*use_VP*/);
 
   int num_walkers = 2;
   int max_values  = 10;


### PR DESCRIPTION
~~Review after https://github.com/QMCPACK/qmcpack/pull/5674~~

## Proposed changes
Eliminate Hamiltonian component internal owned TWF references. function arguments are the only way to access TWF.
I also documented the outlier ACForce and its induced workarounds.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
