### PR TITLE
fix indexing when not in first particle group in ConstantSPOSet

### DIFF
--- a/src/QMCWaveFunctions/tests/ConstantSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/ConstantSPOSet.cpp
@@ -40,21 +40,15 @@ std::unique_ptr<SPOSetT<T>> ConstantSPOSet<T>::makeClone() const
 
 template<typename T>
 std::string ConstantSPOSet<T>::getClassName() const
-{
-  return "ConstantSPOSet";
-};
+{ return "ConstantSPOSet"; }
 
 template<typename T>
 void ConstantSPOSet<T>::checkOutVariables(const OptVariables& active)
-{
-  APP_ABORT("ConstantSPOSet should not call checkOutVariables");
-};
+{ APP_ABORT("ConstantSPOSet should not call checkOutVariables"); }
 
 template<typename T>
 void ConstantSPOSet<T>::setOrbitalSetSize(int norbs)
-{
-  APP_ABORT("ConstantSPOSet should not call setOrbitalSetSize()");
-}
+{ APP_ABORT("ConstantSPOSet should not call setOrbitalSetSize()"); }
 
 template<typename T>
 void ConstantSPOSet<T>::setRefVals(const ValueMatrix& vals)
@@ -84,11 +78,12 @@ template<typename T>
 void ConstantSPOSet<T>::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
 {
   const auto* vp = dynamic_cast<const VirtualParticleSet*>(&P);
-  int ptcl       = vp ? vp->refPtcl : iat;
+  const int ptcl = vp ? vp->refPtcl : iat;
+  auto& pset     = vp ? vp->getRefPS() : P;
   assert(psi.size() == SPOSet::OrbitalSetSize);
 
-  const int group = P.getGroupID(ptcl);
-  const int first = P.first(group);
+  const int group = pset.getGroupID(ptcl);
+  const int first = pset.first(group);
   for (int iorb = 0; iorb < SPOSet::OrbitalSetSize; iorb++)
     psi[iorb] = ref_psi_(ptcl - first, iorb);
 };


### PR DESCRIPTION

## Proposed changes

I'm working on implementing something in my free time, and I'm using ConstantSPOSet as a way to pass in desired values to the wave function component I'm playing with.  ConstantSPOSet is only used for testing, and apparently hasn't been used for multi-group particlesets because the indexing was wrong. ConstantSPOSet::evaluate_notranspose calls ConstantSPOSet::evaluateVGL, which just references the constant VGL data structures.  However, it passes iat as an argument, but iat is referenced wrt to the ParticleSet. That is a problem if you're using a particle from a group other than 0, since the data arrays always start from zero. So the accessing of the VGL arrays needs to be shifted with respect to the start index of the corresponding group. This is a simple bug fix, but doesn't impact any tests using this code since all of them always only have a single group in their particleset for testing. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
mac 

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [ ] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
