### PR TITLE
Disable GitHub actions CI on push events

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -1,10 +1,6 @@
 name: GitHub Actions CI
 
 on:
-  push:
-    branches:
-      - develop
-      - main
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
## Proposed changes

Avoid redundant CI activity. Because we enforce branches are up to date ahead of merge, we only need to check PRs. The GH actions history shows that unneeded CI is being done after merge.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None. Need to monitor in CI. e.g. Ensure CI runs for updated PRs.

## Checklist

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
