### PR TITLE
Fix bounds error in MPC spline evaluation

### DIFF
--- a/src/QMCHamiltonians/MPC.cpp
+++ b/src/QMCHamiltonians/MPC.cpp
@@ -339,11 +339,7 @@ MPC::Return_t MPC::evalLR(ParticleSet& P) const
   double val;
   for (int i = 0; i < NParticles; i++)
   {
-    //PosType r = P.R[i];
-    //PosType u = P.getLattice().toUnit(r);
-    PosType u = P.getLattice().toUnit(P.R[i]);
-    for (int j = 0; j < OHMMS_DIM; j++)
-      u[j] -= std::floor(u[j]);
+    PosType u = P.getLattice().toUnit_floor(P.R[i]);
     eval_UBspline_3d_d(VlongSpline.get(), u[0], u[1], u[2], &val);
     LR += val;
   }


### PR DESCRIPTION
## Proposed changes

Use toUnit_floor in MPC evalLR. Closes #5174.

In mixed precision runs I was able to catch cases with e.g. u={1, 0.953449249, 0.0881103873} triggering the assert. eval_UBspline_3d_d must be called with u[]=[0,1)

There are multiple MPC related issues open. MPC still needs a close look for dangerous or incorrect code, e.g. https://github.com/QMCPACK/qmcpack/issues/5081 (inaccurate energies), https://github.com/QMCPACK/qmcpack/issues/4725 (crash). Full list:  https://github.com/QMCPACK/qmcpack/issues?q=is%3Aissue%20state%3Aopen%20mpc

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

ubu 24  gcc13.3 mixed precision

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
