### PR TITLE
Revert "Nexus: Change deprecated `arr.shape = a,b` pattern to `arr = arr.reshape(a, b)` for numpy arrays"

### DIFF
--- a/nexus/bin/qdens
+++ b/nexus/bin/qdens
@@ -171,7 +171,7 @@ def reblock(data,eq,rb=None,filepath=None):
     # reblock the data
     s = list(d.shape)
     snew = tuple([len(d)//rb,rb]+s[1:])
-    d = d.reshape(snew)
+    d.shape = snew
     d = d.mean(1)
     return d
 #end def reblock
@@ -622,7 +622,7 @@ class StatFile(QDBase):
                         if ncells!=data_cells:
                             self.error('grid does not match number of data cells\ngrid provided: {0}\nnumber of cells in grid: {1}\nnumber of cells in data: {2}'.format(grid,ncells,data_cells))
                         #end if
-                        data.value = data.value.reshape(len(data.value),g[0],g[1],g[2])
+                        data.value.shape = len(data.value),g[0],g[1],g[2]
                     #end for
                 #end for
                 # reblock the data
@@ -696,7 +696,7 @@ class StatFile(QDBase):
                         if ncells!=data_cells:
                             self.error('grid does not match number of data cells\ngrid provided: {0}\nnumber of cells in grid: {1}\nnumber of cells in data: {2}'.format(grid,ncells,data_cells))
                         #end if
-                        data = data.reshape(len(data),g[0],g[1],g[2])
+                        data.shape = len(data),g[0],g[1],g[2]
                     #end for
                 #end for
                 # reblock the data
@@ -1159,7 +1159,7 @@ class QMCDensityProcessor(QDBase):
             if len(cell)!=9:
                 self.error('--cell input misformatted\nexpected 9 elements for 3x3 matrix\nreceived {0} elements with values: {1}'.format(len(cell),cell))
             #end if
-            cell = cell.reshape(3,3)
+            cell.shape = 3,3
             opt.cell = cell
         else:
             opt.cell = cell
@@ -1177,7 +1177,7 @@ class QMCDensityProcessor(QDBase):
             if len(np.array(density_cell).ravel())!=9:
                 self.error('--density_cell input misformatted\nexpected 9 elements for 3x3 matrix\nreceived {0} elements with values: {1}'.format(len(density_cell),density_cell))
             #end if
-            density_cell = density_cell.reshape(3,3)
+            density_cell.shape = 3,3
             opt.density_cell = density_cell
         else:
             opt.density_cell = density_cell

--- a/nexus/bin/qmc-fit
+++ b/nexus/bin/qmc-fit
@@ -313,11 +313,11 @@ def process_scalar_files(scalar_files,equils=None,reblock_factors=None,series_st
         nbe = len(E)%bt
         E = E[nbe:]
         reblock = len(E)//bt
-        E = E.reshape(bt,reblock)
+        E.shape = (bt,reblock)
         if reblock>1:
             E = E.sum(1)/reblock
         #end if
-        E = E.reshape(bt,)
+        E.shape = (bt,)
         Edata[n] = E
     #end for
     Edata = np.array(Edata,dtype=float)

--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -262,7 +262,7 @@ class DatAnalyzer(QBase):
         self.extract_info(filepath)
         lt = np.loadtxt(filepath)
         if len(lt.shape)==1:
-            lt = lt.reshape(1,len(lt))
+            lt.shape = (1,len(lt))
         #end if
         if lt.size==0:
             self.info.load_failed = True

--- a/nexus/nexus/fileio.py
+++ b/nexus/nexus/fileio.py
@@ -371,14 +371,14 @@ class XsfFile(StandardFile):
                     primvec = np.array((lines[i+1]+' '+
                                      lines[i+2]+' '+
                                      lines[i+3]).split(),dtype=float)
-                    primvec = primvec.reshape(3,3)
+                    primvec.shape = 3,3
                     self.add_to_image(image,'primvec',primvec)
                     i+=3
                 elif keyword=='convvec':
                     convvec = np.array((lines[i+1]+' '+
                                      lines[i+2]+' '+
                                      lines[i+3]).split(),dtype=float)
-                    convvec = convvec.reshape(3,3)
+                    convvec.shape = 3,3
                     self.add_to_image(image,'convvec',convvec)
                     i+=3
                 elif keyword=='atoms':
@@ -403,12 +403,12 @@ class XsfFile(StandardFile):
                     #end while
                     elem = np.array(elem,dtype=int)
                     pos  = np.array(pos,dtype=float)
-                    pos = pos.reshape(natoms,3)
+                    pos.shape = natoms,3
                     self.add_to_image(image,'elem',elem)
                     self.add_to_image(image,'pos',pos)
                     if len(force)>0:
                         force = np.array(force,dtype=float)
-                        force = force.reshape(natoms,3)
+                        force.shape = natoms,3
                         self.add_to_image(image,'force',force)
                     #end if
                     i-=1
@@ -431,12 +431,12 @@ class XsfFile(StandardFile):
                         elem = np.array(elem,dtype=str)
                     #end try
                     pos  = np.array(pos,dtype=float)
-                    pos = pos.reshape(natoms,3)
+                    pos.shape = natoms,3
                     self.add_to_image(image,'elem',elem)
                     self.add_to_image(image,'pos',pos)
                     if len(force)>0:
                         force = np.array(force,dtype=float)
-                        force = force.reshape(natoms,3)
+                        force.shape = natoms,3
                         self.add_to_image(image,'force',force)
                     #end if
                     i+=natoms+1
@@ -478,7 +478,7 @@ class XsfFile(StandardFile):
                                                 lines[i+5]).split(),dtype=float)
                                 i+=6
                             #end if
-                            cell = cell.reshape(d,3)
+                            cell.shape = d,3
                             dtokens = []
                             line = lines[i].strip().lower()
                             while not line.startswith('end_datagrid'):
@@ -547,7 +547,7 @@ class XsfFile(StandardFile):
                                                 lines[i+6]).split(),dtype=float)
                                 i+=7
                             #end if
-                            cell = cell.reshape(d,3)
+                            cell.shape = d,3
                             bands = obj()
                             line = lines[i].strip().lower()
                             while not line.startswith('end_bandgrid'):
@@ -562,7 +562,7 @@ class XsfFile(StandardFile):
                             #end while
                             for bi,bv in bands.items():
                                 bands[bi] = np.array(bv,dtype=float)
-                                bands[bi] = bands[bi].reshape(tuple(grid))
+                                bands[bi].shape = tuple(grid)
                             #end for
                             band[grid_identifier] = obj(
                                 grid   = grid,
@@ -836,7 +836,7 @@ class XsfFile(StandardFile):
         corner  = np.array(corner,dtype=float)
         cell    = np.array(cell  ,dtype=float)
         density = np.array(density,dtype=float)
-        density = density.reshape(tuple(grid))
+        density.shape = tuple(grid)
         
         if centered: # shift corner by half a grid cell to center it
             dc = 0.5/grid     
@@ -857,7 +857,7 @@ class XsfFile(StandardFile):
             density[   -1,:g[1],   -1] = d[0,:,0] 
             density[:g[0],   -1,   -1] = d[:,0,0] 
             density[   -1,   -1,   -1] = d[0,0,0] # corner copy
-            density = density.reshape(tuple(grid))
+            density.shape = tuple(grid)
         #end if
 
         self.data = obj()     
@@ -946,7 +946,7 @@ class XsfFile(StandardFile):
             data = data.transpose(permutation)
         #end if
         s = data.shape
-        data = data.reshape(s[0],s[1]*s[2])
+        data.shape = s[0],s[1]*s[2]
         line_data = data.sum(1)*dV/dr
         r_data = density.corner[dim] + dr*np.arange(len(line_data),dtype=float)
         return r_data,line_data

--- a/nexus/nexus/gaussian_process.py
+++ b/nexus/nexus/gaussian_process.py
@@ -1860,7 +1860,7 @@ class GPTestFunction(DevBase):
         exit_on_save  : (Optional) same as GaussianProcessOptimizer.exit_on_save.
         """
         Pmin = np.array(Pmin,dtype=float).ravel()
-        Pmin = Pmin.reshape(1,len(Pmin))
+        Pmin.shape = (1,len(Pmin))
         self.name          = name
         self.niterations   = niterations
         self.param_lower   = param_lower
@@ -1890,14 +1890,14 @@ class GPTestFunction(DevBase):
         if self.deterministic:
             for i in range(npoints):
                 Pi = P[i].ravel()
-                Pi = Pi.reshape(1,len(Pi))
+                Pi.shape = (1,len(Pi))
                 E[i,0]  = self.function(Pi)
                 dE[i,0] = self.sigma
             #end for
         else:
             for i in range(npoints):
                 Pi = P[i].ravel()
-                Pi = Pi.reshape(1,len(Pi))
+                Pi.shape = (1,len(Pi))
                 E[i,0],dE[i,0] = self.function(Pi)
             #end for
         #end if

--- a/nexus/nexus/grid_functions.py
+++ b/nexus/nexus/grid_functions.py
@@ -335,7 +335,7 @@ def unit_grid_points(shape,centered=False,endpoint=None):
     points = np.meshgrid(*linear_grids,indexing='ij')
     points = np.array(points)
     # reshape and transpose the points
-    points = points.reshape(len(points),np.array(shape).prod())
+    points.shape = (len(points),np.array(shape).prod())
     points = points.T
     return points
 #end def unit_grid_points
@@ -1473,7 +1473,7 @@ class StructuredGrid(Grid):
         This should only be a local and temporary change of state.  It should 
         be reversed by calling `reshape_flat` as soon as possible.
         """
-        self.points = self.r.reshape(self.full_points_shape)
+        self.r.shape = self.full_points_shape
     #end def reshape_full
 
 
@@ -1485,7 +1485,7 @@ class StructuredGrid(Grid):
         This function is meant to reverse the temporary state change induced 
         by `reshape_full`.
         """
-        self.points = self.r.reshape(self.flat_points_shape)
+        self.r.shape = self.flat_points_shape
     #end def reshape_flat
 
 
@@ -1710,10 +1710,10 @@ class StructuredGrid(Grid):
         #end for
         if not unit:
             bpoints = self.points_from_unit(upoints)
-            bpoints = bpoints.reshape(nlines,n,self.space_dim)
+            bpoints.shape = nlines,n,self.space_dim
         else:
             bpoints = upoints
-            bpoints = bpoints.reshape(nlines,n,self.grid_dim)
+            bpoints.shape = nlines,n,self.grid_dim
         #end if
         return bpoints
     #end def get_boundary_lines
@@ -3352,7 +3352,7 @@ class GridFunction(GBase):
             if nvtot%nv!=0 or nvtot//nv!=grid.npoints:
                 self.error('value_shape and total number of values are inconsistent.\nTotal number of values: {}\nvalue_shape: {}\nExpected number of values per grid point: {}\nActual number of values per grid point: {}'.format(nvtot,value_shape,nv,nvtot/nv))
             #end if
-            values = values.reshape(grid.npoints,nv)
+            values.shape = (grid.npoints,nv)
         #end if
 
         # assign grid and values
@@ -3395,12 +3395,12 @@ class GridFunction(GBase):
 
 
     def reshape_values_full(self):
-        self.values = self.values.reshape((self.npoints,)+self.value_shape)
+        self.values.shape = (self.npoints,)+self.value_shape
     #end def reshape_values_full
 
 
     def reshape_values_flat(self):
-        self.values = self.values.reshape(self.npoints,self.nvalues)
+        self.values.shape = (self.npoints,self.nvalues)
     #end def reshape_values_flat
 #end class GridFunction
 
@@ -3478,25 +3478,25 @@ class StructuredGridFunction(GridFunction):
     
 
     def reshape_points_full(self):
-        self.values = self.values.reshape(self.grid_shape+(self.nvalues,))
+        self.values.shape = self.grid_shape+(self.nvalues,)
         self.grid.reshape_full()
     #end def reshape_points_full
 
 
     def reshape_points_flat(self):
-        self.values = self.values.reshape(self.npoints,self.nvalues)
+        self.values.shape = (self.npoints,self.nvalues)
         self.grid.reshape_flat()
     #end def reshape_points_flat
 
 
     def reshape_full(self):
-        self.values = self.values.reshape(self.grid_shape+self.value_shape)
+        self.values.shape = self.grid_shape+self.value_shape
         self.grid.reshape_full()
     #end def reshape_full
 
 
     def reshape_flat(self):
-        self.values = self.values.reshape(self.npoints,self.nvalues)
+        self.values.shape = (self.npoints,self.nvalues)
         self.grid.reshape_flat()
     #end def reshape_flat
 
@@ -3571,11 +3571,11 @@ class StructuredGridFunction(GridFunction):
             self.error('cannot plot contours in unit coordinates\ngrid must have dimension 2 to make contour plots\ndimension of grid for this function: {}'.format(self.grid_dim))
         #end if
         X,Y = self.grid.unit_points().T
-        X = X.reshape(self.grid_shape)
-        Y = Y.reshape(self.grid_shape)
+        X.shape = self.grid_shape
+        Y.shape = self.grid_shape
         Zm = self.f.T
         for Z in Zm:
-            Z = Z.reshape(self.grid_shape)
+            Z.shape = self.grid_shape
             fig,ax = self.setup_mpl_fig(fig=fig,dim=self.grid_dim)
             ax.contour(X,Y,Z,**kwargs)
             if boundary:
@@ -3605,11 +3605,11 @@ class StructuredGridFunction(GridFunction):
             self.error('cannot plot contours in unit coordinates\ngrid must have dimension 2 to make contour plots\ndimension of grid for this function: {}'.format(self.grid_dim))
         #end if
         X,Y = self.grid.unit_points().T
-        X = X.reshape(self.grid_shape)
-        Y = Y.reshape(self.grid_shape)
+        X.shape = self.grid_shape
+        Y.shape = self.grid_shape
         Zm = self.f.T
         for Z in Zm:
-            Z = Z.reshape(self.grid_shape)
+            Z.shape = self.grid_shape
             fig,ax = self.setup_mpl_fig(fig=fig,dim=self.grid_dim+1)
             ax.plot_surface(X,Y,Z,**kwargs)
         #end for
@@ -3645,7 +3645,7 @@ class StructuredGridFunction(GridFunction):
             if level is None:
                 level = (f.max()+f.min())/2
             #end if
-            f = f.reshape(self.grid_shape)
+            f.shape = self.grid_shape
             ret = measure.marching_cubes(f,level,spacing=spacing)
             verts = ret[0] 
             faces = ret[1]
@@ -3704,9 +3704,9 @@ class StructuredGridFunctionWithAxes(StructuredGridFunction):
                 self.error('Interpolation is not yet supported for nvalues>1.')
             #end if
             v_shape = v.shape
-            v = v.reshape(v_shape[:-1])
+            v.shape = v_shape[:-1]
             values = scipy_ndimage.map_coordinates(v, indices, **kw)
-            v = v.reshape(v_shape)
+            v.shape = v_shape
         else:
             self.error('Interpolation of type "{}" is not supported.\nValid options are: map_coordinates'.format(type))
         #end if
@@ -3759,11 +3759,11 @@ class StructuredGridFunctionWithAxes(StructuredGridFunction):
             X,Y    = np.dot(ax,self.r.T)
             ax_trans = ax
         #end if
-        X = X.reshape(self.grid_shape)
-        Y = Y.reshape(self.grid_shape)
+        X.shape = self.grid_shape
+        Y.shape = self.grid_shape
         Zm = self.f.T
         for Z in Zm:
-            Z = Z.reshape(self.grid_shape)
+            Z.shape = self.grid_shape
             fig,ax = self.setup_mpl_fig(fig=fig,dim=self.grid_dim)
             ax.contour(X,Y,Z,**kwargs)
             if boundary:
@@ -3802,11 +3802,11 @@ class StructuredGridFunctionWithAxes(StructuredGridFunction):
             self.error('cannot plot surface\ngrid must have dimension 2 to make contour plots\ndimension of grid for this function: {}'.format(self.grid_dim))
         #end if
         X,Y = self.r.T
-        X = X.reshape(self.grid_shape)
-        Y = Y.reshape(self.grid_shape)
+        X.shape = self.grid_shape
+        Y.shape = self.grid_shape
         Zm = self.f.T
         for Z in Zm:
-            Z = Z.reshape(self.grid_shape)
+            Z.shape = self.grid_shape
             fig,ax = self.setup_mpl_fig(fig=fig,dim=self.grid_dim+1)
             ax.plot_surface(X,Y,Z,**kwargs)
         #end for
@@ -3845,7 +3845,7 @@ class StructuredGridFunctionWithAxes(StructuredGridFunction):
             if level is None:
                 level = (f.max()+f.min())/2
             #end if
-            f = f.reshape(self.grid_shape)
+            f.shape = self.grid_shape
             ret = measure.marching_cubes(f,level,spacing=spacing)
             verts = ret[0] 
             faces = ret[1]
@@ -4000,7 +4000,7 @@ class ParallelotopeGridFunction(StructuredGridFunctionWithAxes):
         #end if
 
         # reshape values (for now GridFunction does not support more structured values)
-        values = values.reshape(len(values),values.size//len(values))
+        values.shape = len(values),values.size//len(values)
 
         # normalize the axes
         for d in range(D):

--- a/nexus/nexus/observables.py
+++ b/nexus/nexus/observables.py
@@ -1277,8 +1277,8 @@ class Density(ObservableWithComponents):
                     rsphere   += dr
                     rcenter    = new_center
                     dsphere    = d.interpolate(rsphere,**interp_kwargs)
-                    dsphere = dsphere.reshape(sgrid.shape)
-                    dsphere = dsphere.reshape(len(dsphere),dsphere.size//len(dsphere))
+                    dsphere.shape = sgrid.shape
+                    dsphere.shape = len(dsphere),dsphere.size//len(dsphere)
                     drad += dsphere.mean(axis=1)*4*np.pi*rrad**2
                 #end for
                 drad /= len(atom_indices)

--- a/nexus/nexus/pwscf_analyzer.py
+++ b/nexus/nexus/pwscf_analyzer.py
@@ -772,7 +772,7 @@ class PwscfAnalyzer(SimulationAnalyzer):
                 nb = int(np.floor(float(nv)/autocorr))
                 nexclude = nv-nb*autocorr
                 v = v[nexclude:]
-                v = v.reshape(nb,autocorr)
+                v.shape = nb,autocorr
                 mean,error = simplestats(v.mean(axis=1))
             #end if
             mds[q] = mean,error

--- a/nexus/nexus/pwscf_data_reader.py
+++ b/nexus/nexus/pwscf_data_reader.py
@@ -51,7 +51,7 @@ class QEXML(DevBase):
                     if len(a)==1:
                         a = a[0]
                     elif 'columns' in v and v.size%v.columns==0:
-                        a = a.reshape(v.size//v.columns,v.columns)
+                        a.shape = v.size//v.columns,v.columns
                     #end if
                     self[k] = a
                 else:

--- a/nexus/nexus/pwscf_input.py
+++ b/nexus/nexus/pwscf_input.py
@@ -139,7 +139,7 @@ def array_from_lines(lines):
     nelem = len(a)
     nlines = len(lines)
     dim = nelem//nlines
-    a = a.reshape(nlines,dim)
+    a.shape = nlines,dim
     return a
 #end def array_from_lines
 
@@ -1134,7 +1134,7 @@ class k_points(Card):
             a = array_from_lines(lines[1:])
             self.kpoints = a[:,0:3]
             self.weights = a[:,3]
-            self.weights = self.weights.reshape(self.nkpoints,)
+            self.weights.shape = (self.nkpoints,)
         elif self.specifier == 'automatic':
             a = np.fromstring(lines[0],sep=' ')
             self.grid  = a[0:3]
@@ -2232,14 +2232,14 @@ def generate_any_pwscf_input(**kwargs):
         if s.folded_structure is not None:
             fs = s.folded_structure
             axes = np.array(array_to_string(fs.axes).split(),dtype=float)
-            axes = axes.reshape(fs.axes.shape)
+            axes.shape = fs.axes.shape
             axes = np.dot(s.tmatrix,axes)
             if abs(axes-s.axes).sum()>1e-5:
                 PwscfInput.class_error('supercell axes do not match tiled version of folded cell axes\nyou may have changed one set of axes (super/folded) and not the other\nfolded cell axes:\n'+str(fs.axes)+'\nsupercell axes:\n'+str(s.axes)+'\nfolded axes tiled:\n'+str(axes),'generate_pwscf_input')
             #end if
         else:
             axes = np.array(array_to_string(s.axes).split(),dtype=float)
-            axes = axes.reshape(s.axes.shape)
+            axes.shape = s.axes.shape
         #end if
         s.adjust_axes(axes)
         if use_folded:
@@ -2516,14 +2516,14 @@ def generate_scf_input(prefix       = 'pwscf',
     if s.folded_structure is not None:
         fs = s.folded_structure
         axes = np.array(array_to_string(fs.axes).split(),dtype=float)
-        axes = axes.reshape(fs.axes.shape)
+        axes.shape = fs.axes.shape
         axes = np.dot(s.tmatrix,axes)
         if abs(axes-s.axes).sum()>1e-5:
             PwscfInput.class_error('supercell axes do not match tiled version of folded cell axes\n  you may have changed one set of axes (super/folded) and not the other\n  folded cell axes:\n'+str(fs.axes)+'\n  supercell axes:\n'+str(s.axes)+'\n  folded axes tiled:\n'+str(axes))
         #end if
     else:
         axes = np.array(array_to_string(s.axes).split(),dtype=float)
-        axes = axes.reshape(s.axes.shape)
+        axes.shape = s.axes.shape
     #end if
     s.adjust_axes(axes)
 

--- a/nexus/nexus/qmcpack.py
+++ b/nexus/nexus/qmcpack.py
@@ -1559,7 +1559,7 @@ class Qmcpack(Simulation):
             edata[spinlab] = obj()
             with open(einpath) as f:
                 data = np.array(f.read().split()[1:])
-                data = data.reshape(len(data)//12,12)
+                data.shape = len(data)//12,12
                 data = data.T
                 for darr in data:
                     if darr[0][0]=='K' or darr[0][0]=='E':

--- a/nexus/nexus/qmcpack_input.py
+++ b/nexus/nexus/qmcpack_input.py
@@ -191,7 +191,7 @@ def attribute_to_value(attr):
     elif is_array(attr,int):
         val = np.array(attr.split(),int)
         if val.size==9:
-            val = val.reshape(3,3)
+            val.shape = 3,3
         #end if
     elif is_array(attr,float):
         val = np.array(attr.split(),float)
@@ -3856,14 +3856,14 @@ class QmcpackInput(SimulationInput,Names):
             if structure.folded_structure is not None:
                 fs = structure.folded_structure
                 axes = np.array(pwscf_array_string(fs.axes).split(),dtype=float)
-                axes = axes.reshape(fs.axes.shape)
+                axes.shape = fs.axes.shape
                 axes = np.dot(structure.tmatrix,axes)
                 if np.abs(axes-structure.axes).sum()>1e-5:
                     self.error('supercell axes do not match tiled version of folded cell axes\n  you may have changed one set of axes (super/folded) and not the other\n  folded cell axes:\n'+str(fs.axes)+'\n  supercell axes:\n'+str(structure.axes)+'\n  folded axes tiled:\n'+str(axes))
                 #end if
             else:
                 axes = np.array(pwscf_array_string(structure.axes).split(),dtype=float)
-                axes = axes.reshape(structure.axes.shape)
+                axes.shape = structure.axes.shape
             #end if
             structure.adjust_axes(axes)
 
@@ -4083,7 +4083,7 @@ class QmcpackInput(SimulationInput,Names):
             # reshape single atom case, shape (3,) as shape (1,3)
             pos = np.asarray(pos)
             if len(pos.flatten())==3:
-                pos = pos.reshape(1,3)
+                pos.shape = (1,3)
             #end if
 
             structure = Structure(axes=axes,elem=elem,pos=pos,center=center,units='B')
@@ -5342,14 +5342,14 @@ def generate_simulationcell(bconds='ppp',lr_dim_cutoff=15,lr_tol=None,lr_handler
             if structure.folded_structure is not None:
                 fs = structure.folded_structure
                 axes = np.array(pwscf_array_string(fs.axes).split(),dtype=float)
-                axes = axes.reshape(fs.axes.shape)
+                axes.shape = fs.axes.shape
                 axes = np.dot(structure.tmatrix,axes)
                 if np.abs(axes-structure.axes).sum()>1e-5:
                     QmcpackInput.class_error('in generate_simulationcell\nsupercell axes do not match tiled version of folded cell axes\nyou may have changed one set of axes (super/folded) and not the other\nfolded cell axes:\n'+str(fs.axes)+'\nsupercell axes:\n'+str(structure.axes)+'\nfolded axes tiled:\n'+str(axes))
                 #end if
             else:
                 axes = np.array(pwscf_array_string(structure.axes).split(),dtype=float)
-                axes = axes.reshape(structure.axes.shape)
+                axes.shape = structure.axes.shape
             #end if
             structure.adjust_axes(axes)
 

--- a/nexus/nexus/qmcpack_property_analyzers.py
+++ b/nexus/nexus/qmcpack_property_analyzers.py
@@ -60,9 +60,9 @@ class Bspline(QAobject):
                0.0, 0.0,  3.0, -2.0,
                0.0, 0.0, -3.0,  1.0,
                0.0, 0.0,  1.0,  0.0 ])
-    A   = A.reshape(4,4)
-    dA  = dA.reshape(4,4)
-    d2A = d2A.reshape(4,4)                 
+    A.shape   = 4,4
+    dA.shape  = 4,4
+    d2A.shape = 4,4                 
 
     def __init__(self,params,cusp,rcut):
         p = np.array(params)

--- a/nexus/nexus/qmcpack_quantity_analyzers.py
+++ b/nexus/nexus/qmcpack_quantity_analyzers.py
@@ -148,7 +148,7 @@ class ScalarsDatAnalyzer(DatAnalyzer):
 
         lt = np.loadtxt(filepath)
         if len(lt.shape)==1:
-            lt = lt.reshape(1,len(lt))
+            lt.shape = (1,len(lt))
         #end if
 
         data = lt[:,1:].transpose()
@@ -202,7 +202,7 @@ class DmcDatAnalyzer(DatAnalyzer):
 
         lt = np.loadtxt(filepath)
         if len(lt.shape)==1:
-            lt = lt.reshape(1,len(lt))
+            lt.shape = (1,len(lt))
         #end if
 
         data = lt[:,1:].transpose()
@@ -250,7 +250,7 @@ class DmcDatAnalyzer(DatAnalyzer):
         for varname,samples in data.items():
             samp = samples[nse:]
             if block_avg:
-                samp = samp.reshape(ndmc_blocks,block_size)
+                samp.shape = ndmc_blocks,block_size
                 samp = samp.mean(axis=1)
             #end if
             (mean,var,error,kappa)=simstats(samp)
@@ -993,9 +993,9 @@ class TracesFileHDF(QAobject):
                     else:
                         shape = [nrows]+list(fquantity.shape[0:q.dimension])+[q.unit_size]
                     #end if
-                    quantity = quantity.reshape(tuple(shape))
+                    quantity.shape = tuple(shape)
                     #if len(fquantity.shape)==q.dimension:
-                    #    quantity = quantity.reshape(tuple([nrows]+list(fquantity.shape)))
+                    #    quantity.shape = tuple([nrows]+list(fquantity.shape))
                     ##end if
                     domain[qname] = quantity
                 #end for
@@ -1656,9 +1656,9 @@ class DensityMatricesAnalyzer(HDFAnalyzer):
                     # remove states with insignificant occupation
                     mos = m
                     m = m[sig_occ]
-                    m = m.reshape(nsig,nsig)
+                    m.shape = nsig,nsig
                     merr = merr[sig_occ]
-                    merr = merr.reshape(nsig,nsig)
+                    merr.shape = nsig,nsig
                     # remove off-diagonal elements with insignificant coupling
                     insig_coup = np.ones(m.shape,dtype=bool)
                     for i in range(nsig):
@@ -1706,7 +1706,7 @@ class DensityMatricesAnalyzer(HDFAnalyzer):
                         nb = float(nblocks)
                         for b in range(nblocks):
                             mb = mdata[b,...][sig_occ]
-                            mb = mb.reshape(nsig,nsig)
+                            mb.shape = nsig,nsig
                             mb[insig_coup_stat] = 0.0
                             mj = (nb*m-mb)/(nb-1)
                             mjdata[b,...] = mj
@@ -1960,9 +1960,9 @@ class SpinDensityAnalyzer(DensityAnalyzerBase):
 
         for d in self.data:
             b = len(d.value)
-            d.value = d.value.reshape(b,g[0],g[1],g[2])
+            d.value.shape = (b,g[0],g[1],g[2])
             if 'value_squared' in d:
-                d.value_squared = d.value_squared.reshape(b,g[0],g[1],g[2])
+                d.value_squared.shape = (b,g[0],g[1],g[2])
             #end if
         #end for
     #end def load_data_local
@@ -3316,7 +3316,7 @@ class RectilinearGrid(SpaceGridBase):
         points[:,2] = z.ravel()
         val = self.interpolate(points,[quantity])
         scalars = val[quantity].mean
-        scalars = scalars.reshape(x.shape)
+        scalars.shape = x.shape
         self.plotter.surface_slice(x,y,z,scalars,options)
         return
     #end def surface_slice

--- a/nexus/nexus/rmg_input.py
+++ b/nexus/nexus/rmg_input.py
@@ -2726,7 +2726,7 @@ class PseudopotentialKeyword(FormattedTableRmgKeyword):
 
     def read(self,value):
         d = np.array(value.split(),dtype=str)
-        d = d.reshape(len(d)//2,2)
+        d.shape = len(d)//2,2
         species = d[:,0].flatten()
         pseudos = d[:,1].flatten()
         return obj(species=species,pseudos=pseudos)
@@ -2756,7 +2756,7 @@ class KpointsKeyword(FormattedTableRmgKeyword):
 
     def read(self,value):
         d = np.array(value.split(),dtype=float)
-        d = d.reshape(len(d)//4,4)
+        d.shape = len(d)//4,4
         kpoints = d[:,:3]
         weights = d[:,-1].flatten()
         return obj(kpoints=kpoints,weights=weights)
@@ -2787,7 +2787,7 @@ class KpointsBandstructureKeyword(FormattedTableRmgKeyword):
 
     def read(self,value):
         d = np.array(value.split(),dtype=str)
-        d = d.reshape(len(d)//4,5)
+        d.shape = len(d)//4,5
         kpoints = np.array(d[:,:3],dtype=float)
         counts  = np.array(d[:,3],dtype=int).flatten()
         labels  = d[:,-1].flatten()
@@ -2848,7 +2848,7 @@ class AtomsKeyword(FormattedTableRmgKeyword):
 
         # initial array parse of value table
         d = np.array(value.split(),dtype=str)
-        d = d.reshape(len(d)//nvals,nvals)
+        d.shape = len(d)//nvals,nvals
 
         # extract universal atom labels and positions
         atom_labels = d[:,0]

--- a/nexus/nexus/structure.py
+++ b/nexus/nexus/structure.py
@@ -331,8 +331,8 @@ def kmesh(kaxes,dim,shift=None):
     ndim = len(dim)
     d = np.array(dim)
     s = np.array(shift)
-    s = s.reshape(1,ndim)
-    d = d.reshape(1,ndim)
+    s.shape = 1,ndim
+    d.shape = 1,ndim
     kp = np.empty((1,ndim),dtype=float)
     kgrid = np.empty((d.prod(),ndim))
     n=0
@@ -563,7 +563,7 @@ def optimal_tilematrix(axes,volfac,dn=1,tol=1e-3,filter=trivial_filter,mask=None
             #end for
         #end for
         mats = np.array(mats,dtype=int)
-        mats = mats.reshape((2*dn+1)**(dim*dim),dim,dim)
+        mats.shape = (2*dn+1)**(dim*dim),dim,dim
         opt_tm_matrices[dn] = mats
     else:
         mats = opt_tm_matrices[dn]
@@ -795,7 +795,7 @@ class Structure(Sobj):
 
         if isinstance(axes,str):
             axes = np.array(axes.split(),dtype=float)
-            axes = axes.reshape(dim,dim)
+            axes.shape = dim,dim
         #end if
         if center is None:
             if axes is not None:
@@ -813,7 +813,7 @@ class Structure(Sobj):
         #end if
         if elem_pos is not None:
             ep = np.array(elem_pos.split(),dtype=str)
-            ep = ep.reshape(ep.size//(dim+1),(dim+1))
+            ep.shape = ep.size//(dim+1),(dim+1)
             elem = ep[:,0].ravel()
             pos  = ep[:,1:dim+1]
         #end if
@@ -3344,7 +3344,7 @@ class Structure(Sobj):
                 unique[:] = True
                 nn = nearest_neighbors(1,kpoints)
                 if nkpoints>1:
-                    nn = nn.reshape(nkpoints,)
+                    nn.shape = nkpoints,
                     dist = self.distances(kpoints,kpoints[nn])
                     tol = 1e-8
                     duplicates = np.arange(nkpoints)[dist<tol]
@@ -3533,7 +3533,7 @@ class Structure(Sobj):
             npoints = len(points)
             ntpoints = npoints*int(np.round(np.abs(det(tilemat))))
             if tilevec.size==dim:
-                tilevec = tilevec.reshape(1,dim)
+                tilevec.shape = 1,dim
             #end if
             taxes = dot(tilemat,axes)
             success = False

--- a/nexus/nexus/tests/test_grid_functions.py
+++ b/nexus/nexus/tests/test_grid_functions.py
@@ -37,7 +37,7 @@ def test_coord_conversion():
         ]
 
     th_cos_sin = np.array(th_cos_sin)
-    th_cos_sin = th_cos_sin.reshape(len(th_cos_sin)//3,3)
+    th_cos_sin.shape = len(th_cos_sin)//3,3
     th  = th_cos_sin[:,0]
     cos = th_cos_sin[:,1]
     sin = th_cos_sin[:,2]
@@ -110,7 +110,7 @@ def test_unit_grid_points():
 
     def make_1d(x):
         p = x.copy()
-        p = p.reshape(len(p),1)
+        p.shape = len(p),1
         return p
     #end def make_1d
 
@@ -663,7 +663,7 @@ def test_grid_set_operations():
 
     # set points
     points = np.linspace(0,1,2*10)
-    points = points.reshape(10,2)
+    points.shape = 10,2
     for name in grids_check:
         g = grids[name].copy()
         g.set_points(points)
@@ -778,7 +778,7 @@ def test_grid_translate():
         shift = p.space_dim*(6.7,)
         translate_and_check(g,shift)
         shift = np.array(shift)
-        shift = shift.reshape(p.space_dim,)
+        shift.shape = (p.space_dim,)
         translate_and_check(g,shift)
     #end for
 #end def test_grid_translate
@@ -819,7 +819,7 @@ def test_grid_unit_points():
     
     def make_1d(x):
         p = x.copy()
-        p = p.reshape(len(p),1)
+        p.shape = len(p),1
         return p
     #end def make_1d
 
@@ -1022,7 +1022,7 @@ def test_grid_project():
     
     def make_1d(x):
         p = x.copy()
-        p = p.reshape(len(p),1)
+        p.shape = len(p),1
         return p
     #end def make_1d
 

--- a/nexus/nexus/tests/test_numerics.py
+++ b/nexus/nexus/tests/test_numerics.py
@@ -46,7 +46,7 @@ def test_ndgrid():
         #end for
     #end for
     points = np.array(points)
-    points = points.reshape(3,len(x),len(y),len(z))
+    points.shape = 3,len(x),len(y),len(z)
     points = points
 
     grid = ndgrid(x,y,z)

--- a/nexus/nexus/tests/test_structure.py
+++ b/nexus/nexus/tests/test_structure.py
@@ -498,7 +498,7 @@ def test_matrix_tiling():
         npass = 0
         for tmat in matrix_tilings:
             tmat = np.array(tmat,dtype=int)
-            tmat = tmat.reshape(3,3)
+            tmat.shape = 3,3
             st = s.tile(tmat)
             st.check_tiling()
         #end for
@@ -1311,7 +1311,7 @@ def test_min_image_distances():
     assert(value_eq(dist.max(),1.42143636))
 
     vec = vt.ravel()
-    vec = vec.reshape(np.prod(dt.shape),3)
+    vec.shape = np.prod(dt.shape),3
     vdist = np.linalg.norm(vec,axis=1)
     assert(value_eq(vdist,dist))
 
@@ -1368,7 +1368,7 @@ if versions.scipy_available:
         gr = g.copy()
         npos = len(gr.pos)
         dr = gr.min_image_vectors(center)
-        dr = dr.reshape(npos,3)
+        dr.shape = npos,3
         r = np.linalg.norm(dr,axis=1)
         dilation = 2*r*np.exp(-r)
         for i in range(npos):

--- a/nexus/nexus/vasp_analyzer.py
+++ b/nexus/nexus/vasp_analyzer.py
@@ -261,7 +261,7 @@ class VXML(DevBase):
                 lst.append(field_vals[findex])
             #end for
             arr = np.array(lst,dtype=field.dtype).ravel()
-            arr = arr.reshape(tuple(dim_counts))
+            arr.shape = tuple(dim_counts)
             self[field.name] = arr
         #end for
         #print '  done'

--- a/nexus/nexus/vasp_input.py
+++ b/nexus/nexus/vasp_input.py
@@ -911,7 +911,7 @@ class Kpoints(VFormattedFile):
                     self.mode   = 'basis'  # basis generated mesh
                     self.coord  = self.coord_options(cselect)
                     self.kbasis = np.array(self.join(lines,3,5).split(),dtype=float)
-                    self.kbasis = self.kbasis.reshape(3,3)
+                    self.kbasis.shape = 3,3
                     self.kshift = np.array(lines[6].split(),dtype=float)
                 #end if
             elif cselect=='l': # line mode (band structure)


### PR DESCRIPTION
Reverts QMCPACK/qmcpack#5733