### PR TITLE
Nexus: Revert `not mask` to `mask==False` from #5621

### DIFF
--- a/nexus/lib/structure.py
+++ b/nexus/lib/structure.py
@@ -508,7 +508,7 @@ class MaskFilter(DevBase):
         elif mask.shape!=(dim,dim):
             error('shape of mask array must be {0},{0}\nshape received: {1},{2}\nmask array received: {3}'.format(dim,mask.shape[0],mask.shape[1],omask),'optimal_tilematrix')
         #end if
-        self.mask = not mask
+        self.mask = mask==False
     #end def set
 
     def __call__(self,T):


### PR DESCRIPTION
I've searched through the entire diff of #5621 multiple times. I think this is the only change that slipped through the cracks.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No