### PR TITLE
Add batch restart test using optimizer and vp file

### DIFF
--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -132,10 +132,10 @@ if(NOT QMC_MIXED_PRECISION)
     check.sh
     false)
   
-  add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s002.config.h5 TRUE)
-  add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s002.random.h5 TRUE)
-  add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s003.config.h5 FALSE)
-  add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s003.random.h5 FALSE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s000.config.h5 TRUE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s000.random.h5 TRUE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s001.config.h5 FALSE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s001.random.h5 FALSE)
   
   run_restart_and_check(
     deterministic-restart_batch_opt
@@ -146,10 +146,10 @@ if(NOT QMC_MIXED_PRECISION)
     check.sh
     true)
   
-  add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s002.config.h5 TRUE)
-  add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s002.random.h5 TRUE)
-  add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s003.config.h5 FALSE)
-  add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s003.random.h5 FALSE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s000.config.h5 TRUE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s000.random.h5 TRUE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s001.config.h5 FALSE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s001.random.h5 FALSE)
 endif()
 
 run_restart_and_check(

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -89,6 +89,7 @@ run_restart_and_check(
   2
   check.sh
   false)
+
 run_restart_and_check(
   deterministic-restart
   "${qmcpack_SOURCE_DIR}/tests/io/restart"
@@ -120,6 +121,34 @@ run_restart_and_check(
   4
   check.sh
   true)
+
+run_restart_and_check(
+  deterministic-restart_batch_opt
+  "${qmcpack_SOURCE_DIR}/tests/io/restart_batch_opt"
+  qmc_short_batch
+  2
+  2
+  check.sh
+  false)
+
+add_test_check_file_existence(deterministic-restart_batch_opt-2-2 qmc_short_batch.s003.config.h5 TRUE)
+add_test_check_file_existence(deterministic-restart_batch_opt-2-2 qmc_short_batch.s003.random.h5 TRUE)
+add_test_check_file_existence(deterministic-restart_batch_opt-2-2 qmc_short_batch.s004.config.h5 FALSE)
+add_test_check_file_existence(deterministic-restart_batch_opt-2-2 qmc_short_batch.s004.random.h5 FALSE)
+
+run_restart_and_check(
+  deterministic-restart_batch_opt
+  "${qmcpack_SOURCE_DIR}/tests/io/restart_batch_opt"
+  qmc_short_batch
+  1
+  4
+  check.sh
+  true)
+
+add_test_check_file_existence(deterministic-restart_batch_opt-1-4 qmc_short_batch.s003.config.h5 TRUE)
+add_test_check_file_existence(deterministic-restart_batch_opt-1-4 qmc_short_batch.s003.random.h5 TRUE)
+add_test_check_file_existence(deterministic-restart_batch_opt-1-4 qmc_short_batch.s004.config.h5 FALSE)
+add_test_check_file_existence(deterministic-restart_batch_opt-1-4 qmc_short_batch.s004.random.h5 FALSE)
 
 run_restart_and_check(
   deterministic-restart_dmc
@@ -165,6 +194,7 @@ run_restart_and_check(
   2
   check.sh
   false)
+
 run_restart_and_check(
   deterministic-save_spline_coefs
   "${qmcpack_SOURCE_DIR}/tests/io/save_spline_coefs"

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -108,10 +108,10 @@ run_restart_and_check(
   check.sh
   false)
 
-add_test_check_file_existence(deterministic-restart_batch-2-2 qmc_short_batch.s000.config.h5 TRUE)
-add_test_check_file_existence(deterministic-restart_batch-2-2 qmc_short_batch.s000.random.h5 TRUE)
-add_test_check_file_existence(deterministic-restart_batch-2-2 qmc_short_batch.s001.config.h5 FALSE)
-add_test_check_file_existence(deterministic-restart_batch-2-2 qmc_short_batch.s001.random.h5 FALSE)
+add_test_check_file_existence(deterministic-restart_batch-r2-t2 qmc_short_batch.s000.config.h5 TRUE)
+add_test_check_file_existence(deterministic-restart_batch-r2-t2 qmc_short_batch.s000.random.h5 TRUE)
+add_test_check_file_existence(deterministic-restart_batch-r2-t2 qmc_short_batch.s001.config.h5 FALSE)
+add_test_check_file_existence(deterministic-restart_batch-r2-t2 qmc_short_batch.s001.random.h5 FALSE)
 
 run_restart_and_check(
   deterministic-restart_batch
@@ -131,10 +131,10 @@ run_restart_and_check(
   check.sh
   false)
 
-add_test_check_file_existence(deterministic-restart_batch_opt-2-2 qmc_short_batch.s003.config.h5 TRUE)
-add_test_check_file_existence(deterministic-restart_batch_opt-2-2 qmc_short_batch.s003.random.h5 TRUE)
-add_test_check_file_existence(deterministic-restart_batch_opt-2-2 qmc_short_batch.s004.config.h5 FALSE)
-add_test_check_file_existence(deterministic-restart_batch_opt-2-2 qmc_short_batch.s004.random.h5 FALSE)
+add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s002.config.h5 TRUE)
+add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s002.random.h5 TRUE)
+add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s003.config.h5 FALSE)
+add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s003.random.h5 FALSE)
 
 run_restart_and_check(
   deterministic-restart_batch_opt
@@ -145,10 +145,10 @@ run_restart_and_check(
   check.sh
   true)
 
-add_test_check_file_existence(deterministic-restart_batch_opt-1-4 qmc_short_batch.s003.config.h5 TRUE)
-add_test_check_file_existence(deterministic-restart_batch_opt-1-4 qmc_short_batch.s003.random.h5 TRUE)
-add_test_check_file_existence(deterministic-restart_batch_opt-1-4 qmc_short_batch.s004.config.h5 FALSE)
-add_test_check_file_existence(deterministic-restart_batch_opt-1-4 qmc_short_batch.s004.random.h5 FALSE)
+add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s002.config.h5 TRUE)
+add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s002.random.h5 TRUE)
+add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s003.config.h5 FALSE)
+add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s003.random.h5 FALSE)
 
 run_restart_and_check(
   deterministic-restart_dmc

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -122,33 +122,35 @@ run_restart_and_check(
   check.sh
   true)
 
-run_restart_and_check(
-  deterministic-restart_batch_opt
-  "${qmcpack_SOURCE_DIR}/tests/io/restart_batch_opt"
-  qmc_short_batch
-  2
-  2
-  check.sh
-  false)
-
-add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s002.config.h5 TRUE)
-add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s002.random.h5 TRUE)
-add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s003.config.h5 FALSE)
-add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s003.random.h5 FALSE)
-
-run_restart_and_check(
-  deterministic-restart_batch_opt
-  "${qmcpack_SOURCE_DIR}/tests/io/restart_batch_opt"
-  qmc_short_batch
-  1
-  4
-  check.sh
-  true)
-
-add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s002.config.h5 TRUE)
-add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s002.random.h5 TRUE)
-add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s003.config.h5 FALSE)
-add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s003.random.h5 FALSE)
+if(NOT QMC_MIXED_PRECISION)  
+  run_restart_and_check(
+    deterministic-restart_batch_opt
+    "${qmcpack_SOURCE_DIR}/tests/io/restart_batch_opt"
+    qmc_short_batch
+    2
+    2
+    check.sh
+    false)
+  
+  add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s002.config.h5 TRUE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s002.random.h5 TRUE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s003.config.h5 FALSE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r2-t2 qmc_short_batch.s003.random.h5 FALSE)
+  
+  run_restart_and_check(
+    deterministic-restart_batch_opt
+    "${qmcpack_SOURCE_DIR}/tests/io/restart_batch_opt"
+    qmc_short_batch
+    1
+    4
+    check.sh
+    true)
+  
+  add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s002.config.h5 TRUE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s002.random.h5 TRUE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s003.config.h5 FALSE)
+  add_test_check_file_existence(deterministic-restart_batch_opt-r1-t4 qmc_short_batch.s003.random.h5 FALSE)
+endif()
 
 run_restart_and_check(
   deterministic-restart_dmc

--- a/tests/io/restart_batch_opt/C.BFD.xml
+++ b/tests/io/restart_batch_opt/C.BFD.xml
@@ -1,0 +1,1 @@
+../../solids/diamondC_1x1x1_pp/C.BFD.xml

--- a/tests/io/restart_batch_opt/check.sh
+++ b/tests/io/restart_batch_opt/check.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
 echo "========================================================================================"
-echo "First run : qmc_short_batch.s003.scalar.dat"
-cat qmc_short_batch.s003.scalar.dat
+echo "First run : qmc_short_batch.s001.scalar.dat"
+cat qmc_short_batch.s001.scalar.dat
 
 echo "========================================================================================"
-echo "Restart run : qmc_short_batch.s004.scalar.dat"
-cat qmc_short_batch.s004.scalar.dat
+echo "Restart run : qmc_short_batch.s002.scalar.dat"
+cat qmc_short_batch.s002.scalar.dat
 
 echo "========================================================================================"
 echo "comparing the Kinetic ElecElec IonIon LocalECP up to the 7th digit after the decimal"
 
-sed "/#/d" qmc_short_batch.s003.scalar.dat | awk '{printf("%.7e %.7e %.7e %.7e\n",$5,$6,$7,$8)}' > s001
-sed "/#/d" qmc_short_batch.s004.scalar.dat | awk '{printf("%.7e %.7e %.7e %.7e\n",$5,$6,$7,$8)}' > s002
+sed "/#/d" qmc_short_batch.s001.scalar.dat | awk '{printf("%.7e %.7e %.7e %.7e\n",$5,$6,$7,$8)}' > s001
+sed "/#/d" qmc_short_batch.s002.scalar.dat | awk '{printf("%.7e %.7e %.7e %.7e\n",$5,$6,$7,$8)}' > s002
 diff s001 s002

--- a/tests/io/restart_batch_opt/check.sh
+++ b/tests/io/restart_batch_opt/check.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo "========================================================================================"
+echo "First run : qmc_short_batch.s003.scalar.dat"
+cat qmc_short_batch.s003.scalar.dat
+
+echo "========================================================================================"
+echo "Restart run : qmc_short_batch.s004.scalar.dat"
+cat qmc_short_batch.s004.scalar.dat
+
+echo "========================================================================================"
+echo "comparing the Kinetic ElecElec IonIon LocalECP up to the 7th digit after the decimal"
+
+sed "/#/d" qmc_short_batch.s003.scalar.dat | awk '{printf("%.7e %.7e %.7e %.7e\n",$5,$6,$7,$8)}' > s001
+sed "/#/d" qmc_short_batch.s004.scalar.dat | awk '{printf("%.7e %.7e %.7e %.7e\n",$5,$6,$7,$8)}' > s002
+diff s001 s002

--- a/tests/io/restart_batch_opt/pwscf.pwscf.h5
+++ b/tests/io/restart_batch_opt/pwscf.pwscf.h5
@@ -1,0 +1,1 @@
+../../solids/diamondC_1x1x1_pp/pwscf.pwscf.h5

--- a/tests/io/restart_batch_opt/qmc_short_batch.in.xml
+++ b/tests/io/restart_batch_opt/qmc_short_batch.in.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="qmc_short_batch" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+   </project>
+   <random seed="49154"/>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <sposet_collection type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+            <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
+         </sposet_collection>
+         <determinantset>
+            <slaterdeterminant>
+               <determinant id="updet" group="u" sposet="spo_ud" size="4"/>
+               <determinant id="downdet" group="d" sposet="spo_ud" size="4"/>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <estimator type="flux" name="Flux"/>
+      </hamiltonian>
+   </qmcsystem>
+  <loop max="3">
+    <qmc method="linear_batch" move="pbyp" checkpoint="0">
+      <parameter name="total_walkers"       >    16              </parameter>   
+      <parameter name="blocks">     8  </parameter>
+      <parameter name="warmupsteps"> 64 </parameter>
+      <parameter name="samples"> 128  </parameter>
+      <cost name="energy">                   0.0 </cost>
+      <cost name="unreweightedvariance">     1.0 </cost>
+      <cost name="reweightedvariance">       0.0 </cost>
+      <parameter name="useDrift">  yes </parameter>
+      <parameter name="bigchange">10.0</parameter>
+      <estimator name="LocalEnergy" hdf5="no"/>
+      <parameter name="MinMethod">quartic</parameter>
+      <parameter name="exp0">-6</parameter>
+      <parameter name="alloweddifference"> 1.0e-5 </parameter>
+      <parameter name="stepsize">  0.15 </parameter>
+      <parameter name="nstabilizers"> 1 </parameter>
+      <parameter name="variational_subset"> eC ud </parameter>
+      <parameter name="output_vp_override">yes</parameter>
+    </qmc>
+  </loop>
+   <qmc method="vmc_batch" move="pbyp" checkpoint="-1">
+      <parameter name="total_walkers"       >    16              </parameter>
+      <parameter name="blocks"              >    1               </parameter>
+      <parameter name="steps"               >    1               </parameter>
+      <parameter name="subSteps"            >    1               </parameter>
+      <parameter name="timestep"            >    0.0             </parameter>
+      <parameter name="warmupSteps"         >    0               </parameter>
+   </qmc>
+</simulation>

--- a/tests/io/restart_batch_opt/qmc_short_batch.in.xml
+++ b/tests/io/restart_batch_opt/qmc_short_batch.in.xml
@@ -80,7 +80,7 @@
          <estimator type="flux" name="Flux"/>
       </hamiltonian>
    </qmcsystem>
-  <loop max="3">
+  <loop max="1">
     <qmc method="linear_batch" move="pbyp" checkpoint="0">
       <parameter name="total_walkers"       >    16              </parameter>   
       <parameter name="blocks">     8  </parameter>

--- a/tests/io/restart_batch_opt/qmc_short_batch.restart.xml
+++ b/tests/io/restart_batch_opt/qmc_short_batch.restart.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <simulation>
-   <project id="qmc_short_batch" series="4">
+   <project id="qmc_short_batch" series="2">
       <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
    </project>
    <random seed="49154"/>

--- a/tests/io/restart_batch_opt/qmc_short_batch.restart.xml
+++ b/tests/io/restart_batch_opt/qmc_short_batch.restart.xml
@@ -70,7 +70,7 @@
                </coefficients>
             </correlation>
          </jastrow>
-      <override_variational_parameters href="qmc_short_batch.s002.vp.h5"/>
+      <override_variational_parameters href="qmc_short_batch.s000.vp.h5"/>
       </wavefunction>
       <hamiltonian name="h0" type="generic" target="e">
          <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>

--- a/tests/io/restart_batch_opt/qmc_short_batch.restart.xml
+++ b/tests/io/restart_batch_opt/qmc_short_batch.restart.xml
@@ -82,7 +82,7 @@
       </hamiltonian>
    </qmcsystem>
 
-   <mcwalkerset fileroot="qmc_short_batch.s002" node="-1" nprocs="1" version="0 4" collected="yes"/>
+   <mcwalkerset fileroot="qmc_short_batch.s000" node="-1" nprocs="1" version="0 4" collected="yes"/>
    
    <qmc method="vmc_batch" move="pbyp" checkpoint="-1">
       <parameter name="total_walkers">    16            </parameter>

--- a/tests/io/restart_batch_opt/qmc_short_batch.restart.xml
+++ b/tests/io/restart_batch_opt/qmc_short_batch.restart.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="qmc_short_batch" series="4">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+   </project>
+   <random seed="49154"/>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff">    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge">    -1                    </parameter>
+            <parameter name="mass">    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge">    -1                    </parameter>
+            <parameter name="mass">    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge">    4                     </parameter>
+            <parameter name="valence">    4                     </parameter>
+            <parameter name="atomicnumber">    6                     </parameter>
+            <parameter name="mass">    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <sposet_collection type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+            <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
+         </sposet_collection>
+         <determinantset>
+            <slaterdeterminant>
+               <determinant id="updet" group="u" sposet="spo_ud" size="4"/>
+               <determinant id="downdet" group="d" sposet="spo_ud" size="4"/>
+            </slaterdeterminant>
+         </determinantset>      
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      <override_variational_parameters href="qmc_short_batch.s002.vp.h5"/>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <estimator type="flux" name="Flux"/>
+      </hamiltonian>
+   </qmcsystem>
+
+   <mcwalkerset fileroot="qmc_short_batch.s002" node="-1" nprocs="1" version="0 4" collected="yes"/>
+   
+   <qmc method="vmc_batch" move="pbyp" checkpoint="-1">
+      <parameter name="total_walkers">    16            </parameter>
+      <parameter name="blocks">           1             </parameter>
+      <parameter name="steps">            1             </parameter>
+      <parameter name="subSteps">         1             </parameter>
+      <parameter name="timestep">         0.0           </parameter>
+      <parameter name="warmupSteps">      0             </parameter>
+   </qmc>
+</simulation>


### PR DESCRIPTION
## Proposed changes

Add a restart test explicitly using the vp opt file from an optimization with a subset of parameters optimized.
We were not previously testing the reload of a named opt file in restart. i.e. Using variational_subset and override_variational_parameters. As with the existing restart tests, the check is for consistency with a non-restarted run.

Also fix the naming of the file existence checks. Missed when we adopted the -rN-tT format.

Extra observation:

I initially used oneshiftonly, but with the limited statistics it readily generated a NaN.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

dev container ubu24 gcc mpi

## Checklist

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
