### PR TITLE
Refactor BsplineSet derived classes regarding dump file I/O

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
@@ -35,8 +35,6 @@ class BsplineSet : public SPOSet
 {
 protected:
   static const int D = DIM;
-  ///Index of this adoptor, when multiple adoptors are used for NUMA or distributed cases
-  size_t MyIndex;
   ///first index of the SPOs this Spline handles
   size_t first_spo;
   ///last index of the SPOs this Spline handles
@@ -56,7 +54,7 @@ protected:
   std::vector<int> offset;
 
 public:
-  BsplineSet(const std::string& my_name) : SPOSet(my_name), MyIndex(0), first_spo(0), last_spo(0) {}
+  BsplineSet(const std::string& my_name) : SPOSet(my_name), first_spo(0), last_spo(0) {}
 
   virtual bool isComplex() const         = 0;
   virtual std::string getKeyword() const = 0;

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
@@ -591,7 +591,7 @@ public:
       AtomicCenters[ic].flush_zero();
   }
 
-  bool read_splines(hdf_archive& h5f)
+  bool read_atomic_splines(hdf_archive& h5f)
   {
     bool success = true;
     size_t ncenter;
@@ -629,7 +629,7 @@ public:
     return success;
   }
 
-  bool write_splines(hdf_archive& h5f)
+  bool write_atomic_splines(hdf_archive& h5f)
   {
     bool success = true;
     int ncenter  = AtomicCenters.size();

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
@@ -23,6 +23,7 @@
 #include "spline2/MultiBspline1D.hpp"
 #include "Numerics/SmoothFunctions.hpp"
 #include "hdf/hdf_archive.h"
+#include "SplineUtils.h"
 
 namespace qmcplusplus
 {
@@ -97,9 +98,7 @@ public:
   void bcast_tables(Communicate* comm) { chunked_bcast(comm, SplineInst->getSplinePtr()); }
 
   void gather_tables(Communicate* comm, std::vector<int>& offset)
-  {
-    gatherv(comm, SplineInst->getSplinePtr(), Npad, offset);
-  }
+  { gatherv(comm, SplineInst->getSplinePtr(), Npad, offset); }
 
   template<typename PT, typename VT>
   inline void set_info(const PT& R,
@@ -138,9 +137,7 @@ public:
   inline void flush_zero() { SplineInst->flush_zero(); }
 
   inline void set_spline(AtomicSingleSplineType* spline, int lm, int ispline)
-  {
-    SplineInst->copy_spline(spline, lm * Npad + ispline, 0, BaseN);
-  }
+  { SplineInst->copy_spline(spline, lm * Npad + ispline, 0, BaseN); }
 
   bool read_splines(hdf_archive& h5f)
   {
@@ -153,7 +150,7 @@ public:
       return false;
     if (!h5f.readEntry(spline_npoints_in, "spline_npoints") || spline_npoints_in != spline_npoints)
       return false;
-    return h5f.readEntry(bigtable, "radial_spline");
+    return SplineUtils<ST>::read(*SplineInst, h5f);
   }
 
   bool write_splines(hdf_archive& h5f)
@@ -163,9 +160,7 @@ public:
     success      = success && h5f.writeEntry(spline_npoints, "spline_npoints");
     success      = success && h5f.writeEntry(lmax, "l_max");
     success      = success && h5f.writeEntry(center_pos, "position");
-    einspline_engine<AtomicSplineType> bigtable(SplineInst->getSplinePtr());
-    success = success && h5f.writeEntry(bigtable, "radial_spline");
-    return success;
+    return success && SplineUtils<ST>::write(*SplineInst, h5f);
   }
 
   //evaluate only V

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
@@ -67,6 +67,8 @@ private:
 public:
   HybridRepCplx(const std::string& my_name) : SPLINEBASE(my_name) {}
 
+  auto& getMultiSpline3D() {return *SPLINEBASE::SplineInst; }
+
   bool isRotationSupported() const override { return SPLINEBASE::isRotationSupported(); }
   void storeParamsBeforeRotation() override
   {
@@ -96,10 +98,6 @@ public:
     SPLINEBASE::gather_tables(comm);
     HYBRIDBASE::gather_atomic_tables(comm, SPLINEBASE::offset);
   }
-
-  bool read_splines(hdf_archive& h5f) { return HYBRIDBASE::read_splines(h5f) && SPLINEBASE::read_splines(h5f); }
-
-  bool write_splines(hdf_archive& h5f) { return HYBRIDBASE::write_splines(h5f) && SPLINEBASE::write_splines(h5f); }
 
   void evaluateValue(const ParticleSet& P, const int iat, ValueVector& psi) override
   {

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
@@ -69,6 +69,8 @@ private:
 public:
   HybridRepReal(const std::string& my_name) : SPLINEBASE(my_name) {}
 
+  auto& getMultiSpline3D() {return *SPLINEBASE::SplineInst; }
+
   bool isRotationSupported() const override { return SPLINEBASE::isRotationSupported(); }
   void storeParamsBeforeRotation() override
   {
@@ -98,10 +100,6 @@ public:
     SPLINEBASE::gather_tables(comm);
     HYBRIDBASE::gather_atomic_tables(comm, SPLINEBASE::offset);
   }
-
-  bool read_splines(hdf_archive& h5f) { return HYBRIDBASE::read_splines(h5f) && SPLINEBASE::read_splines(h5f); }
-
-  bool write_splines(hdf_archive& h5f) { return HYBRIDBASE::write_splines(h5f) && SPLINEBASE::write_splines(h5f); }
 
   void evaluateValue(const ParticleSet& P, const int iat, ValueVector& psi) override
   {

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
@@ -23,6 +23,7 @@
 #include "Concurrency/OpenMP.h"
 #include <Timer.h>
 #include "OneSplineOrbData.hpp"
+#include "SplineUtils.h"
 
 namespace qmcplusplus
 {
@@ -154,7 +155,7 @@ std::unique_ptr<SPOSet> HybridRepSetReader<SA>::create_spline_set(const std::str
     hdf_archive h5f(myComm);
     const auto splinefile = getSplineDumpFileName(bandgroup);
     h5f.open(splinefile, H5F_ACC_RDONLY);
-    foundspline = bspline->read_splines(h5f);
+    foundspline = SplineUtils<DataType>::read(bspline->getMultiSpline3D(), h5f) && bspline->read_atomic_splines(h5f);
     if (foundspline)
       app_log() << "  Successfully restored 3D B-spline coefficients from " << splinefile << ". The reading time is "
                 << now.elapsed() << " sec." << std::endl;
@@ -175,7 +176,8 @@ std::unique_ptr<SPOSet> HybridRepSetReader<SA>::create_spline_set(const std::str
       h5f.write(classname, "class_name");
       int sizeD = sizeof(DataType);
       h5f.write(sizeD, "sizeof");
-      bspline->write_splines(h5f);
+      SplineUtils<DataType>::write(bspline->getMultiSpline3D(), h5f);
+      bspline->write_atomic_splines(h5f);
       h5f.close();
       app_log() << "  Stored spline coefficients in " << splinefile << " for potential reuse. The writing time is "
                 << now.elapsed() << " sec." << std::endl;

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
@@ -19,6 +19,7 @@
 #include "CPU/math.hpp"
 #include "CPU/SIMD/inner_product.hpp"
 #include "CPU/BLAS.hpp"
+#include "SplineUtils.h"
 
 namespace qmcplusplus
 {
@@ -38,21 +39,11 @@ inline void SplineC2C<ST>::set_spline(SingleSplineType* spline_r,
 
 template<typename ST>
 bool SplineC2C<ST>::read_splines(hdf_archive& h5f)
-{
-  std::ostringstream o;
-  o << "spline_" << MyIndex;
-  einspline_engine<SplineType> bigtable(SplineInst->getSplinePtr());
-  return h5f.readEntry(bigtable, o.str().c_str()); //"spline_0");
-}
+{ return SplineUtils<ST>::read(*SplineInst, h5f); }
 
 template<typename ST>
 bool SplineC2C<ST>::write_splines(hdf_archive& h5f)
-{
-  std::ostringstream o;
-  o << "spline_" << MyIndex;
-  einspline_engine<SplineType> bigtable(SplineInst->getSplinePtr());
-  return h5f.writeEntry(bigtable, o.str().c_str()); //"spline_0");
-}
+{ return SplineUtils<ST>::write(*SplineInst, h5f); }
 
 template<typename ST>
 void SplineC2C<ST>::storeParamsBeforeRotation()

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
@@ -19,7 +19,6 @@
 #include "CPU/math.hpp"
 #include "CPU/SIMD/inner_product.hpp"
 #include "CPU/BLAS.hpp"
-#include "SplineUtils.h"
 
 namespace qmcplusplus
 {
@@ -36,14 +35,6 @@ inline void SplineC2C<ST>::set_spline(SingleSplineType* spline_r,
   copy_spline<double, ST>(*spline_r, *SplineInst->getSplinePtr(), 2 * ispline);
   copy_spline<double, ST>(*spline_i, *SplineInst->getSplinePtr(), 2 * ispline + 1);
 }
-
-template<typename ST>
-bool SplineC2C<ST>::read_splines(hdf_archive& h5f)
-{ return SplineUtils<ST>::read(*SplineInst, h5f); }
-
-template<typename ST>
-bool SplineC2C<ST>::write_splines(hdf_archive& h5f)
-{ return SplineUtils<ST>::write(*SplineInst, h5f); }
 
 template<typename ST>
 void SplineC2C<ST>::storeParamsBeforeRotation()

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.h
@@ -60,8 +60,6 @@ private:
   CrystalLattice<ST, 3> PrimLattice;
   ///\f$GGt=G^t G \f$, transformation for tensor in LatticeUnit to CartesianUnit, e.g. Hessian
   Tensor<ST, 3> GGt;
-  ///multi bspline set
-  std::shared_ptr<MultiBspline<ST>> SplineInst;
 
   ///Copy of original splines for orbital rotation
   std::shared_ptr<std::vector<ST>> coef_copy_;
@@ -73,6 +71,8 @@ private:
   Matrix<ComplexT> ratios_private;
 
 protected:
+  ///multi bspline set
+  std::shared_ptr<MultiBspline<ST>> SplineInst;
   /// intermediate result vectors
   vContainer_type myV;
   vContainer_type myL;
@@ -160,10 +160,6 @@ public:
   }
 
   void set_spline(SingleSplineType* spline_r, SingleSplineType* spline_i, int twist, int ispline, int level);
-
-  bool read_splines(hdf_archive& h5f);
-
-  bool write_splines(hdf_archive& h5f);
 
   void assign_v(const PointType& r, const vContainer_type& myV, ValueVector& psi, int first, int last) const;
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -18,7 +18,6 @@
 #include "ApplyPhaseC2C.hpp"
 #include "Concurrency/OpenMP.h"
 #include "CPU/BLAS.hpp"
-#include "SplineUtils.h"
 
 namespace qmcplusplus
 {
@@ -35,14 +34,6 @@ inline void SplineC2COMPTarget<ST>::set_spline(SingleSplineType* spline_r,
   copy_spline<double, ST>(*spline_r, *SplineInst->getSplinePtr(), 2 * ispline);
   copy_spline<double, ST>(*spline_i, *SplineInst->getSplinePtr(), 2 * ispline + 1);
 }
-
-template<typename ST>
-bool SplineC2COMPTarget<ST>::read_splines(hdf_archive& h5f)
-{ return SplineUtils<ST>::read(*SplineInst, h5f); }
-
-template<typename ST>
-bool SplineC2COMPTarget<ST>::write_splines(hdf_archive& h5f)
-{ return SplineUtils<ST>::write(*SplineInst, h5f); }
 
 template<typename ST>
 void SplineC2COMPTarget<ST>::storeParamsBeforeRotation()

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -18,6 +18,7 @@
 #include "ApplyPhaseC2C.hpp"
 #include "Concurrency/OpenMP.h"
 #include "CPU/BLAS.hpp"
+#include "SplineUtils.h"
 
 namespace qmcplusplus
 {
@@ -37,28 +38,18 @@ inline void SplineC2COMPTarget<ST>::set_spline(SingleSplineType* spline_r,
 
 template<typename ST>
 bool SplineC2COMPTarget<ST>::read_splines(hdf_archive& h5f)
-{
-  std::ostringstream o;
-  o << "spline_" << MyIndex;
-  einspline_engine<SplineType> bigtable(SplineInst->getSplinePtr());
-  return h5f.readEntry(bigtable, o.str().c_str()); //"spline_0");
-}
+{ return SplineUtils<ST>::read(*SplineInst, h5f); }
 
 template<typename ST>
 bool SplineC2COMPTarget<ST>::write_splines(hdf_archive& h5f)
-{
-  std::ostringstream o;
-  o << "spline_" << MyIndex;
-  einspline_engine<SplineType> bigtable(SplineInst->getSplinePtr());
-  return h5f.writeEntry(bigtable, o.str().c_str()); //"spline_0");
-}
+{ return SplineUtils<ST>::write(*SplineInst, h5f); }
 
 template<typename ST>
 void SplineC2COMPTarget<ST>::storeParamsBeforeRotation()
 {
-  const auto spline_ptr = SplineInst->getSplinePtr();
+  const auto spline_ptr     = SplineInst->getSplinePtr();
   const auto coefs_tot_size = spline_ptr->coefs_size;
-  coef_copy_ = std::make_shared<std::vector<ST>>(coefs_tot_size);
+  coef_copy_                = std::make_shared<std::vector<ST>>(coefs_tot_size);
   std::copy_n(spline_ptr->coefs, coefs_tot_size, coef_copy_->begin());
 }
 
@@ -87,8 +78,8 @@ void SplineC2COMPTarget<ST>::applyRotation(const ValueMatrix& rot_mat, bool use_
     //Note that Nsplines needs to be divided by 2 since spl_coefs and coef_copy_ are stored as reals.
     //Also casting them as ValueType so they are complex to do the correct gemm
     BLAS::gemm('N', 'N', OrbitalSetSize, basis_set_size, OrbitalSetSize, ValueType(1.0, 0.0), rot_mat.data(),
-               OrbitalSetSize, (ValueType*)coef_copy_->data(), Nsplines / 2, ValueType(0.0, 0.0),
-               (ValueType*)spl_coefs, Nsplines / 2);
+               OrbitalSetSize, (ValueType*)coef_copy_->data(), Nsplines / 2, ValueType(0.0, 0.0), (ValueType*)spl_coefs,
+               Nsplines / 2);
   }
   else
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -71,8 +71,6 @@ private:
   CrystalLattice<ST, 3> PrimLattice;
   ///\f$GGt=G^t G \f$, transformation for tensor in LatticeUnit to CartesianUnit, e.g. Hessian
   Tensor<ST, 3> GGt;
-  ///multi bspline set
-  std::shared_ptr<MultiBsplineBase<ST>> SplineInst;
 
   ///Copy of original splines for orbital rotation. Only need these on host
   std::shared_ptr<std::vector<ST>> coef_copy_;
@@ -103,6 +101,8 @@ private:
                            const RefVector<ValueVector>& d2psi_v_list) const;
 
 protected:
+  ///multi bspline set
+  std::shared_ptr<MultiBsplineBase<ST>> SplineInst;
   /// intermediate result vectors
   vContainer_type myV;
   vContainer_type myL;
@@ -223,10 +223,6 @@ public:
   }
 
   void set_spline(SingleSplineType* spline_r, SingleSplineType* spline_i, int twist, int ispline, int level);
-
-  bool read_splines(hdf_archive& h5f);
-
-  bool write_splines(hdf_archive& h5f);
 
   void assign_v(const PointType& r, const vContainer_type& myV, ValueVector& psi, int first, int last) const;
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2R.cpp
@@ -20,7 +20,6 @@
 #include "QMCWaveFunctions/BsplineFactory/contraction_helper.hpp"
 #include "CPU/math.hpp"
 #include "CPU/SIMD/inner_product.hpp"
-#include "SplineUtils.h"
 
 namespace qmcplusplus
 {
@@ -37,14 +36,6 @@ inline void SplineC2R<ST>::set_spline(SingleSplineType* spline_r,
   copy_spline<double, ST>(*spline_r, *SplineInst->getSplinePtr(), 2 * ispline);
   copy_spline<double, ST>(*spline_i, *SplineInst->getSplinePtr(), 2 * ispline + 1);
 }
-
-template<typename ST>
-bool SplineC2R<ST>::read_splines(hdf_archive& h5f)
-{ return SplineUtils<ST>::read(*SplineInst, h5f); }
-
-template<typename ST>
-bool SplineC2R<ST>::write_splines(hdf_archive& h5f)
-{ return SplineUtils<ST>::write(*SplineInst, h5f); }
 
 template<typename ST>
 inline void SplineC2R<ST>::assign_v(const PointType& r,

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2R.cpp
@@ -20,6 +20,7 @@
 #include "QMCWaveFunctions/BsplineFactory/contraction_helper.hpp"
 #include "CPU/math.hpp"
 #include "CPU/SIMD/inner_product.hpp"
+#include "SplineUtils.h"
 
 namespace qmcplusplus
 {
@@ -39,21 +40,11 @@ inline void SplineC2R<ST>::set_spline(SingleSplineType* spline_r,
 
 template<typename ST>
 bool SplineC2R<ST>::read_splines(hdf_archive& h5f)
-{
-  std::ostringstream o;
-  o << "spline_" << MyIndex;
-  einspline_engine<SplineType> bigtable(SplineInst->getSplinePtr());
-  return h5f.readEntry(bigtable, o.str().c_str()); //"spline_0");
-}
+{ return SplineUtils<ST>::read(*SplineInst, h5f); }
 
 template<typename ST>
 bool SplineC2R<ST>::write_splines(hdf_archive& h5f)
-{
-  std::ostringstream o;
-  o << "spline_" << MyIndex;
-  einspline_engine<SplineType> bigtable(SplineInst->getSplinePtr());
-  return h5f.writeEntry(bigtable, o.str().c_str()); //"spline_0");
-}
+{ return SplineUtils<ST>::write(*SplineInst, h5f); }
 
 template<typename ST>
 inline void SplineC2R<ST>::assign_v(const PointType& r,

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
@@ -66,8 +66,6 @@ private:
   Tensor<ST, 3> GGt;
   ///number of complex bands
   int nComplexBands;
-  ///multi bspline set
-  std::shared_ptr<MultiBspline<ST>> SplineInst;
 
   vContainer_type mKK;
   VectorSoaContainer<ST, 3> myKcart;
@@ -76,6 +74,8 @@ private:
   Matrix<TT> ratios_private;
 
 protected:
+  ///multi bspline set
+  std::shared_ptr<MultiBspline<ST>> SplineInst;
   /// intermediate result vectors
   vContainer_type myV;
   vContainer_type myL;
@@ -148,10 +148,6 @@ public:
   }
 
   void set_spline(SingleSplineType* spline_r, SingleSplineType* spline_i, int twist, int ispline, int level);
-
-  bool read_splines(hdf_archive& h5f);
-
-  bool write_splines(hdf_archive& h5f);
 
   void assign_v(const PointType& r, const vContainer_type& myV, ValueVector& psi, int first, int last) const;
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
@@ -16,6 +16,7 @@
 #include "QMCWaveFunctions/BsplineFactory/contraction_helper.hpp"
 #include "ApplyPhaseC2R.hpp"
 #include "Concurrency/OpenMP.h"
+#include "SplineUtils.h"
 
 namespace qmcplusplus
 {
@@ -35,21 +36,11 @@ inline void SplineC2ROMPTarget<ST>::set_spline(SingleSplineType* spline_r,
 
 template<typename ST>
 bool SplineC2ROMPTarget<ST>::read_splines(hdf_archive& h5f)
-{
-  std::ostringstream o;
-  o << "spline_" << MyIndex;
-  einspline_engine<SplineType> bigtable(SplineInst->getSplinePtr());
-  return h5f.readEntry(bigtable, o.str().c_str()); //"spline_0");
-}
+{ return SplineUtils<ST>::read(*SplineInst, h5f); }
 
 template<typename ST>
 bool SplineC2ROMPTarget<ST>::write_splines(hdf_archive& h5f)
-{
-  std::ostringstream o;
-  o << "spline_" << MyIndex;
-  einspline_engine<SplineType> bigtable(SplineInst->getSplinePtr());
-  return h5f.writeEntry(bigtable, o.str().c_str()); //"spline_0");
-}
+{ return SplineUtils<ST>::write(*SplineInst, h5f); }
 
 template<typename ST>
 inline void SplineC2ROMPTarget<ST>::assign_v(const PointType& r,
@@ -370,9 +361,9 @@ void SplineC2ROMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
         const size_t last_cplx  = omptarget::min(last / 2, num_complex_splines);
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = first_cplx; index < last_cplx; index++)
-          C2R::assign_v(pos_scratch[iat * 6], pos_scratch[iat * 6 + 1], pos_scratch[iat * 6 + 2],
-                        psi_iat_ptr, offload_scratch_iat_ptr, myKcart_ptr, myKcart_padded_size, first_spo_local,
-                        nComplexBands_local, index);
+          C2R::assign_v(pos_scratch[iat * 6], pos_scratch[iat * 6 + 1], pos_scratch[iat * 6 + 2], psi_iat_ptr,
+                        offload_scratch_iat_ptr, myKcart_ptr, myKcart_padded_size, first_spo_local, nComplexBands_local,
+                        index);
 
         const size_t first_real = first_cplx + omptarget::min(nComplexBands_local, first_cplx);
         const size_t last_real =

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
@@ -16,7 +16,6 @@
 #include "QMCWaveFunctions/BsplineFactory/contraction_helper.hpp"
 #include "ApplyPhaseC2R.hpp"
 #include "Concurrency/OpenMP.h"
-#include "SplineUtils.h"
 
 namespace qmcplusplus
 {
@@ -33,14 +32,6 @@ inline void SplineC2ROMPTarget<ST>::set_spline(SingleSplineType* spline_r,
   copy_spline<double, ST>(*spline_r, *SplineInst->getSplinePtr(), 2 * ispline);
   copy_spline<double, ST>(*spline_i, *SplineInst->getSplinePtr(), 2 * ispline + 1);
 }
-
-template<typename ST>
-bool SplineC2ROMPTarget<ST>::read_splines(hdf_archive& h5f)
-{ return SplineUtils<ST>::read(*SplineInst, h5f); }
-
-template<typename ST>
-bool SplineC2ROMPTarget<ST>::write_splines(hdf_archive& h5f)
-{ return SplineUtils<ST>::write(*SplineInst, h5f); }
 
 template<typename ST>
 inline void SplineC2ROMPTarget<ST>::assign_v(const PointType& r,

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -76,8 +76,6 @@ private:
   Tensor<ST, 3> GGt;
   ///number of complex bands
   int nComplexBands;
-  ///multi bspline set
-  std::shared_ptr<MultiBsplineBase<ST>> SplineInst;
 
   std::shared_ptr<OffloadVector<ST>> mKK;
   std::shared_ptr<OffloadPosVector<ST>> myKcart;
@@ -105,6 +103,8 @@ private:
                            const RefVector<ValueVector>& d2psi_v_list) const;
 
 protected:
+  ///multi bspline set
+  std::shared_ptr<MultiBsplineBase<ST>> SplineInst;
   /// intermediate result vectors
   vContainer_type myV;
   vContainer_type myL;
@@ -220,10 +220,6 @@ public:
   }
 
   void set_spline(SingleSplineType* spline_r, SingleSplineType* spline_i, int twist, int ispline, int level);
-
-  bool read_splines(hdf_archive& h5f);
-
-  bool write_splines(hdf_archive& h5f);
 
   void assign_v(const PointType& r, const vContainer_type& myV, ValueVector& psi, int first, int last) const;
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
@@ -24,7 +24,6 @@
 #include "CPU/SIMD/inner_product.hpp"
 #include "OMPTarget/OMPTargetMath.hpp"
 #include <cstdint>
-#include "SplineUtils.h"
 
 namespace qmcplusplus
 {
@@ -75,14 +74,6 @@ void SplineR2R<ST>::finalizeConstruction()
     GGt_offload->updateTo();
   }
 }
-
-template<typename ST>
-bool SplineR2R<ST>::read_splines(hdf_archive& h5f)
-{ return SplineUtils<ST>::read(*SplineInst, h5f); }
-
-template<typename ST>
-bool SplineR2R<ST>::write_splines(hdf_archive& h5f)
-{ return SplineUtils<ST>::write(*SplineInst, h5f); }
 
 template<typename ST>
 void SplineR2R<ST>::storeParamsBeforeRotation()

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
@@ -24,6 +24,7 @@
 #include "CPU/SIMD/inner_product.hpp"
 #include "OMPTarget/OMPTargetMath.hpp"
 #include <cstdint>
+#include "SplineUtils.h"
 
 namespace qmcplusplus
 {
@@ -54,9 +55,7 @@ inline void SplineR2R<ST>::set_spline(SingleSplineType* spline_r,
                                       int twist,
                                       int ispline,
                                       int level)
-{
-  copy_spline<double, ST>(*spline_r, *SplineInst->getSplinePtr(), ispline);
-}
+{ copy_spline<double, ST>(*spline_r, *SplineInst->getSplinePtr(), ispline); }
 
 template<typename ST>
 void SplineR2R<ST>::finalizeConstruction()
@@ -79,21 +78,11 @@ void SplineR2R<ST>::finalizeConstruction()
 
 template<typename ST>
 bool SplineR2R<ST>::read_splines(hdf_archive& h5f)
-{
-  std::ostringstream o;
-  o << "spline_" << MyIndex;
-  einspline_engine<SplineType> bigtable(SplineInst->getSplinePtr());
-  return h5f.readEntry(bigtable, o.str().c_str()); //"spline_0");
-}
+{ return SplineUtils<ST>::read(*SplineInst, h5f); }
 
 template<typename ST>
 bool SplineR2R<ST>::write_splines(hdf_archive& h5f)
-{
-  std::ostringstream o;
-  o << "spline_" << MyIndex;
-  einspline_engine<SplineType> bigtable(SplineInst->getSplinePtr());
-  return h5f.writeEntry(bigtable, o.str().c_str()); //"spline_0");
-}
+{ return SplineUtils<ST>::write(*SplineInst, h5f); }
 
 template<typename ST>
 void SplineR2R<ST>::storeParamsBeforeRotation()

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
@@ -67,8 +67,6 @@ private:
   bool IsGamma;
   ///\f$GGt=G^t G \f$, transformation for tensor in LatticeUnit to CartesianUnit, e.g. Hessian
   Tensor<ST, 3> GGt;
-  ///multi bspline set
-  std::shared_ptr<MultiBsplineBase<ST>> SplineInst;
   /// const offload copy of GGt
   std::shared_ptr<OffloadVector<ST>> GGt_offload;
   /// const offload copy of GPrimLattice_G
@@ -83,6 +81,8 @@ private:
   Matrix<TT> ratios_private;
 
 protected:
+  ///multi bspline set
+  std::shared_ptr<MultiBsplineBase<ST>> SplineInst;
   ///primitive cell
   CrystalLattice<ST, 3> PrimLattice;
   /// intermediate result vectors
@@ -182,10 +182,6 @@ public:
   inline void flush_zero() { SplineInst->flush_zero(); }
 
   void set_spline(SingleSplineType* spline_r, SingleSplineType* spline_i, int twist, int ispline, int level);
-
-  bool read_splines(hdf_archive& h5f);
-
-  bool write_splines(hdf_archive& h5f);
 
   /** convert position in PrimLattice unit and return sign */
   inline int convertPos(const PointType& r, PointType& ru) const

--- a/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
@@ -27,6 +27,7 @@
 #include "SplineC2R.h"
 #include "SplineC2ROMPTarget.h"
 #endif
+#include "SplineUtils.h"
 
 namespace qmcplusplus
 {
@@ -48,7 +49,7 @@ std::unique_ptr<SPOSet> SplineSetReader<SA>::create_spline_set(const std::string
     hdf_archive h5f(myComm);
     const auto splinefile = getSplineDumpFileName(bandgroup);
     h5f.open(splinefile, H5F_ACC_RDONLY);
-    foundspline = bspline->read_splines(h5f);
+    foundspline = SplineUtils<typename SA::DataType>::read(*bspline->SplineInst, h5f);
     if (foundspline)
       app_log() << "  Successfully restored 3D B-spline coefficients from " << splinefile << ". The reading time is "
                 << now.elapsed() << " sec." << std::endl;
@@ -72,7 +73,7 @@ std::unique_ptr<SPOSet> SplineSetReader<SA>::create_spline_set(const std::string
       h5f.write(classname, "class_name");
       int sizeD = sizeof(typename SA::DataType);
       h5f.write(sizeD, "sizeof");
-      bspline->write_splines(h5f);
+      SplineUtils<typename SA::DataType>::write(*bspline->SplineInst, h5f);
       h5f.close();
       app_log() << "  Stored spline coefficients in " << splinefile << " for potential reuse. The writing time is "
                 << now.elapsed() << " sec." << std::endl;

--- a/src/QMCWaveFunctions/BsplineFactory/SplineUtils.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineUtils.cpp
@@ -1,0 +1,53 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2026 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "SplineUtils.h"
+#include <sstream>
+#include "spline/einspline_engine.hpp"
+#include "spline/einspline_util.hpp"
+
+namespace qmcplusplus
+{
+template<typename ST>
+bool SplineUtils<ST>::read(MultiBsplineBase<ST>& spline, hdf_archive& h5f)
+{
+  std::ostringstream o;
+  o << "spline_" << my_index;
+  einspline_engine bigtable(spline.getSplinePtr());
+  return h5f.readEntry(bigtable, o.str());
+}
+
+template<typename ST>
+bool SplineUtils<ST>::write(MultiBsplineBase<ST>& spline, hdf_archive& h5f)
+{
+  std::ostringstream o;
+  o << "spline_" << my_index;
+  einspline_engine bigtable(spline.getSplinePtr());
+  return h5f.writeEntry(bigtable, o.str());
+}
+
+template<typename ST>
+bool SplineUtils<ST>::read(MultiBspline1D<ST>& spline, hdf_archive& h5f)
+{
+  einspline_engine bigtable(spline.getSplinePtr());
+  return h5f.readEntry(bigtable, "radial_spline");
+}
+
+template<typename ST>
+bool SplineUtils<ST>::write(MultiBspline1D<ST>& spline, hdf_archive& h5f)
+{
+  einspline_engine bigtable(spline.getSplinePtr());
+  return h5f.writeEntry(bigtable, "radial_spline");
+}
+
+template class SplineUtils<float>;
+template class SplineUtils<double>;
+} // namespace qmcplusplus

--- a/src/QMCWaveFunctions/BsplineFactory/SplineUtils.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineUtils.h
@@ -1,0 +1,39 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2026 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_SPLINE_UTILS_H
+#define QMCPLUSPLUS_SPLINE_UTILS_H
+
+#include "hdf/hdf_archive.h"
+#include "spline2/MultiBsplineBase.hpp"
+#include "spline2/MultiBspline1D.hpp"
+
+namespace qmcplusplus
+{
+template<typename ST>
+class SplineUtils
+{
+  static constexpr size_t my_index = 0;
+
+public:
+  static bool read(MultiBsplineBase<ST>& spline, hdf_archive& h5f);
+  static bool write(MultiBsplineBase<ST>& spline, hdf_archive& h5f);
+  static bool read(MultiBspline1D<ST>& spline, hdf_archive& h5f);
+  static bool write(MultiBspline1D<ST>& spline, hdf_archive& h5f);
+};
+
+extern template class SplineUtils<float>;
+extern template class SplineUtils<double>;
+
+
+} // namespace qmcplusplus
+#endif

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -88,6 +88,7 @@ if(OHMMS_DIM MATCHES 3)
         BsplineFactory/SplineSetReader.cpp
         BsplineFactory/HybridRepSetReader.cpp
         BsplineFactory/OneSplineOrbData.cpp
+        BsplineFactory/SplineUtils.cpp
         BandInfo.cpp
         BsplineFactory/BsplineReader.cpp)
     set(FERMION_OMPTARGET_SRCS Fermion/DiracDeterminantBatched.cpp Fermion/MultiDiracDeterminant.2.cpp)

--- a/src/spline/einspline_util.hpp
+++ b/src/spline/einspline_util.hpp
@@ -20,6 +20,7 @@
 
 #include "mpi/mpi_datatype.h"
 #include "Message/CommOperators.h"
+#include "Host/OutputManager.h"
 #include "OhmmsData/FileUtility.h"
 #include "hdf/hdf_archive.h"
 #include "einspline/multi_bspline_copy.h"
@@ -51,9 +52,7 @@ inline void chunked_bcast(Communicate* comm, T* buffer, size_t ntot)
 
 template<typename ENGT>
 inline void chunked_bcast(Communicate* comm, ENGT* buffer)
-{
-  chunked_bcast(comm, buffer->coefs, buffer->coefs_size);
-}
+{ chunked_bcast(comm, buffer->coefs, buffer->coefs_size); }
 
 template<typename ENGT>
 inline void gatherv(Communicate* comm, ENGT* buffer, const int ncol, std::vector<int>& offset)
@@ -143,9 +142,7 @@ struct h5data_proxy<einspline_engine<ENGT>>
   }
 
   inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
-  {
-    return h5d_write(grp, aname.c_str(), Base::rank, dims, get_address(ref.spliner->coefs), xfer_plist);
-  }
+  { return h5d_write(grp, aname.c_str(), Base::rank, dims, get_address(ref.spliner->coefs), xfer_plist); }
 };
 
 template<typename GT>

--- a/src/spline2/MultiBspline1D.hpp
+++ b/src/spline2/MultiBspline1D.hpp
@@ -18,6 +18,7 @@
 #define QMCPLUSPLUS_MULTIEINSPLINE_1D_HPP
 
 #include "spline2/MultiBsplineEval_helper.hpp"
+#include "CPU/SIMD/aligned_allocator.hpp"
 #include "spline/einspline_engine.hpp"
 #include "spline/einspline_util.hpp"
 
@@ -91,21 +92,15 @@ public:
    */
   template<typename SingleSpline>
   void copy_spline(SingleSpline* aSpline, int i, const int offset_, const int base_)
-  {
-    einspline::set(spline_m, i, aSpline, offset_, base_);
-  }
+  { einspline::set(spline_m, i, aSpline, offset_, base_); }
 
   template<typename PT, typename VT>
   inline void evaluate(const PT& r, VT& psi) const
-  {
-    evaluate_v_impl(r, psi.data());
-  }
+  { evaluate_v_impl(r, psi.data()); }
 
   template<typename PT, typename VT, typename GT, typename LT>
   inline void evaluate_vgl(const PT& r, VT& psi, GT& grad, LT& lap) const
-  {
-    evaluate_vgl_impl(r, psi.data(), grad.data(), lap.data());
-  }
+  { evaluate_vgl_impl(r, psi.data(), grad.data(), lap.data()); }
 
   //template<typename PT, typename VT, typename GT, typename HT>
   //  inline void evaluate_vgh(const PT& r, VT& psi, GT& grad, HT& hess)

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -205,3 +205,12 @@ run_restart_and_check(
   4
   check.sh
   true)
+
+run_restart_and_check(
+  deterministic-save_spline_coefs_hybridrep
+  "${qmcpack_SOURCE_DIR}/tests/io/save_spline_coefs_hybridrep"
+  qmc_short
+  1
+  3
+  check.sh
+  true)

--- a/tests/io/save_spline_coefs_hybridrep/C.BFD.xml
+++ b/tests/io/save_spline_coefs_hybridrep/C.BFD.xml
@@ -1,0 +1,1 @@
+../../solids/diamondC_1x1x1_pp/C.BFD.xml

--- a/tests/io/save_spline_coefs_hybridrep/check.sh
+++ b/tests/io/save_spline_coefs_hybridrep/check.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+[[ -f qmc_short.s002.scalar.dat ]]

--- a/tests/io/save_spline_coefs_hybridrep/pwscf.pwscf.h5
+++ b/tests/io/save_spline_coefs_hybridrep/pwscf.pwscf.h5
@@ -1,0 +1,1 @@
+../../solids/diamondC_1x1x1_pp/pwscf.pwscf.h5

--- a/tests/io/save_spline_coefs_hybridrep/qmc_short.in.xml
+++ b/tests/io/save_spline_coefs_hybridrep/qmc_short.in.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="qmc_short" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+    <parameter name="driver_version">batched</parameter>
+   </project>
+   <random seed="49154"/>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <parameter name="cutoff_radius"       >    1.1                   </parameter>
+            <parameter name="lmax"                >    3                     </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <sposet_collection type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float" hybridrep="yes" save_coefs="yes">
+            <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
+         </sposet_collection>
+         <determinantset>
+            <slaterdeterminant>
+               <determinant id="updet" group="u" sposet="spo_ud" size="4"/>
+               <determinant id="downdet" group="d" sposet="spo_ud" size="4"/>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <estimator type="flux" name="Flux"/>
+      </hamiltonian>
+   </qmcsystem>
+</simulation>

--- a/tests/io/save_spline_coefs_hybridrep/qmc_short.restart.xml
+++ b/tests/io/save_spline_coefs_hybridrep/qmc_short.restart.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="qmc_short" series="2">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+    <parameter name="driver_version">legacy</parameter>
+   </project>
+   <random seed="49154"/>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff">    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge">    -1                    </parameter>
+            <parameter name="mass">    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge">    -1                    </parameter>
+            <parameter name="mass">    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <parameter name="cutoff_radius"       >    1.1                   </parameter>
+            <parameter name="lmax"                >    3                     </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <sposet_collection type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float" hybridrep="yes">
+            <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
+         </sposet_collection>
+         <determinantset>
+            <slaterdeterminant>
+               <determinant id="updet" group="u" sposet="spo_ud" size="4"/>
+               <determinant id="downdet" group="d" sposet="spo_ud" size="4"/>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <estimator type="flux" name="Flux"/>
+      </hamiltonian>
+   </qmcsystem>
+
+   <qmc method="vmc" move="pbyp">
+      <parameter name="total_walkers"       >    16              </parameter>
+      <parameter name="blocks"              >    3               </parameter>
+      <parameter name="steps"               >    2               </parameter>
+      <parameter name="subSteps"            >    2               </parameter>
+      <parameter name="timestep"            >    0.3             </parameter>
+      <parameter name="warmupSteps"         >    10              </parameter>
+   </qmc>
+</simulation>


### PR DESCRIPTION
## Proposed changes
Dump file I/O doesn't needed to be handled through BsplineSet derived classes member functions.
The builder should be able to interact with the underlying MultiSpline objects directly.
See the removed redundant code.
Eventually I'd like to fully build MultiSpline objects first and pass them via the constructor of BsplineSet derived classes.
Unfortunately, access scope (privite, protected, public) will be a bit messy for a while until I get all the pieces in the right place.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)