### PR TITLE
SPOSet size required at construction

### DIFF
--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -27,6 +27,21 @@ using MatrixOperators::diag_product;
 using MatrixOperators::product;
 using MatrixOperators::product_AtB;
 
+static auto cloneSPOSets(const SPOSet::SPOMap& spomap, const std::vector<std::string>& spo_names)
+{
+  std::vector<std::unique_ptr<SPOSet>> sposets;
+  sposets.reserve(spo_names.size());
+  for (const auto& name : spo_names)
+  {
+    auto spo_it = spomap.find(name);
+    if (spo_it == spomap.end())
+      throw UniformCommunicateError("OneBodyDensityMatrices::OneBodyDensityMatrices sposet " + name +
+                                    " does not exist.");
+    sposets.emplace_back(spo_it->second->makeClone());
+  }
+  return sposets;
+}
+
 OneBodyDensityMatrices::OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obdmi,
                                                const Lattice& lattice,
                                                const SpeciesSet& species,
@@ -36,7 +51,7 @@ OneBodyDensityMatrices::OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obd
       input_(obdmi),
       lattice_(std::move(lattice)),
       species_(species),
-      basis_functions_("OneBodyDensityMatrices::basis"),
+      basis_functions_("OneBodyDensityMatrices::basis", cloneSPOSets(spomap, input_.get_basis_sets())),
       is_spinor_(pset_target.isSpinor()),
       timers_("OneBodyDensityMatrix")
 {
@@ -89,20 +104,7 @@ OneBodyDensityMatrices::OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obd
     throw UniformCommunicateError("OneBodyDensityMatrices::OneBodyDensityMatrices only density sampling implemented "
                                   "for calculations using spinors");
 
-
-  // get the sposets that form the basis
-  auto& sposets = input_.get_basis_sets();
-
-  for (int i = 0; i < sposets.size(); ++i)
-  {
-    auto spo_it = spomap.find(sposets[i]);
-    if (spo_it == spomap.end())
-      throw UniformCommunicateError("OneBodyDensityMatrices::OneBodyDensityMatrices sposet " + sposets[i] +
-                                    " does not exist.");
-    basis_functions_.add(spo_it->second->makeClone());
-  }
   basis_size_ = basis_functions_.size();
-
   if (basis_size_ < 1)
     throw UniformCommunicateError("OneBodyDensityMatrices::OneBodyDensityMatrices basis_size must be greater than one");
 
@@ -172,9 +174,7 @@ OneBodyDensityMatrices::OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obd
 
 OneBodyDensityMatrices::OneBodyDensityMatrices(const OneBodyDensityMatrices& obdm, DataLocality dl)
     : OneBodyDensityMatrices(obdm)
-{
-  data_locality_ = dl;
-}
+{ data_locality_ = dl; }
 
 std::unique_ptr<OperatorEstBase> OneBodyDensityMatrices::spawnCrowdClone() const
 {
@@ -530,9 +530,7 @@ void OneBodyDensityMatrices::accumulate(const RefVector<MCPWalker>& walkers,
                                         const RefVector<TrialWaveFunction>& wfns,
                                         const RefVector<QMCHamiltonian>& hams,
                                         RandomBase<FullPrecReal>& rng)
-{
-  implAccumulate(walkers, psets, wfns, rng);
-}
+{ implAccumulate(walkers, psets, wfns, rng); }
 
 void OneBodyDensityMatrices::implAccumulate(const RefVector<MCPWalker>& walkers,
                                             const RefVector<ParticleSet>& psets,

--- a/src/Estimators/tests/test_MagnetizationDensity.cpp
+++ b/src/Estimators/tests/test_MagnetizationDensity.cpp
@@ -108,9 +108,7 @@ public:
     }
   }
   int computeBinAccessor(const MagnetizationDensity& magdens, const Position& r, const int spin_index)
-  {
-    return magdens.computeBin(r, spin_index);
-  }
+  { return magdens.computeBin(r, spin_index); }
 };
 } //namespace testing
 
@@ -366,8 +364,7 @@ TEST_CASE("MagnetizationDensity::IntegrationTest", "[estimators]")
 
   spo_up->setRefVals(mup);
   spo_dn->setRefVals(mdn);
-  auto spinor_set = std::make_unique<SpinorSet>("ConstSpinorSet");
-  spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
+  auto spinor_set = std::make_unique<SpinorSet>("ConstSpinorSet", std::move(spo_up), std::move(spo_dn));
 
   auto dd = std::make_unique<DiracDeterminant<>>(*spinor_set, 0, nelec);
 

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -48,19 +48,16 @@ static const TimerNameList_t<DMTimers> DMTimerNames =
 
 DensityMatrices1B::DensityMatrices1B(ParticleSet& P, const SPOSet::SPOMap& spomap, ParticleSet* Pcl)
     : timers(getGlobalTimerManager(), DMTimerNames, timer_level_fine),
-      basis_functions("DensityMatrices1B::basis"),
       lattice_(P.getLattice()),
       spomap_(spomap),
       Pq(P),
       Pc(Pcl)
-{
-  reset();
-}
+{ reset(); }
 
 DensityMatrices1B::DensityMatrices1B(const DensityMatrices1B& master, ParticleSet& P, TrialWaveFunction& psi)
     : OperatorBase(master),
       timers(getGlobalTimerManager(), DMTimerNames, timer_level_fine),
-      basis_functions(master.basis_functions),
+      basis_functions(std::make_unique<CompositeSPOSet<Value_t>>(*master.basis_functions)),
       lattice_(P.getLattice()),
       spomap_(master.spomap_),
       Pq(P),
@@ -82,9 +79,7 @@ DensityMatrices1B::~DensityMatrices1B()
 
 
 std::unique_ptr<OperatorBase> DensityMatrices1B::makeClone(ParticleSet& qp, TrialWaveFunction& psi) const
-{
-  return std::make_unique<DensityMatrices1B>(*this, qp, psi);
-}
+{ return std::make_unique<DensityMatrices1B>(*this, qp, psi); }
 
 
 void DensityMatrices1B::reset()
@@ -278,14 +273,18 @@ void DensityMatrices1B::set_state(xmlNodePtr cur)
   if (sposets.size() == 0)
     throw std::runtime_error("DensityMatrices1B::put  basis must have at least one sposet");
 
+  std::vector<std::unique_ptr<SPOSet>> spos;
+  spos.reserve(sposets.size());
   for (int i = 0; i < sposets.size(); ++i)
   {
     auto spo_it = spomap_.find(sposets[i]);
     if (spo_it == spomap_.end())
       throw std::runtime_error("DensityMatrices1B::put  sposet " + sposets[i] + " does not exist.");
-    basis_functions.add(spo_it->second->makeClone());
+    spos.emplace_back(spo_it->second->makeClone());
   }
-  basis_size = basis_functions.size();
+
+  basis_functions = std::make_unique<CompositeSPOSet<Value_t>>("DensityMatrices1B::basis", std::move(spos));
+  basis_size      = basis_functions->size();
 
   if (basis_size < 1)
     throw std::runtime_error("DensityMatrices1B::put  basis_size must be greater than one");
@@ -1230,7 +1229,7 @@ inline void DensityMatrices1B::integrate(TrialWaveFunction& psi, ParticleSet& el
 inline void DensityMatrices1B::update_basis(const PosType& r)
 {
   Pq.makeMove(0, r - Pq.R[0]);
-  basis_functions.evaluateValue(Pq, 0, basis_values);
+  basis_functions->evaluateValue(Pq, 0, basis_values);
   Pq.rejectMove(0);
   for (int i = 0; i < basis_size; ++i)
     basis_values[i] *= basis_norms[i];
@@ -1240,7 +1239,7 @@ inline void DensityMatrices1B::update_basis(const PosType& r)
 inline void DensityMatrices1B::update_basis_d012(const PosType& r)
 {
   Pq.makeMove(0, r - Pq.R[0]);
-  basis_functions.evaluateVGL(Pq, 0, basis_values, basis_gradients, basis_laplacians);
+  basis_functions->evaluateVGL(Pq, 0, basis_values, basis_gradients, basis_laplacians);
   Pq.rejectMove(0);
   for (int i = 0; i < basis_size; ++i)
     basis_values[i] *= basis_norms[i];

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -65,7 +65,7 @@ public:
 
   //data members
   bool energy_mat;
-  CompositeSPOSet<Value_t> basis_functions;
+  std::unique_ptr<CompositeSPOSet<Value_t>> basis_functions;
   ValueVector basis_values;
   ValueVector basis_norms;
   GradVector basis_gradients;

--- a/src/QMCHamiltonians/tests/test_SOECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_SOECPotential.cpp
@@ -35,14 +35,10 @@ class TestSOECPotential
 
 public:
   static void copyGridUnrotatedForTest(SOECPotential& so_ecp)
-  {
-    so_ecp.ppset_[0]->rrotsgrid_m_ = so_ecp.ppset_[0]->sgridxyz_m_;
-  }
+  { so_ecp.ppset_[0]->rrotsgrid_m_ = so_ecp.ppset_[0]->sgridxyz_m_; }
 
   static bool didGridChange(SOECPotential& so_ecp)
-  {
-    return so_ecp.ppset_[0]->rrotsgrid_m_ != so_ecp.ppset_[0]->sgridxyz_m_;
-  }
+  { return so_ecp.ppset_[0]->rrotsgrid_m_ != so_ecp.ppset_[0]->sgridxyz_m_; }
 
   static void mw_evaluateImpl(const RefVectorWithLeader<OperatorBase>& o_list,
                               const RefVectorWithLeader<TrialWaveFunction>& twf_list,
@@ -144,8 +140,7 @@ void doSOECPotentialTest(bool use_VPs)
   auto spo_up = std::make_unique<FreeOrbital>("free_orb_up", kup);
   auto spo_dn = std::make_unique<FreeOrbital>("free_orb_dn", kdn);
 
-  auto spinor_set = std::make_unique<SpinorSet>("free_orsposetsb_spinor");
-  spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
+  auto spinor_set = std::make_unique<SpinorSet>("free_orsposetsb_spinor", std::move(spo_up), std::move(spo_dn));
   QMCTraits::IndexType norb = spinor_set->getOrbitalSetSize();
   REQUIRE(norb == 2);
 

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -492,8 +492,7 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
   auto spo_up = std::make_unique<FreeOrbital>("free_orb_up", kup);
   auto spo_dn = std::make_unique<FreeOrbital>("free_orb_dn", kdn);
 
-  auto spinor_set = std::make_unique<SpinorSet>("free_orb_spinor");
-  spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
+  auto spinor_set           = std::make_unique<SpinorSet>("free_orb_spinor", std::move(spo_up), std::move(spo_dn));
   QMCTraits::IndexType norb = spinor_set->getOrbitalSetSize();
   REQUIRE(norb == 2);
 

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineReader.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineReader.h
@@ -131,7 +131,6 @@ protected:
     const int N       = bandgroup.getNumDistinctOrbitals();
     const int numOrbs = bandgroup.getNumSPOs();
 
-    bspline.setOrbitalSetSize(numOrbs);
     bspline.resizeStorage(N);
 
     bspline.first_spo = bandgroup.getFirstSPO();

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
@@ -52,8 +52,8 @@ protected:
   aligned_vector<int> BandIndexMap;
 
 public:
-  BsplineSet(const std::string& my_name, const Lattice& prim_lattice)
-      : SPOSet(my_name), first_spo(0), last_spo(0), prim_lattice_(prim_lattice)
+  BsplineSet(const std::string& my_name, size_t size, const Lattice& prim_lattice)
+      : SPOSet(my_name, size), first_spo(0), last_spo(0), prim_lattice_(prim_lattice)
   {}
 
   virtual bool isComplex() const         = 0;
@@ -116,8 +116,6 @@ public:
   using SPOSet::releaseResource;
 
   std::unique_ptr<SPOSet> makeClone() const override = 0;
-
-  void setOrbitalSetSize(int norbs) override { OrbitalSetSize = norbs; }
 
   void evaluate_notranspose(const ParticleSet& P,
                             int first,

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
@@ -204,8 +204,7 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
   bspline_zd_d->finalizeConstruction();
 
   //register with spin set and we're off to the races.
-  auto spinor_set = std::make_unique<SpinorSet>(spo_object_name);
-  spinor_set->set_spos(std::move(bspline_zd_u), std::move(bspline_zd_d));
+  auto spinor_set = std::make_unique<SpinorSet>(spo_object_name, std::move(bspline_zd_u), std::move(bspline_zd_d));
   return spinor_set;
 };
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
@@ -65,7 +65,9 @@ private:
   using SPLINEBASE::myV;
 
 public:
-  HybridRepCplx(const std::string& my_name, const Lattice& prim_lattice) : SPLINEBASE(my_name, prim_lattice) {}
+  HybridRepCplx(const std::string& my_name, size_t size, const Lattice& prim_lattice)
+      : SPLINEBASE(my_name, size, prim_lattice)
+  {}
 
   bool isRotationSupported() const override { return SPLINEBASE::isRotationSupported(); }
   void storeParamsBeforeRotation() override

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
@@ -67,7 +67,9 @@ private:
   using SPLINEBASE::prim_lattice_;
 
 public:
-  HybridRepReal(const std::string& my_name, const Lattice& prim_lattice) : SPLINEBASE(my_name, prim_lattice) {}
+  HybridRepReal(const std::string& my_name, size_t size, const Lattice& prim_lattice)
+      : SPLINEBASE(my_name, size, prim_lattice)
+  {}
 
   bool isRotationSupported() const override { return SPLINEBASE::isRotationSupported(); }
   void storeParamsBeforeRotation() override

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
@@ -143,7 +143,7 @@ std::unique_ptr<SPOSet> HybridRepSetReader<SA>::create_spline_set(const std::str
                                                                   const BandInfoGroup& bandgroup)
 {
   spline_reader_.setCheckNorm(checkNorm);
-  auto bspline = std::make_unique<SA>(my_name, mybuilder->PrimCell);
+  auto bspline = std::make_unique<SA>(my_name, bandgroup.getNumSPOs(), mybuilder->PrimCell);
   app_log() << "  ClassName = " << bspline->getClassName() << std::endl;
   // set info for Hybrid
   initialize_hybridrep_atomic_centers(*bspline);

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.h
@@ -78,8 +78,8 @@ protected:
   ghContainer_type mygH;
 
 public:
-  SplineC2C(const std::string& my_name, const Lattice& prim_lattice, bool use_offload = false)
-      : BsplineSet(my_name, prim_lattice), GGt(dot(transpose(prim_lattice.G), prim_lattice.G))
+  SplineC2C(const std::string& my_name, size_t size, const Lattice& prim_lattice, bool use_offload = false)
+      : BsplineSet(my_name, size, prim_lattice), GGt(dot(transpose(prim_lattice.G), prim_lattice.G))
   {}
 
   SplineC2C(const SplineC2C& in);

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -106,8 +106,8 @@ protected:
   ghContainer_type mygH;
 
 public:
-  SplineC2COMPTarget(const std::string& my_name, const Lattice& prim_lattice, bool use_offload = true)
-      : BsplineSet(my_name, prim_lattice),
+  SplineC2COMPTarget(const std::string& my_name, size_t size, const Lattice& prim_lattice, bool use_offload = true)
+      : BsplineSet(my_name, size, prim_lattice),
         offload_timer_(createGlobalTimer("SplineC2COMPTarget::offload", timer_level_fine)),
         GGt_offload(std::make_shared<OffloadVector<ST>>(9)),
         prim_lattice_G_offload(std::make_shared<OffloadVector<ST>>(9))

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
@@ -82,8 +82,8 @@ protected:
   ghContainer_type mygH;
 
 public:
-  SplineC2R(const std::string& my_name, const Lattice& prim_lattice, bool use_offload = false)
-      : BsplineSet(my_name, prim_lattice), GGt(dot(transpose(prim_lattice.G), prim_lattice.G)), nComplexBands(0)
+  SplineC2R(const std::string& my_name, size_t size, const Lattice& prim_lattice, bool use_offload = false)
+      : BsplineSet(my_name, size, prim_lattice), GGt(dot(transpose(prim_lattice.G), prim_lattice.G)), nComplexBands(0)
   {}
 
   SplineC2R(const SplineC2R& in);

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -18,6 +18,7 @@
 #ifndef QMCPLUSPLUS_SPLINE_C2R_OMPTARGET_H
 #define QMCPLUSPLUS_SPLINE_C2R_OMPTARGET_H
 
+#include <cstddef>
 #include <memory>
 #include "QMCWaveFunctions/BsplineFactory/BsplineSet.h"
 #include "OhmmsSoA/VectorSoaContainer.h"
@@ -109,8 +110,8 @@ protected:
   ghContainer_type mygH;
 
 public:
-  SplineC2ROMPTarget(const std::string& my_name, const Lattice& prim_lattice, bool use_offload = true)
-      : BsplineSet(my_name, prim_lattice),
+  SplineC2ROMPTarget(const std::string& my_name, size_t size, const Lattice& prim_lattice, bool use_offload = true)
+      : BsplineSet(my_name, size, prim_lattice),
         offload_timer_(createGlobalTimer("SplineC2ROMPTarget::offload", timer_level_fine)),
         nComplexBands(0),
         GGt_offload(std::make_shared<OffloadVector<ST>>(9)),

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
@@ -38,8 +38,8 @@ inline static std::unique_ptr<MultiBsplineBase<T>> create_MultiBsplineDerived(co
 }
 
 template<typename ST>
-SplineR2R<ST>::SplineR2R(const std::string& my_name, const Lattice& prim_lattice, bool use_offload)
-    : BsplineSet(my_name, prim_lattice),
+SplineR2R<ST>::SplineR2R(const std::string& my_name, size_t size, const Lattice& prim_lattice, bool use_offload)
+    : BsplineSet(my_name, size, prim_lattice),
       use_offload_(use_offload),
       offload_timer_(createGlobalTimer("SplineC2ROMPTarget::offload", timer_level_fine)),
       GGt(dot(transpose(prim_lattice.G), prim_lattice.G)),

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
@@ -91,7 +91,7 @@ protected:
   ghContainer_type mygH;
 
 public:
-  SplineR2R(const std::string& my_name, const Lattice& prim_lattice, bool use_offload = false);
+  SplineR2R(const std::string& my_name, size_t size, const Lattice& prim_lattice, bool use_offload = false);
   SplineR2R(const SplineR2R& in);
   virtual std::string getClassName() const override { return "SplineR2R"; }
   virtual std::string getKeyword() const override { return "SplineR2R"; }

--- a/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
@@ -41,7 +41,7 @@ std::unique_ptr<SPOSet> SplineSetReader<SA>::create_spline_set(const std::string
                                                                int spin,
                                                                const BandInfoGroup& bandgroup)
 {
-  auto bspline = std::make_unique<SA>(my_name, mybuilder->PrimCell, use_offload);
+  auto bspline = std::make_unique<SA>(my_name, bandgroup.getNumSPOs(), mybuilder->PrimCell, use_offload);
   app_log() << "  ClassName = " << bspline->getClassName() << std::endl;
   bool foundspline = createSplineDataSpaceLookforDumpFile(bandgroup, *bspline);
   if (foundspline && myComm->rank() == 0)

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -40,11 +40,8 @@ inline void insert_columns(const MAT1& small, MAT2& big, int offset_c)
 } // namespace MatrixOperators
 
 template<typename T>
-CompositeSPOSet<T>::CompositeSPOSet(const std::string& my_name) : SPOSetT<T>(my_name)
-{
-  SPOSet::OrbitalSetSize = 0;
-  component_offsets.reserve(4);
-}
+CompositeSPOSet<T>::CompositeSPOSet(const std::string& my_name) : SPOSetT<T>(my_name, 0)
+{ component_offsets.reserve(4); }
 
 template<typename T>
 CompositeSPOSet<T>::CompositeSPOSet(const CompositeSPOSet& other) : SPOSet(other)
@@ -89,7 +86,8 @@ void CompositeSPOSet<T>::report()
 }
 
 template<typename T>
-std::unique_ptr<SPOSetT<T>> CompositeSPOSet<T>::makeClone() const { return std::make_unique<CompositeSPOSet>(*this); }
+std::unique_ptr<SPOSetT<T>> CompositeSPOSet<T>::makeClone() const
+{ return std::make_unique<CompositeSPOSet>(*this); }
 
 template<typename T>
 void CompositeSPOSet<T>::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
@@ -106,7 +104,11 @@ void CompositeSPOSet<T>::evaluateValue(const ParticleSet& P, int iat, ValueVecto
 }
 
 template<typename T>
-void CompositeSPOSet<T>::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)
+void CompositeSPOSet<T>::evaluateVGL(const ParticleSet& P,
+                                     int iat,
+                                     ValueVector& psi,
+                                     GradVector& dpsi,
+                                     ValueVector& d2psi)
 {
   int n = 0;
   for (int c = 0; c < components.size(); ++c)
@@ -202,9 +204,7 @@ void CompositeSPOSet<T>::evaluate_notranspose(const ParticleSet& P,
                                               GradMatrix& dlogdet,
                                               HessMatrix& grad_grad_logdet,
                                               GGGMatrix& grad_grad_grad_logdet)
-{
-  not_implemented("evaluate_notranspose(P,first,last,logdet,dlogdet,ddlogdet,dddlogdet)");
-}
+{ not_implemented("evaluate_notranspose(P,first,last,logdet,dlogdet,ddlogdet,dddlogdet)"); }
 
 
 std::unique_ptr<SPOSet> CompositeSPOSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
@@ -227,9 +227,7 @@ std::unique_ptr<SPOSet> CompositeSPOSetBuilder::createSPOSetFromXML(xmlNodePtr c
 }
 
 std::unique_ptr<SPOSet> CompositeSPOSetBuilder::createSPOSet(xmlNodePtr cur, SPOSetInputInfo& input)
-{
-  return createSPOSetFromXML(cur);
-}
+{ return createSPOSetFromXML(cur); }
 
 #if !defined(MIXED_PRECISION)
 template class CompositeSPOSet<double>;

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -40,37 +40,54 @@ inline void insert_columns(const MAT1& small, MAT2& big, int offset_c)
 } // namespace MatrixOperators
 
 template<typename T>
-CompositeSPOSet<T>::CompositeSPOSet(const std::string& my_name) : SPOSetT<T>(my_name, 0)
-{ component_offsets.reserve(4); }
+static auto countOrbitals(const std::vector<std::unique_ptr<SPOSetT<T>>>& components)
+{
+  size_t counts = 0;
+  for (const std::unique_ptr<SPOSetT<T>>& spo : components)
+    counts += spo->size();
+  return counts;
+}
 
 template<typename T>
-CompositeSPOSet<T>::CompositeSPOSet(const CompositeSPOSet& other) : SPOSet(other)
+static auto cloneComponents(const std::vector<std::unique_ptr<SPOSetT<T>>>& components)
 {
-  for (auto& element : other.components)
+  std::vector<std::unique_ptr<SPOSetT<T>>> spos;
+  spos.reserve(components.size());
+  for (const std::unique_ptr<SPOSetT<T>>& spo : components)
+    spos.emplace_back(spo->makeClone());
+  return spos;
+}
+
+template<typename T>
+CompositeSPOSet<T>::CompositeSPOSet(const std::string& my_name, std::vector<std::unique_ptr<SPOSet>>&& spos)
+    : SPOSet(my_name, countOrbitals(spos)), components(std::move(spos))
+{
+  component_offsets.push_back(0); //add 0
+  size_t count = 0;
+  for (const std::unique_ptr<SPOSetT<T>>& component : components)
   {
-    this->add(element->makeClone());
+    const int norbs = component->size();
+    component_values.emplace_back(norbs);
+    component_gradients.emplace_back(norbs);
+    component_laplacians.emplace_back(norbs);
+    component_spin_gradients.emplace_back(norbs);
+    component_offsets.push_back(count += norbs);
   }
 }
 
 template<typename T>
-CompositeSPOSet<T>::~CompositeSPOSet() = default;
+CompositeSPOSet<T>::CompositeSPOSet(const CompositeSPOSet& other)
+    : SPOSet(other),
+      components(cloneComponents(other.components)),
+      component_values(other.component_values),
+      component_gradients(other.component_gradients),
+      component_laplacians(other.component_laplacians),
+      component_spin_gradients(other.component_spin_gradients),
+      component_offsets(other.component_offsets)
+{}
 
 template<typename T>
-void CompositeSPOSet<T>::add(std::unique_ptr<SPOSet> component)
-{
-  if (components.empty())
-    component_offsets.push_back(0); //add 0
-
-  int norbs = component->size();
-  components.push_back(std::move(component));
-  component_values.emplace_back(norbs);
-  component_gradients.emplace_back(norbs);
-  component_laplacians.emplace_back(norbs);
-  component_spin_gradients.emplace_back(norbs);
-
-  SPOSet::OrbitalSetSize += norbs;
-  component_offsets.push_back(SPOSet::OrbitalSetSize);
-}
+CompositeSPOSet<T>::~CompositeSPOSet() = default;
 
 template<typename T>
 void CompositeSPOSet<T>::report()
@@ -216,14 +233,16 @@ std::unique_ptr<SPOSet> CompositeSPOSetBuilder::createSPOSetFromXML(xmlNodePtr c
     return nullptr;
   }
 
-  auto spo_now = std::make_unique<CompositeSPOSet<ValueType>>(getXMLAttributeValue(cur, "name"));
+  std::vector<std::unique_ptr<SPOSet>> spos;
+  spos.reserve(spolist.size());
   for (int i = 0; i < spolist.size(); ++i)
   {
     const SPOSet* spo = sposet_builder_factory_.getSPOSet(spolist[i]);
     if (spo)
-      spo_now->add(spo->makeClone());
+      spos.emplace_back(spo->makeClone());
   }
-  return (spo_now->size()) ? std::unique_ptr<SPOSet>{std::move(spo_now)} : nullptr;
+  return spos.size() ? std::make_unique<CompositeSPOSet<ValueType>>(getXMLAttributeValue(cur, "name"), std::move(spos))
+                     : nullptr;
 }
 
 std::unique_ptr<SPOSet> CompositeSPOSetBuilder::createSPOSet(xmlNodePtr cur, SPOSetInputInfo& input)

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -49,14 +49,11 @@ public:
   ///store the precomputed offsets
   std::vector<int> component_offsets;
 
-  CompositeSPOSet(const std::string& my_name);
+  CompositeSPOSet(const std::string& my_name, std::vector<std::unique_ptr<SPOSet>>&& components);
   CompositeSPOSet(const CompositeSPOSet& other);
   ~CompositeSPOSet() override;
 
   std::string getClassName() const override { return "CompositeSPOSet"; }
-
-  ///add a sposet component to this composite sposet
-  void add(std::unique_ptr<SPOSet> component);
 
   ///print out component info
   void report();

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -37,7 +37,7 @@ public:
   using GGGMatrix   = typename SPOSet::GGGMatrix;
 
   ///component SPOSets
-  std::vector<std::unique_ptr<SPOSet>> components;
+  const std::vector<std::unique_ptr<SPOSet>> components;
   ///temporary storage for values
   std::vector<ValueVector> component_values;
   ///temporary storage for gradients

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -63,7 +63,6 @@ public:
 
   //SPOSet interface methods
   ///size is determined by component sposets and nothing else
-  inline void setOrbitalSetSize(int norbs) override {}
 
   std::unique_ptr<SPOSet> makeClone() const override;
 
@@ -80,9 +79,7 @@ public:
 
   ///unimplemented functions call this to abort
   inline void not_implemented(const std::string& method)
-  {
-    APP_ABORT("CompositeSPOSet::" + method + " has not been implemented");
-  }
+  { APP_ABORT("CompositeSPOSet::" + method + " has not been implemented"); }
 
   //methods to be implemented in the future (possibly)
   void evaluate_notranspose(const ParticleSet& P,

--- a/src/QMCWaveFunctions/ElectronGas/FreeOrbital.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/FreeOrbital.cpp
@@ -3,21 +3,26 @@
 
 namespace qmcplusplus
 {
+
+static auto computeOrbitalSetSize(size_t maxk)
+{
+#ifdef QMC_COMPLEX
+  return maxk;
+#else
+  return 2 * maxk - 1; // k=0 has no (cos, sin) split
+#endif
+}
+
 FreeOrbital::FreeOrbital(const std::string& my_name, const std::vector<PosType>& kpts_cart)
-    : SPOSet(my_name),
+    : SPOSet(my_name, computeOrbitalSetSize(kpts_cart.size())),
       kvecs(kpts_cart),
 #ifdef QMC_COMPLEX
       mink(0), // first k at twist may not be 0
 #else
-      mink(1),                   // treat k=0 as special case
+      mink(1), // treat k=0 as special case
 #endif
       maxk(kpts_cart.size())
 {
-#ifdef QMC_COMPLEX
-  OrbitalSetSize = maxk;
-#else
-  OrbitalSetSize = 2 * maxk - 1; // k=0 has no (cos, sin) split
-#endif
   k2neg.resize(maxk);
   for (int ik = 0; ik < maxk; ik++)
     k2neg[ik] = -dot(kvecs[ik], kvecs[ik]);

--- a/src/QMCWaveFunctions/ElectronGas/FreeOrbital.h
+++ b/src/QMCWaveFunctions/ElectronGas/FreeOrbital.h
@@ -62,7 +62,6 @@ public:
   void report(const std::string& pad) const override;
   // ---- begin required overrides
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<FreeOrbital>(*this); }
-  void setOrbitalSetSize(int norbs) override { throw std::runtime_error("not implemented"); }
   // required overrides end ----
 private:
   const std::vector<PosType> kvecs; // kvecs vectors

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.cpp
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.cpp
@@ -17,7 +17,7 @@
 namespace qmcplusplus
 {
 SHOSet::SHOSet(const std::string& my_name, RealType l, PosType c, const std::vector<SHOState*>& sho_states)
-    : SPOSet(my_name), length(l), center(c)
+    : SPOSet(my_name, sho_states.size()), length(l), center(c)
 {
   state_info.resize(sho_states.size());
   for (int s = 0; s < sho_states.size(); ++s)
@@ -29,8 +29,6 @@ SHOSet::SHOSet(const std::string& my_name, RealType l, PosType c, const std::vec
 void SHOSet::initialize()
 {
   using std::sqrt;
-
-  OrbitalSetSize = state_info.size();
 
   qn_max = -1;
   for (int s = 0; s < state_info.size(); ++s)
@@ -523,9 +521,7 @@ void SHOSet::test_overlap()
 
 
 void SHOSet::evaluateThirdDeriv(const ParticleSet& P, int first, int last, GGGMatrix& grad_grad_grad_logdet)
-{
-  not_implemented("evaluateThirdDeriv(P,first,last,dddlogdet)");
-}
+{ not_implemented("evaluateThirdDeriv(P,first,last,dddlogdet)"); }
 
 void SHOSet::evaluate_notranspose(const ParticleSet& P,
                                   int first,
@@ -533,9 +529,7 @@ void SHOSet::evaluate_notranspose(const ParticleSet& P,
                                   ValueMatrix& logdet,
                                   GradMatrix& dlogdet,
                                   HessMatrix& grad_grad_logdet)
-{
-  not_implemented("evaluate_notranspose(P,first,last,logdet,dlogdet,ddlogdet)");
-}
+{ not_implemented("evaluate_notranspose(P,first,last,logdet,dlogdet,ddlogdet)"); }
 
 void SHOSet::evaluate_notranspose(const ParticleSet& P,
                                   int first,
@@ -544,9 +538,7 @@ void SHOSet::evaluate_notranspose(const ParticleSet& P,
                                   GradMatrix& dlogdet,
                                   HessMatrix& grad_grad_logdet,
                                   GGGMatrix& grad_grad_grad_logdet)
-{
-  not_implemented("evaluate_notranspose(P,first,last,logdet,dlogdet,ddlogdet,dddlogdet)");
-}
+{ not_implemented("evaluate_notranspose(P,first,last,logdet,dlogdet,ddlogdet,dddlogdet)"); }
 
 void SHOSet::evaluateGradSource(const ParticleSet& P,
                                 int first,
@@ -554,9 +546,7 @@ void SHOSet::evaluateGradSource(const ParticleSet& P,
                                 const ParticleSet& source,
                                 int iat_src,
                                 GradMatrix& gradphi)
-{
-  not_implemented("evaluateGradSource(P,first,last,source,iat,dphi)");
-}
+{ not_implemented("evaluateGradSource(P,first,last,source,iat,dphi)"); }
 
 void SHOSet::evaluateGradSource(const ParticleSet& P,
                                 int first,
@@ -566,8 +556,6 @@ void SHOSet::evaluateGradSource(const ParticleSet& P,
                                 GradMatrix& grad_phi,
                                 HessMatrix& grad_grad_phi,
                                 GradMatrix& grad_lapl_phi)
-{
-  not_implemented("evaluateGradSource(P,first,last,source,iat,dphi,ddphi,dd2phi)");
-}
+{ not_implemented("evaluateGradSource(P,first,last,source,iat,dphi,ddphi,dd2phi)"); }
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.h
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.h
@@ -39,9 +39,7 @@ struct SHOState : public SPOInfo
   }
 
   inline void sho_report(const std::string& pad = "") const
-  {
-    app_log() << pad << "qn=" << quantum_number << "  e=" << energy << std::endl;
-  }
+  { app_log() << pad << "qn=" << quantum_number << "  e=" << energy << std::endl; }
 };
 
 
@@ -101,13 +99,10 @@ struct SHOSet : public SPOSet
 
   //empty methods
   /// number of orbitals is determined only by initial request
-  inline void setOrbitalSetSize(int norbs) override {}
 
   ///unimplemented functions call this to abort
   inline void not_implemented(const std::string& method)
-  {
-    APP_ABORT("SHOSet::" + method + " has not been implemented.");
-  }
+  { APP_ABORT("SHOSet::" + method + " has not been implemented."); }
 
 
   //methods to be implemented in the future (possibly)

--- a/src/QMCWaveFunctions/LCAO/LCAOSpinorBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOSpinorBuilder.cpp
@@ -56,8 +56,7 @@ std::unique_ptr<SPOSet> LCAOSpinorBuilder::createSPOSetFromXML(xmlNodePtr cur)
   loadMO(*upspo, *dnspo, cur);
 
   //create spinor and register up/dn
-  auto spinor_set = std::make_unique<SpinorSet>(spo_name);
-  spinor_set->set_spos(std::move(upspo), std::move(dnspo));
+  auto spinor_set = std::make_unique<SpinorSet>(spo_name, std::move(upspo), std::move(dnspo));
   return spinor_set;
 }
 

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
@@ -54,7 +54,7 @@ LCAOrbitalSet::LCAOrbitalSet(const std::string& my_name,
                              size_t norbs,
                              bool identity,
                              bool use_offload)
-    : SPOSet(my_name),
+    : SPOSet(my_name, norbs),
       BasisSetSize(bs ? bs->getBasisSetSize() : 0),
       Identity(identity),
       useOMPoffload_(use_offload),
@@ -63,12 +63,10 @@ LCAOrbitalSet::LCAOrbitalSet(const std::string& my_name,
 {
   if (!bs)
     throw std::runtime_error("LCAOrbitalSet cannot take nullptr as its  basis set!");
-  myBasisSet     = std::move(bs);
-  OrbitalSetSize = norbs;
+  myBasisSet = std::move(bs);
   Temp.resize(BasisSetSize);
   Temph.resize(BasisSetSize);
   Tempgh.resize(BasisSetSize);
-  OrbitalSetSize = norbs;
   if (!Identity)
   {
     Tempv.resize(OrbitalSetSize);
@@ -100,11 +98,6 @@ LCAOrbitalSet::LCAOrbitalSet(const LCAOrbitalSet& in)
     Tempghv.resize(OrbitalSetSize);
   }
   LCAOrbitalSet::checkObject();
-}
-
-void LCAOrbitalSet::setOrbitalSetSize(int norbs)
-{
-  throw std::runtime_error("LCAOrbitalSet::setOrbitalSetSize should not be called");
 }
 
 void LCAOrbitalSet::checkObject() const

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
@@ -71,7 +71,6 @@ public:
 
   /** set the OrbitalSetSize and Identity=false and initialize internal storages
     */
-  void setOrbitalSetSize(int norbs) final;
 
   /** return the size of the basis set
     */

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.cpp
@@ -20,21 +20,11 @@ LCAOrbitalSetWithCorrection::LCAOrbitalSetWithCorrection(const std::string& my_n
                                                          bool identity,
                                                          ParticleSet& ions,
                                                          ParticleSet& els)
-    : SPOSet(my_name), lcao(my_name + "_modified", std::move(bs), norbs, identity, false), cusp(ions, els, norbs)
-{
-  OrbitalSetSize = norbs;
-}
-
-void LCAOrbitalSetWithCorrection::setOrbitalSetSize(int norbs)
-{
-  throw std::runtime_error("LCAOrbitalSetWithCorrection::setOrbitalSetSize should not be called");
-}
-
+    : SPOSet(my_name, norbs), lcao(my_name + "_modified", std::move(bs), norbs, identity, false), cusp(ions, els, norbs)
+{}
 
 std::unique_ptr<SPOSet> LCAOrbitalSetWithCorrection::makeClone() const
-{
-  return std::make_unique<LCAOrbitalSetWithCorrection>(*this);
-}
+{ return std::make_unique<LCAOrbitalSetWithCorrection>(*this); }
 
 void LCAOrbitalSetWithCorrection::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
 {

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.h
@@ -50,7 +50,6 @@ public:
 
   std::unique_ptr<SPOSet> makeClone() const final;
 
-  void setOrbitalSetSize(int norbs) final;
 
   void evaluateValue(const ParticleSet& P, int iat, ValueVector& psi) final;
 

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
@@ -35,13 +35,12 @@ std::unique_ptr<SPOSet> PWOrbitalSet::makeClone() const
   return myclone;
 }
 
-void PWOrbitalSet::resize(PWBasisPtr bset, int nbands, bool cleanup)
+void PWOrbitalSet::resize(PWBasisPtr bset, bool cleanup)
 {
-  myBasisSet     = bset;
-  OrbitalSetSize = nbands;
-  OwnBasisSet    = cleanup;
-  BasisSetSize   = myBasisSet->NumPlaneWaves;
-  C              = new ValueMatrix(OrbitalSetSize, BasisSetSize);
+  myBasisSet   = bset;
+  OwnBasisSet  = cleanup;
+  BasisSetSize = myBasisSet->NumPlaneWaves;
+  C            = new ValueMatrix(OrbitalSetSize, BasisSetSize);
   Temp.resize(OrbitalSetSize, PW_MAXINDEX);
   app_log() << "  PWOrbitalSet::resize OrbitalSetSize =" << OrbitalSetSize << " BasisSetSize = " << BasisSetSize
             << std::endl;

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
@@ -35,8 +35,6 @@ std::unique_ptr<SPOSet> PWOrbitalSet::makeClone() const
   return myclone;
 }
 
-void PWOrbitalSet::setOrbitalSetSize(int norbs) {}
-
 void PWOrbitalSet::resize(PWBasisPtr bset, int nbands, bool cleanup)
 {
   myBasisSet     = bset;

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
@@ -69,7 +69,6 @@ public:
   void addVector(const std::vector<ComplexType>& coefs, int jorb);
   void addVector(const std::vector<RealType>& coefs, int jorb);
 
-  void setOrbitalSetSize(int norbs) override;
 
   inline ValueType evaluate(int ib, const PosType& pos)
   {

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
@@ -43,8 +43,8 @@ public:
 
   /** default constructor
   */
-  PWOrbitalSet(const std::string& my_name)
-      : SPOSet(my_name), OwnBasisSet(false), myBasisSet(nullptr), BasisSetSize(0), C(nullptr), IsCloned(false)
+  PWOrbitalSet(const std::string& my_name, size_t size)
+      : SPOSet(my_name, size), OwnBasisSet(false), myBasisSet(nullptr), BasisSetSize(0), C(nullptr), IsCloned(false)
   {}
 
   std::string getClassName() const override { return "PWOrbitalSet"; }
@@ -59,10 +59,9 @@ public:
   std::unique_ptr<SPOSet> makeClone() const override;
   /** resize  the orbital base
    * @param bset PWBasis
-   * @param nbands number of bands
    * @param cleaup if true, owns PWBasis. Will clean up.
    */
-  void resize(PWBasisPtr bset, int nbands, bool cleanup = false);
+  void resize(PWBasisPtr bset, bool cleanup = false);
 
   /** Builder class takes care of the assertion
   */

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSetBuilder.cpp
@@ -188,8 +188,6 @@ std::unique_ptr<SPOSet> PWOrbitalSetBuilder::createPW(xmlNodePtr cur, const std:
   std::string tname = "kpoint_0";
   hfile.push("electrons", false);
   hfile.push("kpoint_0", false);
-  //create a single-particle orbital set
-  auto psi = std::make_unique<SPOSetType>(objname);
   if (transform2grid)
   {
     nb = myParam->numBands;
@@ -197,8 +195,10 @@ std::unique_ptr<SPOSet> PWOrbitalSetBuilder::createPW(xmlNodePtr cur, const std:
     for (int i = 0; i < nb; i++)
       occBand[i] = i;
   }
+  //create a single-particle orbital set
+  auto psi = std::make_unique<SPOSetType>(objname, nb);
   //going to take care of occ
-  psi->resize(new PWBasis(*myBasisSet), nb, true);
+  psi->resize(new PWBasis(*myBasisSet), true);
   if (myParam->hasComplexData(hfile)) //input is complex
   {
     //app_log() << "  PW coefficients are complex." << std::endl;

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
@@ -38,12 +38,11 @@ std::unique_ptr<SPOSet> PWRealOrbitalSet::makeClone() const
   return myclone;
 }
 
-void PWRealOrbitalSet::resize(PWBasisPtr bset, int nbands, bool cleanup)
+void PWRealOrbitalSet::resize(PWBasisPtr bset, bool cleanup)
 {
-  myBasisSet     = bset;
-  OrbitalSetSize = nbands;
-  OwnBasisSet    = cleanup;
-  BasisSetSize   = myBasisSet->NumPlaneWaves;
+  myBasisSet   = bset;
+  OwnBasisSet  = cleanup;
+  BasisSetSize = myBasisSet->NumPlaneWaves;
   CC.resize(OrbitalSetSize, BasisSetSize);
   Temp.resize(OrbitalSetSize, PW_MAXINDEX);
   tempPsi.resize(OrbitalSetSize);

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
@@ -38,8 +38,6 @@ std::unique_ptr<SPOSet> PWRealOrbitalSet::makeClone() const
   return myclone;
 }
 
-void PWRealOrbitalSet::setOrbitalSetSize(int norbs) {}
-
 void PWRealOrbitalSet::resize(PWBasisPtr bset, int nbands, bool cleanup)
 {
   myBasisSet     = bset;

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
@@ -80,7 +80,6 @@ public:
    */
   void addVector(const std::vector<ComplexType>& coefs, int jorb);
 
-  void setOrbitalSetSize(int norbs) override;
 
   inline ValueType evaluate(int ib, const PosType& pos)
   {
@@ -105,9 +104,7 @@ public:
                             ValueMatrix& logdet,
                             GradMatrix& dlogdet,
                             HessMatrix& grad_grad_logdet) override
-  {
-    APP_ABORT("Need specialization of evaluate_notranspose() for grad_grad_logdet. \n");
-  }
+  { APP_ABORT("Need specialization of evaluate_notranspose() for grad_grad_logdet. \n"); }
 
 
   /** boolean

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
@@ -47,8 +47,8 @@ public:
 
   /** default constructor
   */
-  PWRealOrbitalSet(const std::string& my_name)
-      : SPOSet(my_name), OwnBasisSet(false), myBasisSet(nullptr), BasisSetSize(0)
+  PWRealOrbitalSet(const std::string& my_name, size_t size)
+      : SPOSet(my_name, size), OwnBasisSet(false), myBasisSet(nullptr), BasisSetSize(0)
   {}
 
   std::string getClassName() const override { return "PWRealOrbitalSet"; }
@@ -63,10 +63,9 @@ public:
 
   /** resize  the orbital base
    * @param bset PWBasis
-   * @param nbands number of bands
    * @param cleaup if true, owns PWBasis. Will clean up.
    */
-  void resize(PWBasisPtr bset, int nbands, bool cleanup = false);
+  void resize(PWBasisPtr bset, bool cleanup = false);
 
   /** add eigenstate for jorb-th orbital
    * @param coefs real input data

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -20,15 +20,13 @@
 namespace qmcplusplus
 {
 RotatedSPOs::RotatedSPOs(const std::string& my_name, std::unique_ptr<SPOSet>&& spos)
-    : SPOSet(my_name),
+    : SPOSet(my_name, spos->getOrbitalSetSize()),
       OptimizableObject(my_name),
       Phi_(std::move(spos)),
       nel_major_(0),
       params_supplied_(false),
       apply_rotation_timer_(createGlobalTimer("RotatedSPOs::apply_rotation", timer_level_fine))
-{
-  OrbitalSetSize = Phi_->getOrbitalSetSize();
-}
+{}
 
 RotatedSPOs::~RotatedSPOs() {}
 

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -267,7 +267,6 @@ public:
 
   //*********************************************************************************
   //the following functions simply call Phi's corresponding functions
-  void setOrbitalSetSize(int norbs) override { Phi_->setOrbitalSetSize(norbs); }
 
   void checkObject() const override { Phi_->checkObject(); }
 
@@ -299,9 +298,7 @@ public:
                          ValueVector& psi,
                          const ValueVector& psiinv,
                          std::vector<ValueType>& ratios) override
-  {
-    Phi_->evaluateDetRatios(VP, psi, psiinv, ratios);
-  }
+  { Phi_->evaluateDetRatios(VP, psi, psiinv, ratios); }
 
   void evaluateDerivRatios(const VirtualParticleSet& VP,
                            const OptVariables& optvars,
@@ -329,9 +326,7 @@ public:
                      GradVector& dpsi,
                      HessVector& grad_grad_psi,
                      GGGVector& grad_grad_grad_psi) override
-  {
-    Phi_->evaluateVGHGH(P, iat, psi, dpsi, grad_grad_psi, grad_grad_grad_psi);
-  }
+  { Phi_->evaluateVGHGH(P, iat, psi, dpsi, grad_grad_psi, grad_grad_grad_psi); }
 
 
   void evaluate_notranspose(const ParticleSet& P,
@@ -340,14 +335,10 @@ public:
                             ValueMatrix& logdet,
                             GradMatrix& dlogdet,
                             ValueMatrix& d2logdet) override
-  {
-    Phi_->evaluate_notranspose(P, first, last, logdet, dlogdet, d2logdet);
-  }
+  { Phi_->evaluate_notranspose(P, first, last, logdet, dlogdet, d2logdet); }
 
   void evaluate_spin(const ParticleSet& P, int iat, ValueVector& psi, ValueVector& dspin_psi) override
-  {
-    Phi_->evaluate_spin(P, iat, psi, dspin_psi);
-  }
+  { Phi_->evaluate_spin(P, iat, psi, dspin_psi); }
 
   void evaluate_notranspose(const ParticleSet& P,
                             int first,
@@ -355,9 +346,7 @@ public:
                             ValueMatrix& logdet,
                             GradMatrix& dlogdet,
                             HessMatrix& grad_grad_logdet) override
-  {
-    Phi_->evaluate_notranspose(P, first, last, logdet, dlogdet, grad_grad_logdet);
-  }
+  { Phi_->evaluate_notranspose(P, first, last, logdet, dlogdet, grad_grad_logdet); }
 
   void evaluate_notranspose(const ParticleSet& P,
                             int first,
@@ -366,9 +355,7 @@ public:
                             GradMatrix& dlogdet,
                             HessMatrix& grad_grad_logdet,
                             GGGMatrix& grad_grad_grad_logdet) override
-  {
-    Phi_->evaluate_notranspose(P, first, last, logdet, dlogdet, grad_grad_logdet, grad_grad_grad_logdet);
-  }
+  { Phi_->evaluate_notranspose(P, first, last, logdet, dlogdet, grad_grad_logdet, grad_grad_grad_logdet); }
 
   void evaluateGradSource(const ParticleSet& P,
                           int first,
@@ -376,9 +363,7 @@ public:
                           const ParticleSet& source,
                           int iat_src,
                           GradMatrix& grad_phi) override
-  {
-    Phi_->evaluateGradSource(P, first, last, source, iat_src, grad_phi);
-  }
+  { Phi_->evaluateGradSource(P, first, last, source, iat_src, grad_phi); }
 
   void evaluateGradSource(const ParticleSet& P,
                           int first,
@@ -388,9 +373,7 @@ public:
                           GradMatrix& grad_phi,
                           HessMatrix& grad_grad_phi,
                           GradMatrix& grad_lapl_phi) override
-  {
-    Phi_->evaluateGradSource(P, first, last, source, iat_src, grad_phi, grad_grad_phi, grad_lapl_phi);
-  }
+  { Phi_->evaluateGradSource(P, first, last, source, iat_src, grad_phi, grad_grad_phi, grad_lapl_phi); }
 
   //  void evaluateThirdDeriv(const ParticleSet& P, int first, int last, GGGMatrix& grad_grad_grad_logdet)
   //  {Phi->evaluateThridDeriv(P, first, last, grad_grad_grad_logdet); }

--- a/src/QMCWaveFunctions/SPOSet.cpp
+++ b/src/QMCWaveFunctions/SPOSet.cpp
@@ -27,7 +27,7 @@
 namespace qmcplusplus
 {
 template<typename T>
-SPOSetT<T>::SPOSetT(const std::string& my_name) : my_name_(my_name), OrbitalSetSize(0)
+SPOSetT<T>::SPOSetT(const std::string& my_name, size_t size) : my_name_(my_name), OrbitalSetSize(size)
 {}
 
 template<typename T>
@@ -68,9 +68,7 @@ void SPOSetT<T>::evaluateDetSpinorRatios(const VirtualParticleSet& VP,
                                          const std::pair<ValueVector, ValueVector>& spinor_multiplier,
                                          const ValueVector& invrow,
                                          std::vector<ValueType>& ratios)
-{
-  throw std::runtime_error("Need specialization of " + getClassName() + "::evaluateDetSpinorRatios");
-}
+{ throw std::runtime_error("Need specialization of " + getClassName() + "::evaluateDetSpinorRatios"); }
 
 template<typename T>
 void SPOSetT<T>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOSetT>& spo_list,
@@ -112,9 +110,7 @@ void SPOSetT<T>::evaluateVGL_spin(const ParticleSet& P,
                                   GradVector& dpsi,
                                   ValueVector& d2psi,
                                   ValueVector& dspin)
-{
-  throw std::runtime_error("Need specialization of SPOSet::evaluateVGL_spin");
-}
+{ throw std::runtime_error("Need specialization of SPOSet::evaluateVGL_spin"); }
 
 template<typename T>
 void SPOSetT<T>::mw_evaluateVGL(const RefVectorWithLeader<SPOSetT>& spo_list,
@@ -148,9 +144,7 @@ void SPOSetT<T>::mw_evaluateVGLWithSpin(const RefVectorWithLeader<SPOSetT>& spo_
                                         const RefVector<GradVector>& dpsi_v_list,
                                         const RefVector<ValueVector>& d2psi_v_list,
                                         OffloadMatrix<ComplexType>& mw_dspin) const
-{
-  throw std::runtime_error(getClassName() + "::mw_evaluateVGLWithSpin() is not supported. \n");
-}
+{ throw std::runtime_error(getClassName() + "::mw_evaluateVGLWithSpin() is not supported. \n"); }
 
 template<typename T>
 void SPOSetT<T>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithLeader<SPOSetT>& spo_list,
@@ -203,9 +197,7 @@ void SPOSetT<T>::mw_evaluateVGLandDetRatioGradsWithSpin(const RefVectorWithLeade
 
 template<typename T>
 void SPOSetT<T>::evaluateThirdDeriv(const ParticleSet& P, int first, int last, GGGMatrix& grad_grad_grad_logdet)
-{
-  throw std::runtime_error("Need specialization of SPOSet::evaluateThirdDeriv(). \n");
-}
+{ throw std::runtime_error("Need specialization of SPOSet::evaluateThirdDeriv(). \n"); }
 
 template<typename T>
 void SPOSetT<T>::evaluate_notranspose_spin(const ParticleSet& P,
@@ -241,9 +233,7 @@ void SPOSetT<T>::evaluate_notranspose(const ParticleSet& P,
                                       ValueMatrix& logdet,
                                       GradMatrix& dlogdet,
                                       HessMatrix& grad_grad_logdet)
-{
-  throw std::runtime_error("Need specialization of SPOSet::evaluate_notranspose() for grad_grad_logdet. \n");
-}
+{ throw std::runtime_error("Need specialization of SPOSet::evaluate_notranspose() for grad_grad_logdet. \n"); }
 
 template<typename T>
 void SPOSetT<T>::evaluate_notranspose(const ParticleSet& P,
@@ -253,16 +243,12 @@ void SPOSetT<T>::evaluate_notranspose(const ParticleSet& P,
                                       GradMatrix& dlogdet,
                                       HessMatrix& grad_grad_logdet,
                                       GGGMatrix& grad_grad_grad_logdet)
-{
-  throw std::runtime_error("Need specialization of SPOSet::evaluate_notranspose() for grad_grad_grad_logdet. \n");
-}
+{ throw std::runtime_error("Need specialization of SPOSet::evaluate_notranspose() for grad_grad_grad_logdet. \n"); }
 
 
 template<typename T>
 std::unique_ptr<SPOSetT<T>> SPOSetT<T>::makeClone() const
-{
-  throw std::runtime_error("Missing  SPOSetT<T>::makeClone for " + getClassName());
-}
+{ throw std::runtime_error("Missing  SPOSetT<T>::makeClone for " + getClassName()); }
 
 template<typename T>
 void SPOSetT<T>::basic_report(const std::string& pad) const

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -67,7 +67,7 @@ public:
   using OffloadMatrix = Matrix<DT, OffloadPinnedAllocator<DT>>;
 
   /** constructor */
-  SPOSetT(const std::string& my_name, size_t size = 0);
+  SPOSetT(const std::string& my_name, size_t size);
 
   /** destructor
    *
@@ -586,8 +586,7 @@ protected:
   /// name of the object, unique identifier
   const std::string my_name_;
   ///number of Single-particle orbitals.
-  /// It should be marked const. CompositeSPOSet is the last class blocking this change.
-  IndexType OrbitalSetSize;
+  const IndexType OrbitalSetSize;
 };
 
 using SPOSet    = SPOSetT<QMCTraits::QTBase::ValueType>;

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -67,7 +67,7 @@ public:
   using OffloadMatrix = Matrix<DT, OffloadPinnedAllocator<DT>>;
 
   /** constructor */
-  SPOSetT(const std::string& my_name);
+  SPOSetT(const std::string& my_name, size_t size = 0);
 
   /** destructor
    *
@@ -186,13 +186,6 @@ public:
                                      const ValueMatrix& Minv_dn,
                                      const std::vector<int>& detData_up,
                                      const std::vector<std::vector<int>>& lookup_tbl);
-
-  /** set the OrbitalSetSize
-   * @param norbs number of single-particle orbitals
-   * Ye: I prefer to remove this interface in the future. SPOSet builders need to handle the size correctly.
-   * It doesn't make sense allowing to set the value at any place in the code.
-   */
-  virtual void setOrbitalSetSize(int norbs) = 0;
 
   /** evaluate the values of this single-particle orbital set
    * @param P current ParticleSet

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -585,7 +585,8 @@ public:
 protected:
   /// name of the object, unique identifier
   const std::string my_name_;
-  ///number of Single-particle orbitals
+  ///number of Single-particle orbitals.
+  /// It should be marked const. CompositeSPOSet is the last class blocking this change.
   IndexType OrbitalSetSize;
 };
 

--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -28,7 +28,13 @@ struct SpinorSet::SpinorSetMultiWalkerResource : public Resource
   std::vector<RealType> spins;
 };
 
-SpinorSet::SpinorSet(const std::string& my_name) : SPOSet(my_name), spo_up(nullptr), spo_dn(nullptr) {}
+SpinorSet::SpinorSet(const std::string& my_name, std::unique_ptr<SPOSet>&& up, std::unique_ptr<SPOSet>&& dn)
+    : SPOSet(my_name, up->size()), spo_up(std::move(up)), spo_dn(std::move(dn))
+{
+  if (spo_up->size() != spo_dn->size())
+    throw std::runtime_error("SpinorSet::SpinorSet(...):  up and down SPO components have different sizes.");
+}
+
 SpinorSet::~SpinorSet() = default;
 
 void SpinorSet::storeParamsBeforeRotation()
@@ -42,24 +48,6 @@ void SpinorSet::applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy)
   spo_up->applyRotation(rot_mat, use_stored_copy);
   spo_dn->applyRotation(rot_mat, use_stored_copy);
 }
-
-void SpinorSet::set_spos(std::unique_ptr<SPOSet>&& up, std::unique_ptr<SPOSet>&& dn)
-{
-  //Sanity check for input SPO's.  They need to be the same size or
-  IndexType spo_size_up   = up->getOrbitalSetSize();
-  IndexType spo_size_down = dn->getOrbitalSetSize();
-
-  if (spo_size_up != spo_size_down)
-    throw std::runtime_error("SpinorSet::set_spos(...):  up and down SPO components have different sizes.");
-
-  setOrbitalSetSize(spo_size_up);
-
-  spo_up = std::move(up);
-  spo_dn = std::move(dn);
-}
-
-void SpinorSet::setOrbitalSetSize(int norbs) { OrbitalSetSize = norbs; };
-
 
 void SpinorSet::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
 {
@@ -712,10 +700,7 @@ void SpinorSet::evaluateGradSource(const ParticleSet& P,
 
 std::unique_ptr<SPOSet> SpinorSet::makeClone() const
 {
-  auto myclone = std::make_unique<SpinorSet>(my_name_);
-  std::unique_ptr<SPOSet> cloneup(spo_up->makeClone());
-  std::unique_ptr<SPOSet> clonedn(spo_dn->makeClone());
-  myclone->set_spos(std::move(cloneup), std::move(clonedn));
+  auto myclone = std::make_unique<SpinorSet>(my_name_, spo_up->makeClone(), spo_dn->makeClone());
   return myclone;
 }
 

--- a/src/QMCWaveFunctions/SpinorSet.h
+++ b/src/QMCWaveFunctions/SpinorSet.h
@@ -25,7 +25,7 @@ class SpinorSet : public SPOSet
 {
 public:
   /** constructor */
-  SpinorSet(const std::string& my_name);
+  SpinorSet(const std::string& my_name, std::unique_ptr<SPOSet>&& up, std::unique_ptr<SPOSet>&& dn);
   ~SpinorSet() override;
 
   std::string getClassName() const override { return "SpinorSet"; }
@@ -38,14 +38,9 @@ public:
 
   void applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy) override;
 
-  //This class is initialized by separately building the up and down channels of the spinor set and
-  //then registering them.
-  void set_spos(std::unique_ptr<SPOSet>&& up, std::unique_ptr<SPOSet>&& dn);
-
   /** set the OrbitalSetSize
    * @param norbs number of single-particle orbitals
    */
-  void setOrbitalSetSize(int norbs) override;
 
   /** evaluate the values of this spinor set
    * @param P current ParticleSet
@@ -71,11 +66,11 @@ public:
                                const ValueVector& invrow,
                                std::vector<ValueType>& ratios) override;
 
-  void mw_evaluateDetSpinorRatios(const RefVectorWithLeader<SPOSet>& spo_list, 
-                                  const RefVectorWithLeader<const VirtualParticleSet>& vp_list, 
-                                  const RefVector<ValueVector>& psi_list, 
-                                  const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list, 
-                                  const std::vector<const ValueType*>& invRow_ptr_list, 
+  void mw_evaluateDetSpinorRatios(const RefVectorWithLeader<SPOSet>& spo_list,
+                                  const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+                                  const RefVector<ValueVector>& psi_list,
+                                  const RefVector<std::pair<ValueVector, ValueVector>>& spinor_multiplier_list,
+                                  const std::vector<const ValueType*>& invRow_ptr_list,
                                   std::vector<std::vector<ValueType>>& ratios_list) const override;
 
   /** evaluate the values, gradients and laplacians of this single-particle orbital set

--- a/src/QMCWaveFunctions/SpinorSet.h
+++ b/src/QMCWaveFunctions/SpinorSet.h
@@ -210,8 +210,8 @@ private:
       const RefVectorWithLeader<SPOSet>& spo_list) const;
 
   //Sposet for the up and down channels of our spinors.
-  std::unique_ptr<SPOSet> spo_up;
-  std::unique_ptr<SPOSet> spo_dn;
+  const std::unique_ptr<SPOSet> spo_up;
+  const std::unique_ptr<SPOSet> spo_dn;
 
   //temporary arrays for holding the values of the up and down channels respectively.
   ValueVector psi_work_up;

--- a/src/QMCWaveFunctions/tests/ConstantSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/ConstantSPOSet.cpp
@@ -16,9 +16,8 @@ namespace qmcplusplus
 
 template<typename T>
 ConstantSPOSet<T>::ConstantSPOSet(const std::string& my_name, const int nparticles, const int norbitals)
-    : SPOSetT<T>(my_name), numparticles_(nparticles)
+    : SPOSetT<T>(my_name, norbitals), numparticles_(nparticles)
 {
-  SPOSet::OrbitalSetSize = norbitals;
   ref_psi_.resize(numparticles_, SPOSet::OrbitalSetSize);
   ref_egrad_.resize(numparticles_, SPOSet::OrbitalSetSize);
   ref_elapl_.resize(numparticles_, SPOSet::OrbitalSetSize);
@@ -45,10 +44,6 @@ std::string ConstantSPOSet<T>::getClassName() const
 template<typename T>
 void ConstantSPOSet<T>::checkOutVariables(const OptVariables& active)
 { APP_ABORT("ConstantSPOSet should not call checkOutVariables"); }
-
-template<typename T>
-void ConstantSPOSet<T>::setOrbitalSetSize(int norbs)
-{ APP_ABORT("ConstantSPOSet should not call setOrbitalSetSize()"); }
 
 template<typename T>
 void ConstantSPOSet<T>::setRefVals(const ValueMatrix& vals)

--- a/src/QMCWaveFunctions/tests/ConstantSPOSet.h
+++ b/src/QMCWaveFunctions/tests/ConstantSPOSet.h
@@ -46,7 +46,6 @@ public:
 
   void checkOutVariables(const OptVariables& active) override;
 
-  void setOrbitalSetSize(int norbs) override;
 
   /**
   * @brief Setter method to set \phi_j(r_i). Stores input matrix in ref_psi_.

--- a/src/QMCWaveFunctions/tests/FakeSPO.cpp
+++ b/src/QMCWaveFunctions/tests/FakeSPO.cpp
@@ -16,7 +16,7 @@ namespace qmcplusplus
 {
 
 template<typename T>
-FakeSPO<T>::FakeSPO() : SPOSet("one_FakeSPO")
+FakeSPO<T>::FakeSPO(size_t size) : SPOSet("one_FakeSPO", size)
 {
   a.resize(3, 3);
 
@@ -81,15 +81,7 @@ FakeSPO<T>::FakeSPO() : SPOSet("one_FakeSPO")
 
 template<typename T>
 std::unique_ptr<SPOSetT<T>> FakeSPO<T>::makeClone() const
-{
-  return std::make_unique<FakeSPO>(*this);
-}
-
-template<typename T>
-void FakeSPO<T>::setOrbitalSetSize(int norbs)
-{
-  OrbitalSetSize = norbs;
-}
+{ return std::make_unique<FakeSPO>(*this); }
 
 template<typename T>
 void FakeSPO<T>::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)

--- a/src/QMCWaveFunctions/tests/FakeSPO.h
+++ b/src/QMCWaveFunctions/tests/FakeSPO.h
@@ -38,14 +38,13 @@ public:
 
   GradVector gv;
 
-  FakeSPO();
+  FakeSPO(size_t size);
   ~FakeSPO() override {}
 
   std::string getClassName() const override { return "FakeSPO"; }
 
   std::unique_ptr<SPOSet> makeClone() const override;
   virtual void report() {}
-  void setOrbitalSetSize(int norbs) override;
 
   void evaluateValue(const ParticleSet& P, int iat, ValueVector& psi) override;
 
@@ -57,6 +56,7 @@ public:
                             ValueMatrix& logdet,
                             GradMatrix& dlogdet,
                             ValueMatrix& d2logdet) override;
+
 private:
   using SPOSet::OrbitalSetSize;
 };

--- a/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
@@ -34,14 +34,15 @@ TEST_CASE("CompositeSPO::diamond_1x1x1", "[wavefunction")
       MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
   TrialWaveFunction& psi(wavefunction_pool.getWaveFunction().value());
 
-  CompositeSPOSet<SPOSet::ValueType> comp_sposet("one_composite_set");
-
   std::vector<std::string> sposets{"spo_ud", "spo_dm"};
+  std::vector<std::unique_ptr<SPOSet>> spos;
   for (auto sposet_str : sposets)
   {
     auto& sposet = psi.getSPOSet(sposet_str);
-    comp_sposet.add(sposet.makeClone());
+    spos.emplace_back(sposet.makeClone());
   }
+
+  CompositeSPOSet<SPOSet::ValueType> comp_sposet("one_composite_set", std::move(spos));
   CHECK(comp_sposet.size() == 8);
 
   auto& pset = *particle_pool.getParticleSet("e");

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -51,9 +51,8 @@ void check_matrix(Matrix<T1>& a, Matrix<T2>& b)
 template<typename DET>
 void test_DiracDeterminant_first(const DetMatInvertor inverter_kind)
 {
-  auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 3;
-  spo_init->setOrbitalSetSize(norb);
+  auto spo_init  = std::make_unique<FakeSPO<Value>>(norb);
   DET ddb(*spo_init, 0, norb, 1, inverter_kind);
   auto spo = dynamic_cast<FakeSPO<Value>&>(ddb.getPhi());
 
@@ -159,9 +158,8 @@ TEST_CASE("DiracDeterminant_first", "[wavefunction][fermion]")
 template<typename DET>
 void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
 {
-  auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 4;
-  spo_init->setOrbitalSetSize(norb);
+  auto spo_init  = std::make_unique<FakeSPO<Value>>(norb);
   DET ddb(*spo_init, 0, norb, 1, inverter_kind);
   auto spo = dynamic_cast<FakeSPO<Value>&>(ddb.getPhi());
 
@@ -300,9 +298,8 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
 template<typename DET>
 void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
 {
-  auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 4;
-  spo_init->setOrbitalSetSize(norb);
+  auto spo_init  = std::make_unique<FakeSPO<Value>>(norb);
   // maximum delay 2
   DET ddc(*spo_init, 0, norb, 2, inverter_kind);
   auto spo = dynamic_cast<FakeSPO<Value>&>(ddc.getPhi());
@@ -524,8 +521,7 @@ void test_DiracDeterminant_spinor_update(const DetMatInvertor inverter_kind)
   auto spo_up = std::make_unique<FreeOrbital>("free_orb_up", kup);
   auto spo_dn = std::make_unique<FreeOrbital>("free_orb_up", kdn);
 
-  auto spinor_set = std::make_unique<SpinorSet>("free_orb_spinor");
-  spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
+  auto spinor_set = std::make_unique<SpinorSet>("free_orb_spinor", std::move(spo_up), std::move(spo_dn));
 
   DET dd(*spinor_set, 0, nelec, 1, inverter_kind);
   app_log() << " nelec=" << nelec << std::endl;

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -38,9 +38,8 @@ template<PlatformKind PL>
 void test_DiracDeterminantBatched_first()
 {
   using Det      = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
-  auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 3;
-  spo_init->setOrbitalSetSize(norb);
+  auto spo_init  = std::make_unique<FakeSPO<Value>>(norb);
   Det ddb(*spo_init, 0, norb);
   auto spo = dynamic_cast<FakeSPO<Value>&>(ddb.getPhi());
 
@@ -141,9 +140,8 @@ template<PlatformKind PL>
 void test_DiracDeterminantBatched_second()
 {
   using Det      = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
-  auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 4;
-  spo_init->setOrbitalSetSize(norb);
+  auto spo_init  = std::make_unique<FakeSPO<Value>>(norb);
   Det ddb(*spo_init, 0, norb);
   auto spo = dynamic_cast<FakeSPO<Value>&>(ddb.getPhi());
 
@@ -276,9 +274,8 @@ template<PlatformKind PL>
 void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor matrix_inverter_kind)
 {
   using Det      = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
-  auto spo_init  = std::make_unique<FakeSPO<Value>>();
   const int norb = 4;
-  spo_init->setOrbitalSetSize(norb);
+  auto spo_init  = std::make_unique<FakeSPO<Value>>(norb);
   Det ddc(*spo_init, 0, norb, delay_rank, matrix_inverter_kind);
   auto spo = dynamic_cast<FakeSPO<Value>&>(ddc.getPhi());
 
@@ -558,10 +555,9 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   auto spo_up = std::make_unique<FreeOrbital>("free_orb_up", kup);
   auto spo_dn = std::make_unique<FreeOrbital>("free_orb_up", kdn);
 
-  auto spinor_set = std::make_unique<SpinorSet>("free_orb_spinor");
-  spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
+  auto spinor_set = std::make_unique<SpinorSet>("free_orb_spinor", std::move(spo_up), std::move(spo_dn));
 
-  using Det = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
+  using Det   = DiracDeterminantBatched<PL, Value, QMCTraits::QTFull::ValueType>;
   auto dd_ptr = std::make_unique<Det>(*spinor_set, 0, nelec, delay_rank, matrix_inverter_kind);
   app_log() << " nelec=" << nelec << std::endl;
 

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -800,7 +800,7 @@ public:
   template<typename DT>
   using OffloadMatrix = typename SPOSet::template OffloadMatrix<DT>;
 
-  DummySPOSetWithoutMW(const std::string& my_name) : SPOSet(my_name) {}
+  DummySPOSetWithoutMW(const std::string& my_name) : SPOSet(my_name, 3) {}
   void evaluateValue(const ParticleSet& P, int iat, ValueVector& psi) override
   {
     assert(psi.size() == 3);

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -742,8 +742,7 @@ TEST_CASE("RotatedSPOs read and write parameters", "[wavefunction]")
 {
   //There is an issue with the real<->complex parameter parsing to h5 in QMC_COMPLEX.
   //This needs to be fixed in a future PR.
-  auto fake_spo = std::make_unique<FakeSPO<QMCTraits::ValueType>>();
-  fake_spo->setOrbitalSetSize(4);
+  auto fake_spo = std::make_unique<FakeSPO<QMCTraits::ValueType>>(4);
   RotatedSPOs rot("fake_rot", std::move(fake_spo));
   int nel = 2;
   rot.buildOptVariables(nel);
@@ -764,8 +763,7 @@ TEST_CASE("RotatedSPOs read and write parameters", "[wavefunction]")
     rot.writeVariationalParameters(hout);
   }
 
-  auto fake_spo2 = std::make_unique<FakeSPO<QMCTraits::ValueType>>();
-  fake_spo2->setOrbitalSetSize(4);
+  auto fake_spo2 = std::make_unique<FakeSPO<QMCTraits::ValueType>>(4);
 
   RotatedSPOs rot2("fake_rot", std::move(fake_spo2));
   rot2.buildOptVariables(nel);
@@ -803,7 +801,6 @@ public:
   using OffloadMatrix = typename SPOSet::template OffloadMatrix<DT>;
 
   DummySPOSetWithoutMW(const std::string& my_name) : SPOSet(my_name) {}
-  void setOrbitalSetSize(int norbs) override {}
   void evaluateValue(const ParticleSet& P, int iat, ValueVector& psi) override
   {
     assert(psi.size() == 3);


### PR DESCRIPTION
## Proposed changes
This is a long overdue change. With this PR
1. size is set via the SPOSet constructor and is marked const. No longer allowed to change size at a later point. setOrbitalSetSize() removed.
2. CompositeSPOSet and SpinorSet needs change in constructors.
3. 1RDM classes are updated follow CompositeSPOSet changes

## What type(s) of changes does this code introduce?
- Refactoring

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
