### PR TITLE
Refine WaveFunctionPool

### DIFF
--- a/src/Estimators/tests/test_EstimatorManagerCrowd.cpp
+++ b/src/Estimators/tests/test_EstimatorManagerCrowd.cpp
@@ -43,8 +43,8 @@ TEST_CASE("EstimatorManagerCrowd::EstimatorManagerCrowd", "[estimators]")
       MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
   auto& pset            = *(particle_pool.getParticleSet("e"));
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
-  auto& twf             = *(wavefunction_pool.getWaveFunction());
-  auto& ham             = *(hamiltonian_pool.getPrimary());
+  TrialWaveFunction& twf(wavefunction_pool.getWaveFunction().value());
+  auto& ham = *(hamiltonian_pool.getPrimary());
 
   EstimatorManagerNew emn(ham, comm);
   emn.constructEstimators(std::move(emi), pset, twf, ham, particle_pool.getPool());
@@ -72,7 +72,7 @@ TEST_CASE("EstimatorManagerCrowd PerParticleHamiltonianLogger integration", "[es
   // This is where the pset properties "properies" gain the different hamiltonian operator values.
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
 
-  auto& twf = *(wavefunction_pool.getWaveFunction());
+  TrialWaveFunction& twf(wavefunction_pool.getWaveFunction().value());
   auto& ham = *(hamiltonian_pool.getPrimary());
 
   ham.informOperatorsOfListener();

--- a/src/Estimators/tests/test_EstimatorManagerNew.cpp
+++ b/src/Estimators/tests/test_EstimatorManagerNew.cpp
@@ -62,8 +62,8 @@ TEST_CASE("EstimatorManagerNew::EstimatorManagerNew(EstimatorManagerInput,...)",
       MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
   auto& pset            = *(particle_pool.getParticleSet("e"));
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
-  auto& twf             = *(wavefunction_pool.getWaveFunction());
-  auto& ham             = *(hamiltonian_pool.getPrimary());
+  TrialWaveFunction& twf(wavefunction_pool.getWaveFunction().value());
+  auto& ham = *(hamiltonian_pool.getPrimary());
   EstimatorManagerNew emn(ham, comm);
   emn.constructEstimators(std::move(emi), pset, twf, ham, particle_pool.getPool());
 
@@ -109,8 +109,8 @@ TEST_CASE("EstimatorManagerNew_estimator_naming", "[estimators]")
       MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
   auto& pset            = *(particle_pool.getParticleSet("e"));
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
-  auto& twf             = *(wavefunction_pool.getWaveFunction());
-  auto& ham             = *(hamiltonian_pool.getPrimary());
+  TrialWaveFunction& twf(wavefunction_pool.getWaveFunction().value());
+  auto& ham = *(hamiltonian_pool.getPrimary());
   EstimatorManagerNew emn(ham, comm);
   emn.constructEstimators(std::move(emi), pset, twf, ham, particle_pool.getPool());
   EstimatorManagerNewTestAccess emnta(emn);

--- a/src/Estimators/tests/test_MomentumDistribution.cpp
+++ b/src/Estimators/tests/test_MomentumDistribution.cpp
@@ -156,10 +156,10 @@ TEST_CASE("MomentumDistribution::accumulate", "[estimators]")
   for (int iw = 0; iw < nwalkers; ++iw)
     psets.emplace_back(pset);
 
-  auto& trial_wavefunction = *(wavefunction_pool.getWaveFunction());
+  TrialWaveFunction& psi(wavefunction_pool.getWaveFunction().value());
   std::vector<UPtr<TrialWaveFunction>> wfns(nwalkers);
   for (int iw = 0; iw < nwalkers; ++iw)
-    wfns[iw] = trial_wavefunction.makeClone(psets[iw]);
+    wfns[iw] = psi.makeClone(psets[iw]);
 
   //     Initialize walker, pset, wfn
   for (int iw = 0; iw < nwalkers; ++iw)

--- a/src/Estimators/tests/test_StructureFactorEstimator.cpp
+++ b/src/Estimators/tests/test_StructureFactorEstimator.cpp
@@ -133,12 +133,11 @@ TEST_CASE("StructureFactorEstimator::Accumulate", "[estimators]")
 
   auto wavefunction_pool =
       MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
-  auto& spomap = wavefunction_pool.getWaveFunction()->getSPOMap();
 
-  auto& trial_wavefunction = *(wavefunction_pool.getWaveFunction());
+  TrialWaveFunction& psi(wavefunction_pool.getWaveFunction().value());
   std::vector<UPtr<TrialWaveFunction>> twfcs(nwalkers);
   for (int iw = 0; iw < nwalkers; ++iw)
-    twfcs[iw] = trial_wavefunction.makeClone(psets[iw]);
+    twfcs[iw] = psi.makeClone(psets[iw]);
 
   auto ref_wfns = convertUPtrToRefVector(twfcs);
 

--- a/src/QMCDrivers/tests/SetupDMCTest.h
+++ b/src/QMCDrivers/tests/SetupDMCTest.h
@@ -51,7 +51,7 @@ public:
             std::move(dmc_input_copy),
             walker_confs,
             MCPopulation(comm->size(), comm->rank(), particle_pool->getParticleSet("e"),
-                         wavefunction_pool->getWaveFunction(), hamiltonian_pool->getPrimary()),
+                         &wavefunction_pool->getWaveFunction().value().get(), hamiltonian_pool->getPrimary()),
             rng_pool.getRngRefs(),
             comm};
   }

--- a/src/QMCDrivers/tests/test_Crowd.cpp
+++ b/src/QMCDrivers/tests/test_Crowd.cpp
@@ -55,7 +55,7 @@ public:
       walkers.emplace_back(std::make_unique<MCPWalker>(num_particles));
       walkers.back()->R[0] = pos;
       psets.emplace_back(std::make_unique<ParticleSet>(*(pools.particle_pool->getParticleSet("e"))));
-      twfs.emplace_back(pools.wavefunction_pool->getWaveFunction()->makeClone(*psets.back()));
+      twfs.emplace_back(pools.wavefunction_pool->getWaveFunction().value().get().makeClone(*psets.back()));
       hams.emplace_back(pools.hamiltonian_pool->getPrimary()->makeClone(*psets.back(), *twfs.back()));
       crowd.addWalker(*walkers.back(), *psets.back(), *twfs.back(), *hams.back());
     };

--- a/src/QMCDrivers/tests/test_DMCBatched.cpp
+++ b/src/QMCDrivers/tests/test_DMCBatched.cpp
@@ -76,7 +76,7 @@ TEST_CASE("DMCDriver+QMCDriverNew integration", "[drivers]")
 
   DMCBatched dmcdriver(test_project, std::move(qmcdriver_input), nullptr, std::move(dmcdriver_input), walker_confs,
                        MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
-                                    wavefunction_pool.getWaveFunction(), hamiltonian_pool.getPrimary()),
+                                    &wavefunction_pool.getWaveFunction().value().get(), hamiltonian_pool.getPrimary()),
                        rng_pool.getRngRefs(), comm);
 
   // setStatus must be called before process

--- a/src/QMCDrivers/tests/test_MCPopulation.cpp
+++ b/src/QMCDrivers/tests/test_MCPopulation.cpp
@@ -52,7 +52,7 @@ TEST_CASE("MCPopulation::createWalkers", "[particle][population]")
   // keep 3 only configurations.
   WalkerConfigurations walker_confs2;
   walker_confs2.resize(3, 0);
-  for(int iw = 0; iw < walker_confs2.getActiveWalkers(); ++iw)
+  for (int iw = 0; iw < walker_confs2.getActiveWalkers(); ++iw)
     *walker_confs2[iw] = *walker_confs[iw];
   CHECK(walker_confs2.getActiveWalkers() == 3);
   auto old_R00 = walker_confs[0]->R[0][0];
@@ -97,7 +97,7 @@ TEST_CASE("MCPopulation::createWalkers_walker_ids", "[particle][population]")
     pops.emplace_back(num_ranks, i, particle_pool.getParticleSet("e"), &twf, hamiltonian_pool.getPrimary());
 
   std::vector<long> walker_ids;
-  std::array<std::vector<long>,3> per_rank_walker_ids;
+  std::array<std::vector<long>, 3> per_rank_walker_ids;
   for (int i = 0; i < num_ranks; ++i)
   {
     pops[i].createWalkers(8, walker_confs, 2.0);
@@ -113,8 +113,9 @@ TEST_CASE("MCPopulation::createWalkers_walker_ids", "[particle][population]")
   }
   std::sort(walker_ids.begin(), walker_ids.end());
   // Walker IDs cannot collide unless they are -1
-  for (int i = 1; i < walker_ids.size(); ++i) {
-    INFO(" i = " << i );
+  for (int i = 1; i < walker_ids.size(); ++i)
+  {
+    INFO(" i = " << i);
     CHECK(walker_ids[i - 1] != walker_ids[i]);
   }
   int new_walkers = 3;
@@ -142,7 +143,8 @@ TEST_CASE("MCPopulation::createWalkers_walker_ids", "[particle][population]")
   for (int rank = 0; rank < num_ranks; ++rank)
   {
     std::vector<long> rank_expected_ids(11);
-    std::generate(rank_expected_ids.begin(), rank_expected_ids.end(),  [n = 0, rank, num_ranks] () mutable { return (n++) * num_ranks + rank + 1;});
+    std::generate(rank_expected_ids.begin(), rank_expected_ids.end(),
+                  [n = 0, rank, num_ranks]() mutable { return (n++) * num_ranks + rank + 1; });
     CHECK(per_rank_walker_ids[rank] == rank_expected_ids);
     std::cout << NativePrint(rank_expected_ids) << '\n';
   }
@@ -159,8 +161,8 @@ TEST_CASE("MCPopulation::redistributeWalkers", "[particle][population]")
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(runtime_options, comm, particle_pool);
   auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   WalkerConfigurations walker_confs;
-  MCPopulation population(1, comm->rank(), particle_pool.getParticleSet("e"), wavefunction_pool.getWaveFunction(),
-                          hamiltonian_pool.getPrimary());
+  MCPopulation population(1, comm->rank(), particle_pool.getParticleSet("e"),
+                          &wavefunction_pool.getWaveFunction().value().get(), hamiltonian_pool.getPrimary());
 
   population.createWalkers(8, walker_confs);
   REQUIRE(population.get_walkers().size() == 8);
@@ -193,22 +195,22 @@ TEST_CASE("MCPopulation::fissionHighMultiplicityWalkers", "[particle][population
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(runtime_options, comm, particle_pool);
   auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   WalkerConfigurations walker_confs;
-  MCPopulation population(1, comm->rank(), particle_pool.getParticleSet("e"), wavefunction_pool.getWaveFunction(),
-                          hamiltonian_pool.getPrimary());
+  MCPopulation population(1, comm->rank(), particle_pool.getParticleSet("e"),
+                          &wavefunction_pool.getWaveFunction().value().get(), hamiltonian_pool.getPrimary());
 
   population.createWalkers(8, walker_confs);
   auto& walkers = population.get_walkers();
   CHECK(walkers.size() == 8);
-  walkers[0]->Multiplicity=4;
+  walkers[0]->Multiplicity = 4;
   population.fissionHighMultiplicityWalkers();
   CHECK(walkers.size() == 11);
 
-  walkers[2]->Multiplicity=3;
-  walkers[9]->Multiplicity=4;
+  walkers[2]->Multiplicity = 3;
+  walkers[9]->Multiplicity = 4;
   population.fissionHighMultiplicityWalkers();
   CHECK(walkers.size() == 16);
 
-  for(auto& walker : walkers)
+  for (auto& walker : walkers)
     CHECK(walker->Multiplicity == 1.0);
 }
 

--- a/src/QMCDrivers/tests/test_QMCDriverNew.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverNew.cpp
@@ -49,7 +49,8 @@ TEST_CASE("QMCDriverNew tiny case", "[drivers]")
   RandomNumberGeneratorPool rng_pool(1);
   QMCDriverNewTestWrapper qmcdriver(test_project, std::move(qmcdriver_input), walker_confs,
                                     MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
-                                                 wavefunction_pool.getWaveFunction(), hamiltonian_pool.getPrimary()),
+                                                 &wavefunction_pool.getWaveFunction().value().get(),
+                                                 hamiltonian_pool.getPrimary()),
                                     rng_pool.getRngRefs(), comm);
 
   // setStatus must be called before process
@@ -93,7 +94,8 @@ TEST_CASE("QMCDriverNew walker counts", "[drivers]")
   RandomNumberGeneratorPool rng_pool(8);
   QMCDriverNewTestWrapper qmc_batched(test_project, std::move(qmcdriver_copy), walker_confs,
                                       MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
-                                                   wavefunction_pool.getWaveFunction(), hamiltonian_pool.getPrimary()),
+                                                   &wavefunction_pool.getWaveFunction().value().get(),
+                                                   hamiltonian_pool.getPrimary()),
                                       rng_pool.getRngRefs(), comm);
 
   qmc_batched.testAdjustGlobalWalkerCount();
@@ -123,7 +125,8 @@ TEST_CASE("QMCDriverNew test driver operations", "[drivers]")
   RandomNumberGeneratorPool rng_pool(1);
   QMCDriverNewTestWrapper qmcdriver(test_project, std::move(qmcdriver_input), walker_confs,
                                     MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
-                                                 wavefunction_pool.getWaveFunction(), hamiltonian_pool.getPrimary()),
+                                                 &wavefunction_pool.getWaveFunction().value().get(),
+                                                 hamiltonian_pool.getPrimary()),
                                     rng_pool.getRngRefs(), comm);
 
 

--- a/src/QMCDrivers/tests/test_WalkerControl.cpp
+++ b/src/QMCDrivers/tests/test_WalkerControl.cpp
@@ -34,9 +34,9 @@ namespace testing
 UnifiedDriverWalkerControlMPITest::UnifiedDriverWalkerControlMPITest() : wc_(dpools_.comm, Random)
 {
   int num_ranks = dpools_.comm->size();
-  pop_ =
-      std::make_unique<MCPopulation>(num_ranks, dpools_.comm->rank(), dpools_.particle_pool->getParticleSet("e"),
-                                     dpools_.wavefunction_pool->getWaveFunction(), dpools_.hamiltonian_pool->getPrimary());
+  pop_ = std::make_unique<MCPopulation>(num_ranks, dpools_.comm->rank(), dpools_.particle_pool->getParticleSet("e"),
+                                        &dpools_.wavefunction_pool->getWaveFunction().value().get(),
+                                        dpools_.hamiltonian_pool->getPrimary());
 
   pop_->createWalkers(1, walker_confs);
 }

--- a/src/QMCDrivers/tests/test_WalkerLogCollector.cpp
+++ b/src/QMCDrivers/tests/test_WalkerLogCollector.cpp
@@ -42,7 +42,7 @@ TEST_CASE("WalkerLogCollector::collect", "[estimators]")
   // This is where the pset properties "properies" gain the different hamiltonian operator values.
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
 
-  auto& twf = *(wavefunction_pool.getWaveFunction());
+  TrialWaveFunction& twf(wavefunction_pool.getWaveFunction().value());
   auto& ham = *(hamiltonian_pool.getPrimary());
 
   // setup data structures for multiple walkers

--- a/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
@@ -70,7 +70,7 @@ TEST_CASE("integrateListeners", "[hamiltonian]")
   auto& pset_target      = *(particle_pool.getParticleSet("e"));
   //auto& species_set        = pset_target.getSpeciesSet();
   //auto& spo_map            = wavefunction_pool.getWaveFunction("wavefunction")->getSPOMap();
-  auto& trial_wavefunction = *(wavefunction_pool.getWaveFunction());
+  TrialWaveFunction& psi(wavefunction_pool.getWaveFunction().value());
 
   UPtrVector<QMCHamiltonian> hams;
   UPtrVector<TrialWaveFunction> twfs;
@@ -88,7 +88,7 @@ TEST_CASE("integrateListeners", "[hamiltonian]")
   {
     psets.emplace_back(pset_target);
     psets.back().randomizeFromSource(*particle_pool.getParticleSet("ion"));
-    twfs.emplace_back(trial_wavefunction.makeClone(psets.back()));
+    twfs.emplace_back(psi.makeClone(psets.back()));
     hams.emplace_back(hamiltonian_pool.getPrimary()->makeClone(psets.back(), *twfs.back()));
   }
 
@@ -272,8 +272,9 @@ TEST_CASE("integrateListeners", "[hamiltonian]")
 
     // Here we test consistency between the per particle energies and the per hamiltonian energies
     typename decltype(energies)::value_type hamiltonian_local_nrg_sum = 0.0;
-    typename decltype(energies)::value_type energies_sum = 0.0;
-    for (int iw = 0; iw < num_walkers; ++iw) {
+    typename decltype(energies)::value_type energies_sum              = 0.0;
+    for (int iw = 0; iw < num_walkers; ++iw)
+    {
       hamiltonian_local_nrg_sum += ham_list[iw].getLocalEnergy();
       energies_sum += energies[iw];
     }

--- a/src/QMCWaveFunctions/WaveFunctionPool.h
+++ b/src/QMCWaveFunctions/WaveFunctionPool.h
@@ -58,7 +58,7 @@ public:
    * if pname is empty and the pool contains one entry, return the only entry
    * if pname is not empty and not found in the pool, throw error
    */
-  TrialWaveFunction* getWaveFunction(const std::string& pname = "");
+  OptionalRef<TrialWaveFunction> getWaveFunction(const std::string& pname = "");
 
   /** return a xmlNode containing Jastrow
    * @param id name of the wave function

--- a/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
@@ -32,19 +32,19 @@ TEST_CASE("CompositeSPO::diamond_1x1x1", "[wavefunction")
   auto particle_pool = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool =
       MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
-  auto& pset = *particle_pool.getParticleSet("e");
-  auto& twf  = *wavefunction_pool.getWaveFunction();
+  TrialWaveFunction& psi(wavefunction_pool.getWaveFunction().value());
 
   CompositeSPOSet<SPOSet::ValueType> comp_sposet("one_composite_set");
 
   std::vector<std::string> sposets{"spo_ud", "spo_dm"};
   for (auto sposet_str : sposets)
   {
-    auto& sposet = twf.getSPOSet(sposet_str);
+    auto& sposet = psi.getSPOSet(sposet_str);
     comp_sposet.add(sposet.makeClone());
   }
   CHECK(comp_sposet.size() == 8);
 
+  auto& pset = *particle_pool.getParticleSet("e");
   SPOSet::ValueMatrix psiM(pset.R.size(), comp_sposet.getOrbitalSetSize());
   SPOSet::GradMatrix dpsiM(pset.R.size(), comp_sposet.getOrbitalSetSize());
   SPOSet::ValueMatrix d2psiM(pset.R.size(), comp_sposet.getOrbitalSetSize());

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
@@ -245,21 +245,20 @@ TEST_CASE("Rotated LCAO WF0 zero angle", "[qmcapp]")
 
   wp.put(root);
 
-  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
-  REQUIRE(psi != nullptr);
-  REQUIRE(psi->getOrbitals().size() == 1);
+  TrialWaveFunction& psi(wp.getWaveFunction().value());
+  REQUIRE(psi.getOrbitals().size() == 1);
 
   OptVariables opt_vars;
-  psi->checkInVariables(opt_vars);
+  psi.checkInVariables(opt_vars);
   opt_vars.resetIndex();
-  psi->checkOutVariables(opt_vars);
-  psi->resetParameters(opt_vars);
+  psi.checkOutVariables(opt_vars);
+  psi.resetParameters(opt_vars);
 
   ParticleSet* elec = pp.getParticleSet("e");
   elec->update();
 
 
-  double logval = psi->evaluateLog(*elec);
+  double logval = psi.evaluateLog(*elec);
   CHECK(logval == Approx(-11.467952668216984));
 
   CHECK(elec->G[0][0] == ValueApprox(-0.5345224838248487));
@@ -269,14 +268,14 @@ TEST_CASE("Rotated LCAO WF0 zero angle", "[qmcapp]")
   using ValueType = QMCTraits::ValueType;
   Vector<ValueType> dlogpsi(2);
   Vector<ValueType> dhpsioverpsi(2);
-  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+  psi.evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
 
   CHECK(dlogpsi[0] == ValueApprox(32.2062050179872));
   CHECK(dlogpsi[1] == ValueApprox(5.87482925187464));
   CHECK(dhpsioverpsi[0] == ValueApprox(46.0088643114103));
   CHECK(dhpsioverpsi[1] == ValueApprox(7.84119772047731));
 
-  RefVectorWithLeader<TrialWaveFunction> wf_list(*psi, {*psi});
+  RefVectorWithLeader<TrialWaveFunction> wf_list(psi, {psi});
   RefVectorWithLeader<ParticleSet> p_list(*elec, {*elec});
 
   // Test list with one wavefunction
@@ -319,20 +318,19 @@ TEST_CASE("Rotated LCAO WF1", "[qmcapp]")
 
   wp.put(root);
 
-  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
-  REQUIRE(psi != nullptr);
-  REQUIRE(psi->getOrbitals().size() == 1);
+  TrialWaveFunction& psi(wp.getWaveFunction().value());
+  REQUIRE(psi.getOrbitals().size() == 1);
 
   OptVariables opt_vars;
-  psi->checkInVariables(opt_vars);
-  psi->checkOutVariables(opt_vars);
-  psi->resetParameters(opt_vars);
+  psi.checkInVariables(opt_vars);
+  psi.checkOutVariables(opt_vars);
+  psi.resetParameters(opt_vars);
 
   ParticleSet* elec = pp.getParticleSet("e");
   elec->update();
 
 
-  double logval = psi->evaluateLog(*elec);
+  double logval = psi.evaluateLog(*elec);
   CHECK(logval == Approx(-9.26625670653773));
 
   CHECK(elec->G[0][0] == ValueApprox(-0.2758747113720909));
@@ -342,7 +340,7 @@ TEST_CASE("Rotated LCAO WF1", "[qmcapp]")
   using ValueType = QMCTraits::ValueType;
   Vector<ValueType> dlogpsi(2);
   Vector<ValueType> dhpsioverpsi(2);
-  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+  psi.evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
 
 
   CHECK(dlogpsi[0] == ValueApprox(7.58753078998516));
@@ -418,21 +416,20 @@ TEST_CASE("Rotated LCAO WF2 with jastrow", "[qmcapp]")
 
   wp.put(root);
 
-  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
-  REQUIRE(psi != nullptr);
-  REQUIRE(psi->getOrbitals().size() == 2);
+  TrialWaveFunction& psi(wp.getWaveFunction().value());
+  REQUIRE(psi.getOrbitals().size() == 2);
 
   OptVariables opt_vars;
-  psi->checkInVariables(opt_vars);
+  psi.checkInVariables(opt_vars);
   opt_vars.resetIndex();
-  psi->checkOutVariables(opt_vars);
-  psi->resetParameters(opt_vars);
+  psi.checkOutVariables(opt_vars);
+  psi.resetParameters(opt_vars);
 
   ParticleSet* elec = pp.getParticleSet("e");
   elec->update();
 
 
-  double logval = psi->evaluateLog(*elec);
+  double logval = psi.evaluateLog(*elec);
   CHECK(logval == Approx(-15.791249652199634));
 
   CHECK(elec->G[0][0] == ValueApprox(-0.2956989647881321));
@@ -442,7 +439,7 @@ TEST_CASE("Rotated LCAO WF2 with jastrow", "[qmcapp]")
   using ValueType = QMCTraits::ValueType;
   Vector<ValueType> dlogpsi(3);
   Vector<ValueType> dhpsioverpsi(3);
-  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+  psi.evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
 
   CHECK(dlogpsi[0] == ValueApprox(32.206205017987166));
   CHECK(dlogpsi[1] == ValueApprox(5.874829251874641));
@@ -454,8 +451,8 @@ TEST_CASE("Rotated LCAO WF2 with jastrow", "[qmcapp]")
   // Check for out-of-bounds array access when a variable is disabled.
   // When a variable is disabled, myVars.where() returns -1.
   opt_vars.insert("rot-spo-up_orb_rot_0000_0001", 0.0, false);
-  psi->checkOutVariables(opt_vars);
-  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+  psi.checkOutVariables(opt_vars);
+  psi.evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
 }
 
 // Test the case where the rotation has already been applied to
@@ -495,20 +492,19 @@ TEST_CASE("Rotated LCAO WF1, MO coeff rotated, zero angle", "[qmcapp]")
 
   wp.put(root);
 
-  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
-  REQUIRE(psi != nullptr);
-  REQUIRE(psi->getOrbitals().size() == 1);
+  TrialWaveFunction& psi(wp.getWaveFunction().value());
+  REQUIRE(psi.getOrbitals().size() == 1);
 
   OptVariables opt_vars;
-  psi->checkInVariables(opt_vars);
+  psi.checkInVariables(opt_vars);
   opt_vars.resetIndex();
-  psi->checkOutVariables(opt_vars);
-  psi->resetParameters(opt_vars);
+  psi.checkOutVariables(opt_vars);
+  psi.resetParameters(opt_vars);
 
   ParticleSet* elec = pp.getParticleSet("e");
   elec->update();
 
-  double logval = psi->evaluateLog(*elec);
+  double logval = psi.evaluateLog(*elec);
   CHECK(logval == Approx(-9.26625670653773));
 
   CHECK(elec->G[0][0] == ValueApprox(-0.2758747113720909));
@@ -518,7 +514,7 @@ TEST_CASE("Rotated LCAO WF1, MO coeff rotated, zero angle", "[qmcapp]")
   using ValueType = QMCTraits::ValueType;
   Vector<ValueType> dlogpsi(2);
   Vector<ValueType> dhpsioverpsi(2);
-  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+  psi.evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
 
 
   CHECK(dlogpsi[0] == ValueApprox(7.58753078998516));
@@ -559,20 +555,19 @@ TEST_CASE("Rotated LCAO WF1 MO coeff rotated, half angle", "[qmcapp]")
 
   wp.put(root);
 
-  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
-  REQUIRE(psi != nullptr);
-  REQUIRE(psi->getOrbitals().size() == 1);
+  TrialWaveFunction& psi(wp.getWaveFunction().value());
+  REQUIRE(psi.getOrbitals().size() == 1);
 
   OptVariables opt_vars;
-  psi->checkInVariables(opt_vars);
+  psi.checkInVariables(opt_vars);
   opt_vars.resetIndex();
-  psi->checkOutVariables(opt_vars);
-  psi->resetParameters(opt_vars);
+  psi.checkOutVariables(opt_vars);
+  psi.resetParameters(opt_vars);
 
   ParticleSet* elec = pp.getParticleSet("e");
   elec->update();
 
-  double logval = psi->evaluateLog(*elec);
+  double logval = psi.evaluateLog(*elec);
   CHECK(logval == Approx(-9.26625670653773));
 
   CHECK(elec->G[0][0] == ValueApprox(-0.2758747113720909));
@@ -582,7 +577,7 @@ TEST_CASE("Rotated LCAO WF1 MO coeff rotated, half angle", "[qmcapp]")
   using ValueType = QMCTraits::ValueType;
   Vector<ValueType> dlogpsi(2);
   Vector<ValueType> dhpsioverpsi(2);
-  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+  psi.evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
 
 
   CHECK(dlogpsi[0] == ValueApprox(7.58753078998516));
@@ -662,12 +657,11 @@ TEST_CASE("Rotated LCAO rotation consistency", "[qmcapp]")
 
   wp.put(root);
 
-  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
-  REQUIRE(psi != nullptr);
-  REQUIRE(psi->getOrbitals().size() == 1);
+  TrialWaveFunction& psi(wp.getWaveFunction().value());
+  REQUIRE(psi.getOrbitals().size() == 1);
 
   // Type should be pointer to SlaterDet
-  auto orb1       = psi->getOrbitals()[0].get();
+  auto orb1       = psi.getOrbitals()[0].get();
   SlaterDet* sdet = dynamic_cast<SlaterDet*>(orb1);
   REQUIRE(sdet != nullptr);
 
@@ -762,28 +756,26 @@ TEST_CASE("Rotated LCAO Be single determinant", "[qmcapp]")
 
   wp.put(xmlFirstElementChild(root));
 
-
-  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
-  REQUIRE(psi != nullptr);
-  REQUIRE(psi->getOrbitals().size() == 1);
+  TrialWaveFunction& psi(wp.getWaveFunction().value());
+  REQUIRE(psi.getOrbitals().size() == 1);
 
   OptVariables opt_vars;
-  psi->checkInVariables(opt_vars);
+  psi.checkInVariables(opt_vars);
   opt_vars.resetIndex();
-  psi->checkOutVariables(opt_vars);
-  psi->resetParameters(opt_vars);
+  psi.checkOutVariables(opt_vars);
+  psi.resetParameters(opt_vars);
 
   ParticleSet* elec = pp.getParticleSet("e");
   elec->update();
 
 
-  double logval = psi->evaluateLog(*elec);
+  double logval = psi.evaluateLog(*elec);
   CHECK(logval == Approx(-17.768474132175342));
 
   using ValueType = QMCTraits::ValueType;
   Vector<ValueType> dlogpsi(10);
   Vector<ValueType> dhpsioverpsi(10);
-  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+  psi.evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
 
   CHECK(dlogpsi[0] == ValueApprox(0.24797938203759148));
   CHECK(dlogpsi[1] == ValueApprox(0.41454059122930453));
@@ -830,27 +822,26 @@ TEST_CASE("Rotated LCAO Be multi determinant with one determinant", "[qmcapp]")
 
   wp.put(xmlFirstElementChild(root));
 
-  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
-  REQUIRE(psi != nullptr);
-  REQUIRE(psi->getOrbitals().size() == 1);
+  TrialWaveFunction& psi(wp.getWaveFunction().value());
+  REQUIRE(psi.getOrbitals().size() == 1);
 
   OptVariables opt_vars;
-  psi->checkInVariables(opt_vars);
+  psi.checkInVariables(opt_vars);
   opt_vars.resetIndex();
-  psi->checkOutVariables(opt_vars);
-  psi->resetParameters(opt_vars);
+  psi.checkOutVariables(opt_vars);
+  psi.resetParameters(opt_vars);
 
   ParticleSet* elec = pp.getParticleSet("e");
   elec->update();
 
 
-  double logval = psi->evaluateLog(*elec);
+  double logval = psi.evaluateLog(*elec);
   CHECK(logval == Approx(-17.768474132175342));
 
   using ValueType = QMCTraits::ValueType;
   Vector<ValueType> dlogpsi(10);
   Vector<ValueType> dhpsioverpsi(10);
-  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+  psi.evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
 
   CHECK(dlogpsi[0] == ValueApprox(0.24797938203759148));
   CHECK(dlogpsi[1] == ValueApprox(0.41454059122930453));
@@ -897,27 +888,26 @@ TEST_CASE("Rotated LCAO Be two determinant", "[qmcapp]")
 
   wp.put(xmlFirstElementChild(root));
 
-  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
-  REQUIRE(psi != nullptr);
-  REQUIRE(psi->getOrbitals().size() == 1);
+  TrialWaveFunction& psi(wp.getWaveFunction().value());
+  REQUIRE(psi.getOrbitals().size() == 1);
 
   OptVariables opt_vars;
-  psi->checkInVariables(opt_vars);
+  psi.checkInVariables(opt_vars);
   opt_vars.resetIndex();
-  psi->checkOutVariables(opt_vars);
-  psi->resetParameters(opt_vars);
+  psi.checkOutVariables(opt_vars);
+  psi.resetParameters(opt_vars);
 
   ParticleSet* elec = pp.getParticleSet("e");
   elec->update();
 
 
-  double logval = psi->evaluateLog(*elec);
+  double logval = psi.evaluateLog(*elec);
   CHECK(logval == Approx(-17.762687110866413));
 
   using ValueType = QMCTraits::ValueType;
   Vector<ValueType> dlogpsi(16);
   Vector<ValueType> dhpsioverpsi(16);
-  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+  psi.evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
 
   CHECK(dlogpsi[0] == ValueApprox(0.05770308755290168));
   CHECK(dlogpsi[1] == ValueApprox(0.00593995768443123));

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -396,8 +396,8 @@ TEST_CASE("TrialWaveFunction::mw_evalGrad for spinors", "[wavefunction]")
   auto wavefunction_pool =
       MinimalWaveFunctionPool::make_O2_spinor(test_project.getRuntimeOptions(), comm, particle_pool);
 
-  auto& elec    = *(particle_pool).getParticleSet("e");
-  auto& psi_noJ = *(wavefunction_pool).getWaveFunction();
+  auto& elec = *(particle_pool).getParticleSet("e");
+  TrialWaveFunction& psi_noJ(wavefunction_pool.getWaveFunction().value());
 
   elec.update();
   auto logpsi = psi_noJ.evaluateLog(elec);
@@ -414,7 +414,7 @@ TEST_CASE("TrialWaveFunction::mw_evalGrad for spinors", "[wavefunction]")
   // Now tack on a jastrow to make sure it is still the same since jastrows don't contribute
   auto wavefunction_pool2 =
       MinimalWaveFunctionPool::make_O2_spinor_J12(test_project.getRuntimeOptions(), comm, particle_pool);
-  auto& psi = *(wavefunction_pool2).getWaveFunction();
+  TrialWaveFunction& psi = wavefunction_pool2.getWaveFunction().value();
 
   // make clones
   ParticleSet elec_clone(elec);


### PR DESCRIPTION
## Proposed changes
1. Refine `WaveFunctionPool` and `ObjectPool` interaction
2. WaveFunctionPool::getWaveFunction() no longer returns raw pointer.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
