### PR TITLE
Refactor BsplineSet derived classes regarding communication

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
@@ -22,8 +22,6 @@
 #define QMCPLUSPLUS_BSPLINESET_H
 
 #include "QMCWaveFunctions/SPOSet.h"
-#include "spline/einspline_engine.hpp"
-#include "spline/einspline_util.hpp"
 
 namespace qmcplusplus
 {
@@ -50,8 +48,6 @@ protected:
   std::vector<SPOSet::PosType> kPoints;
   ///remap splines to orbitals
   aligned_vector<int> BandIndexMap;
-  ///band offsets used for communication
-  std::vector<int> offset;
 
 public:
   BsplineSet(const std::string& my_name) : SPOSet(my_name), first_spo(0), last_spo(0) {}

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.cpp
@@ -11,9 +11,135 @@
 
 
 #include "HybridRepCenterOrbitals.h"
+#include "hdf/hdf_archive.h"
+#include "SplineUtils.h"
+#include "Message/Communicate.h"
 
 namespace qmcplusplus
 {
+template<typename ST>
+void AtomicOrbitals<ST>::bcast_tables(Communicate& comm)
+{ SplineUtils<ST>::bcast(*SplineInst, comm); }
+
+template<typename ST>
+void AtomicOrbitals<ST>::gather_tables(Communicate& comm, const std::vector<int>& offset)
+{ SplineUtils<ST>::gatherv(*SplineInst, Npad, offset, comm); }
+
+template<typename ST>
+bool AtomicOrbitals<ST>::read_splines(hdf_archive& h5f)
+{
+  einspline_engine<AtomicSplineType> bigtable(SplineInst->getSplinePtr());
+  int lmax_in = 0, spline_npoints_in = 0;
+  ST spline_radius_in;
+  if (!h5f.readEntry(lmax_in, "l_max") || lmax_in != lmax)
+    return false;
+  if (!h5f.readEntry(spline_radius_in, "spline_radius") || spline_radius_in != spline_radius)
+    return false;
+  if (!h5f.readEntry(spline_npoints_in, "spline_npoints") || spline_npoints_in != spline_npoints)
+    return false;
+  return SplineUtils<ST>::read(*SplineInst, h5f);
+}
+
+template<typename ST>
+bool AtomicOrbitals<ST>::write_splines(hdf_archive& h5f)
+{
+  bool success = true;
+  success      = success && h5f.writeEntry(spline_radius, "spline_radius");
+  success      = success && h5f.writeEntry(spline_npoints, "spline_npoints");
+  success      = success && h5f.writeEntry(lmax, "l_max");
+  success      = success && h5f.writeEntry(center_pos, "position");
+  return success && SplineUtils<ST>::write(*SplineInst, h5f);
+}
+
+template<typename ST>
+void HybridRepCenterOrbitals<ST>::bcast_atomic_tables(Communicate* comm)
+{
+  for (int ic = 0; ic < AtomicCenters.size(); ic++)
+    AtomicCenters[ic].bcast_tables(*comm);
+}
+
+template<typename ST>
+void HybridRepCenterOrbitals<ST>::gather_atomic_tables(Communicate* comm, const std::vector<int>& offset)
+{
+  if (comm->size() == 1)
+    return;
+  for (int ic = 0; ic < AtomicCenters.size(); ic++)
+    AtomicCenters[ic].gather_tables(*comm, offset);
+}
+
+template<typename ST>
+bool HybridRepCenterOrbitals<ST>::read_atomic_splines(hdf_archive& h5f)
+{
+  bool success = true;
+  size_t ncenter;
+
+  try
+  {
+    h5f.push("atomic_centers", false);
+  }
+  catch (...)
+  {
+    success = false;
+  }
+  success = success && h5f.readEntry(ncenter, "number_of_centers");
+  if (!success)
+    return success;
+  if (ncenter != AtomicCenters.size())
+    success = false;
+  // read splines of each center
+  for (int ic = 0; ic < AtomicCenters.size(); ic++)
+  {
+    std::ostringstream gname;
+    gname << "center_" << ic;
+    try
+    {
+      h5f.push(gname.str().c_str(), false);
+    }
+    catch (...)
+    {
+      success = false;
+    }
+    success = success && AtomicCenters[ic].read_splines(h5f);
+    h5f.pop();
+  }
+  h5f.pop();
+  return success;
+}
+
+template<typename ST>
+bool HybridRepCenterOrbitals<ST>::write_atomic_splines(hdf_archive& h5f)
+{
+  bool success = true;
+  int ncenter  = AtomicCenters.size();
+  try
+  {
+    h5f.push("atomic_centers", true);
+  }
+  catch (...)
+  {
+    success = false;
+  }
+  success = success && h5f.writeEntry(ncenter, "number_of_centers");
+  // write splines of each center
+  for (int ic = 0; ic < AtomicCenters.size(); ic++)
+  {
+    std::ostringstream gname;
+    gname << "center_" << ic;
+    try
+    {
+      h5f.push(gname.str().c_str(), true);
+    }
+    catch (...)
+    {
+      success = false;
+    }
+    success = success && AtomicCenters[ic].write_splines(h5f);
+    h5f.pop();
+  }
+  h5f.pop();
+  return success;
+}
+
 template class AtomicOrbitals<float>;
 template class AtomicOrbitals<double>;
 template class HybridRepCenterOrbitals<float>;

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
@@ -22,11 +22,13 @@
 #include "Numerics/SoaSphericalTensor.h"
 #include "spline2/MultiBspline1D.hpp"
 #include "Numerics/SmoothFunctions.hpp"
-#include "hdf/hdf_archive.h"
-#include "SplineUtils.h"
+
+class Communicate;
 
 namespace qmcplusplus
 {
+class hdf_archive;
+
 template<class BSPLINESPO>
 class HybridRepSetReader;
 
@@ -95,10 +97,8 @@ public:
     create_spline();
   }
 
-  void bcast_tables(Communicate& comm) { SplineUtils<ST>::bcast(*SplineInst, comm); }
-
-  void gather_tables(Communicate& comm, const std::vector<int>& offset)
-  { SplineUtils<ST>::gatherv(*SplineInst, Npad, offset, comm); }
+  void bcast_tables(Communicate& comm);
+  void gather_tables(Communicate& comm, const std::vector<int>& offset);
 
   template<typename PT, typename VT>
   inline void set_info(const PT& R,
@@ -139,29 +139,8 @@ public:
   inline void set_spline(AtomicSingleSplineType* spline, int lm, int ispline)
   { SplineInst->copy_spline(spline, lm * Npad + ispline, 0, BaseN); }
 
-  bool read_splines(hdf_archive& h5f)
-  {
-    einspline_engine<AtomicSplineType> bigtable(SplineInst->getSplinePtr());
-    int lmax_in = 0, spline_npoints_in = 0;
-    ST spline_radius_in;
-    if (!h5f.readEntry(lmax_in, "l_max") || lmax_in != lmax)
-      return false;
-    if (!h5f.readEntry(spline_radius_in, "spline_radius") || spline_radius_in != spline_radius)
-      return false;
-    if (!h5f.readEntry(spline_npoints_in, "spline_npoints") || spline_npoints_in != spline_npoints)
-      return false;
-    return SplineUtils<ST>::read(*SplineInst, h5f);
-  }
-
-  bool write_splines(hdf_archive& h5f)
-  {
-    bool success = true;
-    success      = success && h5f.writeEntry(spline_radius, "spline_radius");
-    success      = success && h5f.writeEntry(spline_npoints, "spline_npoints");
-    success      = success && h5f.writeEntry(lmax, "l_max");
-    success      = success && h5f.writeEntry(center_pos, "position");
-    return success && SplineUtils<ST>::write(*SplineInst, h5f);
-  }
+  bool read_splines(hdf_archive& h5f);
+  bool write_splines(hdf_archive& h5f);
 
   //evaluate only V
   template<typename VV>
@@ -571,19 +550,8 @@ public:
               << "for the atomic radial splines in hybrid orbital representation" << std::endl;
   }
 
-  void bcast_atomic_tables(Communicate* comm)
-  {
-    for (int ic = 0; ic < AtomicCenters.size(); ic++)
-      AtomicCenters[ic].bcast_tables(*comm);
-  }
-
-  void gather_atomic_tables(Communicate* comm, const std::vector<int>& offset)
-  {
-    if (comm->size() == 1)
-      return;
-    for (int ic = 0; ic < AtomicCenters.size(); ic++)
-      AtomicCenters[ic].gather_tables(*comm, offset);
-  }
+  void bcast_atomic_tables(Communicate* comm);
+  void gather_atomic_tables(Communicate* comm, const std::vector<int>& offset);
 
   inline void flush_zero()
   {
@@ -591,76 +559,8 @@ public:
       AtomicCenters[ic].flush_zero();
   }
 
-  bool read_atomic_splines(hdf_archive& h5f)
-  {
-    bool success = true;
-    size_t ncenter;
-
-    try
-    {
-      h5f.push("atomic_centers", false);
-    }
-    catch (...)
-    {
-      success = false;
-    }
-    success = success && h5f.readEntry(ncenter, "number_of_centers");
-    if (!success)
-      return success;
-    if (ncenter != AtomicCenters.size())
-      success = false;
-    // read splines of each center
-    for (int ic = 0; ic < AtomicCenters.size(); ic++)
-    {
-      std::ostringstream gname;
-      gname << "center_" << ic;
-      try
-      {
-        h5f.push(gname.str().c_str(), false);
-      }
-      catch (...)
-      {
-        success = false;
-      }
-      success = success && AtomicCenters[ic].read_splines(h5f);
-      h5f.pop();
-    }
-    h5f.pop();
-    return success;
-  }
-
-  bool write_atomic_splines(hdf_archive& h5f)
-  {
-    bool success = true;
-    int ncenter  = AtomicCenters.size();
-    try
-    {
-      h5f.push("atomic_centers", true);
-    }
-    catch (...)
-    {
-      success = false;
-    }
-    success = success && h5f.writeEntry(ncenter, "number_of_centers");
-    // write splines of each center
-    for (int ic = 0; ic < AtomicCenters.size(); ic++)
-    {
-      std::ostringstream gname;
-      gname << "center_" << ic;
-      try
-      {
-        h5f.push(gname.str().c_str(), true);
-      }
-      catch (...)
-      {
-        success = false;
-      }
-      success = success && AtomicCenters[ic].write_splines(h5f);
-      h5f.pop();
-    }
-    h5f.pop();
-    return success;
-  }
+  bool read_atomic_splines(hdf_archive& h5f);
+  bool write_atomic_splines(hdf_archive& h5f);
 
   template<typename Cell>
   inline int get_bc_sign(const PointType& r,

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
@@ -95,10 +95,10 @@ public:
     create_spline();
   }
 
-  void bcast_tables(Communicate* comm) { chunked_bcast(comm, SplineInst->getSplinePtr()); }
+  void bcast_tables(Communicate& comm) { SplineUtils<ST>::bcast(*SplineInst, comm); }
 
-  void gather_tables(Communicate* comm, std::vector<int>& offset)
-  { gatherv(comm, SplineInst->getSplinePtr(), Npad, offset); }
+  void gather_tables(Communicate& comm, const std::vector<int>& offset)
+  { SplineUtils<ST>::gatherv(*SplineInst, Npad, offset, comm); }
 
   template<typename PT, typename VT>
   inline void set_info(const PT& R,
@@ -571,18 +571,18 @@ public:
               << "for the atomic radial splines in hybrid orbital representation" << std::endl;
   }
 
-  void bcast_tables(Communicate* comm)
+  void bcast_atomic_tables(Communicate* comm)
   {
     for (int ic = 0; ic < AtomicCenters.size(); ic++)
-      AtomicCenters[ic].bcast_tables(comm);
+      AtomicCenters[ic].bcast_tables(*comm);
   }
 
-  void gather_atomic_tables(Communicate* comm, std::vector<int>& offset)
+  void gather_atomic_tables(Communicate* comm, const std::vector<int>& offset)
   {
     if (comm->size() == 1)
       return;
     for (int ic = 0; ic < AtomicCenters.size(); ic++)
-      AtomicCenters[ic].gather_tables(comm, offset);
+      AtomicCenters[ic].gather_tables(*comm, offset);
   }
 
   inline void flush_zero()

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
@@ -67,8 +67,6 @@ private:
 public:
   HybridRepCplx(const std::string& my_name) : SPLINEBASE(my_name) {}
 
-  auto& getMultiSpline3D() {return *SPLINEBASE::SplineInst; }
-
   bool isRotationSupported() const override { return SPLINEBASE::isRotationSupported(); }
   void storeParamsBeforeRotation() override
   {
@@ -86,18 +84,6 @@ public:
   bool isOMPoffload() const final { return false; }
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<HybridRepCplx>(*this); }
-
-  void bcast_tables(Communicate* comm)
-  {
-    SPLINEBASE::bcast_tables(comm);
-    HYBRIDBASE::bcast_tables(comm);
-  }
-
-  void gather_tables(Communicate* comm)
-  {
-    SPLINEBASE::gather_tables(comm);
-    HYBRIDBASE::gather_atomic_tables(comm, SPLINEBASE::offset);
-  }
 
   void evaluateValue(const ParticleSet& P, const int iat, ValueVector& psi) override
   {
@@ -162,9 +148,7 @@ public:
                             const RefVector<ValueVector>& psi_list,
                             const std::vector<const ValueType*>& invRow_ptr_list,
                             std::vector<std::vector<ValueType>>& ratios_list) const final
-  {
-    BsplineSet::mw_evaluateDetRatios(spo_list, vp_list, psi_list, invRow_ptr_list, ratios_list);
-  }
+  { BsplineSet::mw_evaluateDetRatios(spo_list, vp_list, psi_list, invRow_ptr_list, ratios_list); }
 
   void evaluateVGL(const ParticleSet& P, const int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi) override
   {
@@ -190,9 +174,7 @@ public:
                       const RefVector<ValueVector>& psi_v_list,
                       const RefVector<GradVector>& dpsi_v_list,
                       const RefVector<ValueVector>& d2psi_v_list) const final
-  {
-    BsplineSet::mw_evaluateVGL(sa_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list);
-  }
+  { BsplineSet::mw_evaluateVGL(sa_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list); }
 
   void mw_evaluateVGLandDetRatioGrads(const RefVectorWithLeader<SPOSet>& spo_list,
                                       const RefVectorWithLeader<ParticleSet>& P_list,
@@ -201,9 +183,7 @@ public:
                                       OffloadMWVGLArray& phi_vgl_v,
                                       std::vector<ValueType>& ratios,
                                       std::vector<GradType>& grads) const final
-  {
-    BsplineSet::mw_evaluateVGLandDetRatioGrads(spo_list, P_list, iat, invRow_ptr_list, phi_vgl_v, ratios, grads);
-  }
+  { BsplineSet::mw_evaluateVGLandDetRatioGrads(spo_list, P_list, iat, invRow_ptr_list, phi_vgl_v, ratios, grads); }
 
   void evaluateVGH(const ParticleSet& P,
                    const int iat,
@@ -225,9 +205,7 @@ public:
                      GradVector& dpsi,
                      HessVector& grad_grad_psi,
                      GGGVector& grad_grad_grad_psi) override
-  {
-    APP_ABORT("HybridRepCplx::evaluate_vghgh not implemented!");
-  }
+  { APP_ABORT("HybridRepCplx::evaluate_vghgh not implemented!"); }
 
   void evaluate_notranspose(const ParticleSet& P,
                             int first,

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
@@ -69,8 +69,6 @@ private:
 public:
   HybridRepReal(const std::string& my_name) : SPLINEBASE(my_name) {}
 
-  auto& getMultiSpline3D() {return *SPLINEBASE::SplineInst; }
-
   bool isRotationSupported() const override { return SPLINEBASE::isRotationSupported(); }
   void storeParamsBeforeRotation() override
   {
@@ -88,18 +86,6 @@ public:
   bool isOMPoffload() const final { return false; }
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<HybridRepReal>(*this); }
-
-  void bcast_tables(Communicate* comm)
-  {
-    SPLINEBASE::bcast_tables(comm);
-    HYBRIDBASE::bcast_tables(comm);
-  }
-
-  void gather_tables(Communicate* comm)
-  {
-    SPLINEBASE::gather_tables(comm);
-    HYBRIDBASE::gather_atomic_tables(comm, SPLINEBASE::offset);
-  }
 
   void evaluateValue(const ParticleSet& P, const int iat, ValueVector& psi) override
   {
@@ -166,9 +152,7 @@ public:
                             const RefVector<ValueVector>& psi_list,
                             const std::vector<const ValueType*>& invRow_ptr_list,
                             std::vector<std::vector<ValueType>>& ratios_list) const final
-  {
-    BsplineSet::mw_evaluateDetRatios(spo_list, vp_list, psi_list, invRow_ptr_list, ratios_list);
-  }
+  { BsplineSet::mw_evaluateDetRatios(spo_list, vp_list, psi_list, invRow_ptr_list, ratios_list); }
 
   void evaluateVGL(const ParticleSet& P, const int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi) override
   {
@@ -196,9 +180,7 @@ public:
                       const RefVector<ValueVector>& psi_v_list,
                       const RefVector<GradVector>& dpsi_v_list,
                       const RefVector<ValueVector>& d2psi_v_list) const final
-  {
-    BsplineSet::mw_evaluateVGL(sa_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list);
-  }
+  { BsplineSet::mw_evaluateVGL(sa_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list); }
 
   void mw_evaluateVGLandDetRatioGrads(const RefVectorWithLeader<SPOSet>& spo_list,
                                       const RefVectorWithLeader<ParticleSet>& P_list,
@@ -207,9 +189,7 @@ public:
                                       OffloadMWVGLArray& phi_vgl_v,
                                       std::vector<ValueType>& ratios,
                                       std::vector<GradType>& grads) const final
-  {
-    BsplineSet::mw_evaluateVGLandDetRatioGrads(spo_list, P_list, iat, invRow_ptr_list, phi_vgl_v, ratios, grads);
-  }
+  { BsplineSet::mw_evaluateVGLandDetRatioGrads(spo_list, P_list, iat, invRow_ptr_list, phi_vgl_v, ratios, grads); }
 
   void evaluateVGH(const ParticleSet& P,
                    const int iat,
@@ -232,9 +212,7 @@ public:
                      GradVector& dpsi,
                      HessVector& grad_grad_psi,
                      GGGVector& grad_grad_grad_psi) override
-  {
-    APP_ABORT("HybridRepCplx::evaluateVGHGH not implemented!");
-  }
+  { APP_ABORT("HybridRepCplx::evaluateVGHGH not implemented!"); }
 
   void evaluate_notranspose(const ParticleSet& P,
                             int first,

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
@@ -155,7 +155,7 @@ std::unique_ptr<SPOSet> HybridRepSetReader<SA>::create_spline_set(const std::str
     hdf_archive h5f(myComm);
     const auto splinefile = getSplineDumpFileName(bandgroup);
     h5f.open(splinefile, H5F_ACC_RDONLY);
-    foundspline = SplineUtils<DataType>::read(bspline->getMultiSpline3D(), h5f) && bspline->read_atomic_splines(h5f);
+    foundspline = SplineUtils<DataType>::read(*bspline->SplineInst, h5f) && bspline->read_atomic_splines(h5f);
     if (foundspline)
       app_log() << "  Successfully restored 3D B-spline coefficients from " << splinefile << ". The reading time is "
                 << now.elapsed() << " sec." << std::endl;
@@ -176,7 +176,7 @@ std::unique_ptr<SPOSet> HybridRepSetReader<SA>::create_spline_set(const std::str
       h5f.write(classname, "class_name");
       int sizeD = sizeof(DataType);
       h5f.write(sizeD, "sizeof");
-      SplineUtils<DataType>::write(bspline->getMultiSpline3D(), h5f);
+      SplineUtils<DataType>::write(*bspline->SplineInst, h5f);
       bspline->write_atomic_splines(h5f);
       h5f.close();
       app_log() << "  Stored spline coefficients in " << splinefile << " for potential reuse. The writing time is "
@@ -186,7 +186,7 @@ std::unique_ptr<SPOSet> HybridRepSetReader<SA>::create_spline_set(const std::str
 
   {
     Timer now;
-    bspline->bcast_tables(myComm);
+    SplineUtils<DataType>::bcast(*bspline->SplineInst, *myComm);
     app_log() << "  Time to bcast the table = " << now.elapsed() << std::endl;
   }
   return bspline;
@@ -653,7 +653,20 @@ void HybridRepSetReader<SA>::initialize_hybrid_pio_gather(const int spin,
   if (band_group_comm.isGroupLeader())
   {
     Timer now;
-    bspline.gather_tables(band_group_comm.getGroupLeaderComm());
+    if (bspline.isComplex())
+    {
+      std::vector<int> offset(band_groups.size());
+      for (int i = 0; i < offset.size(); i++)
+        offset[i] = band_groups[i] * 2;
+      SplineUtils<DataType>::gatherv(*bspline.SplineInst, offset, *band_group_comm.getGroupLeaderComm());
+      bspline.gather_atomic_tables(band_group_comm.getGroupLeaderComm(), offset);
+    }
+    else
+    {
+      SplineUtils<DataType>::gatherv(*bspline.SplineInst, band_groups, *band_group_comm.getGroupLeaderComm());
+      bspline.gather_atomic_tables(band_group_comm.getGroupLeaderComm(), band_groups);
+    }
+
     app_log() << "  Time to gather the table = " << now.elapsed() << std::endl;
   }
 }

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.h
@@ -119,21 +119,6 @@ public:
     mygH.resize(npad);
   }
 
-  void bcast_tables(Communicate* comm) { chunked_bcast(comm, SplineInst->getSplinePtr()); }
-
-  void gather_tables(Communicate* comm)
-  {
-    if (comm->size() == 1)
-      return;
-    const int Nbands      = kPoints.size();
-    const int Nbandgroups = comm->size();
-    offset.resize(Nbandgroups + 1, 0);
-    FairDivideLow(Nbands, Nbandgroups, offset);
-    for (size_t ib = 0; ib < offset.size(); ib++)
-      offset[ib] *= 2;
-    gatherv(comm, SplineInst->getSplinePtr(), SplineInst->getSplinePtr()->z_stride, offset);
-  }
-
   template<typename BCT>
   void create_spline(const Ugrid xyz_g[3], const BCT& xyz_bc)
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -126,9 +126,7 @@ public:
   virtual bool isOMPoffload() const override { return true; }
 
   void createResource(ResourceCollection& collection) const override
-  {
-    auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, ComplexT>>());
-  }
+  { auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, ComplexT>>()); }
 
   void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override
   {
@@ -162,22 +160,6 @@ public:
     myL.resize(npad);
     myH.resize(npad);
     mygH.resize(npad);
-  }
-
-  void bcast_tables(Communicate* comm) { chunked_bcast(comm, SplineInst->getSplinePtr()); }
-
-  void gather_tables(Communicate* comm)
-  {
-    if (comm->size() == 1)
-      return;
-    const int Nbands      = kPoints.size();
-    const int Nbandgroups = comm->size();
-    offset.resize(Nbandgroups + 1, 0);
-    FairDivideLow(Nbands, Nbandgroups, offset);
-
-    for (size_t ib = 0; ib < offset.size(); ib++)
-      offset[ib] *= 2;
-    gatherv(comm, SplineInst->getSplinePtr(), SplineInst->getSplinePtr()->z_stride, offset);
   }
 
   template<typename BCT>

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
@@ -104,22 +104,6 @@ public:
     mygH.resize(npad);
   }
 
-  void bcast_tables(Communicate* comm) { chunked_bcast(comm, SplineInst->getSplinePtr()); }
-
-  void gather_tables(Communicate* comm)
-  {
-    if (comm->size() == 1)
-      return;
-    const int Nbands      = kPoints.size();
-    const int Nbandgroups = comm->size();
-    offset.resize(Nbandgroups + 1, 0);
-    FairDivideLow(Nbands, Nbandgroups, offset);
-
-    for (size_t ib = 0; ib < offset.size(); ib++)
-      offset[ib] = offset[ib] * 2;
-    gatherv(comm, SplineInst->getSplinePtr(), SplineInst->getSplinePtr()->z_stride, offset);
-  }
-
   template<typename BCT>
   void create_spline(const Ugrid xyz_g[3], const BCT& xyz_bc)
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -129,9 +129,7 @@ public:
   virtual bool isOMPoffload() const override { return true; }
 
   void createResource(ResourceCollection& collection) const override
-  {
-    auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, TT>>());
-  }
+  { auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, TT>>()); }
 
   void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override
   {
@@ -158,22 +156,6 @@ public:
     myL.resize(npad);
     myH.resize(npad);
     mygH.resize(npad);
-  }
-
-  void bcast_tables(Communicate* comm) { chunked_bcast(comm, SplineInst->getSplinePtr()); }
-
-  void gather_tables(Communicate* comm)
-  {
-    if (comm->size() == 1)
-      return;
-    const int Nbands      = kPoints.size();
-    const int Nbandgroups = comm->size();
-    offset.resize(Nbandgroups + 1, 0);
-    FairDivideLow(Nbands, Nbandgroups, offset);
-
-    for (size_t ib = 0; ib < offset.size(); ib++)
-      offset[ib] = offset[ib] * 2;
-    gatherv(comm, SplineInst->getSplinePtr(), SplineInst->getSplinePtr()->z_stride, offset);
   }
 
   template<typename BCT>

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
@@ -102,9 +102,7 @@ public:
   virtual bool isOMPoffload() const override { return use_offload_; }
 
   void createResource(ResourceCollection& collection) const override
-  {
-    auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, TT>>());
-  }
+  { auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, TT>>()); }
 
   void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override
   {
@@ -151,19 +149,6 @@ public:
     mygH.resize(npad);
 
     IsGamma = ((HalfG[0] == 0) && (HalfG[1] == 0) && (HalfG[2] == 0));
-  }
-
-  void bcast_tables(Communicate* comm) { chunked_bcast(comm, SplineInst->getSplinePtr()); }
-
-  void gather_tables(Communicate* comm)
-  {
-    if (comm->size() == 1)
-      return;
-    const int Nbands      = kPoints.size();
-    const int Nbandgroups = comm->size();
-    offset.resize(Nbandgroups + 1, 0);
-    FairDivideLow(Nbands, Nbandgroups, offset);
-    gatherv(comm, SplineInst->getSplinePtr(), SplineInst->getSplinePtr()->z_stride, offset);
   }
 
   template<typename BCT>

--- a/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
@@ -83,7 +83,7 @@ std::unique_ptr<SPOSet> SplineSetReader<SA>::create_spline_set(const std::string
   {
     myComm->barrier();
     Timer now;
-    bspline->bcast_tables(myComm);
+    SplineUtils<typename SA::DataType>::bcast(*bspline->SplineInst, *myComm);
     app_log() << "  Time to bcast the table = " << now.elapsed() << std::endl;
   }
 
@@ -194,7 +194,16 @@ void SplineSetReader<SA>::initialize_spline_pio_gather(const int spin,
     {
       band_group_comm.getGroupLeaderComm()->barrier();
       Timer now;
-      bspline.gather_tables(band_group_comm.getGroupLeaderComm());
+      if (bspline.isComplex())
+      {
+        std::vector<int> offset(band_groups.size());
+        for (int i = 0; i < offset.size(); i++)
+          offset[i] = band_groups[i] * 2;
+        SplineUtils<typename SA::DataType>::gatherv(*bspline.SplineInst, offset, *band_group_comm.getGroupLeaderComm());
+      }
+      else
+        SplineUtils<typename SA::DataType>::gatherv(*bspline.SplineInst, band_groups,
+                                                    *band_group_comm.getGroupLeaderComm());
       app_log() << "  Time to gather the table = " << now.elapsed() << std::endl;
     }
   }

--- a/src/QMCWaveFunctions/BsplineFactory/SplineUtils.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineUtils.cpp
@@ -48,6 +48,41 @@ bool SplineUtils<ST>::write(MultiBspline1D<ST>& spline, hdf_archive& h5f)
   return h5f.writeEntry(bigtable, "radial_spline");
 }
 
+template<typename ST>
+void SplineUtils<ST>::gatherv(MultiBsplineBase<ST>& spline, const std::vector<int>& offset, Communicate& comm)
+{
+  if (comm.size() == 1)
+    return;
+  qmcplusplus::gatherv(&comm, spline.getSplinePtr(), spline.getSplinePtr()->z_stride, offset);
+}
+
+template<typename ST>
+void SplineUtils<ST>::bcast(MultiBsplineBase<ST>& spline, Communicate& comm)
+{
+  if (comm.size() == 1)
+    return;
+  chunked_bcast(&comm, spline.getSplinePtr());
+}
+
+template<typename ST>
+void SplineUtils<ST>::gatherv(MultiBspline1D<ST>& spline,
+                              size_t stride,
+                              const std::vector<int>& offset,
+                              Communicate& comm)
+{
+  if (comm.size() == 1)
+    return;
+  qmcplusplus::gatherv(&comm, spline.getSplinePtr(), stride, offset);
+}
+
+template<typename ST>
+void SplineUtils<ST>::bcast(MultiBspline1D<ST>& spline, Communicate& comm)
+{
+  if (comm.size() == 1)
+    return;
+  chunked_bcast(&comm, spline.getSplinePtr());
+}
+
 template class SplineUtils<float>;
 template class SplineUtils<double>;
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/BsplineFactory/SplineUtils.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineUtils.h
@@ -16,6 +16,7 @@
 #include "hdf/hdf_archive.h"
 #include "spline2/MultiBsplineBase.hpp"
 #include "spline2/MultiBspline1D.hpp"
+#include "Message/Communicate.h"
 
 namespace qmcplusplus
 {
@@ -27,8 +28,15 @@ class SplineUtils
 public:
   static bool read(MultiBsplineBase<ST>& spline, hdf_archive& h5f);
   static bool write(MultiBsplineBase<ST>& spline, hdf_archive& h5f);
+
   static bool read(MultiBspline1D<ST>& spline, hdf_archive& h5f);
   static bool write(MultiBspline1D<ST>& spline, hdf_archive& h5f);
+
+  static void gatherv(MultiBsplineBase<ST>& spline, const std::vector<int>& offset, Communicate& comm);
+  static void bcast(MultiBsplineBase<ST>& spline, Communicate& comm);
+
+  static void gatherv(MultiBspline1D<ST>& spline, size_t stride, const std::vector<int>& offset, Communicate& comm);
+  static void bcast(MultiBspline1D<ST>& spline, Communicate& comm);
 };
 
 extern template class SplineUtils<float>;

--- a/src/spline/einspline_util.hpp
+++ b/src/spline/einspline_util.hpp
@@ -55,11 +55,12 @@ inline void chunked_bcast(Communicate* comm, ENGT* buffer)
 { chunked_bcast(comm, buffer->coefs, buffer->coefs_size); }
 
 template<typename ENGT>
-inline void gatherv(Communicate* comm, ENGT* buffer, const int ncol, std::vector<int>& offset)
+inline void gatherv(Communicate* comm, ENGT* buffer, const int ncol, const std::vector<int>& offset)
 {
   std::vector<int> counts(offset.size() - 1, 0);
   for (size_t ib = 0; ib < counts.size(); ib++)
     counts[ib] = offset[ib + 1] - offset[ib];
+  const auto& counts_const(counts);
   const size_t coef_type_bytes = sizeof(typename bspline_engine_traits<ENGT>::value_type);
   if (buffer->coefs_size * coef_type_bytes > std::numeric_limits<int>::max())
   {
@@ -73,14 +74,14 @@ inline void gatherv(Communicate* comm, ENGT* buffer, const int ncol, std::vector
     const int nrow          = buffer->coefs_size / (ncol * nx);
     MPI_Datatype columntype = mpi::construct_column_type(buffer->coefs, nrow, ncol);
     for (size_t iz = 0; iz < nx; iz++)
-      comm->gatherv_in_place(buffer->coefs + xs * iz, columntype, counts, offset);
+      comm->gatherv_in_place(buffer->coefs + xs * iz, columntype, counts_const, offset);
     mpi::free_column_type(columntype);
   }
   else
   {
     const int nrow          = buffer->coefs_size / ncol;
     MPI_Datatype columntype = mpi::construct_column_type(buffer->coefs, nrow, ncol);
-    comm->gatherv_in_place(buffer->coefs, columntype, counts, offset);
+    comm->gatherv_in_place(buffer->coefs, columntype, counts_const, offset);
     mpi::free_column_type(columntype);
   }
 }


### PR DESCRIPTION
## Proposed changes

MPI communication doesn't need to be handled through BsplineSet derived classes member functions.
The builder should be able to interact with the underlying MultiSpline objects directly.
See the removed redundant code.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
