### PR TITLE
Nexus: Add backwards compatibility for old Nexus pickles 

### DIFF
--- a/nexus/nexus/generic.py
+++ b/nexus/nexus/generic.py
@@ -61,6 +61,73 @@ def nocopy(value):
 
 sorted_generic = sorted_py2
 
+# There must be a better way to do this than store these, but this was faster for testing
+nexus_modules = [
+    "xmlreader",
+    "fileio",
+    "quantum_package_analyzer",
+    "pwscf",
+    "pwscf_analyzer",
+    "quantum_package_input",
+    "testing",
+    "rmg_input",
+    "machines",
+    "qmcpack_converters",
+    "simulation",
+    "pwscf_postprocessors",
+    "pyscf_sim",
+    "unit_converter",
+    "execute",
+    "qmcpack_result_analyzers",
+    "basisset",
+    "project_manager",
+    "gamess_input",
+    "quantum_package",
+    "pwscf_input",
+    "pyscf_input",
+    "physical_system",
+    "pseudopotential",
+    "nexus_version",
+    "periodic_table",
+    "rmg_analyzer",
+    "memory",
+    "vasp_input",
+    "qmcpack",
+    "numerics",
+    "qmcpack_analyzer",
+    "structure",
+    "gamess_analyzer",
+    "developer",
+    "template_simulation",
+    "bundle",
+    "qmcpack_property_analyzers",
+    "qmcpack_quantity_analyzers",
+    "rmg",
+    "grid_functions",
+    "hdfreader",
+    "utilities",
+    "qmcpack_analyzer_base",
+    "vasp",
+    "generic",
+    "nexus_base",
+    "debug",
+    "qmcpack_method_analyzers",
+    "observables",
+    "gamess",
+    "versions",
+    "vasp_analyzer",
+    "gaussian_process",
+    "pwscf_data_reader",
+    "qmcpack_input",
+    "pyscf_analyzer",
+]
+
+
+class NexusUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        if module in nexus_modules and "nexus." not in module:
+            module = "nexus." + module
+        return super().find_class(module, name)
 
 
 def log(*items,**kwargs):
@@ -441,10 +508,10 @@ class object_interface(object):
         #end if
         fobj = open(fpath,'rb')
         try:
-            tmp = pickle.load(fobj)
+            tmp = NexusUnpickler(fobj).load()
         except:
             try:
-                tmp = pickle.load(fobj,encoding='latin1')
+                tmp = NexusUnpickler(fobj).load(encoding='latin1')
             except:
                 # fallback for files created with protocol 5
                 # in environments that only support up to protocol 4

--- a/nexus/nexus/generic.py
+++ b/nexus/nexus/generic.py
@@ -126,7 +126,8 @@ nexus_modules = [
 
 class NexusUnpickler(pickle.Unpickler):
     """This class is designed for backwards compatibility with pickles generated
-    Nexus was packaged. It shouldn't touch anything but old Nexus pickles.
+    before Nexus was packaged (PR #5700, December 20, 2025). 
+    It shouldn't touch anything but old Nexus pickles.
     """
     def find_class(self, module, name):
         if module in nexus_modules and "nexus." not in module:
@@ -516,8 +517,9 @@ class object_interface(object):
             tmp = pickle.load(fobj)
         except ModuleNotFoundError:
             try:
-                # Old pickles from before Nexus was packaged won't have the correct module path
-                # The custom unpickler will handle this by prepending "nexus." to the module path
+                # Old pickles from before Nexus was packaged (PR #5700, December 20 2025)
+                # won't have the correct module path. The custom unpickler will handle this by 
+                # prepending "nexus." to the module path
                 tmp = NexusUnpickler(fobj).load()
             except UnpicklingError:
                 try:


### PR DESCRIPTION
## Proposed changes

The recent restructure of Nexus (PR #5700) modified the path for all of the Nexus modules, which rendered pickles made before the update non-functional. This PR adds a custom wrapper around `pickle.Unpickler` to check for pickles belonging to an older version of Nexus and prepends `nexus.` to the module name so that the unpickler can properly unpickle the pickle.

Additionally, this PR makes sure that no unpickling errors get silently caught, which was a problem in debugging the unpickling error due to the `ModuleNotFoundError` getting "handled" and eventually turned into an `ImportError`.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, user from Sandia

## Checklist

* * [ ] I have read the pull request guidance and develop docs
* * [ ] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
