### PR TITLE
Pass WFOpt owned rngs to CostFunction.

### DIFF
--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -186,8 +186,6 @@ public:
 
   DriftModifierBase& get_drift_modifier() const { return *drift_modifier_; }
 
-  const RefVector<RandomBase<FullPrecRealType>>& getRngRefs() const { return rngs_; }
-
   /** record the state of the block
    * @param block current block
    *

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -211,7 +211,7 @@ void QMCFixedSampleLinearOptimizeBatched::start()
     ScopedTimer local(initialize_timer_);
     Timer t_deriv;
     optTarget->getConfigurations("");
-    optTarget->setRng(vmcEngine->getRngRefs());
+    optTarget->setRng(rngs_);
     NullEngineHandle handle;
     if (options_LMY_.current_optimizer_type == OptimizerType::STOCHASTIC_RECONFIGURATION_CG)
       optTarget->checkConfigurationsSR(handle);
@@ -255,7 +255,7 @@ void QMCFixedSampleLinearOptimizeBatched::engine_start(cqmc::engine::LMYEngine<V
   Timer t1;
   initialize_timer_.start();
   optTarget->getConfigurations("");
-  optTarget->setRng(vmcEngine->getRngRefs());
+  optTarget->setRng(rngs_);
   optTarget->checkConfigurations(*handle);
 
   initialize_timer_.stop();


### PR DESCRIPTION
## Proposed changes

Although the underlying rng objects are the same. Obtaining rngs via the VMC driver requires unnecessary extended existence of VMC driver.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
