### PR TITLE
Remove unused driver input option k_delay

### DIFF
--- a/src/QMCDrivers/QMCDriverInput.cpp
+++ b/src/QMCDrivers/QMCDriverInput.cpp
@@ -82,7 +82,6 @@ void QMCDriverInput::readXML(xmlNodePtr cur)
   aAttrib.add(update_mode_, "move");
   aAttrib.add(scoped_profiling_, "profiling");
   aAttrib.add(Period4CheckPoint, "checkpoint");
-  aAttrib.add(k_delay_, "kdelay");
   // This does all the parameter parsing setup in the constructor
   aAttrib.put(cur);
 

--- a/src/QMCDrivers/QMCDriverInput.h
+++ b/src/QMCDrivers/QMCDriverInput.h
@@ -94,7 +94,6 @@ protected:
   input::PeriodStride walker_dump_period_{0, 0};
   input::PeriodStride check_point_period_{0, 0};
   bool dump_config_  = false;
-  IndexType k_delay_ = 0;
   bool reset_random_ = false;
 
   // from QMCUpdateBase
@@ -127,7 +126,6 @@ public:
   IndexType get_estimator_measurement_period() const { return estimator_measurement_period_; }
   input::PeriodStride get_walker_dump_period() const { return walker_dump_period_; }
   input::PeriodStride get_check_point_period() const { return check_point_period_; }
-  IndexType get_k_delay() const { return k_delay_; }
   bool get_reset_random() const { return reset_random_; }
   bool get_dump_config() const { return dump_config_; }
 

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -414,9 +414,6 @@ protected:
   ///drift modifer
   std::unique_ptr<DriftModifierBase> drift_modifier_;
 
-  ///the number to delay updates by
-  int k_delay;
-
   /** period of recording walker configurations
    *
    * Default is 0 indicating that only the last configuration will be saved.


### PR DESCRIPTION
## Proposed changes
k_delay was intended for driver control of delayed update. It is currently not supported.
I'm against keeping it in the driver because drivers have no clue about TWF details. This input may or may not have any effect depending on the actual TWF and thus confuses users as a driver input.

## What type(s) of changes does this code introduce?
- Other (please describe): remove unused input parameter

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
