### PR TITLE
Nexus: Add check for failure to properly call `qmcpack` executable

### DIFF
--- a/nexus/nexus/qmcpack.py
+++ b/nexus/nexus/qmcpack.py
@@ -1151,10 +1151,10 @@ class Qmcpack(Simulation):
         errors = self.errfile_text()
 
         ran_to_end  = 'Total Execution' in output
+        run_started = 'QMCPACK' in output
         aborted     = 'Fatal Error' in errors
         files_exist = True
         cusp_run    = False
-
         if not self.has_generic_input():
             if not isinstance(self.input,TracedQmcpackInput):
                 cusp_run = self.input.cusp_correction()
@@ -1186,9 +1186,11 @@ class Qmcpack(Simulation):
             #end if
         #end if
 
+        if not run_started:
+            self.warn("QMCPACK did not start properly!\n")
 
         self.succeeded = ran_to_end
-        self.failed    = aborted
+        self.failed    = aborted or not run_started
         self.finished  = files_exist and (self.job.finished or ran_to_end) and not aborted 
 
         if cusp_run and files_exist:

--- a/nexus/nexus/qmcpack_analyzer.py
+++ b/nexus/nexus/qmcpack_analyzer.py
@@ -220,8 +220,12 @@ class QmcpackAnalyzer(SimulationAnalyzer,QAanalyzer):
             ghost_atoms(*ghosts)
         #end if
 
-        if isinstance(arg0,Simulation):
+        if isinstance(arg0, Simulation):
             sim = arg0
+            if sim.failed:
+                self.warn("Simulation failed, skipping analysis!")
+                self.info.analyzed = sim.failed
+
             if 'analysis_request' in sim:
                 request = sim.analysis_request.copy()
             else:

--- a/nexus/nexus/simulation.py
+++ b/nexus/nexus/simulation.py
@@ -1262,7 +1262,13 @@ class Simulation(NexusCore):
                     if not self.got_output and 'get_output' in nexus_core.stages:
                         self.get_output()
                     #end if
+
+                    analyzed = self.analyzed
+                    if hasattr(self, "info"): # QmcpackAnalyzer uses QAInformation
+                        analyzed |= self.info.analyzed
+
                     if not self.analyzed and 'analyze' in nexus_core.stages:
+
                         self.analyze()
                     #end if
                 #end if

--- a/nexus/nexus/tests/test_qmcpack_simulation.py
+++ b/nexus/nexus/tests/test_qmcpack_simulation.py
@@ -401,7 +401,10 @@ def test_check_sim_status():
     assert(not sim.failed)
 
     outfile = os.path.join(tpath,sim.outfile)
-    out_text = 'Total Execution'
+    out_text = (
+        'QMCPACK\n'
+        'Total Execution'
+    )
     out = open(outfile,'w')
     out.write(out_text)
     out.close()


### PR DESCRIPTION
## Proposed changes

This fixes a bug where Nexus wouldn't be able to detect a run failure if the `qmcpack` executable was not called at all. In my case I forgot to set my `$PATH` to point to `qmcpack/build/bin`, so `mpirun` never got anywhere. To fix this, a check for `'QMCPACK'` in the output file was added, and some logic in the analyzer was added to inform the user of the problem and skip the analysis.

It's a very barebones and simple check, but without sufficient information about other possible failure modes it's the best available that most likely won't get any false positives.

## What type(s) of changes does this code introduce?

- Bugfix
- New feature
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora 43, Python 3.14.2, Numpy 2.4.2

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
