### PR TITLE
Replace per particle mass with mass by group in ParticleSet

### DIFF
--- a/src/Particle/ParticleSet.BC.cpp
+++ b/src/Particle/ParticleSet.BC.cpp
@@ -51,8 +51,6 @@ void ParticleSet::createSK()
     for (int ig = 0; ig < my_species_.getTotalNum(); ++ig)
       my_species_(massind, ig) = 1.0;
   }
-  for (int iat = 0; iat < GroupID.size(); iat++)
-    Mass[iat] = my_species_(massind, GroupID[iat]);
 
   coordinates_->setAllParticlePos(R);
 }

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -94,6 +94,7 @@ ParticleSet::ParticleSet(const ParticleSet& p)
 
   //need explicit copy:
   Mass = p.Mass;
+  mass_by_group_ = p.mass_by_group_;
   Z    = p.Z;
   //std::ostringstream o;
   //o<<p.getName()<<ObjectTag;

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -163,6 +163,9 @@ void ParticleSet::resetGroups()
   }
   for (int iat = 0; iat < Z.size(); iat++)
     Z[iat] = my_species_(qind, GroupID[iat]);
+  z_by_group_.resize(nspecies);
+  for (auto ig = 0; ig < nspecies; ig++)
+    z_by_group_[ig] = my_species_(qind, ig);
   natt        = my_species_.numAttributes();
   int massind = my_species_.addAttribute("mass");
   if (massind == natt)
@@ -180,6 +183,9 @@ void ParticleSet::resetGroups()
     app_log() << "  Distinctive masses for each species " << std::endl;
   for (int iat = 0; iat < Mass.size(); iat++)
     Mass[iat] = my_species_(massind, GroupID[iat]);
+  mass_by_group_.resize(nspecies);
+  for (auto ig = 0; ig < nspecies; ig++)
+    mass_by_group_[ig] = my_species_(massind, ig);
 
   int membersize = my_species_.addAttribute("membersize");
   for (int ig = 0; ig < nspecies; ++ig)

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -65,9 +65,7 @@ ParticleSet::ParticleSet(const SimulationCell& simulation_cell, const DynamicCoo
       TotalNum(0),
       group_offsets_(std::make_shared<Vector<int, OMPallocator<int>>>()),
       coordinates_(createDynamicCoordinates(kind))
-{
-  initPropertyList();
-}
+{ initPropertyList(); }
 
 ParticleSet::ParticleSet(const ParticleSet& p)
     : Properties(p.Properties),
@@ -93,9 +91,8 @@ ParticleSet::ParticleSet(const ParticleSet& p)
   is_spinor_ = p.is_spinor_;
 
   //need explicit copy:
-  Mass = p.Mass;
   mass_by_group_ = p.mass_by_group_;
-  Z    = p.Z;
+  Z              = p.Z;
   //std::ostringstream o;
   //o<<p.getName()<<ObjectTag;
   //this->setName(o.str());
@@ -164,9 +161,6 @@ void ParticleSet::resetGroups()
   }
   for (int iat = 0; iat < Z.size(); iat++)
     Z[iat] = my_species_(qind, GroupID[iat]);
-  z_by_group_.resize(nspecies);
-  for (auto ig = 0; ig < nspecies; ig++)
-    z_by_group_[ig] = my_species_(qind, ig);
   natt        = my_species_.numAttributes();
   int massind = my_species_.addAttribute("mass");
   if (massind == natt)
@@ -182,8 +176,6 @@ void ParticleSet::resetGroups()
     app_log() << "  All the species have the same mass " << m0 << std::endl;
   else
     app_log() << "  Distinctive masses for each species " << std::endl;
-  for (int iat = 0; iat < Mass.size(); iat++)
-    Mass[iat] = my_species_(massind, GroupID[iat]);
   mass_by_group_.resize(nspecies);
   for (auto ig = 0; ig < nspecies; ig++)
     mass_by_group_[ig] = my_species_(massind, ig);
@@ -339,14 +331,10 @@ int ParticleSet::addTable(const ParticleSet& psrc, DTModes modes)
 }
 
 const DistanceTableAA& ParticleSet::getDistTableAA(int table_ID) const
-{
-  return dynamic_cast<DistanceTableAA&>(*DistTables[table_ID]);
-}
+{ return dynamic_cast<DistanceTableAA&>(*DistTables[table_ID]); }
 
 const DistanceTableAB& ParticleSet::getDistTableAB(int table_ID) const
-{
-  return dynamic_cast<DistanceTableAB&>(*DistTables[table_ID]);
-}
+{ return dynamic_cast<DistanceTableAB&>(*DistTables[table_ID]); }
 
 void ParticleSet::update(bool skipSK)
 {

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -83,8 +83,6 @@ public:
   ParticleGradient G;
   ///laplacians of the particles
   ParticleLaplacian L;
-  ///mass of each particle
-  ParticleScalar Mass;
   ///charge of each particle
   ParticleScalar Z;
 
@@ -241,7 +239,6 @@ public:
   }
 
   inline const auto& get_mass_by_group() const { return mass_by_group_; }
-  inline const auto& get_z_by_group() const { return z_by_group_; }
 
   inline const DynamicCoordinates& getCoordinates() const { return *coordinates_; }
 
@@ -506,7 +503,6 @@ public:
     GroupID.clear();
     G.clear();
     L.clear();
-    Mass.clear();
     Z.clear();
 
     coordinates_->resize(0);
@@ -547,10 +543,6 @@ public:
     AttribList.add(GroupID);
 
     //more particle attributes
-    Mass.setTypeName(ParticleTags::scalartype_tag);
-    Mass.setObjName("mass");
-    AttribList.add(Mass);
-
     Z.setTypeName(ParticleTags::scalartype_tag);
     Z.setObjName("charge");
     AttribList.add(Z);
@@ -642,8 +634,7 @@ protected:
 
   /// mass by specie
   Vector<Scalar_t> mass_by_group_;
-  /// Z by specie
-  Vector<Scalar_t> z_by_group_;
+
   ///internal representation of R. It can be an SoA copy of R
   std::unique_ptr<DynamicCoordinates> coordinates_;
 
@@ -689,7 +680,6 @@ protected:
     GroupID.resize(numPtcl);
     G.resize(numPtcl);
     L.resize(numPtcl);
-    Mass.resize(numPtcl);
     Z.resize(numPtcl);
 
     coordinates_->resize(numPtcl);

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -240,6 +240,9 @@ public:
     }
   }
 
+  inline const auto& get_mass_by_group() const { return mass_by_group_; }
+  inline const auto& get_z_by_group() const { return z_by_group_; }
+
   inline const DynamicCoordinates& getCoordinates() const { return *coordinates_; }
 
   void resetGroups();
@@ -637,6 +640,10 @@ protected:
   ///array to handle a group of distinct particles per species
   std::shared_ptr<Vector<int, OMPallocator<int>>> group_offsets_;
 
+  /// mass by specie
+  Vector<Scalar_t> mass_by_group_;
+  /// Z by specie
+  Vector<Scalar_t> z_by_group_;
   ///internal representation of R. It can be an SoA copy of R
   std::unique_ptr<DynamicCoordinates> coordinates_;
 

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -142,7 +142,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
     ScopedTimer pbyp_local_timer(timers.movepbyp_timer);
     for (int ig = 0; ig < pset_leader.groups(); ++ig)
     {
-      TauParams<RealType, CT> taus(sft.qmcdrv_input.get_tau(), sft.population.get_ptclgrp_inv_mass()[ig],
+      TauParams<RealType, CT> taus(sft.qmcdrv_input.get_tau(), 1.0 / pset_leader.get_mass_by_group()[ig],
                                    sft.qmcdrv_input.get_spin_mass());
 
       twf_dispatcher.flex_prepareGroup(walker_twfs, walker_elecs, ig);

--- a/src/QMCDrivers/MCPopulation.cpp
+++ b/src/QMCDrivers/MCPopulation.cpp
@@ -27,21 +27,7 @@ MCPopulation::MCPopulation(int num_ranks,
                            TrialWaveFunction* trial_wf,
                            QMCHamiltonian* hamiltonian)
     : trial_wf_(trial_wf), elec_particle_set_(elecs), hamiltonian_(hamiltonian), num_ranks_(num_ranks), rank_(this_rank)
-{
-  const auto num_groups = elecs->groups();
-  ptclgrp_mass_.resize(num_groups);
-  ptclgrp_inv_mass_.resize(num_groups);
-  for (int ig = 0; ig < num_groups; ++ig)
-  {
-    ptclgrp_mass_[ig]     = elecs->Mass[elecs->first(ig)];
-    ptclgrp_inv_mass_[ig] = 1.0 / ptclgrp_mass_[ig];
-  }
-
-  ptcl_inv_mass_.resize(elecs->getTotalNum());
-  for (int ig = 0; ig < num_groups; ++ig)
-    for (int iat = elecs->first(ig); iat < elecs->last(ig); ++iat)
-      ptcl_inv_mass_[iat] = ptclgrp_inv_mass_[ig];
-}
+{}
 
 MCPopulation::~MCPopulation() = default;
 
@@ -160,9 +146,7 @@ void MCPopulation::createWalkers(IndexType num_walkers, const WalkerConfiguratio
 long MCPopulation::nextWalkerID() { return num_walkers_created_++ * num_ranks_ + rank_ + 1; }
 
 WalkerElementsRef MCPopulation::getWalkerElementsRef(const size_t index)
-{
-  return {*walkers_[index], *walker_elec_particle_sets_[index], *walker_trial_wavefunctions_[index]};
-}
+{ return {*walkers_[index], *walker_elec_particle_sets_[index], *walker_trial_wavefunctions_[index]}; }
 
 std::vector<WalkerElementsRef> MCPopulation::get_walker_elements()
 {

--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -60,11 +60,6 @@ private:
   // By making this a linked list and creating the crowds at the same time we could get first touch.
   UPtrVector<MCPWalker> walkers_;
   UPtrVector<MCPWalker> dead_walkers_;
-  std::vector<RealType> ptclgrp_mass_;
-  ///1/Mass per species
-  std::vector<RealType> ptclgrp_inv_mass_;
-  ///1/Mass per particle
-  std::vector<RealType> ptcl_inv_mass_;
 
   // This is necessary MCPopulation is constructed in a simple call scope in QMCDriverFactory from the legacy MCWalkerConfiguration
   // MCPopulation should have QMCMain scope eventually and the driver will just have a reference to it.
@@ -199,9 +194,7 @@ public:
   void set_target_samples(IndexType samples) { target_samples_ = samples; }
 
   void set_ensemble_property(const MCDataType<QMCTraits::FullPrecRealType>& ensemble_property)
-  {
-    ensemble_property_ = ensemble_property;
-  }
+  { ensemble_property_ = ensemble_property; }
 
   UPtrVector<MCPWalker>& get_walkers() { return walkers_; }
   const UPtrVector<MCPWalker>& get_walkers() const { return walkers_; }
@@ -231,10 +224,6 @@ public:
    *  As operator[] don't use it to ignore the concurrency design.
    */
   std::vector<WalkerElementsRef> get_walker_elements();
-
-  const std::vector<RealType>& get_ptclgrp_mass() const { return ptclgrp_mass_; }
-  const std::vector<RealType>& get_ptclgrp_inv_mass() const { return ptclgrp_inv_mass_; }
-  const std::vector<RealType>& get_ptcl_inv_mass() const { return ptcl_inv_mass_; }
   /// @}
 
 

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -111,7 +111,7 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
       // up and down electrons are "species" within qmpack
       for (int ig = 0; ig < walker_leader.groups(); ++ig) //loop over species
       {
-        TauParams<RealType, CT> taus(sft.qmcdrv_input.get_tau(), sft.population.get_ptclgrp_inv_mass()[ig],
+        TauParams<RealType, CT> taus(sft.qmcdrv_input.get_tau(), 1.0 / walker_leader.get_mass_by_group()[ig],
                                      sft.qmcdrv_input.get_spin_mass());
 
         twf_dispatcher.flex_prepareGroup(walker_twfs, walker_elecs, ig);

--- a/src/QMCHamiltonians/StressPBC.cpp
+++ b/src/QMCHamiltonians/StressPBC.cpp
@@ -292,11 +292,15 @@ SymTensor<StressPBC::RealType, OHMMS_DIM> StressPBC::evaluateKineticSymTensor(Tr
   SymTensor<RealType, OHMMS_DIM> kinetic_tensor;
   Tensor<ComplexType, OHMMS_DIM> complex_ktensor;
 
-  for (int iat = 0; iat < P.getTotalNum(); iat++)
+  auto& mass = P.get_mass_by_group();
+  for (int ig = 0; ig < mass.size(); ++ig)
   {
-    const RealType minv(1.0 / P.Mass[iat]);
-    complex_ktensor += outerProduct(P.G[iat], P.G[iat]) * static_cast<ParticleSet::SingleParticleValue>(minv);
-    complex_ktensor += grad_grad_psi[iat] * minv;
+    const RealType minv = 1.0 / mass[ig];
+    for (int iat = P.first(ig); iat < P.last(ig); ++iat)
+    {
+      complex_ktensor += outerProduct(P.G[iat], P.G[iat]) * static_cast<ParticleSet::SingleParticleValue>(minv);
+      complex_ktensor += grad_grad_psi[iat] * minv;
+    }
   }
 
   for (int i = 0; i < OHMMS_DIM; i++)

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -66,7 +66,6 @@ TrialWaveFunction::TrialWaveFunction(const RuntimeOptions& runtime_options, cons
       PhaseValue(0.0),
       PhaseDiff(0.0),
       log_real_(0.0),
-      OneOverM(1.0),
       use_tasking_(tasking),
       TWF_timers_(getGlobalTimerManager(), create_names(aname), timer_level_medium)
 {
@@ -1186,7 +1185,6 @@ std::unique_ptr<TrialWaveFunction> TrialWaveFunction::makeClone(ParticleSet& tqp
   myclone->BufferCursor_scalar = BufferCursor_scalar;
   for (int i = 0; i < Z.size(); ++i)
     myclone->addComponent(Z[i]->makeClone(tqp));
-  myclone->OneOverM = OneOverM;
   return myclone;
 }
 
@@ -1208,9 +1206,6 @@ void TrialWaveFunction::evaluateDerivatives(ParticleSet& P,
     ScopedTimer z_timer(WFC_timers_[DERIVS_TIMER + TIMER_SKIP * i]);
     Z[i]->evaluateDerivatives(P, optvars, dlogpsi, dhpsioverpsi);
   }
-  //orbitals do not know about mass of particle.
-  for (int i = 0; i < dhpsioverpsi.size(); i++)
-    dhpsioverpsi[i] *= OneOverM;
 }
 
 void TrialWaveFunction::mw_evaluateParameterDerivatives(const RefVectorWithLeader<TrialWaveFunction>& wf_list,

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -526,17 +526,6 @@ public:
   void setTwist(std::vector<RealType>&& t) { myTwist = std::move(t); }
   const std::vector<RealType>& twist() const { return myTwist; }
 
-  inline void setMassTerm(ParticleSet& P)
-  {
-    OneOverM = 1.0 / P.Mass[0];
-    //SpeciesSet tspecies(P.getSpeciesSet());
-    //int massind=tspecies.addAttribute("mass");
-    //RealType mass = tspecies(massind,0);
-    //OneOverM = 1.0/mass;
-  }
-
-  RealType getReciprocalMass() { return OneOverM; }
-
   const std::string& getName() const { return myName; }
 
   bool use_tasking() const { return use_tasking_; }
@@ -593,9 +582,6 @@ private:
 
   ///real part of trial wave function log
   RealType log_real_;
-
-  ///One over mass of target particleset, needed for Local Energy Derivatives
-  RealType OneOverM;
 
   /// if true, using internal tasking implementation
   const bool use_tasking_;

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -58,7 +58,6 @@ std::unique_ptr<TrialWaveFunction> WaveFunctionFactory::buildTWF(xmlNodePtr cur,
   app_summary() << std::endl;
 
   auto targetPsi = std::make_unique<TrialWaveFunction>(runtime_options, psi_name, tasking == "yes");
-  targetPsi->setMassTerm(targetPtcl);
   targetPsi->storeXMLNode(cur);
 
   SPOSetBuilderFactory sposet_builder_factory(myComm, targetPtcl, ptclPool);

--- a/src/QMCWaveFunctions/tests/test_J1OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1OrbitalSoA.cpp
@@ -85,7 +85,6 @@ TEST_CASE("J1 evaluate derivatives Jastrow", "[wavefunction]")
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(jas1, runtime_options);
   auto& twf(*twf_ptr);
-  twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
   twf.prepareGroup(elec_, 0);
 
@@ -186,7 +185,6 @@ TEST_CASE("J1 evaluate derivatives Jastrow with two species", "[wavefunction]")
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(jas1, runtime_options);
   auto& twf(*twf_ptr);
-  twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
   twf.prepareGroup(elec_, 0);
 
@@ -284,7 +282,6 @@ TEST_CASE("J1 evaluate derivatives Jastrow with two species one without Jastrow"
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(jas1, runtime_options);
   auto& twf(*twf_ptr);
-  twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
   twf.prepareGroup(elec_, 0);
 

--- a/src/QMCWaveFunctions/tests/test_J1Spin.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1Spin.cpp
@@ -86,7 +86,6 @@ TEST_CASE("J1 spin evaluate derivatives Jastrow", "[wavefunction]")
   RuntimeOptions runtime_options;
   auto twf_ptr = wf_factory.buildTWF(jas1, runtime_options);
   auto& twf(*twf_ptr);
-  twf.setMassTerm(elec_);
   auto& twf_component_list = twf.getOrbitals();
   auto cloned_j1spin       = twf_component_list[0]->makeClone(elec_);
 
@@ -205,7 +204,6 @@ TEST_CASE("J1 spin evaluate derivatives multiparticle Jastrow", "[wavefunction]"
   RuntimeOptions runtime_options;
   auto twf_ptr = wf_factory.buildTWF(jas1, runtime_options);
   auto& twf(*twf_ptr);
-  twf.setMassTerm(elec_);
   auto& twf_component_list = twf.getOrbitals();
   auto cloned_j1spin       = twf_component_list[0]->makeClone(elec_);
 

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -100,7 +100,6 @@ void test_LiH_msd(const std::string& spo_xml_string,
   CHECK(msd_refvec.size() == 1);
   MultiSlaterDetTableMethod& msd = msd_refvec[0];
 
-  twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
 
   app_log() << "twf.evaluateLog logpsi " << std::setprecision(16) << twf.getLogPsi() << " " << twf.getPhase()
@@ -456,7 +455,6 @@ void test_Bi_msd(const std::string& spo_xml_string,
   elec_.update();
 
   auto& twf(*twf_ptr);
-  twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
 
   //Reference values from QWalk with SOC

--- a/src/QMCWaveFunctions/tests/test_pade_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_pade_jastrow.cpp
@@ -179,7 +179,6 @@ TEST_CASE("Pade2 Jastrow", "[wavefunction]")
   RuntimeOptions runtime_options;
   auto twf_ptr = wf_factory.buildTWF(jas1, runtime_options);
   auto& twf(*twf_ptr);
-  twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
   twf.prepareGroup(elec_, 0);
 


### PR DESCRIPTION
## Proposed changes
Clean up how mass is stored and consumed.
1. removed OneOverM in TWF. It should be handled by the kinetic energy class
2. removed mass related member in MCPopulation.cpp
3. ParticleSet stores mass per group instead of per particle.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
