### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing to QMCPACK
+
+QMCPACK is fully open source, and contributions of any size are very welcome.
+
+Guidelines and examples of different ways to help are given in the QMCPACK manual
+https://qmcpack.readthedocs.io/en/develop/introduction.html#contributing-to-qmcpack . We aim to make contributing straightforward
+with lightweight policies typical of any mid-sized project. Contributions to the manual are described at
+https://qmcpack.readthedocs.io/en/develop/contributing.html -- even the smallest typo fixes are welcome. 
+
+Please open an Issue if you have any questions on features, roadmap, tutorials, installation, possible bugs etc. If you are already
+running QMCPACK, provide as much detail as possible in the report (e.g. copies of Nexus and QMCPACK input files.)
+
+If you like the project but don't have time to contribute, you can still support it by adding a star on GitHub or by citing QMCPACK
+when appropriate. 
+
+Thanks for your interest in improving QMCPACK.


### PR DESCRIPTION
## Proposed changes

An an explicit contributing.md file for the project. Mainly link to our existing contributions guide in our existing documentation. The presence of this file should correct the link used by GitHub in the "About" section, which currently automagically points to the documentation contribution guide.

## What type(s) of changes does this code introduce?

- Documentation or build script changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [X] Documentation has been added (if appropriate)
