### PR TITLE
fix #5763: update utils/determinants_tools.py to avoid OverflowError in sanitize

### DIFF
--- a/utils/determinants_tools.py
+++ b/utils/determinants_tools.py
@@ -45,7 +45,7 @@ def sanitize(det_spin, bit_kind_size):
      >>> sanitize([np.int8(-1)], 8)
      [255]
      '''
-     return [ (s + (1 << bit_kind_size)) if s < 0 else int(s) for s in det_spin]
+     return [ (int(s) + (1 << bit_kind_size)) if s < 0 else int(s) for s in det_spin]
 
 def int_to_bitmask(s, bit_kind_size):
     '''


### PR DESCRIPTION
## Proposed changes

Fix sanitize() OverflowError when det_spin contains NumPy fixed-width integers (e.g. np.int8).
The previous implementation performed arithmetic on the NumPy dtype, which can overflow (e.g., np.int8(-1) + 256) and raises:
OverflowError: Python integer 256 out of bounds for int8
This PR casts to Python int before performing the two’s-complement adjustment so the arithmetic is done in Python integer space. Fixes [#5763](https://github.com/QMCPACK/qmcpack/issues/5763).

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Python doctest: python -m doctest -v utils/determinants_tools.py (18 passed, 0 failed)

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [x] clang-format not applicable (Python-only change)
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
