### PR TITLE
Merge OptVariablesForPsi and OptVariables and renamed as opt_vars

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
@@ -47,25 +47,25 @@ void QMCCostFunction::GradCost(std::vector<Return_rt>& PGradient,
                                Return_rt FiniteDiff)
 {
   for (int j = 0; j < NumOptimizables; j++)
-    OptVariables[j] = PM[j];
+    opt_vars[j] = PM[j];
   if (FiniteDiff > 0)
   {
     QMCTraits::RealType dh = 1.0 / (2.0 * FiniteDiff);
     for (int i = 0; i < NumOptimizables; i++)
     {
       // + FiniteDiff
-      OptVariables[i] = PM[i] + FiniteDiff;
+      opt_vars[i] = PM[i] + FiniteDiff;
       resetPsi();
       correlatedSampling(false);
       auto CostPlus = computedCost();
       // - FiniteDiff
-      OptVariables[i] = PM[i] - FiniteDiff;
+      opt_vars[i] = PM[i] - FiniteDiff;
       resetPsi();
       correlatedSampling(false);
       auto CostMinus = computedCost();
       // calculate gradient
-      PGradient[i]    = (CostPlus - CostMinus) * dh;
-      OptVariables[i] = PM[i]; // revert parameter change
+      PGradient[i] = (CostPlus - CostMinus) * dh;
+      opt_vars[i]  = PM[i]; // revert parameter change
     }
   }
   else
@@ -260,7 +260,7 @@ void QMCCostFunction::checkConfigurations(EngineHandle& handle)
     }
     // Populate local to global index mapping into psiClone internal component 'myVars',
     // because psiClones persist between different sections and need update.
-    psiClones[ip]->checkOutVariables(OptVariables);
+    psiClones[ip]->checkOutVariables(opt_vars);
     //    synchronize the random number generator with the node
     (*MoverRng[ip]) = (*RngSaved[ip]);
     hClones[ip]->setRandomGenerator(MoverRng[ip]);
@@ -286,7 +286,7 @@ void QMCCostFunction::checkConfigurations(EngineHandle& handle)
         Vector<Return_t> Dsaved(NumOptimizables, 0.0);
         Vector<Return_t> HDsaved(NumOptimizables, 0.0);
 
-        etmp = hClones[ip]->evaluateValueAndDerivatives(psi_ref, wRef, OptVariables, Dsaved, HDsaved);
+        etmp = hClones[ip]->evaluateValueAndDerivatives(psi_ref, wRef, opt_vars, Dsaved, HDsaved);
 
 
         //FIXME the ifdef should be removed after the optimizer is made compatible with complex coefficients
@@ -381,7 +381,7 @@ void QMCCostFunction::engine_checkConfigurations(cqmc::engine::LMYEngine<Return_
     }
     // Populate local to global index mapping into psiClone internal component 'myVars',
     // because psiClones persist between different sections and need update.
-    psiClones[ip]->checkOutVariables(OptVariables);
+    psiClones[ip]->checkOutVariables(opt_vars);
     //    synchronize the random number generator with the node
     (*MoverRng[ip]) = (*RngSaved[ip]);
     hClones[ip]->setRandomGenerator(MoverRng[ip]);
@@ -406,7 +406,7 @@ void QMCCostFunction::engine_checkConfigurations(cqmc::engine::LMYEngine<Return_
         Vector<Return_t> Dsaved(NumOptimizables, 0.0);
         Vector<Return_t> HDsaved(NumOptimizables, 0.0);
 
-        etmp = hClones[ip]->evaluateValueAndDerivatives(psi_ref, wRef, OptVariables, Dsaved, HDsaved);
+        etmp = hClones[ip]->evaluateValueAndDerivatives(psi_ref, wRef, opt_vars, Dsaved, HDsaved);
 
         // add non-differentiated derivative vector
         std::vector<Return_t> der_rat_samp(NumOptimizables + 1, 0.0);
@@ -490,9 +490,9 @@ void QMCCostFunction::engine_checkConfigurations(cqmc::engine::LMYEngine<Return_
 
 void QMCCostFunction::resetPsi(bool final_reset)
 {
-  resetOptimizableObjects(Psi, OptVariables);
+  resetOptimizableObjects(Psi, opt_vars);
   for (int i = 0; i < psiClones.size(); ++i)
-    resetOptimizableObjects(*psiClones[i], OptVariables);
+    resetOptimizableObjects(*psiClones[i], opt_vars);
 }
 
 QMCCostFunction::EffectiveWeight QMCCostFunction::correlatedSampling(bool needGrad)
@@ -535,8 +535,7 @@ QMCCostFunction::EffectiveWeight QMCCostFunction::correlatedSampling(bool needGr
         Vector<Return_rt> rHDsaved(NumOptimizables, 0);
 
         saved[ENERGY_NEW] =
-            H_KE_Node[ip]->evaluateValueAndDerivatives(psi_ref, wRef, OptVariables, Dsaved, HDsaved) +
-            saved[ENERGY_FIXED];
+            H_KE_Node[ip]->evaluateValueAndDerivatives(psi_ref, wRef, opt_vars, Dsaved, HDsaved) + saved[ENERGY_FIXED];
 
         for (int i = 0; i < NumOptimizables; i++)
         {

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -113,8 +113,8 @@ void QMCCostFunctionBase::setTargetEnergy(Return_rt et)
   //         *msg_stream << "  Cost Function = " << w_en << "*<E> + " << w_var << "*<Var> + " << w_w << "*<Var(unreweighted)> " << std::endl;
   //         *msg_stream << "  Optimization report = ";
   //         *msg_stream << "cost, walkers, eavg/wgt, eavg/walkers, evar/wgt, evar/walkers, evar_abs\n";
-  //         *msg_stream << "  Optimized variables = " << OptVariables.name(0);
-  //         for (int i=1; i<OptVariables.size(); ++i) *msg_stream << "," << OptVariables.name(i) ;
+  //         *msg_stream << "  Optimized variables = " << opt_vars.name(0);
+  //         for (int i=1; i<opt_vars.size(); ++i) *msg_stream << "," << opt_vars.name(i) ;
   //         *msg_stream << std::endl;
   //       }
 }
@@ -208,8 +208,8 @@ void QMCCostFunctionBase::Report()
                   << curAvg_w << std::setw(16) << curAvg << std::setw(16) << curVar_w << std::setw(16) << curVar
                   << std::setw(16) << curVar_abs << std::endl;
       *msg_stream << " curVars " << std::setw(5) << ReportCounter;
-      for (int i = 0; i < OptVariables.size(); i++)
-        *msg_stream << std::setw(16) << OptVariables[i];
+      for (int i = 0; i < opt_vars.size(); i++)
+        *msg_stream << std::setw(16) << opt_vars[i];
       *msg_stream << std::endl;
     }
     //report the data
@@ -217,7 +217,7 @@ void QMCCostFunctionBase::Report()
   }
 #if defined(QMCCOSTFUNCTION_DEBUG)
   *debug_stream << ReportCounter;
-  OptVariables.print(*debug_stream);
+  opt_vars.print(*debug_stream);
   *debug_stream << std::endl;
 #endif
   ReportCounter++;
@@ -232,13 +232,13 @@ void QMCCostFunctionBase::reportParameters()
   {
     // Pretty print the wave function parameters.
     *msg_stream << "  Updated wave function parameters:\n";
-    OptVariables.print(*msg_stream, 4 /* left padding spaces */, true);
+    opt_vars.print(*msg_stream, 4 /* left padding spaces */, true);
     *msg_stream << std::endl;
 
     std::string vp_fname(RootName + ".vp.h5");
     *msg_stream << "  Updated wavefunction vp file " << vp_fname << std::endl;
     hdf_archive hout;
-    OptVariables.writeToHDF(vp_fname, hout);
+    opt_vars.writeToHDF(vp_fname, hout);
 
     UniqueOptObjRefs opt_obj_refs = Psi.extractOptimizableObjectRefs();
     for (auto opt_obj : opt_obj_refs)
@@ -257,11 +257,11 @@ void QMCCostFunctionBase::reportParameters()
   * While it is possible to call updateXmlNodes() from QMCLinearOptimize.cpp 
   * It is not clean to call xmlSaveFormatFile() from QMCLinearOptimize.cpp 
   *
-  * @param OptVariables.size() OptVariables.name(i) OptVariables[i]
+  * @param opt_vars.size() opt_vars.name(i) opt_vars[i]
   * 
-  * OptVariables.size(): contains the total number of Optimized variables (not Only CI coeff)
-  * OptVariables.name(i): the tag of the optimized variable. To store we use the name of the variable 
-  * OptVariables[i]: The new value of the optimized variable 
+  * opt_vars.size(): contains the total number of Optimized variables (not Only CI coeff)
+  * opt_vars.name(i): the tag of the optimized variable. To store we use the name of the variable 
+  * opt_vars[i]: The new value of the optimized variable 
 */
 void QMCCostFunctionBase::reportParametersH5()
 {
@@ -269,12 +269,12 @@ void QMCCostFunctionBase::reportParametersH5()
   {
     int ci_size = 0;
     std::vector<opt_variables_type::real_type> CIcoeff;
-    for (int i = 0; i < OptVariables.size(); i++)
+    for (int i = 0; i < opt_vars.size(); i++)
     {
       std::array<char, 128> Coeff;
       if (std::snprintf(Coeff.data(), Coeff.size(), "CIcoeff_%d", ci_size + 1) < 0)
         throw std::runtime_error("Error generating fileroot");
-      if (OptVariables.name(i) != Coeff.data())
+      if (opt_vars.name(i) != Coeff.data())
       {
         if (ci_size > 0)
           break;
@@ -282,7 +282,7 @@ void QMCCostFunctionBase::reportParametersH5()
           continue;
       }
 
-      CIcoeff.push_back(OptVariables[i]);
+      CIcoeff.push_back(opt_vars[i]);
       ci_size++;
     }
     if (ci_size > 0)
@@ -382,18 +382,18 @@ bool QMCCostFunctionBase::put(xmlNodePtr q)
     app_log() << "   '" << obj.getName() << "'" << (obj.isOptimized() ? " optimized" : " fixed") << std::endl;
 
   //build optimizables from the wavefunction
-  OptVariables.clear();
+  opt_vars.clear();
   for (OptimizableObject& obj : opt_obj_refs)
     if (obj.isOptimized())
-      obj.checkInVariablesExclusive(OptVariables);
-  OptVariables.resetIndex();
-  app_log() << " Variational subset selects " << OptVariables.size() << " parameters." << std::endl;
+      obj.checkInVariablesExclusive(opt_vars);
+  opt_vars.resetIndex();
+  app_log() << " Variational subset selects " << opt_vars.size() << " parameters." << std::endl;
 
-  //synchronize OptVariables
-  InitVariables = OptVariables;
+  //synchronize opt_vars
+  InitVariables = opt_vars;
   //get the indices
-  Psi.checkOutVariables(OptVariables);
-  NumOptimizables = OptVariables.size();
+  Psi.checkOutVariables(opt_vars);
+  NumOptimizables = opt_vars.size();
   if (NumOptimizables == 0)
   {
     APP_ABORT("QMCCostFunctionBase::put No valid optimizable variables are found.");
@@ -402,7 +402,7 @@ bool QMCCostFunctionBase::put(xmlNodePtr q)
     app_log() << " In total " << NumOptimizables << " parameters being optimized after applying constraints."
               << std::endl;
   //     app_log() << "<active-optimizables> " << std::endl;
-  //     OptVariables.print(app_log());
+  //     opt_vars.print(app_log());
   //     app_log() << "</active-optimizables>" << std::endl;
   if (msg_stream)
     msg_stream->setf(std::ios::scientific, std::ios::floatfield);
@@ -482,7 +482,7 @@ void QMCCostFunctionBase::updateXmlNodes()
       std::string aname(getXMLAttributeValue(cur, "id"));
       if (aname.empty())
         continue;
-      if (auto oit = OptVariables.find(aname); oit != OptVariables.end())
+      if (auto oit = opt_vars.find(aname); oit != opt_vars.end())
         paramNodes[aname] = cur;
     }
     xmlXPathFreeObject(result);
@@ -497,12 +497,12 @@ void QMCCostFunctionBase::updateXmlNodes()
       if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"exponent"); aptr != nullptr)
       {
         std::string expID = aname + "_E";
-        if (auto oit = OptVariables.find(expID); oit != OptVariables.end())
+        if (auto oit = opt_vars.find(expID); oit != opt_vars.end())
           attribNodes[expID] = std::pair<xmlNodePtr, std::string>(cur, "exponent");
       }
       std::string cID = aname + "_C";
       if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"contraction"); aptr != nullptr)
-        if (auto oit = OptVariables.find(cID); oit != OptVariables.end())
+        if (auto oit = opt_vars.find(cID); oit != opt_vars.end())
           attribNodes[cID] = std::pair<xmlNodePtr, std::string>(cur, "contraction");
     }
     xmlXPathFreeObject(result);
@@ -515,9 +515,9 @@ void QMCCostFunctionBase::updateXmlNodes()
       if (aname.empty())
         continue;
       xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"coeff");
-      opt_variables_type::iterator oit(OptVariables.find(aname));
+      opt_variables_type::iterator oit(opt_vars.find(aname));
       if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"coeff"); aptr != NULL)
-        if (auto oit = OptVariables.find(aname); oit != OptVariables.end())
+        if (auto oit = opt_vars.find(aname); oit != opt_vars.end())
           attribNodes[aname] = std::pair<xmlNodePtr, std::string>(cur, "coeff");
     }
     xmlXPathFreeObject(result);
@@ -530,7 +530,7 @@ void QMCCostFunctionBase::updateXmlNodes()
       if (aname.empty())
         continue;
       if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"coeff"); aptr != nullptr)
-        if (auto oit = OptVariables.find(aname); oit != OptVariables.end())
+        if (auto oit = opt_vars.find(aname); oit != opt_vars.end())
           attribNodes[aname] = std::pair<xmlNodePtr, std::string>(cur, "coeff");
     }
     xmlXPathFreeObject(result);
@@ -554,7 +554,7 @@ void QMCCostFunctionBase::updateXmlNodes()
   for (const auto& [pname, pptr] : paramNodes)
   {
     //FIXME real value is forced here to makde sure that the code builds
-    Return_rt v = std::real(OptVariables[pname]);
+    Return_rt v = std::real(opt_vars[pname]);
     getContent(v, pptr);
   }
   for (const auto& [aname, attrib] : attribNodes)
@@ -562,7 +562,7 @@ void QMCCostFunctionBase::updateXmlNodes()
     std::ostringstream vout;
     vout.setf(std::ios::scientific, std::ios::floatfield);
     vout.precision(16);
-    vout << OptVariables[aname];
+    vout << opt_vars[aname];
     xmlSetProp(attrib.first, (const xmlChar*)attrib.second.c_str(), (const xmlChar*)vout.str().c_str());
   }
   for (const auto& [cname, cptr] : coeffNodes)
@@ -579,7 +579,7 @@ void QMCCostFunctionBase::updateXmlNodes()
       //
       aname.append("_");
       std::vector<Return_rt> c;
-      for (const auto& [name, value] : OptVariables)
+      for (const auto& [name, value] : opt_vars)
       {
         if (name.find(aname) == 0)
         {
@@ -619,8 +619,8 @@ void QMCCostFunctionBase::updateXmlNodes()
             length = std::snprintf(lambda_id.data(), lambda_id.size(), "%s_%d_%d", rname.c_str(), i, j);
           if (length < 0)
             throw std::runtime_error("Error generating lambda_id");
-          opt_variables_type::iterator vTarget(OptVariables.find(lambda_id.data()));
-          if (vTarget != OptVariables.end())
+          opt_variables_type::iterator vTarget(opt_vars.find(lambda_id.data()));
+          if (vTarget != opt_vars.end())
           {
             std::ostringstream vout;
             vout.setf(std::ios::scientific, std::ios::floatfield);
@@ -665,7 +665,7 @@ void QMCCostFunctionBase::addCoefficients(xmlXPathContextPtr acontext, const cha
     {
       //check if any optimizables contains the id of coefficients
       bool notlisted = true;
-      opt_variables_type::iterator oit(OptVariables.begin()), oit_end(OptVariables.end());
+      opt_variables_type::iterator oit(opt_vars.begin()), oit_end(opt_vars.end());
       while (notlisted && oit != oit_end)
       {
         const std::string& oname((*oit).first);
@@ -722,7 +722,7 @@ void QMCCostFunctionBase::addCJParams(xmlXPathContextPtr acontext, const char* c
       }
 
       // count the total number of registered F matrix variables
-      opt_variables_type::iterator oit(OptVariables.begin()), oit_end(OptVariables.end());
+      opt_variables_type::iterator oit(opt_vars.begin()), oit_end(opt_vars.end());
       for (; oit != oit_end; ++oit)
       {
         const std::string& oname((*oit).first);
@@ -868,7 +868,7 @@ void QMCCostFunctionBase::addCJParams(xmlXPathContextPtr acontext, const char* c
                 {
                   std::string varname = "cj_" + fid + "_" + aname4;
                   bool notlisted      = true;
-                  opt_variables_type::iterator oit(OptVariables.begin()), oit_end(OptVariables.end());
+                  opt_variables_type::iterator oit(opt_vars.begin()), oit_end(opt_vars.end());
                   while (notlisted && oit != oit_end)
                   {
                     const std::string& oname((*oit).first);
@@ -896,13 +896,13 @@ void QMCCostFunctionBase::addCJParams(xmlXPathContextPtr acontext, const char* c
 
 void QMCCostFunctionBase::printCJParams(xmlNodePtr cur, std::string& rname)
 {
-  opt_variables_type::iterator vit(OptVariables.begin());
+  opt_variables_type::iterator vit(opt_vars.begin());
   // F matrix variables
   if (rname.find("cj_F") < rname.size())
   {
     // get a vector of pairs with f matrix names, values
     std::vector<Return_rt> f_vals;
-    for (auto vit = OptVariables.begin(); vit != OptVariables.end(); ++vit)
+    for (auto vit = opt_vars.begin(); vit != opt_vars.end(); ++vit)
     {
       if ((*vit).first.find("F_") == 0)
       {
@@ -948,7 +948,7 @@ void QMCCostFunctionBase::printCJParams(xmlNodePtr cur, std::string& rname)
     std::string var_prefix = rname.substr(3);
     std::vector<Return_rt> vals;
 
-    for (auto vit = OptVariables.begin(); vit != OptVariables.end(); ++vit)
+    for (auto vit = opt_vars.begin(); vit != opt_vars.end(); ++vit)
     {
       if (vit->first.find(var_prefix) == 0)
       {

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -93,10 +93,10 @@ public:
   ///Path and name of the HDF5 prefix where CI coeffs are saved
   std::string newh5;
   ///assign optimization parameter i
-  Return_rt& Params(int i) { return OptVariables[i]; }
+  Return_rt& Params(int i) { return opt_vars[i]; }
   ///return optimization parameter i
-  Return_t Params(int i) const { return OptVariables[i]; }
-  int getType(int i) const { return OptVariables.getType(i); }
+  Return_t Params(int i) const { return opt_vars[i]; }
+  int getType(int i) const { return opt_vars.getType(i); }
   ///return the cost value for CGMinimization
   Return_rt Cost(bool needGrad = true);
 
@@ -108,17 +108,14 @@ public:
                         const std::vector<Return_rt>& PM,
                         Return_rt FiniteDiff = 0) = 0;
   ///return the number of optimizable parameters
-  inline int getNumParams() const { return OptVariables.size(); }
+  inline int getNumParams() const { return opt_vars.size(); }
   ///return the global number of samples
   inline int getNumSamples() const { return NumSamples; }
   inline void setNumSamples(int newNumSamples) { NumSamples = newNumSamples; }
   ///reset the wavefunction
   virtual void resetPsi(bool final_reset = false) = 0;
 
-  inline void getParameterTypes(std::vector<int>& types) const
-  {
-    return OptVariables.getParameterTypeList(types);
-  }
+  inline void getParameterTypes(std::vector<int>& types) const { return opt_vars.getParameterTypeList(types); }
 
   ///dump the current parameters and other report
   void Report();
@@ -174,7 +171,7 @@ public:
   inline void setneedGrads(bool tf) { needGrads = tf; }
   inline void setDMC() { vmc_or_dmc = 1.0; }
 
-  inline const opt_variables_type& getOptVariables() const { return OptVariables; }
+  inline const opt_variables_type& getOptVariables() const { return opt_vars; }
 
   /// return variance after checkConfigurations
   inline Return_rt getVariance() const
@@ -242,13 +239,13 @@ protected:
   double omega_shift;
 
   ///list of optimizables
-  opt_variables_type OptVariables;
+  opt_variables_type opt_vars;
   // unchanged initial checked-in variables
   opt_variables_type InitVariables;
   /** index mapping for <negate> constraints
    *
-   * - negateVarMap[i][0] : index in OptVariables
-   * - negateVarMap[i][1] : index in OptVariables
+   * - negateVarMap[i][0] : index in opt_vars
+   * - negateVarMap[i][1] : index in opt_vars
    */
   ///index mapping for <negative> constraints
   std::vector<TinyVector<int, 2>> negateVarMap;

--- a/src/QMCDrivers/tests/test_ConjugateGradient.cpp
+++ b/src/QMCDrivers/tests/test_ConjugateGradient.cpp
@@ -42,7 +42,7 @@ public:
       for (int j = 0; j < np; j++)
         Amat_[i * np + j] = Amat[i][j];
       std::string name = "tmp" + std::to_string(i);
-      OptVariables.insert(name, 0);
+      opt_vars.insert(name, 0);
     }
   }
 

--- a/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
@@ -81,7 +81,7 @@ public:
     for (int i = 0; i < nparam; i++)
     {
       std::string varname = "var" + std::to_string(i);
-      costFn.OptVariables.insert(varname, 1.0);
+      costFn.opt_vars.insert(varname, 1.0);
     }
 
     costFn.NumOptimizables = numParam;

--- a/src/QMCWaveFunctions/ExampleHeComponent.cpp
+++ b/src/QMCWaveFunctions/ExampleHeComponent.cpp
@@ -209,7 +209,7 @@ std::unique_ptr<WaveFunctionComponent> ExampleHeComponent::makeClone(ParticleSet
   return std::make_unique<ExampleHeComponent>(*this);
 }
 
-void ExampleHeComponent::resetParametersExclusive(const OptVariablesType& active)
+void ExampleHeComponent::resetParametersExclusive(const opt_variables_type& active)
 {
   if (my_vars_.size())
   {
@@ -226,7 +226,7 @@ void ExampleHeComponent::resetParametersExclusive(const OptVariablesType& active
 }
 
 void ExampleHeComponent::evaluateDerivatives(ParticleSet& P,
-                                             const OptVariablesType& optvars,
+                                             const opt_variables_type& optvars,
                                              Vector<ValueType>& dlogpsi,
                                              Vector<ValueType>& dhpsioverpsi)
 {

--- a/src/QMCWaveFunctions/ExampleHeComponent.h
+++ b/src/QMCWaveFunctions/ExampleHeComponent.h
@@ -32,15 +32,15 @@ public:
         my_table_ee_idx_(els.addTable(els, DTModes::NEED_TEMP_DATA_ON_HOST | DTModes::NEED_VP_FULL_TABLE_ON_HOST)),
         my_table_ei_idx_(els.addTable(ions, DTModes::NEED_VP_FULL_TABLE_ON_HOST)){};
 
-  using OptVariablesType = optimize::VariableSet;
+  using opt_variables_type = optimize::VariableSet;
   using PtclGrpIndexes   = QMCTraits::PtclGrpIndexes;
 
   std::string getClassName() const override { return "ExampleHeComponent"; }
   void extractOptimizableObjectRefs(UniqueOptObjRefs& opt_obj_refs) override { opt_obj_refs.push_back(*this); }
   bool isOptimizable() const override { return true; }
-  void checkInVariablesExclusive(OptVariablesType& active) override { active.insertFrom(my_vars_); }
-  void checkOutVariables(const OptVariablesType& active) override { my_vars_.getIndex(active); }
-  void resetParametersExclusive(const OptVariablesType& active) override;
+  void checkInVariablesExclusive(opt_variables_type& active) override { active.insertFrom(my_vars_); }
+  void checkOutVariables(const opt_variables_type& active) override { my_vars_.getIndex(active); }
+  void resetParametersExclusive(const opt_variables_type& active) override;
 
   LogValue evaluateLog(const ParticleSet& P,
                        ParticleSet::ParticleGradient& G,
@@ -57,7 +57,7 @@ public:
   PsiValue ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override;
 
   void evaluateDerivatives(ParticleSet& P,
-                           const OptVariablesType& optvars,
+                           const opt_variables_type& optvars,
                            Vector<ValueType>& dlogpsi,
                            Vector<ValueType>& dhpsioverpsi) override;
 
@@ -84,7 +84,7 @@ private:
   const int my_table_ee_idx_;
   const int my_table_ei_idx_;
 
-  OptVariablesType my_vars_;
+  opt_variables_type my_vars_;
 };
 
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes
Seems unnecessary to keep separate OptVariablesForPsi and OptVariables. One is enough to serve all needs.
Also did renaming.

## What type(s) of changes does this code introduce?
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
