### PR TITLE
Remove global number of samples awareness in SampleStack

### DIFF
--- a/src/Particle/SampleStack.cpp
+++ b/src/Particle/SampleStack.cpp
@@ -20,10 +20,9 @@ namespace qmcplusplus
  * @param n number of samples per rank
  * @param num_ranks number of ranks. Used to set global number of samples.
  */
-void SampleStack::setMaxSamples(size_t n, size_t num_ranks)
+void SampleStack::setMaxSamples(size_t n)
 {
   max_samples_        = n;
-  global_num_samples_ = n * num_ranks;
   current_sample_count_ = std::min(current_sample_count_, max_samples_);
   sample_vector_.resize(n, MCSample(0));
 }

--- a/src/Particle/SampleStack.h
+++ b/src/Particle/SampleStack.h
@@ -40,9 +40,7 @@ public:
   //@{save/load/clear function for optimization
   inline size_t getNumSamples() const { return current_sample_count_; }
   ///set the number of max samples per rank.
-  void setMaxSamples(size_t n, size_t number_of_ranks = 1);
-  /// Global number of samples is number of samples per rank * number of ranks
-  size_t getGlobalNumSamples() const { return global_num_samples_; }
+  void setMaxSamples(size_t n);
   /// load a single sample from SampleStack
   void loadSample(ParticleSet& pset, size_t iw) const;
 
@@ -57,7 +55,6 @@ public:
 private:
   size_t max_samples_{10};
   size_t current_sample_count_{0};
-  size_t global_num_samples_{max_samples_};
 
   std::vector<MCSample> sample_vector_;
 };

--- a/src/Particle/tests/test_sample_stack.cpp
+++ b/src/Particle/tests/test_sample_stack.cpp
@@ -30,11 +30,9 @@ TEST_CASE("SampleStack", "[particle]")
   const int total_num = 2; // number of particles
 
   // reserve storage
-  int nranks = 2;
-  samples.setMaxSamples(8, nranks);
+  samples.setMaxSamples(8);
   REQUIRE(samples.getMaxSamples() == 8);
   REQUIRE(samples.getNumSamples() == 0);
-  REQUIRE(samples.getGlobalNumSamples() == 16);
 
   // increase storage
   samples.setMaxSamples(10);

--- a/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunctionBatched.cpp
@@ -19,7 +19,7 @@
 
 namespace qmcplusplus
 {
-size_t QMCCostFunctionBatched::total_samples() { return samples_.getGlobalNumSamples(); }
+size_t QMCCostFunctionBatched::total_samples() { return samples_.getNumSamples() * myComm->size(); }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// \brief  Computes the cost function using the LMYEngine for interfacing with batched driver

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -494,7 +494,7 @@ void VMCBatched::enable_sample_collection()
   assert(steps_per_block_ > 0 && "VMCBatched::enable_sample_collection steps_per_block_ must be positive!");
   auto samples = compute_samples_per_rank(qmcdriver_input_.get_max_blocks(), steps_per_block_,
                                           population_.get_num_local_walkers());
-  samples_.setMaxSamples(samples, population_.get_num_ranks());
+  samples_.setMaxSamples(samples);
   collect_samples_ = true;
 
   auto total_samples = samples * population_.get_num_ranks();

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -649,9 +649,6 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
     H.setRandomGenerator(MoverRng[0]);
   }
 
-  //Return_rt wgt_node = 0.0, wgt_node2 = 0.0;
-  Return_rt wgt_tot = 0.0;
-
   // Ensure number of samples did not change after getConfiguration
   assert(rank_local_num_samples_ == samples_.getNumSamples());
 
@@ -797,6 +794,7 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
               vmc_or_dmc, needGrad);
 
   // Sum weights over crowds
+  Return_rt wgt_tot = 0.0;
   Return_rt inv_n_samples = 1.0 / (samples_.getNumSamples() * myComm->size());
   for (int i = 0; i < opt_eval.size(); i++)
     wgt_tot += opt_eval[i]->get_wgt() * inv_n_samples;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -797,9 +797,9 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
               vmc_or_dmc, needGrad);
 
   // Sum weights over crowds
-  Return_rt inv_n_samples = 1.0 / samples_.getGlobalNumSamples();
+  Return_rt inv_n_samples = 1.0 / (samples_.getNumSamples() * myComm->size());
   for (int i = 0; i < opt_eval.size(); i++)
-    wgt_tot += opt_eval[i]->get_wgt() *inv_n_samples;
+    wgt_tot += opt_eval[i]->get_wgt() * inv_n_samples;
 
   //this is MPI barrier
   OHMMS::Controller->barrier();
@@ -851,7 +851,7 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
   }
   //collect everything
   myComm->allreduce(SumValue);
-  return SumValue[SUM_WGT] * SumValue[SUM_WGT] / (SumValue[SUM_WGTSQ] * samples_.getGlobalNumSamples());
+  return inv_n_samples * SumValue[SUM_WGT] * SumValue[SUM_WGT] / SumValue[SUM_WGTSQ];
 }
 
 

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -655,8 +655,6 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
   // Ensure number of samples did not change after getConfiguration
   assert(rank_local_num_samples_ == samples_.getNumSamples());
 
-  Return_rt inv_n_samples = 1.0 / samples_.getGlobalNumSamples();
-
   const size_t opt_num_crowds = walkers_per_crowd_.size();
   // Divide samples among crowds
   std::vector<int> samples_per_crowd_offsets(opt_num_crowds + 1);
@@ -738,8 +736,6 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
           TrialWaveFunction::mw_evaluateDeltaLog(wf_list, p_list, opt_data.get_log_psi_opt(), dummyG_list, dummyL_list,
                                                  compute_all_from_scratch);
 
-          Return_rt inv_n_samples = 1.0 / samples.getGlobalNumSamples();
-
           for (int ib = 0; ib < current_batch_size; ib++)
           {
             const int is = base_sample_index + ib;
@@ -751,7 +747,7 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
             Return_rt weight = vmc_or_dmc * (opt_data.get_log_psi_opt()[ib] - RecordsOnNode[is][LOGPSI_FREE]);
             RecordsOnNode[is][REWEIGHT] = weight;
             // move to opt_data
-            opt_data.get_wgt() += inv_n_samples * weight;
+            opt_data.get_wgt() += weight;
           }
 
           if (needGrad)
@@ -799,9 +795,11 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
   crowd_tasks(opt_num_crowds, evalOptCorrelated, opt_eval, samples_per_crowd_offsets, walkers_per_crowd_, dLogPsi,
               d2LogPsi, RecordsOnNode_, DerivRecords_, HDerivRecords_, samples_, opt_vars, compute_all_from_scratch,
               vmc_or_dmc, needGrad);
+
   // Sum weights over crowds
+  Return_rt inv_n_samples = 1.0 / samples_.getGlobalNumSamples();
   for (int i = 0; i < opt_eval.size(); i++)
-    wgt_tot += opt_eval[i]->get_wgt();
+    wgt_tot += opt_eval[i]->get_wgt() *inv_n_samples;
 
   //this is MPI barrier
   OHMMS::Controller->barrier();


### PR DESCRIPTION
## Proposed changes
SampleStack was unnecessary entangled with global sample count. This PR removes MPI pollution in SampleStack.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
