### PR TITLE
Nexus: fix abspath to realpath

### DIFF
--- a/nexus/bin/eshdf
+++ b/nexus/bin/eshdf
@@ -12,11 +12,11 @@ import numpy as np
 def find_nexus_modules():
     import os
     import sys
-    nexus_lib = os.path.abspath(os.path.join(__file__,'..','..','..','nexus'))
+    nexus_lib = os.path.realpath(os.path.join(__file__,'..','..','..','nexus'))
     assert(os.path.exists(nexus_lib))
     sys.path.insert(0,nexus_lib)
     import nexus
-    nexus_lib2 = os.path.abspath(os.path.join(nexus.__file__,'..','..'))
+    nexus_lib2 = os.path.realpath(os.path.join(nexus.__file__,'..','..'))
     assert nexus_lib2==nexus_lib
 #end def find_nexus_modules
 

--- a/nexus/bin/nxs-redo
+++ b/nexus/bin/nxs-redo
@@ -7,11 +7,11 @@ from optparse import OptionParser
 def find_nexus_modules():
     import os
     import sys
-    nexus_lib = os.path.abspath(os.path.join(__file__,'..','..','..','nexus'))
+    nexus_lib = os.path.realpath(os.path.join(__file__,'..','..','..','nexus'))
     assert(os.path.exists(nexus_lib))
     sys.path.insert(0,nexus_lib)
     import nexus
-    nexus_lib2 = os.path.abspath(os.path.join(nexus.__file__,'..','..'))
+    nexus_lib2 = os.path.realpath(os.path.join(nexus.__file__,'..','..'))
     assert nexus_lib2==nexus_lib
 #end def find_nexus_modules
 

--- a/nexus/bin/nxs-sim
+++ b/nexus/bin/nxs-sim
@@ -7,11 +7,11 @@ from optparse import OptionParser
 def find_nexus_modules():
     import os
     import sys
-    nexus_lib = os.path.abspath(os.path.join(__file__,'..','..','..','nexus'))
+    nexus_lib = os.path.realpath(os.path.join(__file__,'..','..','..','nexus'))
     assert(os.path.exists(nexus_lib))
     sys.path.insert(0,nexus_lib)
     import nexus
-    nexus_lib2 = os.path.abspath(os.path.join(nexus.__file__,'..','..'))
+    nexus_lib2 = os.path.realpath(os.path.join(nexus.__file__,'..','..'))
     assert nexus_lib2==nexus_lib
 #end def find_nexus_modules
 

--- a/nexus/bin/nxs-test
+++ b/nexus/bin/nxs-test
@@ -36,7 +36,7 @@ for d in dirs_check:
 sys.path.insert(0,library_dir)
 
 # add unit test modules
-#sys.path.append(os.path.abspath(os.path.join(__file__,'..','..','nexus','tests')))
+#sys.path.append(os.path.realpath(os.path.join(__file__,'..','..','nexus','tests')))
 
 unit_test_module_lists = dict()
 unit_test_modules      = dict()
@@ -2184,7 +2184,7 @@ def regenerate_reference(update=False):
 
 def find_nexus_modules():
     import sys
-    nexus_lib = os.path.abspath(os.path.join(__file__,'..','..','..','nexus'))
+    nexus_lib = os.path.realpath(os.path.join(__file__,'..','..','..','nexus'))
     assert(os.path.exists(nexus_lib))
     sys.path.append(nexus_lib)
 #end def find_nexus_modules
@@ -2223,8 +2223,8 @@ if __name__=='__main__':
     testing_wrong_nexus_install = False
     try:
         import nexus
-        nexus_file = os.path.abspath(os.path.join(nexus.__file__,'../..'))
-        test_file  = os.path.abspath(os.path.join(__file__,'../..'))
+        nexus_file = os.path.realpath(os.path.join(nexus.__file__,'../..'))
+        test_file  = os.path.realpath(os.path.join(__file__,'../..'))
         testing_wrong_nexus_install = nexus_file!=test_file
     except:
         pass

--- a/nexus/bin/qdens
+++ b/nexus/bin/qdens
@@ -8,11 +8,11 @@ from optparse import OptionParser
 def find_nexus_modules():
     import os
     import sys
-    nexus_lib = os.path.abspath(os.path.join(__file__,'..','..','..','nexus'))
+    nexus_lib = os.path.realpath(os.path.join(__file__,'..','..','..','nexus'))
     assert(os.path.exists(nexus_lib))
     sys.path.insert(0,nexus_lib)
     import nexus
-    nexus_lib2 = os.path.abspath(os.path.join(nexus.__file__,'..','..'))
+    nexus_lib2 = os.path.realpath(os.path.join(nexus.__file__,'..','..'))
     assert nexus_lib2==nexus_lib
 #end def find_nexus_modules
 

--- a/nexus/bin/qdens-radial
+++ b/nexus/bin/qdens-radial
@@ -6,11 +6,11 @@ from optparse import OptionParser
 def find_nexus_modules():
     import os
     import sys
-    nexus_lib = os.path.abspath(os.path.join(__file__,'..','..','..','nexus'))
+    nexus_lib = os.path.realpath(os.path.join(__file__,'..','..','..','nexus'))
     assert(os.path.exists(nexus_lib))
     sys.path.insert(0,nexus_lib)
     import nexus
-    nexus_lib2 = os.path.abspath(os.path.join(nexus.__file__,'..','..'))
+    nexus_lib2 = os.path.realpath(os.path.join(nexus.__file__,'..','..'))
     assert nexus_lib2==nexus_lib
 #end def find_nexus_modules
 

--- a/nexus/bin/qmc-fit
+++ b/nexus/bin/qmc-fit
@@ -31,11 +31,11 @@ except (ImportError,RuntimeError):
 def find_nexus_modules():
     import os
     import sys
-    nexus_lib = os.path.abspath(os.path.join(__file__,'..','..','..','nexus'))
+    nexus_lib = os.path.realpath(os.path.join(__file__,'..','..','..','nexus'))
     assert(os.path.exists(nexus_lib))
     sys.path.insert(0,nexus_lib)
     import nexus
-    nexus_lib2 = os.path.abspath(os.path.join(nexus.__file__,'..','..'))
+    nexus_lib2 = os.path.realpath(os.path.join(nexus.__file__,'..','..'))
     assert nexus_lib2==nexus_lib
 #end def find_nexus_modules
 

--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -8,11 +8,11 @@ from optparse import OptionParser
 def find_nexus_modules():
     import os
     import sys
-    nexus_lib = os.path.abspath(os.path.join(__file__,'..','..','..','nexus'))
+    nexus_lib = os.path.realpath(os.path.join(__file__,'..','..','..','nexus'))
     assert(os.path.exists(nexus_lib))
     sys.path.insert(0,nexus_lib)
     import nexus
-    nexus_lib2 = os.path.abspath(os.path.join(nexus.__file__,'..','..'))
+    nexus_lib2 = os.path.realpath(os.path.join(nexus.__file__,'..','..'))
     assert nexus_lib2==nexus_lib
 #end def find_nexus_modules
 


### PR DESCRIPTION
## Proposed changes

fixes an issue building qmcpack on the SNL clusters. 
Basically, cmake was crashing when trying to compile because it was trying to call nxs-test, and that was throwing an error due to a path mismatch. 


> Installed Nexus package does not reside with this nxs-test executable.
>   Currently installed nexus package: /home/username/codes/qmcpack/nexus
>   Correct Nexus package            : /some/other/path/to/username/codes/qmcpack/nexus
>   Please install the correct Nexus package above.


  
Ultimately, the issue boils down to the fact that when I ssh to an SNL cluster, the directory I'm put in is a symlink to `/home/username`, which i'm calling `/some/other/path/to/username`
Since they are symlinked, they are all the same directory but the nxs-test is doing string comparisons and that triggers the failure. 

The reason is that nxs-test uses os.path.abspath instead of os.path.realpath for checking this. With os.realpath, everything works as expected. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
SNL Amber

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
