### PR TITLE
Remove the primary wavefunction in the wavefunction pool

### DIFF
--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -117,6 +117,27 @@ To continue a run, specify the ``mcwalkerset`` element before your VMC/DMC block
 In the project id section, make sure that the series number is different from any existing ones to avoid overwriting them.
 
 
+``qmc`` element may contain ``qmcsystem`` elements for selecting specific wavefunction and hamiltonian pairs by name.
+In most QMC methods, only one pair of wavefunction and hamiltonian is needed, ``qmcsystem`` is only necessary
+when more than one pair of ``wavefunction`` and ``hamiltonian`` elements where specified in the simultion system specificiation.
+CSVMC driver requires at least two entries of ``qmcsystem`` elements.
+
+  +-----------------+---------------+
+  | Parent elements | ``qmc``       |
+  +-----------------+---------------+
+  | Child elements  | ``qmcsystem`` |
+  +-----------------+---------------+
+
+attributes:
+
++-----------------------------+------------+--------+---------+----------------------------------------+
+| Name                        | Datatype   | Values | Default | Description                            |
++=============================+============+========+=========+========================================+
+| ``wavefunction``            | Text       |        |  ""     | name of the wavefunction to operate on |
++-----------------------------+------------+--------+---------+----------------------------------------+
+| ``hamiltonian``             | Text       |        |  ""     | name of the hamiltonian to operate on  |
++-----------------------------+------------+--------+---------+----------------------------------------+
+
 .. _batched_drivers:
 
 Use of crowds in the batched drivers

--- a/src/Estimators/tests/test_MomentumDistribution.cpp
+++ b/src/Estimators/tests/test_MomentumDistribution.cpp
@@ -156,7 +156,7 @@ TEST_CASE("MomentumDistribution::accumulate", "[estimators]")
   for (int iw = 0; iw < nwalkers; ++iw)
     psets.emplace_back(pset);
 
-  auto& trial_wavefunction = *(wavefunction_pool.getPrimary());
+  auto& trial_wavefunction = *(wavefunction_pool.getWaveFunction());
   std::vector<UPtr<TrialWaveFunction>> wfns(nwalkers);
   for (int iw = 0; iw < nwalkers; ++iw)
     wfns[iw] = trial_wavefunction.makeClone(psets[iw]);

--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -436,7 +436,7 @@ TEST_CASE("OneBodyDensityMatrices::accumulate", "[estimators]")
   std::vector<ParticleSet> psets =
       testing::generateRandomParticleSets(pset_target, pset_source, deterministic_rs, nwalkers, generate_test_data);
 
-  auto& trial_wavefunction = *(wavefunction_pool.getPrimary());
+  auto& trial_wavefunction = *(wavefunction_pool.getWaveFunction());
   std::vector<UPtr<TrialWaveFunction>> twfcs(nwalkers);
   for (int iw = 0; iw < nwalkers; ++iw)
     twfcs[iw] = trial_wavefunction.makeClone(psets[iw]);
@@ -494,7 +494,7 @@ TEST_CASE("OneBodyDensityMatrices::evaluateMatrix", "[estimators]")
     auto& pset_target = *(particle_pool.getParticleSet("e"));
     auto& species_set = pset_target.getSpeciesSet();
     OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, spomap, pset_target);
-    auto& trial_wavefunction = *(wavefunction_pool.getPrimary());
+    auto& trial_wavefunction = *(wavefunction_pool.getWaveFunction());
 
     // Because we can't control or consistent know the global random state we must initialize particle positions to known values.
     pset_target.R = ParticleSet::ParticlePos{

--- a/src/Estimators/tests/test_StructureFactorEstimator.cpp
+++ b/src/Estimators/tests/test_StructureFactorEstimator.cpp
@@ -135,7 +135,7 @@ TEST_CASE("StructureFactorEstimator::Accumulate", "[estimators]")
       MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
   auto& spomap = wavefunction_pool.getWaveFunction()->getSPOMap();
 
-  auto& trial_wavefunction = *(wavefunction_pool.getPrimary());
+  auto& trial_wavefunction = *(wavefunction_pool.getWaveFunction());
   std::vector<UPtr<TrialWaveFunction>> twfcs(nwalkers);
   for (int iw = 0; iw < nwalkers; ++iw)
     twfcs[iw] = trial_wavefunction.makeClone(psets[iw]);

--- a/src/QMCDrivers/tests/SetupDMCTest.h
+++ b/src/QMCDrivers/tests/SetupDMCTest.h
@@ -51,7 +51,7 @@ public:
             std::move(dmc_input_copy),
             walker_confs,
             MCPopulation(comm->size(), comm->rank(), particle_pool->getParticleSet("e"),
-                         wavefunction_pool->getPrimary(), hamiltonian_pool->getPrimary()),
+                         wavefunction_pool->getWaveFunction(), hamiltonian_pool->getPrimary()),
             rng_pool.getRngRefs(),
             comm};
   }

--- a/src/QMCDrivers/tests/test_Crowd.cpp
+++ b/src/QMCDrivers/tests/test_Crowd.cpp
@@ -46,7 +46,7 @@ public:
   {
     crowd_ptr =
         std::make_unique<Crowd>(em, driverwalker_resource_collection_, *pools.particle_pool->getParticleSet("e"),
-                                *pools.wavefunction_pool->getPrimary(), *pools.hamiltonian_pool->getPrimary());
+                                *pools.wavefunction_pool->getWaveFunction(), *pools.hamiltonian_pool->getPrimary());
     Crowd& crowd = *crowd_ptr;
     // To match the minimal particle set
     int num_particles = 2;
@@ -55,7 +55,7 @@ public:
       walkers.emplace_back(std::make_unique<MCPWalker>(num_particles));
       walkers.back()->R[0] = pos;
       psets.emplace_back(std::make_unique<ParticleSet>(*(pools.particle_pool->getParticleSet("e"))));
-      twfs.emplace_back(pools.wavefunction_pool->getPrimary()->makeClone(*psets.back()));
+      twfs.emplace_back(pools.wavefunction_pool->getWaveFunction()->makeClone(*psets.back()));
       hams.emplace_back(pools.hamiltonian_pool->getPrimary()->makeClone(*psets.back(), *twfs.back()));
       crowd.addWalker(*walkers.back(), *psets.back(), *twfs.back(), *hams.back());
     };
@@ -87,7 +87,7 @@ TEST_CASE("Crowd integration", "[drivers]")
   DriverWalkerResourceCollection driverwalker_resource_collection_;
 
   Crowd crowd(em, driverwalker_resource_collection_, *pools.particle_pool->getParticleSet("e"),
-              *pools.wavefunction_pool->getPrimary(), *pools.hamiltonian_pool->getPrimary());
+              *pools.wavefunction_pool->getWaveFunction(), *pools.hamiltonian_pool->getPrimary());
 }
 
 TEST_CASE("Crowd redistribute walkers")

--- a/src/QMCDrivers/tests/test_DMCBatched.cpp
+++ b/src/QMCDrivers/tests/test_DMCBatched.cpp
@@ -76,7 +76,7 @@ TEST_CASE("DMCDriver+QMCDriverNew integration", "[drivers]")
 
   DMCBatched dmcdriver(test_project, std::move(qmcdriver_input), nullptr, std::move(dmcdriver_input), walker_confs,
                        MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
-                                    wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
+                                    wavefunction_pool.getWaveFunction(), hamiltonian_pool.getPrimary()),
                        rng_pool.getRngRefs(), comm);
 
   // setStatus must be called before process

--- a/src/QMCDrivers/tests/test_MCPopulation.cpp
+++ b/src/QMCDrivers/tests/test_MCPopulation.cpp
@@ -159,7 +159,7 @@ TEST_CASE("MCPopulation::redistributeWalkers", "[particle][population]")
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(runtime_options, comm, particle_pool);
   auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   WalkerConfigurations walker_confs;
-  MCPopulation population(1, comm->rank(), particle_pool.getParticleSet("e"), wavefunction_pool.getPrimary(),
+  MCPopulation population(1, comm->rank(), particle_pool.getParticleSet("e"), wavefunction_pool.getWaveFunction(),
                           hamiltonian_pool.getPrimary());
 
   population.createWalkers(8, walker_confs);
@@ -193,7 +193,7 @@ TEST_CASE("MCPopulation::fissionHighMultiplicityWalkers", "[particle][population
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(runtime_options, comm, particle_pool);
   auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   WalkerConfigurations walker_confs;
-  MCPopulation population(1, comm->rank(), particle_pool.getParticleSet("e"), wavefunction_pool.getPrimary(),
+  MCPopulation population(1, comm->rank(), particle_pool.getParticleSet("e"), wavefunction_pool.getWaveFunction(),
                           hamiltonian_pool.getPrimary());
 
   population.createWalkers(8, walker_confs);

--- a/src/QMCDrivers/tests/test_QMCDriverNew.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverNew.cpp
@@ -49,7 +49,7 @@ TEST_CASE("QMCDriverNew tiny case", "[drivers]")
   RandomNumberGeneratorPool rng_pool(1);
   QMCDriverNewTestWrapper qmcdriver(test_project, std::move(qmcdriver_input), walker_confs,
                                     MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
-                                                 wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
+                                                 wavefunction_pool.getWaveFunction(), hamiltonian_pool.getPrimary()),
                                     rng_pool.getRngRefs(), comm);
 
   // setStatus must be called before process
@@ -93,7 +93,7 @@ TEST_CASE("QMCDriverNew walker counts", "[drivers]")
   RandomNumberGeneratorPool rng_pool(8);
   QMCDriverNewTestWrapper qmc_batched(test_project, std::move(qmcdriver_copy), walker_confs,
                                       MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
-                                                   wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
+                                                   wavefunction_pool.getWaveFunction(), hamiltonian_pool.getPrimary()),
                                       rng_pool.getRngRefs(), comm);
 
   qmc_batched.testAdjustGlobalWalkerCount();
@@ -123,7 +123,7 @@ TEST_CASE("QMCDriverNew test driver operations", "[drivers]")
   RandomNumberGeneratorPool rng_pool(1);
   QMCDriverNewTestWrapper qmcdriver(test_project, std::move(qmcdriver_input), walker_confs,
                                     MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
-                                                 wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
+                                                 wavefunction_pool.getWaveFunction(), hamiltonian_pool.getPrimary()),
                                     rng_pool.getRngRefs(), comm);
 
 

--- a/src/QMCDrivers/tests/test_SFNBranch.cpp
+++ b/src/QMCDrivers/tests/test_SFNBranch.cpp
@@ -84,7 +84,7 @@ TEST_CASE("SFNBranch::branch(MCPopulation...)", "[drivers]")
   SetupPools pools;
   SetupSFNBranch setup_sfnb(pools.comm);
   std::unique_ptr<SFNBranch> sfnb =
-      setup_sfnb(*pools.particle_pool->getParticleSet("e"), *pools.wavefunction_pool->getPrimary(),
+      setup_sfnb(*pools.particle_pool->getParticleSet("e"), *pools.wavefunction_pool->getWaveFunction(),
                  *pools.hamiltonian_pool->getPrimary());
 }
 

--- a/src/QMCDrivers/tests/test_WalkerControl.cpp
+++ b/src/QMCDrivers/tests/test_WalkerControl.cpp
@@ -36,7 +36,7 @@ UnifiedDriverWalkerControlMPITest::UnifiedDriverWalkerControlMPITest() : wc_(dpo
   int num_ranks = dpools_.comm->size();
   pop_ =
       std::make_unique<MCPopulation>(num_ranks, dpools_.comm->rank(), dpools_.particle_pool->getParticleSet("e"),
-                                     dpools_.wavefunction_pool->getPrimary(), dpools_.hamiltonian_pool->getPrimary());
+                                     dpools_.wavefunction_pool->getWaveFunction(), dpools_.hamiltonian_pool->getPrimary());
 
   pop_->createWalkers(1, walker_confs);
 }

--- a/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
@@ -70,7 +70,7 @@ TEST_CASE("integrateListeners", "[hamiltonian]")
   auto& pset_target      = *(particle_pool.getParticleSet("e"));
   //auto& species_set        = pset_target.getSpeciesSet();
   //auto& spo_map            = wavefunction_pool.getWaveFunction("wavefunction")->getSPOMap();
-  auto& trial_wavefunction = *(wavefunction_pool.getPrimary());
+  auto& trial_wavefunction = *(wavefunction_pool.getWaveFunction());
 
   UPtrVector<QMCHamiltonian> hams;
   UPtrVector<TrialWaveFunction> twfs;

--- a/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
@@ -52,7 +52,7 @@ TEST_CASE("HamiltonianPool", "[qmcapp]")
 
   RuntimeOptions runtime_options;
   WaveFunctionPool wfp(runtime_options, pp, c);
-  wfp.addFactory(WaveFunctionFactory::buildEmptyTWFForTesting(runtime_options, "psi0"), true);
+  wfp.add("psi0", WaveFunctionFactory::buildEmptyTWFForTesting(runtime_options, "psi0"));
 
   HamiltonianPool hpool(pp, wfp, c);
 

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -39,7 +39,9 @@ WaveFunctionFactory::WaveFunctionFactory(ParticleSet& qp, const PSetMap& pset, C
 
 WaveFunctionFactory::~WaveFunctionFactory() = default;
 
-std::unique_ptr<TrialWaveFunction> WaveFunctionFactory::buildTWF(xmlNodePtr cur, const RuntimeOptions& runtime_options)
+std::unique_ptr<TrialWaveFunction> WaveFunctionFactory::buildTWF(xmlNodePtr cur,
+                                                                 const RuntimeOptions& runtime_options,
+                                                                 const std::string psi_name)
 {
   // YL: how can this happen?
   if (cur == NULL)
@@ -47,20 +49,18 @@ std::unique_ptr<TrialWaveFunction> WaveFunctionFactory::buildTWF(xmlNodePtr cur,
 
   ReportEngine PRE(class_name_, "build");
 
-  std::string psiName("psi0"), tasking;
+  std::string tasking;
   OhmmsAttributeSet pAttrib;
-  pAttrib.add(psiName, "id");
-  pAttrib.add(psiName, "name");
   pAttrib.add(tasking, "tasking", {"no", "yes"});
   pAttrib.put(cur);
 
   app_summary() << std::endl;
   app_summary() << " Many-body wavefunction" << std::endl;
   app_summary() << " -------------------" << std::endl;
-  app_summary() << "  Name: " << psiName << "   Tasking: " << (tasking == "yes" ? "yes" : "no") << std::endl;
+  app_summary() << "  Name: " << psi_name << "   Tasking: " << (tasking == "yes" ? "yes" : "no") << std::endl;
   app_summary() << std::endl;
 
-  auto targetPsi = std::make_unique<TrialWaveFunction>(runtime_options, psiName, tasking == "yes");
+  auto targetPsi = std::make_unique<TrialWaveFunction>(runtime_options, psi_name, tasking == "yes");
   targetPsi->setMassTerm(targetPtcl);
   targetPsi->storeXMLNode(cur);
 

--- a/src/QMCWaveFunctions/WaveFunctionFactory.h
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.h
@@ -46,7 +46,9 @@ public:
   ~WaveFunctionFactory();
 
   ///read from xmlNode
-  std::unique_ptr<TrialWaveFunction> buildTWF(xmlNodePtr cur, const RuntimeOptions& runtime_options);
+  std::unique_ptr<TrialWaveFunction> buildTWF(xmlNodePtr cur,
+                                              const RuntimeOptions& runtime_options,
+                                              const std::string psi_name = "");
 
   /// create an empty TrialWaveFunction for testing use.
   std::unique_ptr<TrialWaveFunction> static buildEmptyTWFForTesting(const RuntimeOptions& runtime_options,

--- a/src/QMCWaveFunctions/WaveFunctionPool.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionPool.cpp
@@ -30,7 +30,6 @@ WaveFunctionPool::WaveFunctionPool(const RuntimeOptions& runtime_options, Partic
     : MPIObjectBase(c),
       ObjectPool("wavefunction"),
       runtime_options_(runtime_options),
-      primary_psi_(nullptr),
       ptcl_pool_(pset_pool)
 {}
 
@@ -52,19 +51,17 @@ bool WaveFunctionPool::put(xmlNodePtr cur)
 
   WaveFunctionFactory psiFactory(*qp, ptcl_pool_.getPool(), myComm);
   auto psi = psiFactory.buildTWF(cur, runtime_options_);
-  addFactory(std::move(psi), empty() || role == "primary");
+  addFactory(std::move(psi));
   return true;
 }
 
-void WaveFunctionPool::addFactory(std::unique_ptr<TrialWaveFunction> psi, bool primary)
+void WaveFunctionPool::addFactory(std::unique_ptr<TrialWaveFunction> psi)
 {
   if (contains(psi->getName()))
     throw UniformCommunicateError("wavefunction " + psi->getName() + " exists. Cannot be added to the pool.");
 
   app_log() << "  Adding " << psi->getName() << " TrialWaveFunction to the pool" << std::endl;
 
-  if (primary)
-    primary_psi_ = psi.get();
   add(psi->getName(), std::move(psi));
 }
 

--- a/src/QMCWaveFunctions/WaveFunctionPool.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionPool.cpp
@@ -27,21 +27,19 @@ namespace qmcplusplus
 template class ObjectPool<TrialWaveFunction>;
 
 WaveFunctionPool::WaveFunctionPool(const RuntimeOptions& runtime_options, ParticleSetPool& pset_pool, Communicate* c)
-    : MPIObjectBase(c),
-      ObjectPool("wavefunction"),
-      runtime_options_(runtime_options),
-      ptcl_pool_(pset_pool)
+    : MPIObjectBase(c), ObjectPool("wavefunction"), runtime_options_(runtime_options), ptcl_pool_(pset_pool)
 {}
 
 WaveFunctionPool::~WaveFunctionPool() = default;
 
 bool WaveFunctionPool::put(xmlNodePtr cur)
 {
-  std::string target("e"), role("extra");
+  std::string target("e"), psi_name("psi0");
   OhmmsAttributeSet pAttrib;
   pAttrib.add(target, "target");
   pAttrib.add(target, "ref");
-  pAttrib.add(role, "role");
+  pAttrib.add(psi_name, "id");
+  pAttrib.add(psi_name, "name");
   pAttrib.put(cur);
 
   ParticleSet* qp = ptcl_pool_.getParticleSet(target);
@@ -49,20 +47,15 @@ bool WaveFunctionPool::put(xmlNodePtr cur)
   if (qp == nullptr)
     myComm->barrier_and_abort("target particle set named '" + target + "' not found");
 
+  if (contains(psi_name))
+    throw UniformCommunicateError("\"" + psi_name + "\" exists in the wavefunction pool. Pleaes rename the wavefunction node.");
+
+
   WaveFunctionFactory psiFactory(*qp, ptcl_pool_.getPool(), myComm);
-  auto psi = psiFactory.buildTWF(cur, runtime_options_);
-  addFactory(std::move(psi));
-  return true;
-}
-
-void WaveFunctionPool::addFactory(std::unique_ptr<TrialWaveFunction> psi)
-{
-  if (contains(psi->getName()))
-    throw UniformCommunicateError("wavefunction " + psi->getName() + " exists. Cannot be added to the pool.");
-
-  app_log() << "  Adding " << psi->getName() << " TrialWaveFunction to the pool" << std::endl;
-
+  auto psi = psiFactory.buildTWF(cur, runtime_options_, psi_name);
   add(psi->getName(), std::move(psi));
+  app_log() << "  Added \"" << psi_name << "\" to the wavefunction pool" << std::endl;
+  return true;
 }
 
 TrialWaveFunction* WaveFunctionPool::getWaveFunction(const std::string& pname)
@@ -77,8 +70,5 @@ TrialWaveFunction* WaveFunctionPool::getWaveFunction(const std::string& pname)
   }
 }
 
-xmlNodePtr WaveFunctionPool::getWaveFunctionNode(const std::string& id)
-{
-  return getWaveFunction(id)->getNode();
-}
+xmlNodePtr WaveFunctionPool::getWaveFunctionNode(const std::string& id) { return getWaveFunction(id)->getNode(); }
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/WaveFunctionPool.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionPool.cpp
@@ -48,8 +48,8 @@ bool WaveFunctionPool::put(xmlNodePtr cur)
     myComm->barrier_and_abort("target particle set named '" + target + "' not found");
 
   if (contains(psi_name))
-    throw UniformCommunicateError("\"" + psi_name + "\" exists in the wavefunction pool. Pleaes rename the wavefunction node.");
-
+    throw UniformCommunicateError("\"" + psi_name +
+                                  "\" already exists in the wavefunction pool. Please rename this wavefunction node.");
 
   WaveFunctionFactory psiFactory(*qp, ptcl_pool_.getPool(), myComm);
   auto psi = psiFactory.buildTWF(cur, runtime_options_, psi_name);

--- a/src/QMCWaveFunctions/WaveFunctionPool.h
+++ b/src/QMCWaveFunctions/WaveFunctionPool.h
@@ -53,8 +53,6 @@ public:
 
   bool put(xmlNodePtr cur);
 
-  TrialWaveFunction* getPrimary() { return primary_psi_; }
-
   /** look up wavefunction by name
    * @param pname wavefunction name to look up
    * if pname is empty and the pool contains one entry, return the only entry
@@ -75,14 +73,11 @@ public:
 
   /** add a TrialWaveFunction* to myPool
    */
-  void addFactory(std::unique_ptr<TrialWaveFunction> psi, bool primary);
+  void addFactory(std::unique_ptr<TrialWaveFunction> psi);
 
 private:
   /// @brief top-level runtime options from project data information
   const RuntimeOptions& runtime_options_;
-
-  /// pointer to the primary TrialWaveFunction
-  TrialWaveFunction* primary_psi_;
 
   /** pointer to ParticleSetPool
    *

--- a/src/QMCWaveFunctions/WaveFunctionPool.h
+++ b/src/QMCWaveFunctions/WaveFunctionPool.h
@@ -71,10 +71,6 @@ public:
    */
   inline const PoolType& getPool() const { return myPool; }
 
-  /** add a TrialWaveFunction* to myPool
-   */
-  void addFactory(std::unique_ptr<TrialWaveFunction> psi);
-
 private:
   /// @brief top-level runtime options from project data information
   const RuntimeOptions& runtime_options_;

--- a/src/integration_testing/MockGoldWalkerElements.cpp
+++ b/src/integration_testing/MockGoldWalkerElements.cpp
@@ -24,7 +24,7 @@ MockGoldWalkerElements::MockGoldWalkerElements(Communicate* comm,
       pset_ions(*(particle_pool.getParticleSet("ion"))),
       wavefunction_pool(wavefunction_pool_fac_func(runtime_opt, comm, particle_pool)),
       hamiltonian_pool(ham_pool_fac_func(comm, particle_pool, wavefunction_pool)),
-      twf(*(wavefunction_pool.getPrimary())),
+      twf(*(wavefunction_pool.getWaveFunction())),
       ham(*(hamiltonian_pool.getPrimary()))
 {}
 


### PR DESCRIPTION
Review after #5799

## Proposed changes
The old definition of primary is quite lousy.
In the following case, the first entry `psi0` is implicit chosen as the primary
```
<wavefunction name="psi0"/>
<wavefunction name="psi1"/>
```
In the following case, "psi1" is considered primary.
```
<wavefunction name="psi0"/>
<wavefunction name="psi1" role="primary"/>
```
The information of primary is stored in the wavefunction pool with a raw pointer. Quite messy.

With this PR, wavefunction pool no longer designates the primary wavefunction.

Driver use `qmcsystem` node to pick up the needed objects.
```
<qmc="csvmc"> 
  <qmcsystem wavefunction="psi1" hamiltonian="h1">
</qmc>
```
Most regular drivers like VMC/DMC only need one pair wavefunction and hamiltonian.
```
<qmc="vmc"> 
  <qmcsystem wavefunction="psi1" />
</qmc>
```
In this example, the VMC driver uses explicitly "psi1" from the wavefunction pool. If there is no `<qmcsystem>` node or `wavefunction` has empty name. The default wavefuncition will be used.
default wavefuncition is defined if there is only object in the pool. Otherwise, user got error message requesting explicit names.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
