### PR TITLE
Format `PyscfToQmcpack.py` and `PyscfToQmcpack_Spline.py`

### DIFF
--- a/src/QMCTools/PyscfToQmcpack.py
+++ b/src/QMCTools/PyscfToQmcpack.py
@@ -12,118 +12,131 @@
 
 from __future__ import print_function
 
-def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],sp_twist=[],weight=1.0,cas_idx=None,kmap=None):
-  import h5py, re, sys
-  from collections import defaultdict
-  from pyscf.pbc import gto, scf, df, dft
-  from pyscf import lib, mcscf, fci
-  from pyscf.pbc import tools
-  from numpy import empty
-  import numpy
-  
 
-  PBC=False
-  Gamma=False
-  Restricted=True
-  Complex=False
-  Python3=False
-  Python2=False
-  if len(sp_twist)== 0:
-       sp_twist=[0.0,0.0,0.0]
-  if sys.version_info >= (3, 0):
-     sys.stdout.write("Using Python 3.x\n") 
-     Python3=True
-  else:
-     sys.stdout.write("Using Python 2.x\n") 
-     Python2=True
- 
-
-  val=str(mf.dump_flags)
-  ComputeMode= re.split('[. ]',val)
-
-  SizeMode=len(ComputeMode)
-  for i in range(SizeMode):
-     if ComputeMode[i] in ("UHF","KUHF","UKS","SymAdaptedUHF","SymAdaptedUKS"):
-           Restricted=False
-     if ComputeMode[i]=="pbc":
-           PBC=True
-           if Restricted==False:
-              sys.exit("Unrestricted calculations with PBC not supported (yet) - contact Developers")
-
-  if PBC and len(kpts) == 0:
-        Gamma=True
-  
-  def get_supercell(cell,kmesh=[]):
-    latt_vec = cell.lattice_vectors()
-    if len(kmesh)==0:
-        # Guess kmesh
-        scaled_k = cell.get_scaled_kpts(kpts).round(8)
-        kmesh = (len(numpy.unique(scaled_k[:,0])),
-                 len(numpy.unique(scaled_k[:,1])),
-                 len(numpy.unique(scaled_k[:,2])))
-
-    R_rel_a = numpy.arange(kmesh[0])
-    R_rel_b = numpy.arange(kmesh[1])
-    R_rel_c = numpy.arange(kmesh[2])
-    R_vec_rel = lib.cartesian_prod((R_rel_a, R_rel_b, R_rel_c))
-    R_vec_abs = numpy.einsum('nu, uv -> nv', R_vec_rel, latt_vec)
+def savetoqmcpack(
+    cell,
+    mf,
+    title="Default",
+    kpts=[],
+    kmesh=[],
+    sp_twist=[],
+    weight=1.0,
+    cas_idx=None,
+    kmap=None
+):
+    import h5py, re, sys
+    from collections import defaultdict
+    from pyscf.pbc import gto, scf, df, dft
+    from pyscf import lib, mcscf, fci
+    from pyscf.pbc import tools
+    from numpy import empty
+    import numpy
 
 
-    # R_rel_mesh has to be construct exactly same to the Ts in super_cell function
-    scell = tools.super_cell(cell, kmesh)
-    return scell, kmesh
+    PBC        = False
+    Gamma      = False
+    Restricted = True
+    Complex    = False
+    Python3    = False
+    Python2    = False
+    if len(sp_twist) == 0:
+        sp_twist = [0.0,0.0,0.0]
 
-  def get_phase(cell, kpts, kmesh=[]):
+    if sys.version_info >= (3, 0):
+        sys.stdout.write("Using Python 3.x\n") 
+        Python3 = True
+    else:
+        sys.stdout.write("Using Python 2.x\n") 
+        Python2 = True
+
+    val = str(mf.dump_flags)
+    ComputeMode = re.split('[. ]', val)
+
+    SizeMode = len(ComputeMode)
+    for i in range(SizeMode):
+        if ComputeMode[i] in ("UHF", "KUHF", "UKS", "SymAdaptedUHF", "SymAdaptedUKS"):
+            Restricted = False
+        if ComputeMode[i] == "pbc":
+            PBC = True
+            if Restricted == False:
+                sys.exit("Unrestricted calculations with PBC not supported (yet) - contact Developers")
+
+    if PBC and len(kpts) == 0:
+        Gamma = True
+
+    def get_supercell(cell, kmesh=[]):
+        latt_vec = cell.lattice_vectors()
+        if len(kmesh) == 0:
+            # Guess kmesh
+            scaled_k = cell.get_scaled_kpts(kpts).round(8)
+            kmesh = (
+                len(numpy.unique(scaled_k[:,0])),
+                len(numpy.unique(scaled_k[:,1])),
+                len(numpy.unique(scaled_k[:,2])),
+            )
+
+        R_rel_a = numpy.arange(kmesh[0])
+        R_rel_b = numpy.arange(kmesh[1])
+        R_rel_c = numpy.arange(kmesh[2])
+        R_vec_rel = lib.cartesian_prod((R_rel_a, R_rel_b, R_rel_c))
+        R_vec_abs = numpy.einsum('nu, uv -> nv', R_vec_rel, latt_vec)
+
+        # R_rel_mesh has to be construct exactly same to the Ts in super_cell function
+        scell = tools.super_cell(cell, kmesh)
+        return scell, kmesh
+
+    def get_phase(cell, kpts, kmesh=[]):
         '''
         The unitary transformation that transforms the supercell basis k-mesh
         adapted basis.
         '''
- 
+
         latt_vec = cell.lattice_vectors()
         if kmesh is None:
             # Guess kmesh
             scaled_k = cell.get_scaled_kpts(kpts).round(8)
-            kmesh = (len(numpy.unique(scaled_k[:,0])),
-                     len(numpy.unique(scaled_k[:,1])),
-                     len(numpy.unique(scaled_k[:,2])))
- 
+            kmesh = (
+                len(numpy.unique(scaled_k[:,0])),
+                len(numpy.unique(scaled_k[:,1])),
+                len(numpy.unique(scaled_k[:,2])),
+            )
+
         R_rel_a = numpy.arange(kmesh[0])
         R_rel_b = numpy.arange(kmesh[1])
         R_rel_c = numpy.arange(kmesh[2])
 
-
         R_vec_rel = lib.cartesian_prod((R_rel_a, R_rel_b, R_rel_c))
         R_vec_abs = numpy.einsum('nu, uv -> nv', R_vec_rel, latt_vec)
- 
+
         NR = len(R_vec_abs)
-        phase = numpy.exp(1j*numpy.einsum('Ru, ku -> Rk', R_vec_abs, kpts))
+        phase = numpy.exp(1j * numpy.einsum('Ru, ku -> Rk', R_vec_abs, kpts))
         phase /= numpy.sqrt(NR)  # normalization in supercell
- 
+
         # R_rel_mesh has to be construct exactly same to the Ts in super_cell function
         scell = tools.super_cell(cell, kmesh)
         return scell, phase
 
 
-  def mo_k2gamma(cell, mo_energy, mo_coeff, kpts, kmesh=None):
+    def mo_k2gamma(cell, mo_energy, mo_coeff, kpts, kmesh=None):
         scell, phase = get_phase(cell, kpts, kmesh)
- 
+
         E_g = numpy.hstack(mo_energy)
         C_k = numpy.asarray(mo_coeff)
         Nk, Nao, Nmo = C_k.shape
         NR = phase.shape[0]
- 
+
         # Transform AO indices
         C_gamma = numpy.einsum('Rk, kum -> Rukm', phase, C_k)
         C_gamma = C_gamma.reshape(Nao*NR, Nk*Nmo)
- 
+
         E_sort_idx = numpy.argsort(E_g)
-        E_desort_idx=numpy.argsort(  E_sort_idx )
+        E_desort_idx = numpy.argsort(E_sort_idx)
         E_g = E_g[E_sort_idx]
         C_gamma = C_gamma[:,E_sort_idx]
         s = scell.pbc_intor('int1e_ovlp')
         #assert(abs(reduce(numpy.dot, (C_gamma.conj().T, s, C_gamma))
         #           - numpy.eye(Nmo*Nk)).max() < 1e-7)
- 
+
         # Transform MO indices
         E_k_degen = abs(E_g[1:] - E_g[:-1]).max() < 1e-5
         if numpy.any(E_k_degen):
@@ -131,496 +144,627 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],sp_twist=[],weight=1.
             degen_mask = numpy.append(False, E_k_degen) | numpy.append(E_k_degen, False)
             shift = min(E_g[degen_mask]) - .1
             f = numpy.dot(C_gamma[:,degen_mask] * (E_g[degen_mask] - shift),
-                       C_gamma[:,degen_mask].conj().T)
+                    C_gamma[:,degen_mask].conj().T)
             #assert(abs(f.imag).max() < 1e-5)
- 
+
             e, na_orb = la.eigh(f.real, s, type=2)
             C_gamma[:,degen_mask] = na_orb[:, e>0]
- 
+
         #assert(abs(C_gamma.imag).max() < 1e-2)
         #C_gamma = C_gamma.real
         #assert(abs(reduce(numpy.dot, (C_gamma.conj().T, s, C_gamma))
         #           - numpy.eye(Nmo*Nk)).max() < 1e-2)
- 
+
         s_k = cell.pbc_intor('int1e_ovlp', kpts=kpts)
         # overlap between k-point unitcell and gamma-point supercell
-        s_k_g = numpy.einsum('kuv,Rk->kuRv', s_k, phase.conj()).reshape(Nk,Nao,NR*Nao)
+        s_k_g = numpy.einsum('kuv,Rk->kuRv', s_k, phase.conj()).reshape(Nk, Nao, NR*Nao)
         # The unitary transformation from k-adapted orbitals to gamma-point orbitals
         mo_phase = lib.einsum('kum,kuv,vi->kmi', C_k.conj(), s_k_g, C_gamma)
-        C_gamma_unsorted=C_gamma[:,E_desort_idx]
-        E_g_unsorted=E_g[E_desort_idx]
+        C_gamma_unsorted = C_gamma[:,E_desort_idx]
+        E_g_unsorted = E_g[E_desort_idx]
         #return E_g_unsorted, C_gamma_unsorted, 
         return E_g, C_gamma, E_g_unsorted,C_gamma_unsorted
 
+    IonName = dict([
+        ("H",  1),
+        ("He", 2),
+        ("Li", 3),
+        ("Be", 4),
+        ("B",  5),
+        ("C",  6),
+        ("N",  7),
+        ("O",  8),
+        ("F",  9),
+        ("Ne", 10),
+        ("Na", 11),
+        ("Mg", 12),
+        ("Al", 13),
+        ("Si", 14),
+        ("P",  15),
+        ("S",  16),
+        ("Cl", 17),
+        ("Ar", 18),
+        ("K",  19),
+        ("Ca", 20),
+        ("Sc", 21),
+        ("Ti", 22),
+        ("V",  23),
+        ("Cr", 24),
+        ("Mn", 25),
+        ("Fe", 26),
+        ("Co", 27),
+        ("Ni", 28),
+        ("Cu", 29),
+        ("Zn", 30),
+        ("Ga", 31),
+        ("Ge", 32),
+        ("As", 33),
+        ("Se", 34),
+        ("Br", 35),
+        ("Kr", 36),
+        ("Rb", 37),
+        ("Sr", 38),
+        ("Y",  39),
+        ("Zr", 40),
+        ("Nb", 41),
+        ("Mo", 42),
+        ("Tc", 43),
+        ("Ru", 44),
+        ("Rh", 45),
+        ("Pd", 46),
+        ("Ag", 47),
+        ("Cd", 48),
+        ("In", 49),
+        ("Sn", 50),
+        ("Sb", 51),
+        ("Te", 52),
+        ("I",  53),
+        ("Xe", 54),
+        ("Cs", 55),
+        ("Ba", 56),
+        ("La", 57),
+        ("Ce", 58),
+        ("Pr", 59),
+        ("Nd", 60),
+        ("Pm", 61),
+        ("Sm", 62),
+        ("Eu", 63),
+        ("Gd", 64),
+        ("Tb", 65),
+        ("Dy", 66),
+        ("Ho", 67),
+        ("Er", 68),
+        ("Tm", 69),
+        ("Yb", 70),
+        ("Lu", 71),
+        ("Hf", 72),
+        ("Ta", 73),
+        ("W",  74),
+        ("Re", 75),
+        ("Os", 76),
+        ("Ir", 77),
+        ("Pt", 78),
+        ("Au", 79),
+        ("Hg", 80),
+        ("Tl", 81),
+        ("Pb", 82),
+        ("Bi", 83),
+        ("Po", 84),
+        ("At", 85),
+        ("Rn", 86),
+        ("Fr", 87),
+        ("Ra", 88),
+        ("Ac", 89),
+        ("Th", 90),
+        ("Pa", 91),
+        ("U",  92),
+        ("Np", 93),
+    ])
 
-  IonName=dict([('H',1),  ('He',2),  ('Li',3),('Be',4),  ('B', 5),  ('C', 6),  ('N', 7),('O', 8),  ('F', 9),   ('Ne',10),   ('Na',11),('Mg',12),   ('Al',13),   ('Si',14),   ('P', 15),   ('S', 16),('Cl',17),   ('Ar',18),   ('K', 19),   ('Ca',20),   ('Sc',21),   ('Ti',22),   ('V', 23),   ('Cr',24),   ('Mn',25),   ('Fe',26),   ('Co',27),   ('Ni',28),   ('Cu',29),   ('Zn',30),   ('Ga',31),   ('Ge',32),   ('As',33),   ('Se',34),   ('Br',35),   ('Kr',36),   ('Rb',37),   ('Sr',38),   ('Y', 39),  ('Zr',40),   ('Nb',41),   ('Mo',42),   ('Tc',43),   ('Ru',44),   ('Rh',45),   ('Pd',46),   ('Ag',47),   ('Cd',48),   ('In',49),   ('Sn',50),   ('Sb',51),   ('Te',52),   ('I', 53),   ('Xe',54),   ('Cs',55),   ('Ba',56),   ('La',57),   ('Ce',58), ('Pr',59),   ('Nd',60),   ('Pm',61),   ('Sm',62),   ('Eu',63),   ('Gd',64),   ('Tb',65),   ('Dy',66),   ('Ho',67),  ('Er',68),   ('Tm',69),   ('Yb',70),   ('Lu',71),   ('Hf',72),   ('Ta',73),   ('W', 74),   ('Re',75),   ('Os',76),   ('Ir',77),   ('Pt',78),   ('Au',79),   ('Hg',80), ('Tl',81),   ('Pb',82),  ('Bi',83),   ('Po',84),   ('At',85),   ('Rn',86),   ('Fr',87),   ('Ra',88),   ('Ac',89),   ('Th',90),   ('Pa',91),   ('U', 92),   ('Np',93)]) 
+    H5_qmcpack = h5py.File(title+'.h5', 'w')
+    groupApp = H5_qmcpack.create_group("application")
+    if Python3: 
+        strList = ['PySCF']
+        asciiList = [n.encode("ascii", "ignore") for n in strList]
+        groupApp.create_dataset('code', (1,), 'S5', asciiList)
+    else:
+        CodeData  = groupApp.create_dataset("code", (1,), dtype="S5")
+        CodeData[0:] = "PySCF"
+
+    CodeVer = groupApp.create_dataset("version", (3,), dtype="i4")
+    CodeVer[0:] = 1
+    CodeVer[1:] = 4
+    CodeVer[2:] = 2
+
+    GroupPBC=H5_qmcpack.create_group("PBC")
+    GroupPBC.create_dataset("PBC", (1,), dtype="b1", data=PBC)
+    if len(kpts) != 0:
+        loc_cell, kmesh = get_supercell(cell, kmesh)
+    else:
+        loc_cell = cell
+
+    natom = loc_cell.natm
+
+    dt = h5py.special_dtype(vlen=bytes)
+    #Group Atoms
+    groupAtom=H5_qmcpack.create_group("atoms")
+
+    #Dataset Number Of Atoms
+    groupAtom.create_dataset("number_of_atoms", (1,), dtype="i4", data=natom)
+
+    #Dataset Number Of Species 
+    #Species contains (Atom_Name, Atom_Number,Atom_Charge,Atom_Core)
+    l_atoms = [
+        (
+            loc_cell.atom_pure_symbol(x),
+            IonName[loc_cell.atom_pure_symbol(x)],
+            loc_cell.atom_charge(x),
+            loc_cell.atom_nelec_core(x),
+        ) for x in range(natom)
+    ] 
 
 
-
-  H5_qmcpack=h5py.File(title+'.h5','w')
-  groupApp=H5_qmcpack.create_group("application")
-  if Python3: 
-     strList=['PySCF']
-     asciiList = [n.encode("ascii", "ignore") for n in strList]
-     groupApp.create_dataset('code', (1,),'S5', asciiList)
-  else:
-     CodeData  = groupApp.create_dataset("code",(1,),dtype="S5")
-     CodeData[0:] = "PySCF"
-
-  CodeVer  = groupApp.create_dataset("version",(3,),dtype="i4")
-  CodeVer[0:] = 1
-  CodeVer[1:] = 4
-  CodeVer[2:] = 2
-
-  GroupPBC=H5_qmcpack.create_group("PBC")
-  GroupPBC.create_dataset("PBC",(1,),dtype="b1",data=PBC)
-  if len(kpts)!= 0:
-     loc_cell,kmesh=get_supercell(cell,kmesh)
-  else:
-     loc_cell=cell
-  
-  natom=loc_cell.natm
-
-  dt = h5py.special_dtype(vlen=bytes)
-  #Group Atoms
-  groupAtom=H5_qmcpack.create_group("atoms")
-
-  #Dataset Number Of Atoms
-  groupAtom.create_dataset("number_of_atoms",(1,),dtype="i4",data=natom)
-
-  #Dataset Number Of Species 
-  #Species contains (Atom_Name, Atom_Number,Atom_Charge,Atom_Core)
-  l_atoms = [ (loc_cell.atom_pure_symbol(x),IonName[loc_cell.atom_pure_symbol(x)],loc_cell.atom_charge(x),loc_cell.atom_nelec_core(x)) for x in  range(natom)  ] 
-
-
-  d = defaultdict(list)
-  for i,t in enumerate(l_atoms):
+    d = defaultdict(list)
+    for i, t in enumerate(l_atoms):
         d[t].append(i)
 
-
-  idxSpeciestoAtoms = dict()
-  uniq_atoms= dict()
-  for i, (k,v) in enumerate(d.items()):
+    idxSpeciestoAtoms = dict()
+    uniq_atoms= dict()
+    for i, (k, v) in enumerate(d.items()):
         idxSpeciestoAtoms[i] = v
         uniq_atoms[i] = k
 
-  idxAtomstoSpecies = dict()
-  for k, l_v in idxSpeciestoAtoms.items():
+    idxAtomstoSpecies = dict()
+    for k, l_v in idxSpeciestoAtoms.items():
         for v in l_v:
             idxAtomstoSpecies[v] = k
- 
-  NbSpecies=len(idxSpeciestoAtoms.keys())
 
-  groupAtom.create_dataset("number_of_species",(1,),dtype="i4",data=NbSpecies)
+    NbSpecies = len(idxSpeciestoAtoms.keys())
 
-  #Dataset positions 
-  MyPos=groupAtom.create_dataset("positions",(natom,3),dtype="f8")
-  for x in range(natom): 
-    MyPos[x:]=loc_cell.atom_coord(x)
+    groupAtom.create_dataset("number_of_species", (1,), dtype="i4", data=NbSpecies)
 
-  #Group Atoms
-  for x in range(NbSpecies):
-    atmname=str(uniq_atoms[x][0])
-    groupSpecies=groupAtom.create_group("species_"+str(x))
-    groupSpecies.create_dataset("atomic_number",(1,),dtype="i4",data=uniq_atoms[x][1])
-    mylen="S"+str(len(atmname))
-    if Python3:
-       strList=[atmname]
-       asciiList = [n.encode("ascii", "ignore") for n in strList]
-       groupSpecies.create_dataset('name', (1,),mylen, asciiList)
-    else:
-       AtmName=groupSpecies.create_dataset("name",(1,),dtype=mylen)
-       AtmName[0:]=atmname
+    #Dataset positions 
+    MyPos=groupAtom.create_dataset("positions", (natom, 3), dtype="f8")
+    for x in range(natom): 
+        MyPos[x:] = loc_cell.atom_coord(x)
 
-    groupSpecies.create_dataset("charge",(1,),dtype="f8",data=uniq_atoms[x][2])
-    groupSpecies.create_dataset("core",(1,),dtype="f8",data=uniq_atoms[x][3])
-  SpeciesID=groupAtom.create_dataset("species_ids",(natom,),dtype="i4")
-
-  for x in range(natom):
-      SpeciesID[x:]  = idxAtomstoSpecies[x]
-
-
-
-  #Parameter Group
-  GroupParameter=H5_qmcpack.create_group("parameters")
-  GroupParameter.create_dataset("ECP",(1,),dtype="b1",data=bool(loc_cell.has_ecp()))
-  bohrUnit=True
-  Spin=loc_cell.spin 
-
-  GroupParameter.create_dataset("Unit",(1,),dtype="b1",data=bohrUnit) 
-  GroupParameter.create_dataset("NbAlpha",(1,),dtype="i4",data=loc_cell.nelec[0]) 
-  GroupParameter.create_dataset("NbBeta",(1,),dtype="i4",data=loc_cell.nelec[1]) 
-  GroupParameter.create_dataset("NbTotElec",(1,),dtype="i4",data=loc_cell.nelec[0]+loc_cell.nelec[1])
-  GroupParameter.create_dataset("spin",(1,),dtype="i4",data=Spin) 
-   
-
-  #basisset Group
-  GroupBasisSet=H5_qmcpack.create_group("basisset")
-  #Dataset Number Of Atoms
-  GroupBasisSet.create_dataset("NbElements",(1,),dtype="i4",data=NbSpecies)
-  if Python3:
-     strList=['LCAOBSet']
-     asciiList = [n.encode("ascii", "ignore") for n in strList]
-     GroupBasisSet.create_dataset('name', (1,),'S8', asciiList)
-  else:
-     LCAOName=GroupBasisSet.create_dataset("name",(1,),dtype="S8")
-     LCAOName[0:]="LCAOBSet"
-
-  #atomicBasisSets Group
-  for x in range(NbSpecies):
-
-    MyIdx=idxSpeciestoAtoms[x][0]
-    atomicBasisSetGroup=GroupBasisSet.create_group("atomicBasisSet"+str(x))
-    mylen="S"+str(len(uniq_atoms[x][0]))
-
-    if Python3:
-       strList=[uniq_atoms[x][0]]
-       asciiList = [n.encode("ascii", "ignore") for n in strList]
-       atomicBasisSetGroup.create_dataset('elementType', (1,),mylen, asciiList)
-       if loc_cell.cart==True:
-          strList=['cartesian']
-          asciiList = [n.encode("ascii", "ignore") for n in strList]
-          atomicBasisSetGroup.create_dataset('angular', (1,),'S9', asciiList)
-
-          strList=['Gamess']
-          asciiList = [n.encode("ascii", "ignore") for n in strList]
-          atomicBasisSetGroup.create_dataset('expandYlm', (1,),'S6', asciiList)
-
-       else:
-          strList=['spherical']
-          asciiList = [n.encode("ascii", "ignore") for n in strList]
-          atomicBasisSetGroup.create_dataset('angular', (1,),'S9', asciiList)
-
-          strList=['pyscf']
-          asciiList = [n.encode("ascii", "ignore") for n in strList]
-          atomicBasisSetGroup.create_dataset('expandYlm', (1,),'S5', asciiList)
-    else:
-       elemtype=atomicBasisSetGroup.create_dataset("elementType",(1,),dtype=mylen)
-       elemtype[0:]=uniq_atoms[x][0]
-       if loc_cell.cart==True:
-          Angular=atomicBasisSetGroup.create_dataset("angular",(1,),dtype="S9")
-          ExpandYLM=atomicBasisSetGroup.create_dataset("expandYlm",(1,),dtype="S6")
-          Angular[0:]="cartesian"
-          ExpandYLM[0:]="Gamess"
-       else:
-          Angular=atomicBasisSetGroup.create_dataset("angular",(1,),dtype="S9")
-          Angular[0:]="spherical"
-          ExpandYLM=atomicBasisSetGroup.create_dataset("expandYlm",(1,),dtype="S5")
-          ExpandYLM[0:]="pyscf"
-
-
-
-    atomicBasisSetGroup.create_dataset("grid_npts",(1,),dtype="i4",data=1001)
-    atomicBasisSetGroup.create_dataset("grid_rf",(1,),dtype="i4",data=100)
-    atomicBasisSetGroup.create_dataset("grid_ri",(1,),dtype="f8",data=1e-06)
-
-    mylen="S"+str(len(loc_cell.basis))
-    if Python3:
-      strList=['log']
-      asciiList = [n.encode("ascii", "ignore") for n in strList]
-      atomicBasisSetGroup.create_dataset('grid_type', (1,),'S3', asciiList)
-      if (len(loc_cell.basis)<=2):
-         strList=['gaussian']
-         asciiList = [n.encode("ascii", "ignore") for n in strList]
-         atomicBasisSetGroup.create_dataset('name', (1,),'S8', asciiList)
-      elif isinstance(loc_cell.basis,dict):
-         strList=['custom']
-         asciiList = [n.encode("ascii", "ignore") for n in strList]
-         atomicBasisSetGroup.create_dataset('name', (1,),'S6', asciiList)
-      else:
-         strList=[loc_cell.basis]
-         asciiList = [n.encode("ascii", "ignore") for n in strList]
-         atomicBasisSetGroup.create_dataset('name', (1,),mylen, asciiList)
-      strList=['no']
-      asciiList = [n.encode("ascii", "ignore") for n in strList]
-      atomicBasisSetGroup.create_dataset('normalized', (1,),'S2', asciiList)
-    else:
-      gridType=atomicBasisSetGroup.create_dataset("grid_type",(1,),dtype="S3")
-      gridType[0:]="log"
-      if (len(loc_cell.basis)<=2):
-        nameBase=atomicBasisSetGroup.create_dataset("name",(1,),dtype="S8")
-        nameBase[0:]="gaussian"
-      else:
-        nameBase=atomicBasisSetGroup.create_dataset("name",(1,),dtype=mylen)
-        nameBase[0:]=loc_cell.basis
-
-      Normalized=atomicBasisSetGroup.create_dataset("normalized",(1,),dtype="S2")
-      Normalized[0:]="no"
-
-
-       
-
-
- 
-
-    nshell = loc_cell.atom_shell_ids(MyIdx)
-    n=0
-    for i in nshell:
-        l = loc_cell.bas_angular(i)   
-        contracted_coeffs = loc_cell.bas_ctr_coeff(i)
-        contracted_exp =loc_cell.bas_exp(i)
-        for line in zip(*contracted_coeffs):
-          BasisGroup=atomicBasisSetGroup.create_group("basisGroup"+str(n))
-
-
-          mylen="S"+str(len((uniq_atoms[x][0]+str(n)+str(l))))
-          if Python3:
-            strList=['Gaussian'] 
+    #Group Atoms
+    for x in range(NbSpecies):
+        atmname = str(uniq_atoms[x][0])
+        groupSpecies = groupAtom.create_group("species_"+str(x))
+        groupSpecies.create_dataset("atomic_number", (1,), dtype="i4", data=uniq_atoms[x][1])
+        mylen = "S"+str(len(atmname))
+        if Python3:
+            strList = [atmname]
             asciiList = [n.encode("ascii", "ignore") for n in strList]
-            BasisGroup.create_dataset('type',(1,),'S8',asciiList)
+            groupSpecies.create_dataset('name', (1,), mylen, asciiList)
+        else:
+            AtmName = groupSpecies.create_dataset("name", (1,), dtype=mylen)
+            AtmName[0:] = atmname
 
+        groupSpecies.create_dataset("charge", (1,), dtype="f8", data=uniq_atoms[x][2])
+        groupSpecies.create_dataset("core", (1,), dtype="f8", data=uniq_atoms[x][3])
 
-            strList=[uniq_atoms[x][0]+str(n)+str(l)] 
-            asciiList = [n.encode("ascii", "ignore") for n in strList]
-            BasisGroup.create_dataset('rid', (1,),mylen, asciiList)
-          else:
-            basisType=BasisGroup.create_dataset("type",(1,),dtype="S8")
-            basisType[0:]="Gaussian"
-            RID=BasisGroup.create_dataset("rid",(1,),dtype=mylen)
-            RID[0:]=(uniq_atoms[x][0]+str(n)+str(l))
+    SpeciesID = groupAtom.create_dataset("species_ids", (natom,), dtype="i4")
 
+    for x in range(natom):
+        SpeciesID[x:] = idxAtomstoSpecies[x]
 
-          BasisGroup.create_dataset("Shell_coord",(3,),dtype="f8",data=loc_cell.bas_coord(i))
-          BasisGroup.create_dataset("NbRadFunc",(1,),dtype="i4",data=loc_cell.bas_nprim(i))
-          Val_l=BasisGroup.create_dataset("l",(1,),dtype="i4",data=l)
-          Val_n=BasisGroup.create_dataset("n",(1,),dtype="i4",data=n)
-          RadGroup=BasisGroup.create_group("radfunctions")
-          #print "<basisGroup",n," rid=",uniq_atoms[x][0]+str(n)+str(l)," n=",n,"  l=",l ,"NbRadFunc=",loc_cell.bas_nprim(i),"type=Gaussian>"
-          IdRad=0
+    #Parameter Group
+    GroupParameter = H5_qmcpack.create_group("parameters")
+    GroupParameter.create_dataset("ECP", (1,), dtype="b1", data=bool(loc_cell.has_ecp()))
+    bohrUnit = True
+    Spin = loc_cell.spin
 
-          for e,c in zip(contracted_exp,line):
-              DataRadGrp=RadGroup.create_group("DataRad"+str(IdRad))
-              DataRadGrp.create_dataset("exponent",(1,),dtype="f8",data=e)
-              DataRadGrp.create_dataset("contraction",(1,),dtype="f8",data=c)
-              #print  "<radfunc exponent=",e," contraction=",c, "DataRad=",n,"IdRad=",IdRad,"/>"
-              IdRad+=1
-          n+=1
+    GroupParameter.create_dataset("Unit", (1,), dtype="b1", data=bohrUnit) 
+    GroupParameter.create_dataset("NbAlpha", (1,), dtype="i4", data=loc_cell.nelec[0]) 
+    GroupParameter.create_dataset("NbBeta", (1,), dtype="i4", data=loc_cell.nelec[1]) 
+    GroupParameter.create_dataset("NbTotElec", (1,), dtype="i4", data=loc_cell.nelec[0]+loc_cell.nelec[1])
+    GroupParameter.create_dataset("spin", (1,), dtype="i4", data=Spin) 
 
-    atomicBasisSetGroup.create_dataset("NbBasisGroups",(1,),dtype="i4",data=n)
-
-  def is_complex(l):
-      try:
-              return is_complex(l[0])
-      except:
-              return bool(l.imag)
-
-    
-
-
-
-  if loc_cell.cart==True:
-    # Generated from read_order.py in Numerics/codegen
-    d_gms_order = {
-        0:[""],
-        1:["x","y","z"],
-        2:["xx","yy","zz","xy","xz","yz"],
-        3:["xxx","yyy","zzz","xxy","xxz","yyx","yyz","zzx","zzy","xyz"],
-        4:["xxxx","yyyy","zzzz","xxxy","xxxz","yyyx","yyyz","zzzx","zzzy","xxyy","xxzz","yyzz","xxyz","yyxz","zzxy"],
-        5:["xxxxx","yyyyy","zzzzz","xxxxy","xxxxz","yyyyx","yyyyz","zzzzx","zzzzy","xxxyy","xxxzz","yyyxx","yyyzz","zzzxx","zzzyy","xxxyz","yyyxz","zzzxy","xxyyz","xxzzy","yyzzx"],
-        6:["xxxxxx","yyyyyy","zzzzzz","xxxxxy","xxxxxz","yyyyyx","yyyyyz","zzzzzx","zzzzzy","xxxxyy","xxxxzz","yyyyxx","yyyyzz","zzzzxx","zzzzyy","xxxxyz","yyyyxz","zzzzxy","xxxyyy","xxxzzz","yyyzzz","xxxyyz","xxxzzy","yyyxxz","yyyzzx","zzzxxy","zzzyyx","xxyyzz"],
-    }
-    
-    d_l = {'s':0, 'p':1, 'd':2, 'f':3, 'g':4, 'h':5, 'i':6}
-  
-    def n_orbital(n):
-      if n==0:
-          return 1
-      elif n==1:
-          return 3
-      else:
-          return 2*n_orbital(n-1)-n_orbital(n-2)+1
-  
-  
-    def compare_gamess_style(item1, item2):
-      # Warning:
-      # 	- d_gms_order is a global variable
-      n1,n2 = map(len,(item1,item2))
-      assert (n1 == n2)
-      try:
-          l = d_gms_order[n1]
-      except KeyError:
-          return 0
-      else:
-          a = l.index(item1)
-          b = l.index(item2)
-          return ((a>b) - (a<b)) #cmp( a, b )
- 
-    def compare_python3(item1, item2):
-         return compare_gamess_style(item1[0],item2[0])
- 
-    ao_label = loc_cell.ao_labels(False)
-  
-  
-    # Create a list of shell
-    l_l = []
-    for label, name, t, l in ao_label:
-          # Change yyx -> xyy "
-          q =  "".join(sorted(l, key=l.count, reverse=True))
-          l_l.append(q)
-  
-    # Pyscf ordering of shell
-    l_order = list(range(len(l_l)))
-  
-    # Shell ordering indexed
-    n = 1
-    l_order_new = []
-    for  i,(label, name, t, l) in enumerate(ao_label):
-          r = d_l[t[-1]]
-          # print r,n_orbital(r)
-          if n != 1:
-                  n-=1
-          else:
-                  from functools import cmp_to_key
-                  n = n_orbital(r)
-                  unordered_l = l_l[i:i+n]
-                  unordered = l_order[i:i+n]
-                  #print i,n,unordered 
-                  ordered = [x for _,x in sorted(zip(unordered_l,unordered),key=cmp_to_key(compare_python3))]
-                  l_order_new.extend(ordered)
-  
-    
-    def order_mo_coef(ll):
-          # Order a list of transposed mo_coeff (Ao,Mo) -> (Mo,Ao) ordered
-          # Warning:
-          #	- l_order_new is used as global variable
-          #	- gamess order
-  
-          ll_new= []
-          for l in zip(*ll):
-              ll_new.append([l[i] for i in l_order_new])
-          return ll_new
-  
-  mo_coeff = mf.mo_coeff
-  if len(kpts)==0:
-     Complex=False
-  else:
-     Complex=True
-  GroupParameter.create_dataset("IsComplex",(1,),dtype="b1",data=Complex)
-
- 
-  GroupParameter.create_dataset("SpinRestricted",(1,),dtype="b1",data=Restricted)
-  GroupDet=H5_qmcpack.create_group("Super_Twist")
-  if not PBC:
-    if Restricted==True:
-      NbAO, NbMO =mo_coeff.shape 
-      if loc_cell.cart==True:
-        eigenset=GroupDet.create_dataset("eigenset_0",(NbMO,NbAO),dtype="f8",data=order_mo_coef(mo_coeff))
-      else:
-        eigenset=GroupDet.create_dataset("eigenset_0",(NbMO,NbAO),dtype="f8",data=list(zip(*mo_coeff)))
-
-      eigenvalue=GroupDet.create_dataset("eigenval_0",(1,NbMO),dtype="f8",data=mf.mo_energy)
+    #basisset Group
+    GroupBasisSet = H5_qmcpack.create_group("basisset")
+    #Dataset Number Of Atoms
+    GroupBasisSet.create_dataset("NbElements", (1,), dtype="i4", data=NbSpecies)
+    if Python3:
+        strList = ['LCAOBSet']
+        asciiList = [n.encode("ascii", "ignore") for n in strList]
+        GroupBasisSet.create_dataset('name', (1,), 'S8', asciiList)
     else:
-      NbAO, NbMO =mo_coeff[0].shape 
-      if loc_cell.cart==True:
-        eigenset_up=GroupDet.create_dataset("eigenset_0",(NbMO,NbAO),dtype="f8",data=order_mo_coef(mo_coeff[0]))
-        eigenset_dn=GroupDet.create_dataset("eigenset_1",(NbMO,NbAO),dtype="f8",data=order_mo_coef(mo_coeff[1]))
-      else:
-        eigenset_up=GroupDet.create_dataset("eigenset_0",(NbMO,NbAO),dtype="f8",data=list(zip(*mo_coeff[0])))
-        eigenset_dn=GroupDet.create_dataset("eigenset_1",(NbMO,NbAO),dtype="f8",data=list(zip(*mo_coeff[1])))
+        LCAOName = GroupBasisSet.create_dataset("name", (1,), dtype="S8")
+        LCAOName[0:] = "LCAOBSet"
 
-      eigenvalue_up=GroupDet.create_dataset("eigenval_0",(1,NbMO),dtype="f8",data=mf.mo_energy[0])
-      eigenvalue_dn=GroupDet.create_dataset("eigenval_1",(1,NbMO),dtype="f8",data=mf.mo_energy[1])
- 
-  else:
-    #Cell Parameters
-    GroupCell=H5_qmcpack.create_group("Cell")
-    GroupCell.create_dataset("LatticeVectors",(3,3),dtype="f8",data=loc_cell.lattice_vectors())
+    #atomicBasisSets Group
+    for x in range(NbSpecies):
 
-    def get_mo(mo_coeff, cart):
-        return order_mo_coef(mo_coeff) if cart else list(zip(*mo_coeff))
+        MyIdx = idxSpeciestoAtoms[x][0]
+        atomicBasisSetGroup = GroupBasisSet.create_group("atomicBasisSet"+str(x))
+        mylen = "S"+str(len(uniq_atoms[x][0]))
 
-    #Supertwist Coordinate
-    GroupDet.create_dataset("Coord",(1,3),dtype="f8",data=sp_twist)
+        if Python3:
+            strList = [uniq_atoms[x][0]]
+            asciiList = [n.encode("ascii", "ignore") for n in strList]
+            atomicBasisSetGroup.create_dataset('elementType', (1,), mylen, asciiList)
+            if loc_cell.cart == True:
+                strList = ['cartesian']
+                asciiList = [n.encode("ascii", "ignore") for n in strList]
+                atomicBasisSetGroup.create_dataset('angular', (1,), 'S9', asciiList)
 
-    if Gamma:  
-       E_g=mf.mo_energy
-       E_g_unsorted=E_g
-       mo_coeff_ = get_mo(mo_coeff, loc_cell.cart) 
-       mo_coeff_unsorted = mo_coeff_ 
-       NbAO, NbMO =mo_coeff.shape 
-    else: 
-      if kmap is not None:
-           if cas_idx is not None:
-               mo_k = numpy.array([c[:, cas_idx] for c in (mf.mo_coeff[idx] for idx in kmap)])
-               e_k = numpy.array([e[cas_idx] for e in (mf.mo_energy[idx] for idx in kmap)])
-           else:
-               mo_k = numpy.array([mf.mo_coeff[idx] for idx in kmap])
-               e_k = numpy.array([mf.mo_energy[idx] for idx in kmap])
-      else:
-           mo_k = numpy.array([c[:,cas_idx] for c in mf.mo_coeff] if cas_idx is not None else mf.mo_coeff)
-           e_k =  numpy.array([e[cas_idx] for e in mf.mo_energy] if cas_idx is not None else mf.mo_energy)
+                strList = ['Gamess']
+                asciiList = [n.encode("ascii", "ignore") for n in strList]
+                atomicBasisSetGroup.create_dataset('expandYlm', (1,), 'S6', asciiList)
 
-      E_g, C_gamma,E_g_unsorted,C_unsorted = mo_k2gamma(cell, e_k, mo_k, kpts,kmesh)
-      mo_coeff=C_gamma
-      NbAO, NbMO =mo_coeff.shape 
+            else:
+                strList = ['spherical']
+                asciiList = [n.encode("ascii", "ignore") for n in strList]
+                atomicBasisSetGroup.create_dataset('angular', (1,), 'S9', asciiList)
 
-      mo_coeff_ = get_mo(mo_coeff.real, loc_cell.cart) 
-      mo_coeff_imag = get_mo(mo_coeff.imag, loc_cell.cart) 
-      mo_coeff_unsorted = get_mo(C_unsorted.real, loc_cell.cart) 
-      mo_coeff_unsorted_imag = get_mo(C_unsorted.imag, loc_cell.cart) 
-      eigenset_imag=GroupDet.create_dataset("eigenset_0_imag",(NbMO,NbAO),dtype="f8",data=mo_coeff_imag) 
-      eigenset_unsorted_imag=GroupDet.create_dataset("eigenset_unsorted_0_imag",(NbMO,NbAO),dtype="f8",data=mo_coeff_unsorted_imag) 
+                strList = ['pyscf']
+                asciiList = [n.encode("ascii", "ignore") for n in strList]
+                atomicBasisSetGroup.create_dataset('expandYlm', (1,), 'S5', asciiList)
+        else:
+            elemtype = atomicBasisSetGroup.create_dataset("elementType", (1,), dtype=mylen)
+            elemtype[0:] = uniq_atoms[x][0]
+            if loc_cell.cart == True:
+                Angular = atomicBasisSetGroup.create_dataset("angular", (1,), dtype="S9")
+                ExpandYLM = atomicBasisSetGroup.create_dataset("expandYlm", (1,), dtype="S6")
+                Angular[0:] = "cartesian"
+                ExpandYLM[0:] = "Gamess"
+            else:
+                Angular = atomicBasisSetGroup.create_dataset("angular", (1,), dtype="S9")
+                Angular[0:] = "spherical"
+                ExpandYLM = atomicBasisSetGroup.create_dataset("expandYlm", (1,), dtype="S5")
+                ExpandYLM[0:] = "pyscf"
 
 
+        atomicBasisSetGroup.create_dataset("grid_npts", (1,), dtype="i4", data=1001)
+        atomicBasisSetGroup.create_dataset("grid_rf", (1,), dtype="i4", data=100)
+        atomicBasisSetGroup.create_dataset("grid_ri", (1,), dtype="f8", data=1e-06)
+
+        mylen = "S"+str(len(loc_cell.basis))
+        if Python3:
+            strList = ['log']
+            asciiList = [n.encode("ascii", "ignore") for n in strList]
+            atomicBasisSetGroup.create_dataset('grid_type', (1,), 'S3', asciiList)
+            if (len(loc_cell.basis)<=2):
+                strList = ['gaussian']
+                asciiList = [n.encode("ascii", "ignore") for n in strList]
+                atomicBasisSetGroup.create_dataset('name', (1,), 'S8', asciiList)
+            elif isinstance(loc_cell.basis,dict):
+                strList = ['custom']
+                asciiList = [n.encode("ascii", "ignore") for n in strList]
+                atomicBasisSetGroup.create_dataset('name', (1,), 'S6', asciiList)
+            else:
+                strList = [loc_cell.basis]
+                asciiList = [n.encode("ascii", "ignore") for n in strList]
+                atomicBasisSetGroup.create_dataset('name', (1,), mylen, asciiList)
+            strList = ['no']
+            asciiList = [n.encode("ascii", "ignore") for n in strList]
+            atomicBasisSetGroup.create_dataset('normalized', (1,), 'S2', asciiList)
+        else:
+            gridType = atomicBasisSetGroup.create_dataset("grid_type", (1,), dtype="S3")
+            gridType[0:] = "log"
+            if (len(loc_cell.basis) <= 2):
+                nameBase=atomicBasisSetGroup.create_dataset("name", (1,), dtype="S8")
+                nameBase[0:] = "gaussian"
+            else:
+                nameBase=atomicBasisSetGroup.create_dataset("name", (1,), dtype=mylen)
+                nameBase[0:] = loc_cell.basis
+
+            Normalized = atomicBasisSetGroup.create_dataset("normalized", (1,), dtype="S2")
+            Normalized[0:] = "no"
 
 
-    eigenset=GroupDet.create_dataset("eigenset_0",(NbMO,NbAO),dtype="f8",data=mo_coeff_) 
-    eigenvalue=GroupDet.create_dataset("eigenval_0",(1,NbMO),dtype="f8",data=E_g)
- 
-    #Unsorted Mo_coeffs for Multideterminants order matching QP
-    eigenset_unsorted=GroupDet.create_dataset("eigenset_unsorted_0",(NbMO,NbAO),dtype="f8",data=mo_coeff_unsorted) 
-    eigenvalue_unsorted=GroupDet.create_dataset("eigenval_unsorted_0",(1,NbMO),dtype="f8",data=E_g_unsorted)
- 
-    
+        nshell = loc_cell.atom_shell_ids(MyIdx)
+        n = 0
+        for i in nshell:
+            l = loc_cell.bas_angular(i)   
+            contracted_coeffs = loc_cell.bas_ctr_coeff(i)
+            contracted_exp = loc_cell.bas_exp(i)
+            for line in zip(*contracted_coeffs):
+                BasisGroup = atomicBasisSetGroup.create_group("basisGroup"+str(n))
 
-  GroupParameter.create_dataset("numMO",(1,),dtype="i4",data=NbMO)
-  GroupParameter.create_dataset("numAO",(1,),dtype="i4",data=NbAO)
-  
-  is_multidet = isinstance(mf, (mcscf.casci.CASCI, mcscf.mc1step.CASSCF))
+                mylen = "S"+str(len((uniq_atoms[x][0]+str(n)+str(l))))
+                if Python3:
+                    strList = ['Gaussian'] 
+                    asciiList = [n.encode("ascii", "ignore") for n in strList]
+                    BasisGroup.create_dataset('type', (1,), 'S8', asciiList)
 
-  if is_multidet:
-    make_multidet(cell, mf, title, H5_qmcpack)
-    print(f'Multideterminant wavefunction saved to {title}_multidet.h5')
+                    strList = [uniq_atoms[x][0]+str(n)+str(l)] 
+                    asciiList = [n.encode("ascii", "ignore") for n in strList]
+                    BasisGroup.create_dataset('rid', (1,), mylen, asciiList)
+                else:
+                    basisType = BasisGroup.create_dataset("type", (1,), dtype="S8")
+                    basisType[0:] = "Gaussian"
+                    RID = BasisGroup.create_dataset("rid", (1,), dtype=mylen)
+                    RID[0:] = (uniq_atoms[x][0] + str(n) + str(l))
 
-  # Close the file before exiting
-  H5_qmcpack.close()
+                BasisGroup.create_dataset("Shell_coord", (3,), dtype="f8", data=loc_cell.bas_coord(i))
+                BasisGroup.create_dataset("NbRadFunc", (1,), dtype="i4", data=loc_cell.bas_nprim(i))
+                Val_l = BasisGroup.create_dataset("l", (1,), dtype="i4", data=l)
+                Val_n = BasisGroup.create_dataset("n", (1,), dtype="i4", data=n)
+                RadGroup = BasisGroup.create_group("radfunctions")
+                #print "<basisGroup",n," rid=",uniq_atoms[x][0]+str(n)+str(l)," n=",n,"  l=",l ,"NbRadFunc=",loc_cell.bas_nprim(i),"type=Gaussian>"
 
-  print ('Wavefunction successfully saved to QMCPACK HDF5 Format')
-  print ('Use: "convert4qmc -orbitals  {}.h5" to generate QMCPACK input files'.format(title))
+                IdRad = 0
+                for e, c in zip(contracted_exp, line):
+                    DataRadGrp=RadGroup.create_group("DataRad" + str(IdRad))
+                    DataRadGrp.create_dataset("exponent", (1,), dtype="f8", data=e)
+                    DataRadGrp.create_dataset("contraction", (1,), dtype="f8", data=c)
+                    #print  "<radfunc exponent=",e," contraction=",c, "DataRad=",n,"IdRad=",IdRad,"/>"
+                    IdRad += 1
+                n += 1
+
+        atomicBasisSetGroup.create_dataset("NbBasisGroups", (1,), dtype="i4", data=n)
+
+    def is_complex(l):
+        try:
+            return is_complex(l[0])
+        except:
+            return bool(l.imag)
+
+
+    if loc_cell.cart == True:
+        # Generated from read_order.py in Numerics/codegen
+        d_gms_order = {
+            0: [""],
+            1: ["x","y","z"],
+            2: [
+                "xx","yy","zz",
+                "xy","xz","yz"
+            ],
+            3: [
+                "xxx","yyy","zzz",
+                "xxy","xxz",
+                "yyx","yyz",
+                "zzx","zzy",
+                "xyz"
+            ],
+            4: [
+                "xxxx","yyyy","zzzz",
+                "xxxy","xxxz",
+                "yyyx","yyyz",
+                "zzzx","zzzy",
+                "xxyy","xxzz","yyzz",
+                "xxyz","yyxz","zzxy"
+            ],
+            5: [
+                "xxxxx","yyyyy","zzzzz",
+                "xxxxy","xxxxz",
+                "yyyyx","yyyyz",
+                "zzzzx","zzzzy",
+                "xxxyy","xxxzz",
+                "yyyxx","yyyzz",
+                "zzzxx","zzzyy",
+                "xxxyz","yyyxz","zzzxy",
+                "xxyyz","xxzzy",
+                "yyzzx"
+            ],
+            6: [
+                "xxxxxx","yyyyyy","zzzzzz",
+                "xxxxxy","xxxxxz",
+                "yyyyyx","yyyyyz",
+                "zzzzzx","zzzzzy",
+                "xxxxyy","xxxxzz",
+                "yyyyxx","yyyyzz",
+                "zzzzxx","zzzzyy",
+                "xxxxyz","yyyyxz","zzzzxy",
+                "xxxyyy","xxxzzz","yyyzzz",
+                "xxxyyz","xxxzzy",
+                "yyyxxz","yyyzzx",
+                "zzzxxy","zzzyyx",
+                "xxyyzz"
+            ],
+        }
+
+        d_l = {
+            's': 0,
+            'p': 1,
+            'd': 2,
+            'f': 3,
+            'g': 4,
+            'h': 5,
+            'i': 6
+        }
+
+        def n_orbital(n):
+            if n == 0:
+                return 1
+            elif n == 1:
+                return 3
+            else:
+                return 2 * n_orbital(n - 1) - n_orbital(n - 2) + 1
+
+
+        def compare_gamess_style(item1, item2):
+            # Warning:
+            # 	- d_gms_order is a global variable
+            n1, n2 = map(len, (item1, item2))
+            assert(n1 == n2)
+            try:
+                l = d_gms_order[n1]
+            except KeyError:
+                return 0
+            else:
+                a = l.index(item1)
+                b = l.index(item2)
+                return ((a > b) - (a < b)) #cmp( a, b )
+
+
+        def compare_python3(item1, item2):
+            return compare_gamess_style(item1[0], item2[0])
+
+
+        ao_label = loc_cell.ao_labels(False)
+
+        # Create a list of shell
+        l_l = []
+        for label, name, t, l in ao_label:
+            # Change yyx -> xyy "
+            q =  "".join(sorted(l, key=l.count, reverse=True))
+            l_l.append(q)
+
+        # Pyscf ordering of shell
+        l_order = list(range(len(l_l)))
+
+        # Shell ordering indexed
+        n = 1
+        l_order_new = []
+        for i, (label, name, t, l) in enumerate(ao_label):
+            r = d_l[t[-1]]
+            # print r,n_orbital(r)
+            if n != 1:
+                n -= 1
+            else:
+                from functools import cmp_to_key
+                n = n_orbital(r)
+                unordered_l = l_l[i:i+n]
+                unordered = l_order[i:i+n]
+                #print i,n,unordered 
+                ordered = [x for _, x in sorted(zip(unordered_l, unordered), key=cmp_to_key(compare_python3))]
+                l_order_new.extend(ordered)
+
+
+        def order_mo_coef(ll):
+            # Order a list of transposed mo_coeff (Ao,Mo) -> (Mo,Ao) ordered
+            # Warning:
+            #	- l_order_new is used as global variable
+            #	- gamess order
+
+            ll_new = []
+            for l in zip(*ll):
+                ll_new.append([l[i] for i in l_order_new])
+            return ll_new
+
+    mo_coeff = mf.mo_coeff
+    if len(kpts) == 0:
+        Complex = False
+    else:
+        Complex = True
+    GroupParameter.create_dataset("IsComplex", (1,), dtype="b1", data=Complex)
+
+
+    GroupParameter.create_dataset("SpinRestricted", (1,), dtype="b1", data=Restricted)
+    GroupDet = H5_qmcpack.create_group("Super_Twist")
+    if not PBC:
+        if Restricted == True:
+            NbAO, NbMO = mo_coeff.shape
+            if loc_cell.cart == True:
+                eigenset = GroupDet.create_dataset("eigenset_0", (NbMO, NbAO), dtype="f8", data=order_mo_coef(mo_coeff))
+            else:
+                eigenset = GroupDet.create_dataset("eigenset_0", (NbMO, NbAO), dtype="f8", data=list(zip(*mo_coeff)))
+
+            eigenvalue = GroupDet.create_dataset("eigenval_0", (1, NbMO), dtype="f8", data=mf.mo_energy)
+        else:
+            NbAO, NbMO = mo_coeff[0].shape 
+            if loc_cell.cart == True:
+                eigenset_up = GroupDet.create_dataset("eigenset_0", (NbMO, NbAO), dtype="f8", data=order_mo_coef(mo_coeff[0]))
+                eigenset_dn = GroupDet.create_dataset("eigenset_1", (NbMO, NbAO), dtype="f8", data=order_mo_coef(mo_coeff[1]))
+            else:
+                eigenset_up = GroupDet.create_dataset("eigenset_0", (NbMO, NbAO), dtype="f8", data=list(zip(*mo_coeff[0])))
+                eigenset_dn = GroupDet.create_dataset("eigenset_1", (NbMO, NbAO), dtype="f8", data=list(zip(*mo_coeff[1])))
+
+            eigenvalue_up = GroupDet.create_dataset("eigenval_0", (1, NbMO), dtype="f8", data=mf.mo_energy[0])
+            eigenvalue_dn = GroupDet.create_dataset("eigenval_1", (1, NbMO), dtype="f8", data=mf.mo_energy[1])
+
+    else:
+        #Cell Parameters
+        GroupCell=H5_qmcpack.create_group("Cell")
+        GroupCell.create_dataset("LatticeVectors", (3, 3), dtype="f8", data=loc_cell.lattice_vectors())
+
+        def get_mo(mo_coeff, cart):
+            return order_mo_coef(mo_coeff) if cart else list(zip(*mo_coeff))
+
+        #Supertwist Coordinate
+        GroupDet.create_dataset("Coord", (1, 3), dtype="f8", data=sp_twist)
+
+        if Gamma:  
+            E_g = mf.mo_energy
+            E_g_unsorted = E_g
+            mo_coeff_ = get_mo(mo_coeff, loc_cell.cart) 
+            mo_coeff_unsorted = mo_coeff_ 
+            NbAO, NbMO = mo_coeff.shape 
+        else:
+            if kmap is not None:
+                if cas_idx is not None:
+                    mo_k = numpy.array([c[:, cas_idx] for c in (mf.mo_coeff[idx] for idx in kmap)])
+                    e_k = numpy.array([e[cas_idx] for e in (mf.mo_energy[idx] for idx in kmap)])
+                else:
+                    mo_k = numpy.array([mf.mo_coeff[idx] for idx in kmap])
+                    e_k = numpy.array([mf.mo_energy[idx] for idx in kmap])
+            else:
+                mo_k = numpy.array([c[:, cas_idx] for c in mf.mo_coeff] if cas_idx is not None else mf.mo_coeff)
+                e_k =  numpy.array([e[cas_idx] for e in mf.mo_energy] if cas_idx is not None else mf.mo_energy)
+
+            E_g, C_gamma, E_g_unsorted, C_unsorted = mo_k2gamma(cell, e_k, mo_k, kpts, kmesh)
+            mo_coeff = C_gamma
+            NbAO, NbMO = mo_coeff.shape 
+
+            mo_coeff_ = get_mo(mo_coeff.real, loc_cell.cart) 
+            mo_coeff_imag = get_mo(mo_coeff.imag, loc_cell.cart) 
+            mo_coeff_unsorted = get_mo(C_unsorted.real, loc_cell.cart) 
+            mo_coeff_unsorted_imag = get_mo(C_unsorted.imag, loc_cell.cart) 
+            eigenset_imag = GroupDet.create_dataset("eigenset_0_imag", (NbMO, NbAO), dtype="f8", data=mo_coeff_imag) 
+            eigenset_unsorted_imag = GroupDet.create_dataset("eigenset_unsorted_0_imag", (NbMO, NbAO), dtype="f8", data=mo_coeff_unsorted_imag) 
+
+
+        eigenset = GroupDet.create_dataset("eigenset_0", (NbMO, NbAO), dtype="f8", data=mo_coeff_) 
+        eigenvalue = GroupDet.create_dataset("eigenval_0", (1, NbMO), dtype="f8", data=E_g)
+
+        #Unsorted Mo_coeffs for Multideterminants order matching QP
+        eigenset_unsorted = GroupDet.create_dataset("eigenset_unsorted_0", (NbMO, NbAO), dtype="f8", data=mo_coeff_unsorted) 
+        eigenvalue_unsorted = GroupDet.create_dataset("eigenval_unsorted_0", (1, NbMO), dtype="f8", data=E_g_unsorted)
+
+
+    GroupParameter.create_dataset("numMO", (1,), dtype="i4", data=NbMO)
+    GroupParameter.create_dataset("numAO", (1,), dtype="i4", data=NbAO)
+
+    is_multidet = isinstance(mf, (mcscf.casci.CASCI, mcscf.mc1step.CASSCF))
+
+    if is_multidet:
+        make_multidet(cell, mf, title, H5_qmcpack)
+        print(f'Multideterminant wavefunction saved to {title}_multidet.h5')
+
+    # Close the file before exiting
+    H5_qmcpack.close()
+
+    print('Wavefunction successfully saved to QMCPACK HDF5 Format')
+    print('Use: "convert4qmc -orbitals  {}.h5" to generate QMCPACK input files'.format(title))
 
 
 def make_multidet(cell, mf, title, h5_handle):
-  import numpy
-  import h5py, re, sys
-  a = mf.fcisolver.large_ci(mf.ci, mf.ncas, mf.nelecas, tol=0.0, return_strs=True)
-  dets_a = []
-  dets_b = []
-  coeffs = []
-  cas_mo_start_a = cell.nelec[0]-mf.nelecas[0]
-  cas_mo_start_b = cell.nelec[1]-mf.nelecas[1]
-  n = 64 # chunk length
-  for idx,i in enumerate(a):
-      occ_a = numpy.array(list(i[1][2:]),dtype=int)
-      occ_b = numpy.array(list(i[2][2:]),dtype=int)
-      string_a = '0'*(len(mf.mo_coeff) - cas_mo_start_a - len(occ_a)) + i[1][2:] + '1'*cas_mo_start_a
-      string_b = '0'*(len(mf.mo_coeff) - cas_mo_start_b - len(occ_b)) + i[2][2:] + '1'*cas_mo_start_b
-      chunks_a = [int(string_a[j:j+n],2) for j in range(0, len(string_a), n)]
-      chunks_b = [int(string_b[j:j+n],2) for j in range(0, len(string_b), n)]
-      dets_a.append(chunks_a)
-      dets_b.append(chunks_b)
-      coeffs.append(i[0])
-  H5_qmcpack_multidet = h5py.File(title+'_multidet.h5','w')
-  groupApp=H5_qmcpack_multidet.create_group("MultiDet")
-  dets_a = numpy.array(dets_a)
-  dets_b = numpy.array(dets_b)
+    import numpy
+    import h5py, re, sys
+    a = mf.fcisolver.large_ci(mf.ci, mf.ncas, mf.nelecas, tol=0.0, return_strs=True)
+    dets_a = []
+    dets_b = []
+    coeffs = []
+    cas_mo_start_a = cell.nelec[0] - mf.nelecas[0]
+    cas_mo_start_b = cell.nelec[1] - mf.nelecas[1]
+    n = 64 # chunk length
+    for idx, i in enumerate(a):
+        occ_a = numpy.array(list(i[1][2:]), dtype=int)
+        occ_b = numpy.array(list(i[2][2:]), dtype=int)
+        string_a = '0'*(len(mf.mo_coeff) - cas_mo_start_a - len(occ_a)) + i[1][2:] + '1'*cas_mo_start_a
+        string_b = '0'*(len(mf.mo_coeff) - cas_mo_start_b - len(occ_b)) + i[2][2:] + '1'*cas_mo_start_b
+        chunks_a = [int(string_a[j:j+n], 2) for j in range(0, len(string_a), n)]
+        chunks_b = [int(string_b[j:j+n], 2) for j in range(0, len(string_b), n)]
+        dets_a.append(chunks_a)
+        dets_b.append(chunks_b)
+        coeffs.append(i[0])
 
-  dt = numpy.dtype(numpy.uint64)
-  groupApp.create_dataset('CI_Alpha',dets_a.shape,dtype=dt, data = dets_a)
-  groupApp.create_dataset('CI_Beta',dets_b.shape,dtype=dt, data = dets_b)
-  groupApp.create_dataset('Coeff', (len(coeffs),),dtype = float,data = coeffs)
-  groupApp.create_dataset('NbDet', (1,),dtype = "i4",data = len(coeffs))
-  groupApp.create_dataset('Nbits', (1,),dtype = "i4",data = len(dets_a[0]))
-  groupApp.create_dataset('nstate', (1,),dtype = "i4",data = mf.mo_coeff.shape[0])
-  groupApp.create_dataset('nexcitedstate', (1,),dtype = "i4",data = 2)
+    H5_qmcpack_multidet = h5py.File(title+'_multidet.h5','w')
+    groupApp = H5_qmcpack_multidet.create_group("MultiDet")
+    dets_a = numpy.array(dets_a)
+    dets_b = numpy.array(dets_b)
 
-  H5_qmcpack_multidet.close()
+    dt = numpy.dtype(numpy.uint64)
+    groupApp.create_dataset('CI_Alpha',      dets_a.shape,   dtype=dt,    data=dets_a)
+    groupApp.create_dataset('CI_Beta',       dets_b.shape,   dtype=dt,    data=dets_b)
+    groupApp.create_dataset('Coeff',         (len(coeffs),), dtype=float, data=coeffs)
+    groupApp.create_dataset('NbDet',         (1,),           dtype="i4",  data=len(coeffs))
+    groupApp.create_dataset('Nbits',         (1,),           dtype="i4",  data=len(dets_a[0]))
+    groupApp.create_dataset('nstate',        (1,),           dtype="i4",  data=mf.mo_coeff.shape[0])
+    groupApp.create_dataset('nexcitedstate', (1,),           dtype="i4",  data=2)
+
+    H5_qmcpack_multidet.close()

--- a/src/QMCTools/PyscfToQmcpack_Spline.py
+++ b/src/QMCTools/PyscfToQmcpack_Spline.py
@@ -18,519 +18,554 @@ import os
 try:
   from lxml import etree
 except:
-  import sys
-  sys.exit("Error: lxml python module is needed for the generation of the XML file by PyscfToQmcpack_Spline.py. Install as other packages, either directly or with a package manager.")
+    import sys
+    sys.exit("Error: lxml python module is needed for the generation of the XML file by PyscfToQmcpack_Spline.py. Install as other packages, either directly or with a package manager.")
 
 try:
-  import pandas as pd
+    import pandas as pd
 except:
-  import sys
-  sys.exit("Error: Pandas python module is needed for the save_eigensystem and eigensystem functions by PyscfToQmcpack_Spline.py. Install as other packages, either directly or with a package manager.")
+    import sys
+    sys.exit("Error: Pandas python module is needed for the save_eigensystem and eigensystem functions by PyscfToQmcpack_Spline.py. Install as other packages, either directly or with a package manager.")
 
 
 def pyscf2qmcpackspline(cell,mf,title="Default", kpts=[], kmesh=[],  sp_twist=[]):
-  import sys, re
+    import sys, re
 
-  Restricted=True
-  PBC=False
-  Gamma=False
+    Restricted = True
+    PBC        = False
+    Gamma      = False
 
-  # Python version check
-  if sys.version_info < (3, 2):
-       sys.exit("Python < 3.2 not supported")
+    # Python version check
+    if sys.version_info < (3, 2):
+        sys.exit("Python < 3.2 not supported")
 
-  # FFT mesh check
-  if np.any(cell.mesh % 2 == 0):
-       sys.exit("Even number of FFT mesh not supported")	
+    # FFT mesh check
+    if np.any(cell.mesh % 2 == 0):
+        sys.exit("Even number of FFT mesh not supported")	
     
-  #Twists generation not yet implemented
-  if len(sp_twist)== 0:
-       sp_twist=[0.0,0.0,0.0]
+    #Twists generation not yet implemented
+    if len(sp_twist) == 0:
+        sp_twist=[0.0, 0.0, 0.0]
 
-  val=str(mf)
-  ComputeMode= re.split('[. ]',val)
+    val = str(mf)
+    ComputeMode = re.split('[. ]',val)
 
-  SizeMode=len(ComputeMode)
-  for i in range(SizeMode):
-     if ComputeMode[i] in ("UHF","KUHF","UKS"):
-           Restricted=False
-           sys.exit("Unrestricted calculations not supported")
+    SizeMode = len(ComputeMode)
+    for i in range(SizeMode):
+        if ComputeMode[i] in ("UHF","KUHF","UKS"):
+            Restricted = False
+            sys.exit("Unrestricted calculations not supported")
 
-     if ComputeMode[i]=="pbc":
-           PBC = True
+        if ComputeMode[i] == "pbc":
+            PBC = True
 
 
-  if not PBC:
+    if not PBC:
         sys.exit("Open boundary condition without lattice vectors not supported")
-     
-  if PBC and len(kpts) == 0:
-        Gamma=True
+        
+    if PBC and len(kpts) == 0:
+        Gamma = True
 
-  if len(kpts)!= 0:
-     sys.exit("K-point scf not supported")
-  else:
-     loc_cell=cell
- 
-  h5_fname = "{}.h5".format(title)
-  xml_fname = "{}.xml".format(title)
+    if len(kpts) != 0:
+        sys.exit("K-point scf not supported")
+    else:
+        loc_cell=cell
+    
+    h5_fname = "{}.h5".format(title)
+    xml_fname = "{}.xml".format(title)
 
-  tile = [1, 1, 1]
-  tilematrix = [0]*9
-  for dim, val in enumerate(tile):
-    tilematrix[4*dim] = val
-   
-
-  tilematrix_str = " ".join(map(str,tilematrix))
-
-  gvecs, eig_df = save_eigensystem(mf, save=False)
-
-  # generate wave function file
-  # ================================================
-  generate_pwscf_h5(loc_cell,gvecs,eig_df,h5_fname)  
-
-  # generate QMCPACK input file
-  # ================================================ 
-  h5_handle = h5py.File(h5_fname,'r')
-  inp = InputXml()
-  # build <simulationcell>
-  sc_node = inp.simulationcell_from_cell(loc_cell)
-  # build <particleset>
-  pset_node = inp.particleset_from_hdf5(h5_handle)
-  psedinit_node = inp.particleset_initialposition_from_hdf5(h5_handle)
-  wavefunction_node = inp.wavefunction(h5_handle,h5_fname, tilematrix_str)
-  hamiltonien_node = inp.hamiltonian(h5_handle, loc_cell)
-
-  # assemble <qmcsystem>
-  sys_node = etree.Element('qmcsystem')
-
-  sys_children = [sc_node]
-  for child in sys_children:
-    sys_node.append(child)
+    tile = [1, 1, 1]
+    tilematrix = [0]*9
+    for dim, val in enumerate(tile):
+        tilematrix[4*dim] = val
 
 
-  # write input
-  root = etree.Element('simulation')
-  doc = etree.ElementTree(root)
-  #Change name!!!
-  root.append(etree.fromstring('<project id="{}" series="0"/>'.format(title)))
-  root.append(sys_node)
+    tilematrix_str = " ".join(map(str, tilematrix))
 
-  for node in [pset_node,psedinit_node,wavefunction_node,hamiltonien_node]:
-      root.append(node)
+    gvecs, eig_df = save_eigensystem(mf, save=False)
 
-  a = inp.vmc_dmc(h5_handle)
-  root.extend(a)
+    # generate wave function file
+    # ================================================
+    generate_pwscf_h5(loc_cell, gvecs, eig_df, h5_fname)
 
-  doc.write(xml_fname,pretty_print=True)
-  print ('Wavefunction successfully saved to QMCPACK HDF5 spline format')
+    # generate QMCPACK input file
+    # ================================================ 
+    h5_handle = h5py.File(h5_fname, 'r')
+    inp = InputXml()
+    # build <simulationcell>
+    sc_node = inp.simulationcell_from_cell(loc_cell)
+    # build <particleset>
+    pset_node = inp.particleset_from_hdf5(h5_handle)
+    psedinit_node = inp.particleset_initialposition_from_hdf5(h5_handle)
+    wavefunction_node = inp.wavefunction(h5_handle,h5_fname, tilematrix_str)
+    hamiltonien_node = inp.hamiltonian(h5_handle, loc_cell)
 
+    # assemble <qmcsystem>
+    sys_node = etree.Element('qmcsystem')
 
-
-def get_supercell(cell,kmesh=[]):
-  latt_vec = cell.lattice_vectors()
-  if len(kmesh)==0:
-      # Guess kmesh
-      scaled_k = cell.get_scaled_kpts(kpts).round(8)
-      kmesh = (len(np.unique(scaled_k[:,0])),
-               len(np.unique(scaled_k[:,1])),
-               len(np.unique(scaled_k[:,2])))
-
-  R_rel_a = np.arange(kmesh[0])
-  R_rel_b = np.arange(kmesh[1])
-  R_rel_c = np.arange(kmesh[2])
-  R_vec_rel = lib.cartesian_prod((R_rel_a, R_rel_b, R_rel_c))
-  R_vec_abs = np.einsum('nu, uv -> nv', R_vec_rel, latt_vec)
+    sys_children = [sc_node]
+    for child in sys_children:
+        sys_node.append(child)
 
 
-  # R_rel_mesh has to be construct exactly same to the Ts in super_cell function
-  scell = tools.super_cell(cell, kmesh)
-  return scell, kmesh
+    # write input
+    root = etree.Element('simulation')
+    doc = etree.ElementTree(root)
+    #Change name!!!
+    root.append(etree.fromstring('<project id="{}" series="0"/>'.format(title)))
+    root.append(sys_node)
+
+    for node in [pset_node, psedinit_node, wavefunction_node, hamiltonien_node]:
+        root.append(node)
+
+    a = inp.vmc_dmc(h5_handle)
+    root.extend(a)
+
+    doc.write(xml_fname, pretty_print=True)
+    print('Wavefunction successfully saved to QMCPACK HDF5 spline format')
+
+
+def get_supercell(cell, kmesh=[]):
+    latt_vec = cell.lattice_vectors()
+    if len(kmesh) == 0:
+        # Guess kmesh
+        scaled_k = cell.get_scaled_kpts(kpts).round(8)
+        kmesh = (
+            len(np.unique(scaled_k[:,0])),
+            len(np.unique(scaled_k[:,1])),
+            len(np.unique(scaled_k[:,2])),
+        )
+
+    R_rel_a = np.arange(kmesh[0])
+    R_rel_b = np.arange(kmesh[1])
+    R_rel_c = np.arange(kmesh[2])
+    R_vec_rel = lib.cartesian_prod((R_rel_a, R_rel_b, R_rel_c))
+    R_vec_abs = np.einsum('nu, uv -> nv', R_vec_rel, latt_vec)
+
+
+    # R_rel_mesh has to be construct exactly same to the Ts in super_cell function
+    scell = tools.super_cell(cell, kmesh)
+    return scell, kmesh
 #end def get_supercell
 
 
-def save_eigensystem(mf,gvec_fname = 'gvectors.dat'
-                     ,eigsys_fname = 'eigensystem.json',save=True):
-  import os
-  if os.path.isfile(eigsys_fname) and os.path.isfile(gvec_fname):
-    gvecs = np.loadtxt(gvec_fname)
-    eig_df = pd.read_json(eigsys_fname).set_index(
-      ['ikpt','ispin','istate'],drop=True).sort_index()
-  else:
-    data = []
-    ikpt  = 0 # gamma-point calculation
-    ispin = 0 # restricted (same orbitals for up and down electrons)
-    # get MOs in plane-wave basis
-    aoR = ao_on_grid(mf.cell)
-    gvecs,psig = mo_coeff_to_psig(mf.mo_coeff,aoR,mf.cell.gs,mf.cell.vol)
-    nstate,npw,ncomp = psig.shape
-    for istate in range(nstate):
-      entry = {'ikpt':ikpt,'ispin':ispin,'istate':istate,
-        'reduced_k':mf.kpt,'evalue':mf.mo_energy[istate],'evector':psig[istate,:,:]}
-      data.append(entry)
-    # end for istate
-    eig_df = pd.DataFrame(data).set_index(
-      ['ikpt','ispin','istate'],drop=True).sort_index()
-  # end if
-  if save:
-    eig_df.reset_index().to_json(eigsys_fname)
-    np.savetxt(gvec_fname,gvecs)
-  # end if
-  return gvecs,eig_df
+def save_eigensystem(
+    mf,
+    gvec_fname = 'gvectors.dat',
+    eigsys_fname = 'eigensystem.json',
+    save=True,
+):
+    import os
+    if os.path.isfile(eigsys_fname) and os.path.isfile(gvec_fname):
+        gvecs = np.loadtxt(gvec_fname)
+        eig_df = pd.read_json(eigsys_fname).set_index(
+        ['ikpt', 'ispin', 'istate'],drop=True).sort_index()
+    else:
+        data = []
+        ikpt  = 0 # gamma-point calculation
+        ispin = 0 # restricted (same orbitals for up and down electrons)
+        # get MOs in plane-wave basis
+        aoR = ao_on_grid(mf.cell)
+        gvecs, psig = mo_coeff_to_psig(mf.mo_coeff, aoR, mf.cell.gs, mf.cell.vol)
+        nstate, npw, ncomp = psig.shape
+        for istate in range(nstate):
+            entry = {
+                'ikpt': ikpt,
+                'ispin': ispin,
+                'istate': istate,
+                'reduced_k': mf.kpt,
+                'evalue': mf.mo_energy[istate],
+                'evector': psig[istate,:,:],
+            }
+            data.append(entry)
+        # end for istate
+        eig_df = pd.DataFrame(data).set_index(
+            ['ikpt','ispin','istate'], drop=True
+        ).sort_index()
+    # end if
+    if save:
+        eig_df.reset_index().to_json(eigsys_fname)
+        np.savetxt(gvec_fname, gvecs)
+    # end if
+    return gvecs, eig_df
 # end def save_eigensystem
 
 def ao_on_grid(cell):
-  from pyscf.pbc.dft import gen_grid,numint
-  coords = gen_grid.gen_uniform_grids(cell)
-  aoR    = numint.eval_ao(cell,coords)
-  return aoR
+    from pyscf.pbc.dft import gen_grid, numint
+    coords = gen_grid.gen_uniform_grids(cell)
+    aoR    = numint.eval_ao(cell, coords)
+    return aoR
 # end def ao_on_grid
 
-def mo_coeff_to_psig(mo_coeff,aoR,cell_gs,cell_vol,int_gvecs=None):
-  """
-   Inputs:
-     mo_coeff: molecular orbital in AO basis, each column is an MO, shape (nao,nmo)
-     aoR: atomic orbitals on a real-space grid, each column is an AO, shape (ngrid,nao)
-     cell_gs: 2*cell_gs+1 should be the shape of real-space grid (e.g. (5,5,5))
-     cell_vol: cell volume, used for FFT normalization
-     int_gvecs: specify the order of plane-waves using reciprocal lattice points
-   Outputs:
-       3. plane-wave coefficients representing the MOs, shape (ngrid,nmo)
-  """
-  import sys
+def mo_coeff_to_psig(mo_coeff, aoR, cell_gs, cell_vol, int_gvecs=None):
+    """
+    Inputs:
+        mo_coeff: molecular orbital in AO basis, each column is an MO, shape (nao,nmo)
+        aoR: atomic orbitals on a real-space grid, each column is an AO, shape (ngrid,nao)
+        cell_gs: 2*cell_gs+1 should be the shape of real-space grid (e.g. (5,5,5))
+        cell_vol: cell volume, used for FFT normalization
+        int_gvecs: specify the order of plane-waves using reciprocal lattice points
+    Outputs:
+        3. plane-wave coefficients representing the MOs, shape (ngrid,nmo)
+    """
+    import sys
 
-  # provide the order of reciprocal lattice vectors to skip
-  if int_gvecs is None: # use internal order
-    nx,ny,nz = cell_gs
-    from itertools import product
-    int_gvecs = np.array([gvec for gvec in product(
-      range(-nx,nx+1),range(-ny,ny+1),range(-nz,nz+1))],dtype=int)
-  else:
-    assert (int_gvecs.dtype is int)
-  # end if
-  npw = len(int_gvecs) # number of plane waves 
+    # provide the order of reciprocal lattice vectors to skip
+    if int_gvecs is None: # use internal order
+        nx, ny, nz = cell_gs
+        from itertools import product
+        int_gvecs = np.array(
+            [
+                gvec for gvec in product(
+                    range(-nx, nx + 1), range(-ny, ny + 1), range(-nz, nz + 1)
+                )
+            ], dtype=int
+        )
+    else:
+        assert(int_gvecs.dtype is int)
+    # end if
+    npw = len(int_gvecs) # number of plane waves
 
-  # put molecular orbitals on real-space grid
-  moR = np.dot(aoR,mo_coeff)
-  nao,nmo = moR.shape
-  rgrid_shape = 2*np.array(cell_gs)+1
-  assert nao == np.prod(rgrid_shape)
+    # put molecular orbitals on real-space grid
+    moR = np.dot(aoR, mo_coeff)
+    nao, nmo = moR.shape
+    rgrid_shape = 2*np.array(cell_gs)+1
+    assert(nao == np.prod(rgrid_shape))
 
-  # for each MO, FFT to get psig
-  psig = np.zeros([nmo,npw,2]) # store real & complex
-  for istate in range(nmo):
-    # fill real-space FFT grid
-    rgrid = moR[:,istate].reshape(rgrid_shape)
-    # get plane-wave coefficients (on reciprocal-space FFT grid)
-    moG   = np.fft.fftn(rgrid)/np.prod(rgrid_shape)*np.sqrt(cell_vol)
-    orb_norm = np.sum(moG*np.conj(moG)).real
+    # for each MO, FFT to get psig
+    psig = np.zeros([nmo, npw, 2]) # store real & complex
+    for istate in range(nmo):
+        # fill real-space FFT grid
+        rgrid = moR[:, istate].reshape(rgrid_shape)
+        # get plane-wave coefficients (on reciprocal-space FFT grid)
+        moG = np.fft.fftn(rgrid) / np.prod(rgrid_shape) * np.sqrt(cell_vol)
+        orb_norm = np.sum(moG * np.conj(moG)).real
 
-    if abs(1.-orb_norm) > 1.e-6:
-      print('Orbital normalization failed in state:'+str(istate)+' with norm:'+str(orb_norm))
-      sys.exit(0)
+        if abs(1.0 - orb_norm) > 1e-6:
+            print('Orbital normalization failed in state:'+str(istate)+' with norm:'+str(orb_norm))
+            sys.exit(0)
 
-    # transfer plane-wave coefficients to psig in specified order
-    for igvec in range(npw):
-      comp_val = moG[tuple(int_gvecs[igvec])]
-      psig[istate,igvec,:] = comp_val.real,comp_val.imag
-    # end for igvec
-  # end for istate
-  return int_gvecs,psig
+        # transfer plane-wave coefficients to psig in specified order
+        for igvec in range(npw):
+            comp_val = moG[tuple(int_gvecs[igvec])]
+            psig[istate, igvec, :] = comp_val.real, comp_val.imag
+        # end for igvec
+    # end for istate
+    return int_gvecs, psig
 # end def mo_coeff_to_psig
 
-def generate_pwscf_h5(cell,gvecs,eig_df,h5_fname):
+def generate_pwscf_h5(cell, gvecs, eig_df, h5_fname):
 
-  # if eigensystem was saved to disk, use the following to read
-  #import numpy as np
-  #import pandas as pd
-  #gvecs = np.loadtxt('../1_eigsys/gvectors.dat')
-  #eig_df= pd.read_json('../1_eigsys/eigensystem.json').set_index(
-  #  ['ikpt','ispin','istate'],drop=True).sort_index()
+    # if eigensystem was saved to disk, use the following to read
+    #import numpy as np
+    #import pandas as pd
+    #gvecs = np.loadtxt('../1_eigsys/gvectors.dat')
+    #eig_df= pd.read_json('../1_eigsys/eigensystem.json').set_index(
+    #  ['ikpt','ispin','istate'],drop=True).sort_index()
 
-  new = h5py.File(h5_fname,'w')
-  ref = PwscfH5()
-  nelecs = ref.system_from_cell(new,cell)
-  ref.create_electrons_group(new,gvecs,eig_df,nelecs)
+    new = h5py.File(h5_fname, 'w')
+    ref = PwscfH5()
+    nelecs = ref.system_from_cell(new, cell)
+    ref.create_electrons_group(new, gvecs, eig_df, nelecs)
 
-  # transfer version info. !!!! hard code for now
-  new.create_dataset('application/code',data=[np.bytes_('PySCF')])
-  new.create_dataset('application/version',data=[np.bytes_('1.7.5')])
-  new.create_dataset('format',data=[np.bytes_('ES-HDF')])
-  new.create_dataset('version',data=[2,1,0])
-  new.close()
+    # transfer version info. !!!! hard code for now
+    new.create_dataset('application/code', data=[np.bytes_('PySCF')])
+    new.create_dataset('application/version', data=[np.bytes_('1.7.5')])
+    new.create_dataset('format', data=[np.bytes_('ES-HDF')])
+    new.create_dataset('version', data=[2, 1, 0])
+    new.close()
 # end def generate_pwscf_h5
 
 # =======================================================================
 # Class for bspline h5 generator
 # =======================================================================
 class PwscfH5:
-  def __init__(self):
-    self.locations = {
-      'gvectors':'electrons/kpoint_0/gvectors',
-       'nkpt':'electrons/number_of_kpoints',
-       'nspin':'electrons/number_of_spins',
-       'nstate':'electrons/kpoint_0/spin_0/number_of_states', # !!!! same number of states per kpt
-       'axes':'supercell/primitive_vectors'
+    def __init__(self):
+        self.locations = {
+            'gvectors': 'electrons/kpoint_0/gvectors',
+            'nkpt':     'electrons/number_of_kpoints',
+            'nspin':    'electrons/number_of_spins',
+            'nstate':   'electrons/kpoint_0/spin_0/number_of_states', # !!!! same number of states per kpt
+            'axes':     'supercell/primitive_vectors',
         }
-    self.dtypes = {
-        'nkpt':int,
-        'nspin':int,
-        'nstate':int
+        self.dtypes = {
+            'nkpt':int,
+            'nspin':int,
+            'nstate':int,
         }
-    self.fp = None # h5py.File object (like a file pointer)
-  def __del__(self):
-    if self.fp is not None:
-      self.fp.close()
+        self.fp = None # h5py.File object (like a file pointer)
 
-  # =======================================================================
-  # Basic Read Methods i.e. basic read/write and path access
-  # =======================================================================
-  def read(self,fname,force=False):
-    """ open 'fname' for reading and save handle in this class """
-    if not os.path.isfile(fname):
-      raise RuntimeError('%s not found' % fname)
-    if (self.fp is None) or force:
-      self.fp = h5py.File(fname)
-    else:
-      raise RuntimeError('already tracking a file %s'%str(self.fp))
+    def __del__(self):
+        if self.fp is not None:
+            self.fp.close()
 
-  def val(self,loc):
-    """ get value array of an arbitrary entry at location 'loc' """
-    return self.fp[loc][()]
+    # =======================================================================
+    # Basic Read Methods i.e. basic read/write and path access
+    # =======================================================================
+    def read(self, fname, force=False):
+        """ open 'fname' for reading and save handle in this class """
+        if not os.path.isfile(fname):
+            raise RuntimeError('%s not found' % fname)
+        if (self.fp is None) or force:
+            self.fp = h5py.File(fname)
+        else:
+            raise RuntimeError('already tracking a file %s' % str(self.fp))
 
-  def get(self,name):
-    """ get value array of a known entry """
-    loc   = self.locations[name]
-    return self.fp[loc][()]
+    def val(self, loc):
+        """ get value array of an arbitrary entry at location 'loc' """
+        return self.fp[loc][()]
 
-  # =======================================================================
-  # Advance Read Methods i.e. more specific to QMCPACK 3.0.0
-  # =======================================================================
+    def get(self, name):
+        """ get value array of a known entry """
+        loc = self.locations[name]
+        return self.fp[loc][()]
 
-  # construct typical paths
-  #  e.g. electrons/kpoint_0/spin_0/state_0
-  @staticmethod
-  def kpoint_path(ikpt):
-    path = 'electrons/kpoint_%d' % (ikpt)
-    return path
-  @staticmethod
-  def spin_path(ikpt,ispin):
-    path = 'electrons/kpoint_%d/spin_%d' % (ikpt,ispin)
-    return path
-  @staticmethod
-  def state_path(ikpt,ispin,istate):
-    path = 'electrons/kpoint_%d/spin_%d/state_%d/' % (ikpt,ispin,istate)
-    return path
+    # =======================================================================
+    # Advance Read Methods i.e. more specific to QMCPACK 3.0.0
+    # =======================================================================
 
-  # access specific eigenvalue or eigenvector
-  def psig(self,ikpt=0,ispin=0,istate=0):
-    psig_loc = self.state_path(ikpt,ispin,istate)+'psi_g'
-    return self.fp[psig_loc][()]
+    # construct typical paths
+    #  e.g. electrons/kpoint_0/spin_0/state_0
+    @staticmethod
+    def kpoint_path(ikpt):
+        path = 'electrons/kpoint_%d' % (ikpt)
+        return path
 
-  def psir(self,ikpt=0,ispin=0,istate=0):
-    psir_loc = self.state_path(ikpt,ispin,istate)+'psi_r'
-    return self.fp[psir_loc][()]
+    @staticmethod
+    def spin_path(ikpt, ispin):
+        path = 'electrons/kpoint_%d/spin_%d' % (ikpt, ispin)
+        return path
 
-  def eigenvalues(self):
-    """ return all eigenvalues, shape=(nkpt,nspin,nstate) """
-    nkpt   = self.get('nkpt')[0]
-    nspin  = self.get('nspin')[0]
-    nstate = self.get('nstate')[0] # !!!! same number of states per kpt
+    @staticmethod
+    def state_path(ikpt, ispin, istate):
+        path = 'electrons/kpoint_%d/spin_%d/state_%d/' % (ikpt, ispin, istate)
+        return path
 
-    evals  = np.zeros([nkpt,nspin,nstate])
-    for ikpt in range(nkpt):
-      for ispin in range(nspin):
-        path = self.spin_path(ikpt,ispin)
-        evals[ikpt,ispin,:] = self.val(
-        os.path.join(path,'eigenvalues')
-        )
-    return evals
-
-  @classmethod
-  def psig_to_psir(self,gvecs,psig,rgrid_shape,vol):
-    """ contruct orbital given in planewave basis
-    Inputs: 
-     gvecs: gvectors in reciprocal lattice units i.e. integers
-     psig: planewave coefficients, should have the same length as gvecs
-     vol: simulation cell volume, used to normalized fft
-    Output:
-     rgrid: orbital on a real-space grid """
-    assert len(gvecs) == len(psig)
-
-    kgrid = np.zeros(rgrid_shape,dtype=complex)
-    for igvec in range(len(gvecs)):
-      kgrid[tuple(gvecs[igvec])] = psig[igvec]
-    # end for
-    rgrid = np.fft.ifftn(kgrid) * np.prod(rgrid_shape)/vol
-    return rgrid
-  # end def psig_to_psir
-
-  def get_psir_from_psig(self,ikpt,ispin,istate,rgrid_shape=None,mesh_factor=1.0):
-    """ FFT psig to psir at the given (kpoint,spin,state) """
-    # get lattice which defines the FFT grid
-    axes = self.get('axes')
-    vol  = np.dot(np.cross(axes[0],axes[1]),axes[2])
-    # get MO in plane-wave basis
-    gvecs = self.get('gvectors').astype(int)
-    psig_arr = self.psig(ikpt=ikpt,ispin=ispin,istate=istate)
-    psig = psig_arr[:,0] + 1j*psig_arr[:,1]
-    # determine real-space grid size (QMCPACK 3.0.0 convention)
-    #  ref: QMCWaveFunctions/Experimental/EinsplineSetBuilder.cpp::ReadGvectors_ESHDF()
-    if rgrid_shape is not None: # !!!! override grid size
-      pass
-    else:
-      rgrid_shape = map(int, np.ceil(gvecs.max(axis=0)*4*mesh_factor) )
-    # end if
-    psir = self.psig_to_psir(gvecs,psig,rgrid_shape,vol)
-    return psir
-  # end def get_psir_from_psig
-
-  # build entire eigensystem as a dataframe
-  def eigensystem(self):
-    """ construct dataframe containing eigenvalues and eigenvectors
-    labeled by (kpoint,spin,state) indices """
-    import pandas as pd
-
-    data = []
-    nkpt = self.get('nkpt')
-    nspin= self.get('nspin')
-    for ikpt in range(nkpt):
-      k_grp = self.fp[self.kpoint_path(ikpt)]
-      rkvec = k_grp['reduced_k'][()]
-      for ispin in range(nspin):
-        spin_loc = self.spin_path(ikpt,ispin)
-        sp_grp   = self.fp[spin_loc]
-        nstate   = sp_grp['number_of_states'][(0)]
-        evals    = sp_grp['eigenvalues'][()]
-        for istate in range(nstate):
-          st_loc = self.state_path(ikpt,ispin,istate)
-          st_grp = self.fp[st_loc]
-          evector= st_grp['psi_g'][()] # shape (ngvec,2) (real,complex)
-          entry  = {'ikpt':ikpt,'ispin':ispin,'istate':istate,
-            'reduced_k':rkvec,'evalue':evals[istate],'evector':evector}
-          data.append(entry)
-        # end for istate
-      # end for ispin
-    # end for ikpt
-    df = pd.DataFrame(data).set_index(['ikpt','ispin','istate'],drop=True)
-    return df
-  # end def eigensystem
-
-  # =======================================================================
-  # Advance Write Methods, some specialized for pyscf
-  # =======================================================================
-  @staticmethod
-  def create_electrons_group(h5_handle,gvec,df,nelec):
-    """ create and fill the /electrons group in hdf5 handle
-    Inputs:
-      h5_handle: hdf5 handle generated by h5py.File
-      gvec: 2D numpy array of reciprocal space vectors (npw,ndim)
-      df: dataframe containing the eigensystem,
-         indexed by (kpt,spin,state), contains (evalue,evector,reduced_k)
-      nelec: a list of the number of electrons per atom (if no pseudopotential, then 'species_id' returned by system_from_cell should do)
-    Output:
-      None
-    Effect:
-      fill /electrons group in 'h5_handle' """
-    flat_df = df.reset_index()
-    kpoints = flat_df['ikpt'].unique()
-    spins   = flat_df['ispin'].unique()
-    nkpt,nspin = len(kpoints),len(spins)
-    # transfer orbitals (electrons group)
-    for ikpt in range(nkpt):
-      # !!!! assume no symmetry was used to generate the kpoints
-      kpt_path = 'electrons/kpoint_%d'%ikpt
-      kgrp = h5_handle.create_group(kpt_path)
-      kgrp.create_dataset('num_sym',data=[1])
-      kgrp.create_dataset('symgroup',data=[1])
-      kgrp.create_dataset('weight',data=[1])
-
-      rkvec = df.loc[ikpt,'reduced_k'].values[0]
-      kgrp.create_dataset('reduced_k',data=rkvec)
-      if ikpt == 0: # store gvectors in kpoint_0
-        kgrp.create_dataset('gvectors',data=gvec)
-        kgrp.create_dataset('number_of_gvectors',data=[len(gvec)])
-      # end if 
-
-      for ispin in range(nspin): # assume ispin==0
-        nstate = len(df.loc[(ikpt,ispin)])
-        spin_path = os.path.join(kpt_path,'spin_%d'%ispin)
-        spgrp     = h5_handle.create_group(spin_path)
-        spgrp.create_dataset('number_of_states',data=[nstate])
-
-        evals = np.zeros(nstate) # fill eigenvalues during eigenvector read
-        for istate in range(nstate):
-          state_path = os.path.join(spin_path,'state_%d'%istate)
-          psig = df.loc[(ikpt,ispin,istate),'evector']
-          psig_path = os.path.join(state_path,'psi_g')
-          h5_handle.create_dataset(psig_path,data=psig)
-          evals[istate] = df.loc[(ikpt,ispin,istate),'evalue']
-        # end for istate
-        spgrp.create_dataset('eigenvalues',data=evals)
-      # end for ispin
-    # end for ikpt
-    # transfer orbital info
-    h5_handle.create_dataset('electrons/number_of_electrons',data=nelec)
-    h5_handle.create_dataset('electrons/number_of_kpoints',data=[nkpt])
-    # !!!! hard-code restricted orbitals
-    h5_handle.create_dataset('electrons/number_of_spins',data=[1])
-  # end def create_electrons_group
-
-  @staticmethod
-  def system_from_cell(h5_handle,cell):
-    """ create and fill the /supercell and /atoms groups
-     Inputs:
-       h5_handle: hdf5 handle generated by h5py.File
-       cell: pyscf.pbc.gto.Cell class
-     Outputs:
-       species_id: a list of atomic numbers for each atom
-     Effect:
-       fill /supercell and /atoms group in 'h5_handle'
-    """
-
-    # write lattice
-    axes = cell.lattice_vectors() # always in bohr
-    h5_handle.create_dataset('supercell/primitive_vectors',data=axes)
+    # access specific eigenvalue or eigenvector
+    def psig(self, ikpt=0, ispin=0, istate=0):
+        psig_loc = self.state_path(ikpt, ispin, istate) + 'psi_g'
+        return self.fp[psig_loc][()]
 
 
-    # write atoms
-    pos  = cell.atom_coords() # always in bohr
-    elem = [cell.atom_symbol(i) for i in range(cell.natm)]
-    assert len(pos) == len(elem)
-    h5_handle.create_dataset('atoms/number_of_atoms',data=[len(elem)])
-    h5_handle.create_dataset('atoms/positions',data=pos)
+    def psir(self, ikpt=0, ispin=0, istate=0):
+        psir_loc = self.state_path(ikpt,ispin,istate) + 'psi_r'
+        return self.fp[psir_loc][()]
 
-    # write species info
-    species, indices  = np.unique(elem, return_index=True)
-    h5_handle.create_dataset('atoms/number_of_species',data=[len(species)])
-    atomic_number = {}
-    number_of_electrons = {}
-    species_map = {}
-    nelecs = cell.nelec
 
-    for ispec,name in enumerate(species):
-      species_map[name] = ispec
-      atomic_number[name] = cell.atom_nelec_core(indices[ispec]) + cell.atom_charge(indices[ispec])
-      number_of_electrons[name] = cell.atom_charge(indices[ispec])
-      spec_grp = h5_handle.create_group('atoms/species_%d'%ispec)
+    def eigenvalues(self):
+        """ return all eigenvalues, shape=(nkpt,nspin,nstate) """
+        nkpt   = self.get('nkpt')[0]
+        nspin  = self.get('nspin')[0]
+        nstate = self.get('nstate')[0] # !!!! same number of states per kpt
 
-      # write name
-      if name not in species_map.keys():
-        raise NotImplementedError('unknown element %s' % name)
-      # end if
-      spec_grp.create_dataset('name',data=[np.bytes_(name)])
+        evals  = np.zeros([nkpt, nspin, nstate])
+        for ikpt in range(nkpt):
+            for ispin in range(nspin):
+                path = self.spin_path(ikpt, ispin)
+                evals[ikpt, ispin,:] = self.val(
+                    os.path.join(path, 'eigenvalues')
+                )
+        return evals
 
-      # write atomic number and valence
-      Zn   = atomic_number[name]
-      spec_grp.create_dataset('atomic_number',data=[Zn])
-      Zps = number_of_electrons[name]
-      spec_grp.create_dataset('valence_charge',data=[Zps])
-    # end for ispec 
-    species_ids = [species_map[name] for name in elem]
-    h5_handle.create_dataset('atoms/species_ids',data=species_ids)
+    @classmethod
+    def psig_to_psir(self, gvecs, psig, rgrid_shape, vol):
+        """ contruct orbital given in planewave basis
+        Inputs:
+            gvecs: gvectors in reciprocal lattice units i.e. integers
+            psig: planewave coefficients, should have the same length as gvecs
+            vol: simulation cell volume, used to normalized fft
+        Output:
+            rgrid: orbital on a real-space grid
+        """
+        assert len(gvecs) == len(psig)
 
-    return nelecs
-  # end def system_from_cell
+        kgrid = np.zeros(rgrid_shape, dtype=complex)
+        for igvec in range(len(gvecs)):
+            kgrid[tuple(gvecs[igvec])] = psig[igvec]
+        # end for
+        rgrid = np.fft.ifftn(kgrid) * np.prod(rgrid_shape) / vol
+        return rgrid
+    # end def psig_to_psir
 
+    def get_psir_from_psig(
+        self,
+        ikpt,
+        ispin,
+        istate,
+        rgrid_shape=None,
+        mesh_factor=1.0,
+    ):
+        """ FFT psig to psir at the given (kpoint,spin,state) """
+        # get lattice which defines the FFT grid
+        axes = self.get('axes')
+        vol  = np.dot(np.cross(axes[0], axes[1]), axes[2])
+        # get MO in plane-wave basis
+        gvecs = self.get('gvectors').astype(int)
+        psig_arr = self.psig(ikpt=ikpt, ispin=ispin, istate=istate)
+        psig = psig_arr[:,0] + 1j*psig_arr[:,1]
+        # determine real-space grid size (QMCPACK 3.0.0 convention)
+        #  ref: QMCWaveFunctions/Experimental/EinsplineSetBuilder.cpp::ReadGvectors_ESHDF()
+        if rgrid_shape is not None: # !!!! override grid size
+            pass
+        else:
+            rgrid_shape = map(int, np.ceil(gvecs.max(axis=0) * 4 * mesh_factor))
+        # end if
+        psir = self.psig_to_psir(gvecs, psig, rgrid_shape, vol)
+        return psir
+    # end def get_psir_from_psig
+
+    # build entire eigensystem as a dataframe
+    def eigensystem(self):
+        """ construct dataframe containing eigenvalues and eigenvectors
+        labeled by (kpoint,spin,state) indices """
+        import pandas as pd
+
+        data  = []
+        nkpt  = self.get('nkpt')
+        nspin = self.get('nspin')
+        for ikpt in range(nkpt):
+            k_grp = self.fp[self.kpoint_path(ikpt)]
+            rkvec = k_grp['reduced_k'][()]
+            for ispin in range(nspin):
+                spin_loc = self.spin_path(ikpt, ispin)
+                sp_grp   = self.fp[spin_loc]
+                nstate   = sp_grp['number_of_states'][(0)]
+                evals    = sp_grp['eigenvalues'][()]
+                for istate in range(nstate):
+                    st_loc  = self.state_path(ikpt, ispin, istate)
+                    st_grp  = self.fp[st_loc]
+                    evector = st_grp['psi_g'][()] # shape (ngvec,2) (real,complex)
+                    entry   = {
+                        'ikpt':ikpt,
+                        'ispin':ispin,
+                        'istate':istate,
+                        'reduced_k':rkvec,
+                        'evalue':evals[istate],
+                        'evector':evector,
+                    }
+                    data.append(entry)
+                # end for istate
+            # end for ispin
+        # end for ikpt
+        df = pd.DataFrame(data).set_index(['ikpt', 'ispin', 'istate'], drop=True)
+        return df
+    # end def eigensystem
+
+    # =======================================================================
+    # Advance Write Methods, some specialized for pyscf
+    # =======================================================================
+    @staticmethod
+    def create_electrons_group(h5_handle, gvec, df, nelec):
+        """ create and fill the /electrons group in hdf5 handle
+        Inputs:
+            h5_handle: hdf5 handle generated by h5py.File
+            gvec: 2D numpy array of reciprocal space vectors (npw,ndim)
+            df: dataframe containing the eigensystem,
+                indexed by (kpt,spin,state), contains (evalue,evector,reduced_k)
+            nelec: a list of the number of electrons per atom (if no pseudopotential, then 'species_id' returned by system_from_cell should do)
+        Output:
+            None
+        Effect:
+            fill /electrons group in 'h5_handle'
+        """
+        flat_df = df.reset_index()
+        kpoints = flat_df['ikpt'].unique()
+        spins   = flat_df['ispin'].unique()
+        nkpt, nspin = len(kpoints), len(spins)
+        # transfer orbitals (electrons group)
+        for ikpt in range(nkpt):
+            # !!!! assume no symmetry was used to generate the kpoints
+            kpt_path = 'electrons/kpoint_%d' % ikpt
+            kgrp = h5_handle.create_group(kpt_path)
+            kgrp.create_dataset('num_sym', data=[1])
+            kgrp.create_dataset('symgroup', data=[1])
+            kgrp.create_dataset('weight', data=[1])
+
+            rkvec = df.loc[ikpt, 'reduced_k'].values[0]
+            kgrp.create_dataset('reduced_k', data=rkvec)
+            if ikpt == 0: # store gvectors in kpoint_0
+                kgrp.create_dataset('gvectors', data=gvec)
+                kgrp.create_dataset('number_of_gvectors', data=[len(gvec)])
+            # end if 
+
+            for ispin in range(nspin): # assume ispin==0
+                nstate = len(df.loc[(ikpt, ispin)])
+                spin_path = os.path.join(kpt_path, 'spin_%d' % ispin)
+                spgrp     = h5_handle.create_group(spin_path)
+                spgrp.create_dataset('number_of_states', data=[nstate])
+
+                evals = np.zeros(nstate) # fill eigenvalues during eigenvector read
+                for istate in range(nstate):
+                    state_path = os.path.join(spin_path, 'state_%d' % istate)
+                    psig = df.loc[(ikpt, ispin, istate), 'evector']
+                    psig_path = os.path.join(state_path, 'psi_g')
+                    h5_handle.create_dataset(psig_path, data=psig)
+                    evals[istate] = df.loc[(ikpt, ispin, istate), 'evalue']
+                # end for istate
+                spgrp.create_dataset('eigenvalues', data=evals)
+            # end for ispin
+        # end for ikpt
+        # transfer orbital info
+        h5_handle.create_dataset('electrons/number_of_electrons', data=nelec)
+        h5_handle.create_dataset('electrons/number_of_kpoints', data=[nkpt])
+        # !!!! hard-code restricted orbitals
+        h5_handle.create_dataset('electrons/number_of_spins', data=[1])
+    # end def create_electrons_group
+
+    @staticmethod
+    def system_from_cell(h5_handle, cell):
+        """ create and fill the /supercell and /atoms groups
+        Inputs:
+            h5_handle: hdf5 handle generated by h5py.File
+            cell: pyscf.pbc.gto.Cell class
+        Outputs:
+            species_id: a list of atomic numbers for each atom
+        Effect:
+            fill /supercell and /atoms group in 'h5_handle'
+        """
+
+        # write lattice
+        axes = cell.lattice_vectors() # always in bohr
+        h5_handle.create_dataset('supercell/primitive_vectors', data=axes)
+
+        # write atoms
+        pos  = cell.atom_coords() # always in bohr
+        elem = [cell.atom_symbol(i) for i in range(cell.natm)]
+        assert(len(pos) == len(elem))
+        h5_handle.create_dataset('atoms/number_of_atoms', data=[len(elem)])
+        h5_handle.create_dataset('atoms/positions', data=pos)
+
+        # write species info
+        species, indices = np.unique(elem, return_index=True)
+        h5_handle.create_dataset('atoms/number_of_species', data=[len(species)])
+        atomic_number = {}
+        number_of_electrons = {}
+        species_map = {}
+        nelecs = cell.nelec
+
+        for ispec, name in enumerate(species):
+            species_map[name] = ispec
+            atomic_number[name] = cell.atom_nelec_core(indices[ispec]) + cell.atom_charge(indices[ispec])
+            number_of_electrons[name] = cell.atom_charge(indices[ispec])
+            spec_grp = h5_handle.create_group('atoms/species_%d' % ispec)
+
+            # write name
+            if name not in species_map.keys():
+                raise NotImplementedError('unknown element %s' % name)
+            # end if
+            spec_grp.create_dataset('name', data=[np.bytes_(name)])
+
+            # write atomic number and valence
+            Zn   = atomic_number[name]
+            spec_grp.create_dataset('atomic_number', data=[Zn])
+            Zps = number_of_electrons[name]
+            spec_grp.create_dataset('valence_charge', data=[Zps])
+        # end for ispec
+        species_ids = [species_map[name] for name in elem]
+        h5_handle.create_dataset('atoms/species_ids', data=species_ids)
+
+        return nelecs
+    # end def system_from_cell
 # end class PwscfH5
 
 
@@ -538,405 +573,502 @@ class PwscfH5:
 # Class for xml generator
 # =======================================================================
 class InputXml:
-  def __init__(self):
-    pass
-  # end def
+    def __init__(self):
+        pass
+    # end def
 
   # =======================================================================
   # Basic Methods (applicable to all xml files)
   # =======================================================================
-  def read(self,fname):
-    self.fname = fname
-    parser = etree.XMLParser(remove_blank_text=True)
-    self.root = etree.parse(fname,parser)
-  # end def
+    def read(self, fname):
+        self.fname = fname
+        parser = etree.XMLParser(remove_blank_text=True)
+        self.root = etree.parse(fname, parser)
+    # end def
 
-  def write(self,fname=None,pretty_print=True):
-    if fname is None:
-      self.root.write(self.fname,pretty_print=pretty_print)
-    else:
-      self.root.write(fname,pretty_print=pretty_print)
-    # end if
-  # end def
+    def write(self, fname=None, pretty_print=True):
+        if fname is None:
+            self.root.write(self.fname, pretty_print=pretty_print)
+        else:
+            self.root.write(fname, pretty_print=pretty_print)
+        # end if
+    # end def
 
-  def show(self,node):
-    """ print text representation of an xml node """
-    print (etree.tostring(node,pretty_print=True))
+    def show(self, node):
+        """ print text representation of an xml node """
+        print(etree.tostring(node, pretty_print=True))
 
-  # pass along xpath expression e.g. './/particleset'
-  def find(self,xpath):
-    return self.root.find(xpath)
-  # end def
+    # pass along xpath expression e.g. './/particleset'
+    def find(self, xpath):
+        return self.root.find(xpath)
+    # end def
 
-  def find_all(self,xpath):
-    return self.root.findall(xpath)
-  # end def
-
-
-  @classmethod
-  def arr2text(self,arr):
-    """ format convert a numpy array into a text string """
-    text = ''
-    if len(arr.shape) == 1: # vector
-      text = " ".join(arr.astype(str))
-    elif len(arr.shape) == 2: # matrix
-      mat  = [self.arr2text(line) for line in arr]
-      text = "\n      " + "\n      ".join(mat) + "\n"
-    else:
-      raise RuntimeError('arr2text can only convert vector or matrix.')
-    # end if
-    return text
-  # end def
-
-  @classmethod
-  def text2arr(self,text,dtype=float,flatten=False):
-    tlist = text.strip(' ').strip('\n').split('\n')
-    if len(tlist) == 1:
-      return np.array(tlist,dtype=dtype)
-    else:
-      if flatten:
-        mytext = '\n'.join(['\n'.join(line.split()) for line in tlist])
-        myarr = self.text2arr(mytext)
-        return myarr.flatten()
-      else:
-        return np.array([line.split() for line in tlist],dtype=dtype)
-      # end if
-    # end if
-  # end def
-
-  @classmethod
-  def node2dict(self,node):
-    entry = dict(node.attrib)
-    if node.text:
-      entry.update({'text':node.text})
-    # end if
-    return entry
-  # end def node2dict
-
-  # =======================================================================
-  # Simple Methods Specific to QMCPACK
-  # =======================================================================
-  def find_pset(self,name='e'):
-    """ return xml node specifying the particle set with given name
-     by default return the quantum particle set 'e' """
-    return self.find('.//particleset[@name="%s"]'%name)
-  # end find_pset
-
-  # =======================================================================
-  # Advance Methods i.e. specific to pyscf or QMCPACK 3.0
-  # =======================================================================
-
-  # ----------------
-  # simulationcell
-  def simulationcell_from_cell(self,cell,bconds='p p p',lr_cut=15.0):
-    """ construct the <simulationcell> xml element from pyscf.pbc.gto.Cell class
-     Inputs:
-       cell: pyscf.pbc.gto.Cell class, should have lattice_vectors() and unit
-       bconds: boundary conditions in each of the x,y,z directions, p for periodic, n for non-periodic, default to 'p p p ' 
-       lr_cut: long-range cutoff parameter rc*kc, default to 15
-     Output: 
-       etree.Element representing <simulationcell>
-     Effect:
-       none
-    """
-
-    # write primitive lattice vectors
-    axes = cell.lattice_vectors() # rely on pyscf to return a.u.
-    lat_node = etree.Element('parameter'
-      ,attrib={'name':'lattice','units':'bohr'})
-    lat_node.text = self.arr2text(axes) + "      "
-
-    # write boundary conditions
-    bconds_node = etree.Element('parameter',{'name':'bconds'})
-    bconds_node.text = bconds
-
-    # write long-range cutoff parameter
-    lr_node = etree.Element('parameter',{'name':'LR_dim_cutoff'})
-    lr_node.text = str(lr_cut)
-
-    # build <simulationcell>
-    sc_node = etree.Element('simulationcell')
-    sc_node.append(lat_node)
-    sc_node.append(bconds_node)
-    sc_node.append(lr_node)
-    return sc_node
-  # end def simulationcell_from_cell
-  # ----------------
-
-  def particleset_from_hdf5(self,h5_handle):
-    atom_grp = h5_handle.get('atoms')
-    nspec = atom_grp.get('number_of_species')[(0)]
-    species_ids = atom_grp.get('species_ids')[()]
-    positions = atom_grp.get('positions')[()]
-
-    natom_total = atom_grp.get('number_of_atoms')[(0)]
-    # Get the name of the atoms
-    groups = []
-    for ispec in range(nspec):
-      # turn h5 group into dictionary (i.e. h5ls -d)
-      sp_grp         = atom_grp.get('species_%d'%ispec)
-      name           = sp_grp.get('name')[(0)]
-      valence_charge = sp_grp.get('valence_charge')[(0)]
-      atomic_number  = sp_grp.get('atomic_number')[(0)]
-
-      # locate particles of this species
-      atom_idx = np.where(species_ids==ispec)
-      pos_arr  = positions[atom_idx]
-      natom    = len(pos_arr)
-      # build xml node
-      charge_node = etree.Element('parameter',{'name':'charge'})
-      charge_node.text = str(valence_charge)
-      valence_node = etree.Element('parameter',{'name':'valence'})
-      valence_node.text = str(valence_charge)
-      atomic_number_node = etree.Element('parameter',{'name':'atomicnumber'})
-      atomic_number_node.text = str(atomic_number)
-
-      grp_children = [charge_node,valence_node,atomic_number_node]
-      grp_node = etree.Element('group',{'name':name})
-      for child in grp_children:
-        grp_node.append(child)
-      groups.append(grp_node)
+    def find_all(self, xpath):
+        return self.root.findall(xpath)
+    # end def
 
 
-    pos_node = etree.Element('attrib',{'name':'position','datatype':'posArray'})
-    pos_node.text = self.arr2text(positions) + "    "
-    groups.append(pos_node)
+    @classmethod
+    def arr2text(self, arr):
+        """ format convert a numpy array into a text string """
+        text = ''
+        if len(arr.shape) == 1: # vector
+            text = " ".join(arr.astype(str))
+        elif len(arr.shape) == 2: # matrix
+            mat  = [self.arr2text(line) for line in arr]
+            text = "\n      " + "\n      ".join(mat) + "\n"
+        else:
+            raise RuntimeError('arr2text can only convert vector or matrix.')
+        # end if
+        return text
+    # end def
 
-    ionid_node = etree.Element('attrib',{'name':'ionid','datatype':'stringArray'})
-    ionid_node.text = self.arr2text(np.array([atom_grp.get('species_{}/name'.format(id_))[(0)]  for id_ in species_ids]))
+    @classmethod
+    def text2arr(self, text, dtype=float, flatten=False):
+        tlist = text.strip(' ').strip('\n').split('\n')
+        if len(tlist) == 1:
+            return np.array(tlist, dtype=dtype)
+        else:
+            if flatten:
+                mytext = '\n'.join(['\n'.join(line.split()) for line in tlist])
+                myarr = self.text2arr(mytext)
+                return myarr.flatten()
+            else:
+                return np.array([line.split() for line in tlist], dtype=dtype)
+            # end if
+        # end if
+    # end def
 
-    groups.append(ionid_node)
+    @classmethod
+    def node2dict(self, node):
+        entry = dict(node.attrib)
+        if node.text:
+            entry.update({'text': node.text})
+        # end if
+        return entry
+    # end def node2dict
 
-    # build <particleset>
-    pset_node = etree.Element('particleset',{'name':'ion0','size':str(natom_total)})
-    for group in groups:
-      pset_node.append(group)
+    # =======================================================================
+    # Simple Methods Specific to QMCPACK
+    # =======================================================================
+    def find_pset(self, name='e'):
+        """ return xml node specifying the particle set with given name
+        by default return the quantum particle set 'e'
+        """
+        return self.find('.//particleset[@name="%s"]' % name)
+    # end find_pset
 
-    return pset_node
+    # =======================================================================
+    # Advance Methods i.e. specific to pyscf or QMCPACK 3.0
+    # =======================================================================
 
-  def particleset_initialposition_from_hdf5(self,h5_handle):
-    pset_node = etree.Element('particleset',{'name':'e','random':"yes", 'randomsrc':'ion0'})
+    # ----------------
+    # simulationcell
+    def simulationcell_from_cell(self, cell, bconds='p p p', lr_cut=15.0):
+        """ construct the <simulationcell> xml element from pyscf.pbc.gto.Cell class
+        Inputs:
+            cell: pyscf.pbc.gto.Cell class, should have lattice_vectors() and unit
+            bconds: boundary conditions in each of the x,y,z directions, p for periodic, n for non-periodic, default to 'p p p ' 
+            lr_cut: long-range cutoff parameter rc*kc, default to 15
+        Output:
+            etree.Element representing <simulationcell>
+        Effect:
+            none
+        """
 
-    # size = number of electron up and down
-    elec_alpha_beta = h5_handle.get('electrons/number_of_electrons')[()]
-    l_name = ("u","d")
-    for name, electron in zip(l_name,elec_alpha_beta):
-      groupe_node = etree.Element('group',{'name':"{}".format(name),'size':"{}".format(electron)})
-      param_node = etree.Element('parameter',{'name':'charge'})
-      param_node.text=str(-1)
-      groupe_node.append(param_node)
-      pset_node.append(groupe_node)
-    return pset_node
+        # write primitive lattice vectors
+        axes = cell.lattice_vectors() # rely on pyscf to return a.u.
+        lat_node = etree.Element(
+            'parameter',
+            attrib={
+                'name' : 'lattice',
+                'units': 'bohr',
+            }
+        )
+        lat_node.text = self.arr2text(axes) + "      "
 
-  def wavefunction(self,h5_handle,h5_path,tilematrix):
-    wf_node = etree.Element('wavefunction', {'name':"psi0", 'target':"e"})
+        # write boundary conditions
+        bconds_node = etree.Element('parameter', {'name': 'bconds'})
+        bconds_node.text = bconds
 
-    determinantset_node = etree.Element('determinantset', {"type":"einspline",
-                                                           "href":"{}".format(h5_path),
-                                                           "source":"ion0",
-                                                           "tilematrix":"{}".format(tilematrix),
-                                                           "twistnum":"0",
-                                                           "meshfactor":"1.0"})
-    basisset_node = etree.Element('basisset')
-    determinantset_node.append(basisset_node)
+        # write long-range cutoff parameter
+        lr_node = etree.Element('parameter', {'name': 'LR_dim_cutoff'})
+        lr_node.text = str(lr_cut)
 
-    atom_grp = h5_handle.get('electrons')
-    alpha, beta = atom_grp.get('number_of_electrons')[()]
+        # build <simulationcell>
+        sc_node = etree.Element('simulationcell')
+        sc_node.append(lat_node)
+        sc_node.append(bconds_node)
+        sc_node.append(lr_node)
+        return sc_node
+    # end def simulationcell_from_cell
+    # ----------------
 
-    # Slaterdet,imamt
-    slaterdet_node = etree.fromstring('''
-    <slaterdeterminant>
-        <determinant id="updet" size="{}" ref="updet">
-          <occupation mode="ground" spindataset="0">
-          </occupation>
-        </determinant>
-        <determinant id="downdet" size="{}" ref="downdet">
-          <occupation mode="ground" spindataset="0">
-          </occupation>
-        </determinant>
-      </slaterdeterminant>
-      '''.format(alpha, beta))
+    def particleset_from_hdf5(self, h5_handle):
+        atom_grp = h5_handle.get('atoms')
+        nspec = atom_grp.get('number_of_species')[(0)]
+        species_ids = atom_grp.get('species_ids')[()]
+        positions = atom_grp.get('positions')[()]
 
-    determinantset_node.append(slaterdet_node)
+        natom_total = atom_grp.get('number_of_atoms')[(0)]
+        # Get the name of the atoms
+        groups = []
+        for ispec in range(nspec):
+            # turn h5 group into dictionary (i.e. h5ls -d)
+            sp_grp         = atom_grp.get('species_%d' % ispec)
+            name           = sp_grp.get('name')[(0)]
+            valence_charge = sp_grp.get('valence_charge')[(0)]
+            atomic_number  = sp_grp.get('atomic_number')[(0)]
 
-    wf_node.append(determinantset_node)
-    # Jastrow
-    jastrow_node = etree.fromstring('''
-    <jastrow name="J2" type="Two-Body" function="Bspline" print="yes">
-      <correlation speciesA="u" speciesB="u" size="10">
-        <coefficients id="uu" type="Array"> 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0</coefficients>
-      </correlation>
-      <correlation speciesA="u" speciesB="d" size="10">
-        <coefficients id="ud" type="Array"> 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0</coefficients>
-      </correlation>
-    </jastrow>''')
-    wf_node.append(jastrow_node)
+            # locate particles of this species
+            atom_idx = np.where(species_ids == ispec)
+            pos_arr  = positions[atom_idx]
+            natom    = len(pos_arr)
+            # build xml node
+            charge_node = etree.Element('parameter', {'name': 'charge'})
+            charge_node.text = str(valence_charge)
 
-    # Species_id
-    atom_grp = h5_handle.get('atoms')
-    species_ids = atom_grp.get('species_ids')[()]
-    list_atom = sorted(set(atom_grp.get('species_{}/name'.format(id_))[(0)].decode()  for id_ in species_ids))
+            valence_node = etree.Element('parameter', {'name': 'valence'})
+            valence_node.text = str(valence_charge)
 
-    jastrow_node =   etree.Element('jastrow', {'name':"J1", 'type':"One-Body", "function":"Bspline", "print":"yes", "source":"ion0"})
+            atomic_number_node = etree.Element('parameter', {'name': 'atomicnumber'})
+            atomic_number_node.text = str(atomic_number)
 
-    for atom in list_atom:
-      jastrow_node.append(etree.fromstring('''
-      <correlation elementType="{}" cusp="0.0" size="10">
-        <coefficients id="{}" type="Array"> 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0</coefficients>
-      </correlation>'''.format(atom, atom)))
+            grp_children = [charge_node, valence_node, atomic_number_node]
+            grp_node = etree.Element('group', {'name': name})
+            for child in grp_children:
+                grp_node.append(child)
+            groups.append(grp_node)
 
-    wf_node.append(jastrow_node)
-    return wf_node
+        pos_node = etree.Element(
+            'attrib',
+            {
+                'name': 'position',
+                'datatype': 'posArray',
+            }
+        )
+        pos_node.text = self.arr2text(positions) + "    "
+        groups.append(pos_node)
 
-  def hamiltonian(self,h5_handle, cell):
+        ionid_node = etree.Element(
+            'attrib',
+            {
+                'name': 'ionid',
+                'datatype': 'stringArray',
+            }
+        )
+        ionid_node.text = self.arr2text(
+            np.array([atom_grp.get('species_{}/name'.format(id_))[(0)] for id_ in species_ids])
+        )
 
-    atom_grp = h5_handle.get('atoms')
-    species_ids = atom_grp.get('species_ids')[()]
-    list_atom = sorted(set(atom_grp.get('species_{}/name'.format(id_))[(0)].decode()  for id_ in species_ids))
+        groups.append(ionid_node)
 
-    if cell.has_ecp():
-      hamiltonian_node = etree.fromstring('''
-      <hamiltonian name="h0" type="generic" target="e">
-        <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
-        <pairpot name="IonIon" type="coulomb" source="ion0" target="ion0"/>
-        <pairpot name="PseudoPot" type="pseudo" source="ion0" wavefunction="psi0" format="xml">
-        </pairpot>
-  </hamiltonian>''')
-      # Add the list of ecp file for each atom.
-      for element in list_atom:
-        pset_node = etree.Element('pseudo',{'elementType':element,'href':"{}.qmcpp.xml".format(element)})
-        hamiltonian_node[-1].append(pset_node)
-    else:
-      hamiltonian_node = etree.fromstring('''
-      <hamiltonian name="h0" type="generic" target="e">
-        <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
-        <pairpot name="IonIon" type="coulomb" source="ion0" target="ion0"/>
-        <pairpot type="coulomb" name="ElecIon" source="ion0" target="e"/>
-      </hamiltonian>''')
+        # build <particleset>
+        pset_node = etree.Element(
+            'particleset',
+            {
+                'name': 'ion0',
+                'size': str(natom_total),
+            }
+        )
+        for group in groups:
+            pset_node.append(group)
 
-    return hamiltonian_node
+        return pset_node
 
-  def vmc_dmc(self, h5_handle):
+    def particleset_initialposition_from_hdf5(self, h5_handle):
+        pset_node = etree.Element(
+            'particleset',
+            {
+                'name': 'e',
+                'random': "yes",
+                'randomsrc': 'ion0',
+            }
+        )
 
-    vmc_init_comment = '''
-    Example initial VMC to measure initial energy and variance 
-    '''
-    vmc_init = '''
-    <qmc method="vmc" move="pbyp" checkpoint="-1">
-      <estimator name="LocalEnergy" hdf5="no"/>
-      <parameter name="warmupSteps">100</parameter>
-      <parameter name="blocks">20</parameter>
-      <parameter name="steps">50</parameter>
-      <parameter name="substeps">8</parameter>
-      <parameter name="timestep">0.5</parameter>
-      <parameter name="usedrift">no</parameter>
-  </qmc>
-    '''
-    loop_comment = '''
-    Example initial VMC optimization 
- 
-    Number of steps required will be computed from total requested sample 
-    count and total number of walkers 
-    '''
-    loop= '''
-    <loop max="4">
-      <qmc method="linear" move="pbyp" checkpoint="-1">
-        <estimator name="LocalEnergy" hdf5="no"/>
-        <parameter name="warmupSteps">100</parameter>
-        <parameter name="blocks">20</parameter>
-        <parameter name="timestep">0.5</parameter>
-        <parameter name="walkers">1</parameter>
-        <parameter name="samples">16000</parameter>
-        <parameter name="substeps">4</parameter>
-        <parameter name="usedrift">no</parameter>
-        <parameter name="MinMethod">OneShiftOnly</parameter>
-        <parameter name="minwalkers">0.003</parameter>
-      </qmc>
-  </loop>
-    '''
-    loop_followup_comment='''
-    Example follow-up VMC optimization using more samples for greater accuracy
-    '''
+        # size = number of electron up and down
+        elec_alpha_beta = h5_handle.get('electrons/number_of_electrons')[()]
+        l_name = ("u", "d")
+        for name, electron in zip(l_name,elec_alpha_beta):
+            groupe_node = etree.Element(
+                'group',
+                {
+                    'name': "{}".format(name),
+                    'size': "{}".format(electron),
+                }
+            )
+            param_node = etree.Element('parameter', {'name':'charge'})
+            param_node.text = str(-1)
+            groupe_node.append(param_node)
+            pset_node.append(groupe_node)
+        return pset_node
 
-    loop_followup = '''
-    <loop max="10">
-      <qmc method="linear" move="pbyp" checkpoint="-1">
-        <estimator name="LocalEnergy" hdf5="no"/>
-        <parameter name="warmupSteps">100</parameter>
-        <parameter name="blocks">20</parameter>
-        <parameter name="timestep">0.5</parameter>
-        <parameter name="walkers">1</parameter>
-        <parameter name="samples">64000</parameter>
-        <parameter name="substeps">4</parameter>
-        <parameter name="usedrift">no</parameter>
-        <parameter name="MinMethod">OneShiftOnly</parameter>
-        <parameter name="minwalkers">0.3</parameter>
-      </qmc>
-  </loop>
-    '''
-    # Generate production VMC and DMC
-    vmc_comment = '''Production VMC and DMC
-    Examine the results of the optimization before running these blocks.
-    e.g. Choose the best optimized jastrow from all obtained, put in 
-    wavefunction file, do not reoptimize.'''
+    def wavefunction(self, h5_handle, h5_path, tilematrix):
+        wf_node = etree.Element(
+            'wavefunction',
+            {
+                'name': "psi0",
+                'target': "e",
+            }
+        )
 
-    vmc = ''' 
-    <qmc method="vmc" move="pbyp" checkpoint="-1">
-      <estimator name="LocalEnergy" hdf5="no"/>
-      <parameter name="warmupSteps">100</parameter>
-      <parameter name="blocks">200</parameter>
-      <parameter name="steps">50</parameter>
-      <parameter name="substeps">8</parameter>
-      <parameter name="timestep">0.5</parameter>
-      <parameter name="usedrift">no</parameter>
-      <!--Sample count should match targetwalker count for DMC. Will be obtained from all nodes.-->
-      <parameter name="samples">16000</parameter>
-  </qmc>'''
+        determinantset_node = etree.Element(
+            'determinantset',
+            {
+                "type": "einspline",
+                "href": "{}".format(h5_path),
+                "source": "ion0",
+                "tilematrix": "{}".format(tilematrix),
+                "twistnum": "0",
+                "meshfactor": "1.0",
+            }
+        )
+        basisset_node = etree.Element('basisset')
+        determinantset_node.append(basisset_node)
 
-    dmc_comment = ""
-    dmc ='''
-    <qmc method="dmc" move="pbyp" checkpoint="20">
-      <estimator name="LocalEnergy" hdf5="no"/>
-      <parameter name="targetwalkers">16000</parameter>
-      <parameter name="reconfiguration">no</parameter>
-      <parameter name="warmupSteps">100</parameter>
-      <parameter name="timestep">0.005</parameter>
-      <parameter name="steps">100</parameter>
-      <parameter name="blocks">100</parameter>
-      <parameter name="nonlocalmoves">yes</parameter>
-  </qmc>
-    '''
-    a = []
+        atom_grp = h5_handle.get('electrons')
+        alpha, beta = atom_grp.get('number_of_electrons')[()]
 
-    l_xml = (vmc_init, loop, loop_followup, vmc, dmc)
-    l_xml_comment =  (vmc_init_comment, loop_comment, loop_followup_comment, vmc_comment, dmc_comment)
-    for comment, qmc in zip(l_xml_comment,l_xml):
-      a.append(etree.Comment(comment))
-      a.append(etree.fromstring(qmc))
-    return a
+        # Slaterdet,imamt
+        slaterdet_node = etree.fromstring('''
+        <slaterdeterminant>
+            <determinant id="updet" size="{}" ref="updet">
+              <occupation mode="ground" spindataset="0">
+              </occupation>
+            </determinant>
+            <determinant id="downdet" size="{}" ref="downdet">
+              <occupation mode="ground" spindataset="0">
+              </occupation>
+            </determinant>
+        </slaterdeterminant>
+        '''.format(alpha, beta)
+        )
 
-  # ----------------
-  # numerics
-  # grid
-  def radial_function(self,node):
-    assert node.tag=='radfunc'
+        determinantset_node.append(slaterdet_node)
 
-    # read grid definitions ( e.g. np.linspace(ri,rf,npts) for linear grid )
-    gnode = node.find('.//grid')      # expected attributes: 
-    grid_defs = self.node2dict(gnode) #   type,ri,rf,npts,units
-    ri = float(grid_defs['ri'])
-    rf = float(grid_defs['rf'])
-    npts = int(grid_defs['npts'])
-    gtype = grid_defs['type']
-    units = grid_defs['units']
+        wf_node.append(determinantset_node)
+        # Jastrow
+        jastrow_node = etree.fromstring('''
+            <jastrow name="J2" type="Two-Body" function="Bspline" print="yes">
+              <correlation speciesA="u" speciesB="u" size="10">
+                <coefficients id="uu" type="Array"> 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0</coefficients>
+              </correlation>
+              <correlation speciesA="u" speciesB="d" size="10">
+                <coefficients id="ud" type="Array"> 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0</coefficients>
+              </correlation>
+            </jastrow>'''
+        )
+        wf_node.append(jastrow_node)
 
-    # read 
-    dnode = node.find('.//data')
-    rval  = self.text2arr(dnode.text,flatten=True) # read as 1D vector
-    assert len(rval) == npts
-    entry = {'type':gtype,'units':units,'ri':ri,'rf':rf,'npts':npts,'rval':rval}
-    return entry
-  # end def radial_function
-  # ----------------
+        # Species_id
+        atom_grp = h5_handle.get('atoms')
+        species_ids = atom_grp.get('species_ids')[()]
+        list_atom = sorted(
+            set(
+                atom_grp.get('species_{}/name'.format(id_))[(0)].decode() for id_ in species_ids
+            )
+        )
 
+        jastrow_node = etree.Element(
+            'jastrow',
+            {
+                'name': "J1",
+                'type': "One-Body",
+                "function": "Bspline",
+                "print": "yes",
+                "source": "ion0",
+            }
+        )
+
+        for atom in list_atom:
+            jastrow_node.append(etree.fromstring('''
+                <correlation elementType="{}" cusp="0.0" size="10">
+                  <coefficients id="{}" type="Array"> 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0</coefficients>
+                </correlation>'''.format(atom, atom)
+            ))
+
+        wf_node.append(jastrow_node)
+        return wf_node
+
+    def hamiltonian(self, h5_handle, cell):
+
+        atom_grp = h5_handle.get('atoms')
+        species_ids = atom_grp.get('species_ids')[()]
+        list_atom = sorted(set(atom_grp.get('species_{}/name'.format(id_))[(0)].decode()  for id_ in species_ids))
+
+        if cell.has_ecp():
+            hamiltonian_node = etree.fromstring('''
+                <hamiltonian name="h0" type="generic" target="e">
+                    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+                    <pairpot name="IonIon" type="coulomb" source="ion0" target="ion0"/>
+                    <pairpot name="PseudoPot" type="pseudo" source="ion0" wavefunction="psi0" format="xml">
+                    </pairpot>
+                </hamiltonian>'''
+            )
+            # Add the list of ecp file for each atom.
+            for element in list_atom:
+                pset_node = etree.Element(
+                    'pseudo',
+                    {
+                        'elementType': element,
+                        'href': "{}.qmcpp.xml".format(element)
+                    }
+                )
+                hamiltonian_node[-1].append(pset_node)
+        else:
+            hamiltonian_node = etree.fromstring('''
+                <hamiltonian name="h0" type="generic" target="e">
+                  <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+                  <pairpot name="IonIon" type="coulomb" source="ion0" target="ion0"/>
+                  <pairpot type="coulomb" name="ElecIon" source="ion0" target="e"/>
+                </hamiltonian>'''
+            )
+
+        return hamiltonian_node
+
+    def vmc_dmc(self, h5_handle):
+
+        vmc_init_comment = '''
+        Example initial VMC to measure initial energy and variance 
+        '''
+
+        vmc_init = '''
+        <qmc method="vmc" move="pbyp" checkpoint="-1">
+          <estimator name="LocalEnergy" hdf5="no"/>
+          <parameter name="warmupSteps">100</parameter>
+          <parameter name="blocks">20</parameter>
+          <parameter name="steps">50</parameter>
+          <parameter name="substeps">8</parameter>
+          <parameter name="timestep">0.5</parameter>
+          <parameter name="usedrift">no</parameter>
+        </qmc>
+        '''
+
+        loop_comment = '''
+        Example initial VMC optimization 
+    
+        Number of steps required will be computed from total requested sample 
+        count and total number of walkers 
+        '''
+
+        loop= '''
+        <loop max="4">
+          <qmc method="linear" move="pbyp" checkpoint="-1">
+            <estimator name="LocalEnergy" hdf5="no"/>
+            <parameter name="warmupSteps">100</parameter>
+            <parameter name="blocks">20</parameter>
+            <parameter name="timestep">0.5</parameter>
+            <parameter name="walkers">1</parameter>
+            <parameter name="samples">16000</parameter>
+            <parameter name="substeps">4</parameter>
+            <parameter name="usedrift">no</parameter>
+            <parameter name="MinMethod">OneShiftOnly</parameter>
+            <parameter name="minwalkers">0.003</parameter>
+          </qmc>
+        </loop>
+        '''
+
+        loop_followup_comment='''
+        Example follow-up VMC optimization using more samples for greater accuracy
+        '''
+
+        loop_followup = '''
+        <loop max="10">
+          <qmc method="linear" move="pbyp" checkpoint="-1">
+            <estimator name="LocalEnergy" hdf5="no"/>
+            <parameter name="warmupSteps">100</parameter>
+            <parameter name="blocks">20</parameter>
+            <parameter name="timestep">0.5</parameter>
+            <parameter name="walkers">1</parameter>
+            <parameter name="samples">64000</parameter>
+            <parameter name="substeps">4</parameter>
+            <parameter name="usedrift">no</parameter>
+            <parameter name="MinMethod">OneShiftOnly</parameter>
+            <parameter name="minwalkers">0.3</parameter>
+          </qmc>
+        </loop>
+        '''
+        # Generate production VMC and DMC
+        vmc_comment = '''Production VMC and DMC
+        Examine the results of the optimization before running these blocks.
+        e.g. Choose the best optimized jastrow from all obtained, put in 
+        wavefunction file, do not reoptimize.'''
+
+        vmc = ''' 
+        <qmc method="vmc" move="pbyp" checkpoint="-1">
+          <estimator name="LocalEnergy" hdf5="no"/>
+          <parameter name="warmupSteps">100</parameter>
+          <parameter name="blocks">200</parameter>
+          <parameter name="steps">50</parameter>
+          <parameter name="substeps">8</parameter>
+          <parameter name="timestep">0.5</parameter>
+          <parameter name="usedrift">no</parameter>
+          <!--Sample count should match targetwalker count for DMC. Will be obtained from all nodes.-->
+          <parameter name="samples">16000</parameter>
+        </qmc>'''
+
+        dmc_comment = ""
+        dmc ='''
+        <qmc method="dmc" move="pbyp" checkpoint="20">
+          <estimator name="LocalEnergy" hdf5="no"/>
+          <parameter name="targetwalkers">16000</parameter>
+          <parameter name="reconfiguration">no</parameter>
+          <parameter name="warmupSteps">100</parameter>
+          <parameter name="timestep">0.005</parameter>
+          <parameter name="steps">100</parameter>
+          <parameter name="blocks">100</parameter>
+          <parameter name="nonlocalmoves">yes</parameter>
+        </qmc>
+        '''
+        a = []
+
+        l_xml = (
+            vmc_init,
+            loop,
+            loop_followup,
+            vmc,
+            dmc,
+        )
+        l_xml_comment = (
+            vmc_init_comment,
+            loop_comment,
+            loop_followup_comment,
+            vmc_comment,
+            dmc_comment,
+        )
+        for comment, qmc in zip(l_xml_comment, l_xml):
+            a.append(etree.Comment(comment))
+            a.append(etree.fromstring(qmc))
+        return a
+
+    # ----------------
+    # numerics
+    # grid
+    def radial_function(self, node):
+        assert node.tag == 'radfunc'
+
+        # read grid definitions ( e.g. np.linspace(ri,rf,npts) for linear grid )
+        gnode = node.find('.//grid')      # expected attributes: 
+        grid_defs = self.node2dict(gnode) #   type,ri,rf,npts,units
+        ri = float(grid_defs['ri'])
+        rf = float(grid_defs['rf'])
+        npts = int(grid_defs['npts'])
+        gtype = grid_defs['type']
+        units = grid_defs['units']
+
+        # read 
+        dnode = node.find('.//data')
+        rval  = self.text2arr(dnode.text, flatten=True) # read as 1D vector
+        assert len(rval) == npts
+        entry = {
+            'type': gtype,
+            'units': units,
+            'ri': ri,
+            'rf': rf,
+            'npts': npts,
+            'rval': rval,
+        }
+        return entry
+    # end def radial_function
+    # ----------------
 # end class


### PR DESCRIPTION
## Proposed changes

Format `PyscfToQmcpack.py` and `PyscfToQmcpack_Spline.py` to fit typical Python formatting. Almost all changes are whitespace only, but there is an occasional trailing comma added in some cases. 

Nothing functional has actually changed, just formatting.

## What type(s) of changes does this code introduce?

- Code style update (formatting, renaming)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Laptop
## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
