### PR TITLE
Use cache for docker build

### DIFF
--- a/.github/workflows/ghcr-develop.yaml
+++ b/.github/workflows/ghcr-develop.yaml
@@ -40,4 +40,5 @@ jobs:
           tags: | 
             ghcr.io/qmcpack/qmcpack_complete_develop:latest
           platforms: linux/amd64
-
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Proposed changes

Try using the cache for the "complete" container to accelerate the builds. Typical build time without cache = 50 min

https://docs.docker.com/build/cache/backends/gha/

## What type(s) of changes does this code introduce?

- New feature
- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None. We will need to watch the GHA status over the next few builds.

## Checklist


* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
