### PR TITLE
Updated build_ornl_cades_baseline.sh

### DIFF
--- a/config/build_ornl_cades_baseline.sh
+++ b/config/build_ornl_cades_baseline.sh
@@ -8,24 +8,24 @@
 ## * Execute this script in qmcpack git top level directory                        ##
 ##   ./config/build_ornl_cades_baseline.sh                                         ##
 ##                                                                                 ##
-## Last verified: May 23, 2024                                                     ##
+## Last verified: Nov 26, 2025                                                     ##
 #####################################################################################
 
 # module files resulting from module imports below:
 # Currently Loaded Modules:
-#  1) DefApps   2) gcc/12.2.0   3) openmpi/4.0.4   4) boost/1.83.0   5) fftw/3.3.10
-#  6) openblas/0.3.23   7) hdf5/1.14.3   8) cmake/3.26.3
+#  1) DefApps   2) gcc/13.3.0   3) openmpi/5.0.5   4) boost/1.86.0   5) fftw/3.3.10
+#  6) openblas/0.3.28   7) hdf5/1.14.5   8) cmake/3.30.5
 
 source $MODULESHOME/init/bash
 module purge
 module load DefApps
-module load gcc/12.2.0
-module load openmpi/4.0.4
-module load boost/1.83.0
+module load gcc/13.3.0
+module load openmpi/5.0.5
+module load boost/1.86.0
 module load fftw/3.3.10
-module load openblas/0.3.23
-module load hdf5/1.14.3
-module load cmake/3.26.3
+module load openblas/0.3.28
+module load hdf5/1.14.5
+module load cmake/3.30.5
  
 module list
 


### PR DESCRIPTION
## Proposed changes

Update the ORNL CADES Baseline build script to use newer module versions available on the system. Older versions of the modules are no longer available. 

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Baseline 
## Checklist

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
