### PR TITLE
Remove another unused kDelay in QMCDriver

### DIFF
--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -393,7 +393,6 @@ void QMCDriver::setWalkerOffsets()
  *   -- 1 = do not write anything
  *   -- 0 = dump after the completion of a qmc section
  *   -- n = dump after n blocks
- * - kdelay = "0|1|n" default=0
  */
 bool QMCDriver::putQMCInfo(xmlNodePtr cur)
 {
@@ -412,7 +411,6 @@ bool QMCDriver::putQMCInfo(xmlNodePtr cur)
   int defaultw      = omp_get_max_threads();
   OhmmsAttributeSet aAttrib;
   aAttrib.add(Period4CheckPoint, "checkpoint");
-  aAttrib.add(kDelay, "kdelay");
   aAttrib.put(cur);
   if (cur != NULL)
   {

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -220,8 +220,6 @@ protected:
    * using MyCounter++ as in RQMC.
    */
   int MyCounter;
-  ///the number to delay updates by
-  int kDelay;
   /** period of dumping walker configurations and everything else for restart
    *
    * The unit is a block.

--- a/src/QMCDrivers/QMCDriverInput.cpp
+++ b/src/QMCDrivers/QMCDriverInput.cpp
@@ -30,7 +30,6 @@ namespace qmcplusplus
  *   -- 1 = do not write anything
  *   -- 0 = dump after the completion of a qmc section
  *   -- n = dump after n blocks
- * - kdelay = "0|1|n" default=0
  */
 void QMCDriverInput::readXML(xmlNodePtr cur)
 {


### PR DESCRIPTION
## Proposed changes
Another unused input.

## What type(s) of changes does this code introduce?
- Other (please describe): cleaning

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
