### PR TITLE
Copy nexus module files by nexus/install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ set(ENABLE_SANITIZER "" CACHE STRING "Valid input: ${VALID_SANITIZERS} or left e
 option(INSTALL_NEXUS "Install Nexus alongside QMCPACK" ON)
 if(INSTALL_NEXUS)
   install(
-    CODE "EXECUTE_PROCESS(COMMAND ${qmcpack_SOURCE_DIR}/nexus/install --leave_paths \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/bin)"
+    CODE "EXECUTE_PROCESS(COMMAND ${qmcpack_SOURCE_DIR}/nexus/install --leave_paths \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX})"
   )
 endif()
 

--- a/nexus/install
+++ b/nexus/install
@@ -111,12 +111,21 @@ if install_dir!=source_dir:
     if not os.path.exists(install_dir):
         os.makedirs(install_dir)
     #end if
+    install_bin_dir = os.path.join(install_dir,'bin')
+    if not os.path.exists(install_bin_dir):
+        os.makedirs(install_bin_dir)
+    #end if
+    install_nexus_dir = os.path.join(install_dir,'nexus')
+    if not os.path.exists(install_nexus_dir):
+        os.makedirs(install_nexus_dir)
+    #end if
 
     # copy binaries
-    execute('cp {0}/bin/* {1}'.format(source_dir,install_dir))
+    execute('cp {0}/bin/[^_]* {1}'.format(source_dir,install_bin_dir))
+    execute('cp {0}/nexus/*.py {1}'.format(source_dir,install_nexus_dir))
 
     # update path in nxs-test
-    nxs_test = os.path.join(install_dir,'nxs-test')
+    nxs_test = os.path.join(install_bin_dir,'nxs-test')
     f = open(nxs_test,'r')
     contents = f.read()
     f.close()
@@ -126,7 +135,8 @@ if install_dir!=source_dir:
     f.close()
 
     # update bin directory for install
-    bin_dir = install_dir
+    bin_dir = install_bin_dir
+    lib_dir = install_dir
 #end if
 
 # install library (add lib path to PYTHONPATH)


### PR DESCRIPTION
## Proposed changes
Closes https://github.com/QMCPACK/qmcpack/issues/5764
Instead of installing just `nexus/bin` files, nexus module files are also copied to the install destination for fully functional nexus scripts like `qmca` using exactly matched nexus module files.

There are issues remaining around nxs-test copied into the installation. `nexus/tests` files are not copied.
`nexus/install` also writes QMCPACK source directory into `nxs-test` script and make it depending on QMCPACK source.
That can be tackled separately.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
