### PR TITLE
Fix Python executable  in RUN_PYSCF_TEST

### DIFF
--- a/CMake/run_pyscf.cmake
+++ b/CMake/run_pyscf.cmake
@@ -17,7 +17,7 @@ function(RUN_PYSCF_TEST BASE_NAME SRC_DIR TEST_INPUT_PREFIX TEST_NAME)
   set(MY_WORKDIR ${CMAKE_CURRENT_BINARY_DIR}/${BASE_NAME})
   message(VERBOSE "Adding test ${BASE_NAME}")
   copy_directory("${SRC_DIR}" "${MY_WORKDIR}")
-  add_pyscf_test(${BASE_NAME} python ${MY_WORKDIR} ${TEST_INPUT_PREFIX}.py)
+  add_pyscf_test(${BASE_NAME} ${Python3_EXECUTABLE} ${MY_WORKDIR} ${TEST_INPUT_PREFIX}.py)
 endfunction()
 
 function(SOFTLINK_H5 SOURCE TARGET PREFIX FILENAME TEST_NAME)


### PR DESCRIPTION
## Proposed changes

Found a direct invocation of "python". Breaks test if not available or is the wrong python for pyscf.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

ubuntu24 dev container with pyscf added

## Checklist

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
