### PR TITLE
Change how wavefunction is accessed when constructing hamiltonian

### DIFF
--- a/docs/hamiltonianobservable.rst
+++ b/docs/hamiltonianobservable.rst
@@ -46,27 +46,29 @@ for individual potentials is given in the sections that follow.
 
 attributes:
 
-  +------------------------+--------------+----------------------+-------------+------------------------------------------+
-  | **Name**               | **Datatype** | **Values**           | **Default** | **Description**                          |
-  +========================+==============+======================+=============+==========================================+
-  | ``name/id``:math:`^o`  | text         | *anything*           | h0          | Unique id for this Hamiltonian instance  |
-  +------------------------+--------------+----------------------+-------------+------------------------------------------+
-  | ``type``:math:`^o`     | text         |                      | generic     | *No current function*                    |
-  +------------------------+--------------+----------------------+-------------+------------------------------------------+
-  | ``role``:math:`^o`     | text         | primary/extra        | extra       | Designate as Hamiltonian or not          |
-  +------------------------+--------------+----------------------+-------------+------------------------------------------+
-  | ``source``:math:`^o`   | text         | ``particleset.name`` | i           | Identify classical ``particleset``       |
-  +------------------------+--------------+----------------------+-------------+------------------------------------------+
-  | ``target``:math:`^o`   | text         | ``particleset.name`` | e           | Identify quantum ``particleset``         |
-  +------------------------+--------------+----------------------+-------------+------------------------------------------+
-  | ``default``:math:`^o`  | boolean      | yes/no               | yes         | Include kinetic energy term implicitly   |
-  +------------------------+--------------+----------------------+-------------+------------------------------------------+
+  +----------------------------+--------------+-----------------------+-------------+------------------------------------------+
+  | **Name**                   | **Datatype** | **Values**            | **Default** | **Description**                          |
+  +============================+==============+=======================+=============+==========================================+
+  | ``name/id``:math:`^o`      | text         | *anything*            | h0          | Unique id for this Hamiltonian instance  |
+  +----------------------------+--------------+-----------------------+-------------+------------------------------------------+
+  | ``role``:math:`^o`         | text         | primary/extra         | extra       | Designate as Hamiltonian or not          |
+  +----------------------------+--------------+-----------------------+-------------+------------------------------------------+
+  | ``target``:math:`^o`       | text         | ``particleset.name``  | e           | Identify quantum ``particleset``         |
+  +----------------------------+--------------+-----------------------+-------------+------------------------------------------+
+  | ``wavefunction``:math:`^o` | text         | ``wavefunction.name`` | ""          | Identify ``wavefunction``                |
+  +----------------------------+--------------+-----------------------+-------------+------------------------------------------+
+  | ``default``:math:`^o`      | boolean      | yes/no                | yes         | Include kinetic energy term implicitly   |
+  +----------------------------+--------------+-----------------------+-------------+------------------------------------------+
 
 Additional information:
 
--  **target:** Must be set to the name of the quantum ``particleset``.
+-  **target** Must be set to the name of the quantum ``particleset``.
    The default value is typically sufficient. In normal usage, no other
    attributes are provided.
+
+-  **wavefunction** is only required when there are more than one ``wavefunction`` xml node and at least
+   one hamiltonian component or observable requires the detailed knowledge of the wavefunction that it operates on.
+   If the specified value is not an empty string, it must match the ``name`` attribute of a ``wavefunction`` xml node.
 
 .. code-block::
   :caption: All electron Hamiltonian XML element.
@@ -83,9 +85,9 @@ Additional information:
   :caption: Pseudopotential Hamiltonian XML element.
   :name: Listing 15
 
-  <hamiltonian target="e">
+  <hamiltonian target="e" wavefunction="psi0">
     <pairpot name="ElecElec"  type="coulomb" source="e" target="e"/>
-    <pairpot name="PseudoPot" type="pseudo"  source="i" wavefunction="psi0" format="xml">
+    <pairpot name="PseudoPot" type="pseudo"  source="i" format="xml">
       <pseudo elementType="Li" href="Li.xml"/>
       <pseudo elementType="H" href="H.xml"/>
     </pairpot>
@@ -320,8 +322,6 @@ attributes:
   +------------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
   | ``forces``                   | boolean      | yes/no                | no                     | *Deprecated*                                     |
   +------------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
-  | ``wavefunction``:math:`^r`   | text         | ``wavefunction.name`` | invalid                | Identify wavefunction                            |
-  +------------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
   | ``format``:math:`^r`         | text         | xml/table             | table                  | Select file format                               |
   +------------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
   | ``algorithm``:math:`^o`      | text         | batched/non-batched   | batched                | Choose NLPP algorithm                            |
@@ -386,13 +386,13 @@ Additional information:
   :caption: QMCPXML element for pseudopotential electron-ion interaction (psf files).
   :name: Listing 19
 
-    <pairpot name="PseudoPot" type="pseudo"  source="i" wavefunction="psi0" format="psf"/>
+    <pairpot name="PseudoPot" type="pseudo"  source="i" format="psf"/>
 
 .. code-block::
   :caption: QMCPXML element for pseudopotential electron-ion interaction (xml files). If SOC terms present in xml, they are added to local energy
   :name: Listing 20
 
-    <pairpot name="PseudoPot" type="pseudo"  source="i" wavefunction="psi0" format="xml">
+    <pairpot name="PseudoPot" type="pseudo"  source="i" format="xml">
       <pseudo elementType="Li" href="Li.xml"/>
       <pseudo elementType="H" href="H.xml"/>
     </pairpot>
@@ -401,7 +401,7 @@ Additional information:
   :caption: QMCPXML element for pseudopotential to accumulate the spin-orbit energy, but do not include in local energy
   :name: Listing 21
 
-    <pairpot name="PseudoPot" type="pseudo" source="i" wavefunction="psi0" format="xml" physicalSO="no">
+    <pairpot name="PseudoPot" type="pseudo" source="i" format="xml" physicalSO="no">
       <pseudo elementType="Pb" href="Pb.xml"/>
     </pairpot>
 
@@ -598,14 +598,12 @@ attributes:
   +-----------------------+--------------+------------------------+-------------+----------------------------+
   | ``source``:math:`^o`  | text         | ``particleset.name``   | e           | Identify quantum particles |
   +-----------------------+--------------+------------------------+-------------+----------------------------+
-  | ``psi``:math:`^o`     | text         | ``wavefunction.name``  | psi0        | Identify wavefunction      |
-  +-----------------------+--------------+------------------------+-------------+----------------------------+
 
 .. code-block::
   :caption: "Chiesa" kinetic energy finite-size postcorrection.
   :name: Listing 23
 
-     <estimator name="KEcorr" type="chiesa" source="e" psi="psi0"/>
+     <estimator name="KEcorr" type="chiesa" source="e"/>
 
 Density estimator
 ~~~~~~~~~~~~~~~~~

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -49,8 +49,6 @@
 #endif
 #include "QMCHamiltonians/SkPot.h"
 #include "OhmmsData/AttributeSet.h"
-#include "Message/UniformCommunicateError.h"
-#include "Fermion/MultiSlaterDetTableMethod.h"
 
 namespace qmcplusplus
 {
@@ -242,15 +240,8 @@ bool HamiltonianFactory::build(xmlNodePtr cur)
       else if (potType == "selfhealingoverlap" || potType == "SelfHealingOverlap")
       {
         app_log() << "  Adding SelfHealingOverlap" << std::endl;
-
-        auto msd_refvec = targetPsi->findMSD();
-        if (msd_refvec.size() != 1)
-          throw UniformCommunicateError("SelfHealingOverlap requires one and only one multi slater determinant "
-                                        "component in the trial wavefunction.");
-
-        const MultiSlaterDetTableMethod& msd = msd_refvec[0];
         std::unique_ptr<SelfHealingOverlapLegacy> apot =
-            std::make_unique<SelfHealingOverlapLegacy>(msd.getLinearExpansionCoefs().size());
+            std::make_unique<SelfHealingOverlapLegacy>(*targetPsi);
         apot->put(element);
         targetH->addOperator(std::move(apot), potName, false);
       }

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -23,6 +23,7 @@
  *@brief Definition of a HamiltonianFactory
  */
 #include "HamiltonianFactory.h"
+#include "Message/UniformCommunicateError.h"
 #include "QMCHamiltonians/QMCHamiltonian.h"
 #include "QMCHamiltonians/BareKineticEnergy.h"
 #include "QMCHamiltonians/ConservedEnergy.h"
@@ -55,14 +56,13 @@ namespace qmcplusplus
 HamiltonianFactory::HamiltonianFactory(const std::string& hName,
                                        ParticleSet& qp,
                                        const PSetMap& pset,
-                                       const PsiPoolType& oset,
+                                       OptionalRef<TrialWaveFunction>&& psi_optional,
                                        Communicate* c)
     : MPIObjectBase(c),
       targetH(std::make_unique<QMCHamiltonian>(hName)),
       targetPtcl(qp),
       ptclPool(pset),
-      psiPool(oset),
-      psiName("psi0")
+      psi_optional_(psi_optional)
 {
   //PBCType is zero or 1 but should be generalized
   PBCType = targetPtcl.getLattice().SuperCellEnum;
@@ -93,16 +93,10 @@ bool HamiltonianFactory::build(xmlNodePtr cur)
   app_summary() << "  Name: " << targetH->getName() << std::endl;
   app_summary() << std::endl;
 
-  std::string htype("generic"), source("i"), defaultKE("yes");
+  std::string defaultKE("yes");
   OhmmsAttributeSet hAttrib;
-  hAttrib.add(htype, "type");
-  hAttrib.add(source, "source");
   hAttrib.add(defaultKE, "default");
   hAttrib.put(cur);
-  auto psi_it(psiPool.find(psiName));
-  if (psi_it == psiPool.end())
-    APP_ABORT("Unknown psi \"" + psiName + "\" for target Psi");
-  TrialWaveFunction* targetPsi = psi_it->second.get();
   // KineticEnergy must be the first element in the hamiltonian array.
   if (defaultKE != "no")
     targetH->addOperator(std::make_unique<BareKineticEnergy>(targetPtcl), "Kinetic");
@@ -240,18 +234,31 @@ bool HamiltonianFactory::build(xmlNodePtr cur)
       else if (potType == "selfhealingoverlap" || potType == "SelfHealingOverlap")
       {
         app_log() << "  Adding SelfHealingOverlap" << std::endl;
-        std::unique_ptr<SelfHealingOverlapLegacy> apot =
-            std::make_unique<SelfHealingOverlapLegacy>(*targetPsi);
-        apot->put(element);
-        targetH->addOperator(std::move(apot), potName, false);
+        if (!psi_optional_)
+          throw UniformCommunicateError(
+              "Self-healing overlap estimator requires an explicitly associated wavefunction. Please specify the "
+              "wavefunction attribute of the hamiltonian node in the xml input.");
+        else
+        {
+          std::unique_ptr<SelfHealingOverlapLegacy> apot = std::make_unique<SelfHealingOverlapLegacy>(*psi_optional_);
+          apot->put(element);
+          targetH->addOperator(std::move(apot), potName, false);
+        }
       }
       else if (potType == "orbitalimages")
       {
         app_log() << "  Adding OrbitalImages" << std::endl;
-        std::unique_ptr<OrbitalImages> apot =
-            std::make_unique<OrbitalImages>(targetPtcl, ptclPool, myComm, targetPsi->getSPOMap());
-        apot->put(element);
-        targetH->addOperator(std::move(apot), potName, false);
+        if (!psi_optional_)
+          throw UniformCommunicateError(
+              "Orbital image estimator requires an explicitly associated wavefunction. Please specify the wavefunction "
+              "attribute of the hamiltonian node in the xml input.");
+        else
+        {
+          std::unique_ptr<OrbitalImages> apot =
+              std::make_unique<OrbitalImages>(targetPtcl, ptclPool, myComm, psi_optional_->get().getSPOMap());
+          apot->put(element);
+          targetH->addOperator(std::move(apot), potName, false);
+        }
       }
 #if !defined(REMOVE_TRACEMANAGER)
       else if (potType == "energydensity" || potType == "EnergyDensity")
@@ -278,10 +285,17 @@ bool HamiltonianFactory::build(xmlNodePtr cur)
         {
           APP_ABORT("Unknown source \"" + source + "\" for DensityMatrices1B");
         }
-        std::unique_ptr<DensityMatrices1B> apot =
-            std::make_unique<DensityMatrices1B>(targetPtcl, targetPsi->getSPOMap(), Pc);
-        apot->put(element);
-        targetH->addOperator(std::move(apot), potName, false);
+        if (!psi_optional_)
+          throw UniformCommunicateError(
+              "One-body density matrix estimator requires an explicitly associated wavefunction. Please specify the "
+              "wavefunction attribute of the hamiltonian node in the xml input.");
+        else
+        {
+          std::unique_ptr<DensityMatrices1B> apot =
+              std::make_unique<DensityMatrices1B>(targetPtcl, psi_optional_->get().getSPOMap(), Pc);
+          apot->put(element);
+          targetH->addOperator(std::move(apot), potName, false);
+        }
       }
 #endif
       else if (potType == "sk")
@@ -297,10 +311,8 @@ bool HamiltonianFactory::build(xmlNodePtr cur)
 #if OHMMS_DIM == 3
       else if (potType == "chiesa")
       {
-        std::string PsiName    = "psi0";
         std::string SourceName = "e";
         OhmmsAttributeSet hAttrib;
-        hAttrib.add(PsiName, "psi");
         hAttrib.add(SourceName, "source");
         hAttrib.put(element);
         auto pit(ptclPool.find(SourceName));
@@ -309,14 +321,15 @@ bool HamiltonianFactory::build(xmlNodePtr cur)
           APP_ABORT("Unknown source \"" + SourceName + "\" for Chiesa correction.");
         }
         ParticleSet& source = *pit->second;
-        auto psi_it(psiPool.find(PsiName));
-        if (psi_it == psiPool.end())
+        if (!psi_optional_)
+          throw UniformCommunicateError(
+              "Chiesa correction estimator requires an explicitly associated wavefunction. Please specify the "
+              "wavefunction attribute of the hamiltonian node in the xml input.");
+        else
         {
-          APP_ABORT("Unknown psi \"" + PsiName + "\" for Chiesa correction.");
+          std::unique_ptr<ChiesaCorrection> chiesa = std::make_unique<ChiesaCorrection>(source, *psi_optional_);
+          targetH->addOperator(std::move(chiesa), "KEcorr", false);
         }
-        const TrialWaveFunction& psi             = *psi_it->second;
-        std::unique_ptr<ChiesaCorrection> chiesa = std::make_unique<ChiesaCorrection>(source, psi);
-        targetH->addOperator(std::move(chiesa), "KEcorr", false);
       }
       else if (potType == "skall")
       {

--- a/src/QMCHamiltonians/HamiltonianFactory.h
+++ b/src/QMCHamiltonians/HamiltonianFactory.h
@@ -29,13 +29,12 @@ class HamiltonianFactory : public MPIObjectBase
 {
 public:
   using PSetMap     = std::map<std::string, const std::unique_ptr<ParticleSet>>;
-  using PsiPoolType = std::map<std::string, const std::unique_ptr<TrialWaveFunction>>;
 
   ///constructor
   HamiltonianFactory(const std::string& hName,
                      ParticleSet& qp,
                      const PSetMap& pset,
-                     const PsiPoolType& oset,
+                     OptionalRef<TrialWaveFunction>&& psi_optional,
                      Communicate* c);
 
   ///read from xmlNode
@@ -62,11 +61,8 @@ private:
   ParticleSet& targetPtcl;
   ///reference to the PSetMap
   const PSetMap& ptclPool;
-  ///reference to the TrialWaveFunction Pool
-  const PsiPoolType& psiPool;
-
-  ///name of the TrialWaveFunction
-  std::string psiName;
+  ///optional reference to a TrialWaveFunction object
+  const OptionalRef<TrialWaveFunction> psi_optional_;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/HamiltonianPool.cpp
+++ b/src/QMCHamiltonians/HamiltonianPool.cpp
@@ -40,12 +40,13 @@ HamiltonianPool::~HamiltonianPool() = default;
 bool HamiltonianPool::put(xmlNodePtr cur)
 {
   ReportEngine PRE("HamiltonianPool", "put");
-  std::string id("h0"), target("e"), role("extra");
+  std::string id("h0"), target("e"), role("extra"), psi_name;
   OhmmsAttributeSet hAttrib;
   hAttrib.add(id, "id");
   hAttrib.add(id, "name");
   hAttrib.add(role, "role");
   hAttrib.add(target, "target");
+  hAttrib.add(psi_name, "wavefunction");
   hAttrib.put(cur);
   ParticleSet* qp = ptcl_pool_.getParticleSet(target);
   if (qp == 0)
@@ -64,7 +65,7 @@ bool HamiltonianPool::put(xmlNodePtr cur)
         "Hamiltonian object named \"" + id +
         "\" already exists in the pool! Please set a different name using \"name\" attribute of \"hamiltonian\" node.");
 
-  HamiltonianFactory ham_fac(id, *qp, ptcl_pool_.getPool(), psi_pool_.getPool(), myComm);
+  HamiltonianFactory ham_fac(id, *qp, ptcl_pool_.getPool(), psi_pool_.getWaveFunction(psi_name), myComm);
   ham_fac.put(cur);
   myPool.emplace(id, ham_fac.releaseHamiltonian());
   if (set2Primary)

--- a/src/QMCHamiltonians/SelfHealingOverlapLegacy.h
+++ b/src/QMCHamiltonians/SelfHealingOverlapLegacy.h
@@ -34,8 +34,8 @@ public:
   using PosType     = QMCTraits::PosType;
 
   //constructor/destructor
-  SelfHealingOverlapLegacy(const size_t msd_size);
-  ~SelfHealingOverlapLegacy() override {}
+  SelfHealingOverlapLegacy(const TrialWaveFunction& wfn);
+  ~SelfHealingOverlapLegacy() override;
 
   //standard interface
   std::string getClassName() const override { return "SelfHealingOverlapLegacy"; }

--- a/src/QMCHamiltonians/tests/test_RotatedSPOs_NLPP.cpp
+++ b/src/QMCHamiltonians/tests/test_RotatedSPOs_NLPP.cpp
@@ -172,7 +172,7 @@ void test_hcpBe_rotation(bool use_single_det, bool use_nlpp_batched)
   if (use_nlpp_batched)
     ham_input = ham_input_nlpp_batched;
 
-  HamiltonianFactory hf("h0", elec, pp.getPool(), wp.getPool(), c);
+  HamiltonianFactory hf("h0", elec, pp.getPool(), wp.getWaveFunction(), c);
 
   Libxml2Document doc2;
   bool okay2 = doc2.parseFromString(ham_input);

--- a/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
@@ -59,9 +59,9 @@ TEST_CASE("HamiltonianFactory", "[hamiltonian]")
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
 
   RuntimeOptions runtime_options;
-  auto psi_ptr = WaveFunctionFactory::buildEmptyTWFForTesting(runtime_options, "psi0");
+  TrialWaveFunction psi(runtime_options, "psi0");
 
-  HamiltonianFactory hf("h0", elec, particle_set_map, *psi_ptr, c);
+  HamiltonianFactory hf("h0", elec, particle_set_map, psi, c);
 
   const char* hamiltonian_xml = R"(<hamiltonian name="h0" type="generic" target="e">
          <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
@@ -112,9 +112,9 @@ TEST_CASE("HamiltonianFactory pseudopotential", "[hamiltonian]")
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
 
   RuntimeOptions runtime_options;
-  auto psi_ptr = WaveFunctionFactory::buildEmptyTWFForTesting(runtime_options, "psi0");
+  TrialWaveFunction psi(runtime_options, "psi0");
 
-  HamiltonianFactory hf("h0", elec, particle_set_map, *psi_ptr, c);
+  HamiltonianFactory hf("h0", elec, particle_set_map, psi, c);
 
   const char* hamilonian_xml = R"(<hamiltonian name="h0" type="generic" target="e">
     <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">

--- a/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
@@ -59,10 +59,9 @@ TEST_CASE("HamiltonianFactory", "[hamiltonian]")
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
 
   RuntimeOptions runtime_options;
-  HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", WaveFunctionFactory::buildEmptyTWFForTesting(runtime_options, "psi0"));
+  auto psi_ptr = WaveFunctionFactory::buildEmptyTWFForTesting(runtime_options, "psi0");
 
-  HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
+  HamiltonianFactory hf("h0", elec, particle_set_map, *psi_ptr, c);
 
   const char* hamiltonian_xml = R"(<hamiltonian name="h0" type="generic" target="e">
          <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
@@ -113,10 +112,9 @@ TEST_CASE("HamiltonianFactory pseudopotential", "[hamiltonian]")
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
 
   RuntimeOptions runtime_options;
-  HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", WaveFunctionFactory::buildEmptyTWFForTesting(runtime_options, "psi0"));
+  auto psi_ptr = WaveFunctionFactory::buildEmptyTWFForTesting(runtime_options, "psi0");
 
-  HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
+  HamiltonianFactory hf("h0", elec, particle_set_map, *psi_ptr, c);
 
   const char* hamilonian_xml = R"(<hamiltonian name="h0" type="generic" target="e">
     <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">

--- a/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
@@ -52,7 +52,7 @@ TEST_CASE("HamiltonianPool", "[qmcapp]")
 
   RuntimeOptions runtime_options;
   WaveFunctionPool wfp(runtime_options, pp, c);
-  wfp.add("psi0", WaveFunctionFactory::buildEmptyTWFForTesting(runtime_options, "psi0"));
+  wfp.add("psi0", std::make_unique<TrialWaveFunction>(runtime_options, "psi0"));
 
   HamiltonianPool hpool(pp, wfp, c);
 

--- a/src/QMCWaveFunctions/WaveFunctionFactory.h
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.h
@@ -50,11 +50,6 @@ public:
                                               const RuntimeOptions& runtime_options,
                                               const std::string psi_name = "");
 
-  /// create an empty TrialWaveFunction for testing use.
-  std::unique_ptr<TrialWaveFunction> static buildEmptyTWFForTesting(const RuntimeOptions& runtime_options,
-                                                                    const std::string_view name)
-  { return std::make_unique<TrialWaveFunction>(runtime_options, name); }
-
 private:
   /** add Fermion wavefunction term */
   bool addFermionTerm(TrialWaveFunction& psi, SPOSetBuilderFactory& spo_factory, xmlNodePtr cur);


### PR DESCRIPTION
## Proposed changes
new way, associate a wavefunction to the whole hamiltonian. See first line.
 ```
          <hamiltonian name="h0" wavefunction="psi0" target="e">
             <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
             <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
             <pairpot type="pseudo" name="PseudoPot" source="ion0" format="xml">
                <pseudo elementType="C" href="C.BFD.xml"/>
             </pairpot>
             <estimator name="KEcorr" type="chiesa" source="e"/>
             <estimator type="flux" name="Flux"/>
          </hamiltonian>
``` 
old way, "pseudo" and "KEcorr" individually select wavefunction. This is unnecessary.
```
          <hamiltonian name="h0" type="generic" target="e">
             <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
             <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
             <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
                <pseudo elementType="C" href="C.BFD.xml"/>
             </pairpot>
             <estimator name="KEcorr" type="chiesa" source="e" psi="psi0"/>
             <estimator type="flux" name="Flux"/>
          </hamiltonian>
```
zero change required for existing input files because `wavefunction` attribute is optional when there is only one wavefunction xml node in the input.

Close #5777
## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
