### PR TITLE
Remove SPO index shifting feature in BsplineSet

### DIFF
--- a/src/QMCWaveFunctions/BandInfo.cpp
+++ b/src/QMCWaveFunctions/BandInfo.cpp
@@ -17,9 +17,9 @@
 #include "QMCWaveFunctions/SPOSetInfo.h"
 namespace qmcplusplus
 {
-BandInfoGroup::BandInfoGroup() : FirstSPO(0), NumSPOs(0), FirstBand(0) {}
+BandInfoGroup::BandInfoGroup() : NumSPOs(0), FirstBand(0) {}
 
-void BandInfoGroup::selectBands(const std::vector<BandInfo>& bigspace, int first_orb, int num_spos, bool relative)
+void BandInfoGroup::selectBands(const std::vector<BandInfo>& bigspace, int first_orb, int num_spos)
 {
   app_log() << "BandInfoGroup::selectBands bigspace has " << bigspace.size() << " distinct orbitals " << std::endl;
   myBands.clear();
@@ -40,7 +40,6 @@ void BandInfoGroup::selectBands(const std::vector<BandInfo>& bigspace, int first
     APP_ABORT("BandInfoGroup::selectBands failed due to iorb>=N");
   }
 
-  FirstSPO   = (relative) ? n_lower : 0;
   FirstBand  = iorb;
   NumSPOs    = 0;
   int ns_max = num_spos - 1;
@@ -55,7 +54,6 @@ void BandInfoGroup::selectBands(const std::vector<BandInfo>& bigspace, int first
   app_log() << "BandInfoGroup::selectBands using distinct orbitals [" << first_orb << "," << iorb << ")" << std::endl;
   app_log() << "  Number of distinct bands " << myBands.size() << std::endl;
   app_log() << "  First Band index " << FirstBand << std::endl;
-  app_log() << "  First SPO index " << FirstSPO << std::endl;
   app_log() << "  Size of SPOs " << NumSPOs << std::endl;
 }
 

--- a/src/QMCWaveFunctions/BandInfo.cpp
+++ b/src/QMCWaveFunctions/BandInfo.cpp
@@ -19,51 +19,6 @@ namespace qmcplusplus
 {
 BandInfoGroup::BandInfoGroup() : FirstSPO(0), NumSPOs(0), FirstBand(0) {}
 
-void BandInfoGroup::selectBands(const std::vector<BandInfo>& bigspace, double emin, double emax)
-{
-  myBands.clear();
-  if (emin > emax)
-    return;
-
-  int iorb    = 0;
-  int N       = bigspace.size();
-  int n_lower = 0;
-  do
-  {
-    if (bigspace[iorb].Energy >= emin)
-      break;
-    n_lower += (bigspace[iorb].MakeTwoCopies) ? 2 : 1;
-    ++iorb;
-  } while (iorb < N);
-
-  if (iorb >= N)
-  {
-    APP_ABORT("BandInfoGroup::selectBands failed due to iorb>=N");
-  }
-
-  FirstSPO  = n_lower;
-  FirstBand = iorb;
-  NumSPOs   = 0;
-  while (iorb < N)
-  {
-    if (bigspace[iorb].Energy >= emax)
-      break;
-    myBands.push_back(bigspace[iorb]);
-    NumSPOs += (bigspace[iorb].MakeTwoCopies) ? 2 : 1;
-    ++iorb;
-  }
-
-  app_log() << "BandInfoGroup::selectBands using energy [" << emin << "," << emax << ")" << std::endl;
-  app_log() << "  Number of distinct bands " << myBands.size() << std::endl;
-  app_log() << "  First Band index " << FirstBand << std::endl;
-  app_log() << "  First SPO index " << FirstSPO << std::endl;
-  app_log() << "  Size of SPOs " << NumSPOs << std::endl;
-
-  //for(int i=0; i<myBands.size(); ++i)
-  //  app_log() << myBands[i].TwistIndex << " " << myBands[i].Energy << std::endl;
-  app_log().flush();
-}
-
 void BandInfoGroup::selectBands(const std::vector<BandInfo>& bigspace, int first_orb, int num_spos, bool relative)
 {
   app_log() << "BandInfoGroup::selectBands bigspace has " << bigspace.size() << " distinct orbitals " << std::endl;
@@ -104,52 +59,4 @@ void BandInfoGroup::selectBands(const std::vector<BandInfo>& bigspace, int first
   app_log() << "  Size of SPOs " << NumSPOs << std::endl;
 }
 
-//  void BandInfoGroup::selectBands(const std::vector<BandInfo>& bigspace, int first_orb, int last_orb)
-//  {
-//    app_log() << "BandInfoGroup::selectBands bigspace has " << bigspace.size() << " distinct orbitals " << std::endl;
-//    myBands.clear();
-//
-//    int iorb=0;
-//    int N=bigspace.size();
-//    bool skipit=true;
-//    int n_lower=0;
-//    do
-//    {
-//      if(iorb>=first_orb) break;
-//      n_lower += (bigspace[iorb].MakeTwoCopies)?2:1;
-//      ++iorb;
-//    } while(iorb<N);
-//
-//    if(iorb>=N)
-//    {
-//      APP_ABORT("BandInfoGroup::selectBands failed due to iorb>=N");
-//    }
-//
-//    if(first_orb != iorb)
-//    {
-//      APP_ABORT("Cannot locate the first SPO ");
-//    }
-//
-//    int num_orbs=last_orb-first_orb;
-//    if(num_orbs<=0)
-//    {
-//      APP_ABORT("BandInfoGroup::selectBands(bigspace,first_orb,last_orb) Illegal range ");
-//    }
-//
-//    FirstSPO=n_lower;
-//    FirstBand=iorb;
-//    NumSPOs=0;
-//    while(iorb<N)
-//    {
-//      if(myBands.size()>=num_orbs) break;
-//      myBands.push_back(bigspace[iorb]);
-//      NumSPOs += (bigspace[iorb].MakeTwoCopies)?2:1;
-//      ++iorb;
-//    }
-//
-//    //for(int i=0; i<myBands.size(); ++i)
-//    //  app_log() << myBands[i].TwistIndex << " " << myBands[i].Energy << std::endl;
-//
-//    app_log().flush();
-//  }
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/BandInfo.h
+++ b/src/QMCWaveFunctions/BandInfo.h
@@ -67,8 +67,6 @@ struct BandInfoGroup
 {
   ///index of the group
   int GroupID;
-  ///starting SPO
-  int FirstSPO;
   ///number of SPOs handled by this object
   int NumSPOs;
   ///starting band
@@ -83,20 +81,15 @@ struct BandInfoGroup
   BandInfoGroup();
   ///return the size of this band
   inline int getNumDistinctOrbitals() const { return myBands.size(); }
-  ///return the indext of the first SPO set
-  inline int getFirstSPO() const { return FirstSPO; }
-  ///return the indext of the last SPO set
-  inline int getLastSPO() const { return NumSPOs + FirstSPO; }
   ///return the number of SPOs
   inline int getNumSPOs() const { return NumSPOs; }
 
-  /** get the bands within [first_spo,first_spo+num_spos)
+  /** get the bands within [first_orb,first_orb+num_spos)
    * @param bigspace a set of sorted bands
    * @param first_orb index of the first uniquie orbitals
    * @param num_spos number of SPOs to be created
-   * @param relative if(relative) FirstSPO is set to any valid state index  \f$[0,\infty)\f$
    */
-  void selectBands(const std::vector<BandInfo>& bigspace, int first_orb, int num_spos, bool relative);
+  void selectBands(const std::vector<BandInfo>& bigspace, int first_orb, int num_spos);
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/BandInfo.h
+++ b/src/QMCWaveFunctions/BandInfo.h
@@ -90,14 +90,6 @@ struct BandInfoGroup
   ///return the number of SPOs
   inline int getNumSPOs() const { return NumSPOs; }
 
-  /** select the bands within an energy range [emin,emax)
-   *
-   * @param bigspace a set of sorted bands
-   * @param emin minimum energy
-   * @param emax maxmimum energy
-   */
-  void selectBands(const std::vector<BandInfo>& bigspace, double emin, double emax);
-
   /** get the bands within [first_spo,first_spo+num_spos)
    * @param bigspace a set of sorted bands
    * @param first_orb index of the first uniquie orbitals

--- a/src/QMCWaveFunctions/BsplineFactory/ApplyPhaseC2C.hpp
+++ b/src/QMCWaveFunctions/BsplineFactory/ApplyPhaseC2C.hpp
@@ -24,7 +24,6 @@ inline void assign_v(ST x,
                      const ST* restrict offload_scratch_ptr,
                      const ST* restrict myKcart_ptr,
                      size_t myKcart_padded_size,
-                     size_t first_spo,
                      int index)
 {
   const ST* restrict kx = myKcart_ptr;
@@ -38,9 +37,9 @@ inline void assign_v(ST x,
   ST s, c, p = -(x * kx[index] + y * ky[index] + z * kz[index]);
   omptarget::sincos(p, &s, &c);
 
-  const ST val_r         = val[index * 2];
-  const ST val_i         = val[index * 2 + 1];
-  psi[first_spo + index] = TT(val_r * c - val_i * s, val_i * c + val_r * s);
+  const ST val_r = val[index * 2];
+  const ST val_i = val[index * 2 + 1];
+  psi[index]     = TT(val_r * c - val_i * s, val_i * c + val_r * s);
 }
 
 /** assign_vgl
@@ -57,7 +56,6 @@ inline void assign_vgl(ST x,
                        const ST G[9],
                        const ST* myKcart_ptr,
                        size_t myKcart_padded_size,
-                       size_t first_spo,
                        int index)
 {
   constexpr ST two(2);
@@ -113,12 +111,11 @@ inline void assign_vgl(ST x,
   TT* restrict dpsi_z = results_scratch_ptr + orb_padded_size * 3;
   TT* restrict d2psi  = results_scratch_ptr + orb_padded_size * 4;
 
-  const size_t psiIndex = first_spo + index;
-  psi[psiIndex]         = TT(c * val_r - s * val_i, c * val_i + s * val_r);
-  d2psi[psiIndex]       = TT(c * lap_r - s * lap_i, c * lap_i + s * lap_r);
-  dpsi_x[psiIndex]      = TT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
-  dpsi_y[psiIndex]      = TT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
-  dpsi_z[psiIndex]      = TT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
+  psi[index]    = TT(c * val_r - s * val_i, c * val_i + s * val_r);
+  d2psi[index]  = TT(c * lap_r - s * lap_i, c * lap_i + s * lap_r);
+  dpsi_x[index] = TT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
+  dpsi_y[index] = TT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
+  dpsi_z[index] = TT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
 }
 } // namespace C2C
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/BsplineFactory/ApplyPhaseC2R.hpp
+++ b/src/QMCWaveFunctions/BsplineFactory/ApplyPhaseC2R.hpp
@@ -24,7 +24,6 @@ inline void assign_v(ST x,
                      const ST* restrict offload_scratch_ptr,
                      const ST* restrict myKcart_ptr,
                      size_t myKcart_padded_size,
-                     size_t first_spo,
                      int nComplexBands,
                      int index)
 {
@@ -43,7 +42,7 @@ inline void assign_v(ST x,
 
   const ST val_r        = val[jr];
   const ST val_i        = val[ji];
-  const size_t psiIndex = first_spo + index + omptarget::min(index, nComplexBands);
+  const size_t psiIndex = index + omptarget::min(index, nComplexBands);
   psi_s[psiIndex]       = val_r * c - val_i * s;
   if (index < nComplexBands)
     psi_s[psiIndex + 1] = val_i * c + val_r * s;
@@ -63,7 +62,6 @@ inline void assign_vgl(ST x,
                        const ST G[9],
                        const ST* myKcart_ptr,
                        size_t myKcart_padded_size,
-                       size_t first_spo,
                        int nComplexBands,
                        int index)
 {
@@ -120,7 +118,7 @@ inline void assign_vgl(ST x,
   TT* restrict dpsi_z = results_scratch_ptr + orb_padded_size * 3;
   TT* restrict d2psi  = results_scratch_ptr + orb_padded_size * 4;
 
-  const size_t psiIndex = first_spo + index + omptarget::min(index, nComplexBands);
+  const size_t psiIndex = index + omptarget::min(index, nComplexBands);
 
   psi[psiIndex]    = c * val_r - s * val_i;
   d2psi[psiIndex]  = c * lap_r - s * lap_i;

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineReader.cpp
@@ -110,7 +110,7 @@ std::unique_ptr<SPOSet> BsplineReader::create_spline_set(const std::string& spo_
   vals.TwistIndex = fullband[0].TwistIndex;
   vals.GroupID    = 0;
   vals.myName     = make_bandgroup_name(spo_name, spin, mybuilder->twist_num_, mybuilder->TileMatrix, 0, size);
-  vals.selectBands(fullband, 0, size, false);
+  vals.selectBands(fullband, 0, size);
 
   return create_spline_set(spo_name, spin, vals);
 }
@@ -138,8 +138,7 @@ std::unique_ptr<SPOSet> BsplineReader::create_spline_set(const std::string& spo_
   vals.GroupID    = 0;
   vals.myName     = make_bandgroup_name(spo_name, spin, mybuilder->twist_num_, mybuilder->TileMatrix,
                                         input_info.min_index(), input_info.max_index());
-  vals.selectBands(fullband, spo2band[spin][input_info.min_index()], input_info.max_index() - input_info.min_index(),
-                   false);
+  vals.selectBands(fullband, spo2band[spin][input_info.min_index()], input_info.max_index() - input_info.min_index());
 
   return create_spline_set(spo_name, spin, vals);
 }

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineReader.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineReader.h
@@ -133,9 +133,6 @@ protected:
 
     bspline.resizeStorage(N);
 
-    bspline.first_spo = bandgroup.getFirstSPO();
-    bspline.last_spo  = bandgroup.getLastSPO();
-
     const std::vector<BandInfo>& cur_bands = bandgroup.myBands;
     for (int iorb = 0, num = 0; iorb < N; iorb++)
     {

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
@@ -35,8 +35,6 @@ protected:
   static const int D = DIM;
   ///first index of the SPOs this Spline handles
   size_t first_spo;
-  ///last index of the SPOs this Spline handles
-  size_t last_spo;
   ///primitive cell
   const Lattice prim_lattice_;
   ///sign bits at the G/2 boundaries
@@ -53,7 +51,7 @@ protected:
 
 public:
   BsplineSet(const std::string& my_name, size_t size, const Lattice& prim_lattice)
-      : SPOSet(my_name, size), first_spo(0), last_spo(0), prim_lattice_(prim_lattice)
+      : SPOSet(my_name, size), first_spo(0), prim_lattice_(prim_lattice)
   {}
 
   virtual bool isComplex() const         = 0;

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
@@ -33,8 +33,6 @@ class BsplineSet : public SPOSet
 {
 protected:
   static const int D = DIM;
-  ///first index of the SPOs this Spline handles
-  size_t first_spo;
   ///primitive cell
   const Lattice prim_lattice_;
   ///sign bits at the G/2 boundaries
@@ -51,7 +49,7 @@ protected:
 
 public:
   BsplineSet(const std::string& my_name, size_t size, const Lattice& prim_lattice)
-      : SPOSet(my_name, size), first_spo(0), prim_lattice_(prim_lattice)
+      : SPOSet(my_name, size), prim_lattice_(prim_lattice)
   {}
 
   virtual bool isComplex() const         = 0;

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
@@ -328,7 +328,7 @@ inline void SplineC2C<ST>::assign_vgl_from_l(const PointType& r, ValueVector& ps
   const ST* restrict g1 = myG.data(1);
   const ST* restrict g2 = myG.data(2);
 
-  const size_t last_cplx = last_spo > psi.size() ? psi.size() : last_spo;
+  const size_t last_cplx = OrbitalSetSize > psi.size() ? psi.size() : OrbitalSetSize;
   const size_t N         = last_cplx - first_spo;
 #pragma omp simd
   for (size_t j = 0; j < N; ++j)

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
@@ -165,7 +165,7 @@ inline void SplineC2C<ST>::assign_v(const PointType& r,
     const ST val_r = myV[2 * j];
     const ST val_i = myV[2 * j + 1];
     qmcplusplus::sincos(-(x * kx[j] + y * ky[j] + z * kz[j]), &s, &c);
-    psi[j + first_spo] = ComplexT(val_r * c - val_i * s, val_i * c + val_r * s);
+    psi[j] = ComplexT(val_r * c - val_i * s, val_i * c + val_r * s);
   }
 }
 
@@ -299,16 +299,15 @@ inline void SplineC2C<ST>::assign_vgl(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    const ST lcart_r      = SymTrace(h00[jr], h01[jr], h02[jr], h11[jr], h12[jr], h22[jr], symGG);
-    const ST lcart_i      = SymTrace(h00[ji], h01[ji], h02[ji], h11[ji], h12[ji], h22[ji], symGG);
-    const ST lap_r        = lcart_r + mKK[j] * val_r + two * (kX * dX_i + kY * dY_i + kZ * dZ_i);
-    const ST lap_i        = lcart_i + mKK[j] * val_i - two * (kX * dX_r + kY * dY_r + kZ * dZ_r);
-    const size_t psiIndex = j + first_spo;
-    psi[psiIndex]         = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
-    dpsi[psiIndex][0]     = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
-    dpsi[psiIndex][1]     = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
-    dpsi[psiIndex][2]     = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
-    d2psi[psiIndex]       = ComplexT(c * lap_r - s * lap_i, c * lap_i + s * lap_r);
+    const ST lcart_r = SymTrace(h00[jr], h01[jr], h02[jr], h11[jr], h12[jr], h22[jr], symGG);
+    const ST lcart_i = SymTrace(h00[ji], h01[ji], h02[ji], h11[ji], h12[ji], h22[ji], symGG);
+    const ST lap_r   = lcart_r + mKK[j] * val_r + two * (kX * dX_i + kY * dY_i + kZ * dZ_i);
+    const ST lap_i   = lcart_i + mKK[j] * val_i - two * (kX * dX_r + kY * dY_r + kZ * dZ_r);
+    psi[j]           = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
+    dpsi[j][0]       = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
+    dpsi[j][1]       = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
+    dpsi[j][2]       = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
+    d2psi[j]         = ComplexT(c * lap_r - s * lap_i, c * lap_i + s * lap_r);
   }
 }
 
@@ -329,7 +328,7 @@ inline void SplineC2C<ST>::assign_vgl_from_l(const PointType& r, ValueVector& ps
   const ST* restrict g2 = myG.data(2);
 
   const size_t last_cplx = OrbitalSetSize > psi.size() ? psi.size() : OrbitalSetSize;
-  const size_t N         = last_cplx - first_spo;
+  const size_t N         = last_cplx;
 #pragma omp simd
   for (size_t j = 0; j < N; ++j)
   {
@@ -366,12 +365,11 @@ inline void SplineC2C<ST>::assign_vgl_from_l(const PointType& r, ValueVector& ps
     const ST lap_r = myL[jr] + mKK[j] * val_r + two * (kX * dX_i + kY * dY_i + kZ * dZ_i);
     const ST lap_i = myL[ji] + mKK[j] * val_i - two * (kX * dX_r + kY * dY_r + kZ * dZ_r);
 
-    const size_t psiIndex = j + first_spo;
-    psi[psiIndex]         = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
-    dpsi[psiIndex][0]     = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
-    dpsi[psiIndex][1]     = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
-    dpsi[psiIndex][2]     = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
-    d2psi[psiIndex]       = ComplexT(c * lap_r - s * lap_i, c * lap_i + s * lap_r);
+    psi[j]     = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
+    dpsi[j][0] = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
+    dpsi[j][1] = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
+    dpsi[j][2] = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
+    d2psi[j]   = ComplexT(c * lap_r - s * lap_i, c * lap_i + s * lap_r);
   }
 }
 
@@ -460,11 +458,10 @@ void SplineC2C<ST>::assign_vgh(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    const size_t psiIndex = j + first_spo;
-    psi[psiIndex]         = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
-    dpsi[psiIndex][0]     = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
-    dpsi[psiIndex][1]     = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
-    dpsi[psiIndex][2]     = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
+    psi[j]     = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
+    dpsi[j][0] = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
+    dpsi[j][1] = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
+    dpsi[j][2] = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
 
     const ST h_xx_r =
         v_m_v(h00[jr], h01[jr], h02[jr], h11[jr], h12[jr], h22[jr], g00, g01, g02, g00, g01, g02) + kX * (gX_i + dX_i);
@@ -504,15 +501,15 @@ void SplineC2C<ST>::assign_vgh(const PointType& r,
     const ST h_zz_i =
         v_m_v(h00[ji], h01[ji], h02[ji], h11[ji], h12[ji], h22[ji], g20, g21, g22, g20, g21, g22) - kZ * (gZ_r + dZ_r);
 
-    grad_grad_psi[psiIndex][0] = ComplexT(c * h_xx_r - s * h_xx_i, c * h_xx_i + s * h_xx_r);
-    grad_grad_psi[psiIndex][1] = ComplexT(c * h_xy_r - s * h_xy_i, c * h_xy_i + s * h_xy_r);
-    grad_grad_psi[psiIndex][2] = ComplexT(c * h_xz_r - s * h_xz_i, c * h_xz_i + s * h_xz_r);
-    grad_grad_psi[psiIndex][3] = ComplexT(c * h_yx_r - s * h_yx_i, c * h_yx_i + s * h_yx_r);
-    grad_grad_psi[psiIndex][4] = ComplexT(c * h_yy_r - s * h_yy_i, c * h_yy_i + s * h_yy_r);
-    grad_grad_psi[psiIndex][5] = ComplexT(c * h_yz_r - s * h_yz_i, c * h_yz_i + s * h_yz_r);
-    grad_grad_psi[psiIndex][6] = ComplexT(c * h_zx_r - s * h_zx_i, c * h_zx_i + s * h_zx_r);
-    grad_grad_psi[psiIndex][7] = ComplexT(c * h_zy_r - s * h_zy_i, c * h_zy_i + s * h_zy_r);
-    grad_grad_psi[psiIndex][8] = ComplexT(c * h_zz_r - s * h_zz_i, c * h_zz_i + s * h_zz_r);
+    grad_grad_psi[j][0] = ComplexT(c * h_xx_r - s * h_xx_i, c * h_xx_i + s * h_xx_r);
+    grad_grad_psi[j][1] = ComplexT(c * h_xy_r - s * h_xy_i, c * h_xy_i + s * h_xy_r);
+    grad_grad_psi[j][2] = ComplexT(c * h_xz_r - s * h_xz_i, c * h_xz_i + s * h_xz_r);
+    grad_grad_psi[j][3] = ComplexT(c * h_yx_r - s * h_yx_i, c * h_yx_i + s * h_yx_r);
+    grad_grad_psi[j][4] = ComplexT(c * h_yy_r - s * h_yy_i, c * h_yy_i + s * h_yy_r);
+    grad_grad_psi[j][5] = ComplexT(c * h_yz_r - s * h_yz_i, c * h_yz_i + s * h_yz_r);
+    grad_grad_psi[j][6] = ComplexT(c * h_zx_r - s * h_zx_i, c * h_zx_i + s * h_zx_r);
+    grad_grad_psi[j][7] = ComplexT(c * h_zy_r - s * h_zy_i, c * h_zy_i + s * h_zy_r);
+    grad_grad_psi[j][8] = ComplexT(c * h_zz_r - s * h_zz_i, c * h_zz_i + s * h_zz_r);
   }
 }
 
@@ -614,11 +611,10 @@ void SplineC2C<ST>::assign_vghgh(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    const size_t psiIndex = j + first_spo;
-    psi[psiIndex]         = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
-    dpsi[psiIndex][0]     = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
-    dpsi[psiIndex][1]     = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
-    dpsi[psiIndex][2]     = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
+    psi[j]     = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
+    dpsi[j][0] = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
+    dpsi[j][1] = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
+    dpsi[j][2] = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
 
     //intermediates for computation of hessian. \partial_i \partial_j phi in cartesian coordinates.
     const ST f_xx_r = v_m_v(h00[jr], h01[jr], h02[jr], h11[jr], h12[jr], h22[jr], g00, g01, g02, g00, g01, g02);
@@ -649,15 +645,15 @@ void SplineC2C<ST>::assign_vghgh(const PointType& r,
     const ST h_yz_i = f_yz_i - (kZ * dY_r + kY * dZ_r) - kZ * kY * val_i;
     const ST h_zz_i = f_zz_i - 2 * kZ * dZ_r - kZ * kZ * val_i;
 
-    grad_grad_psi[psiIndex][0] = ComplexT(c * h_xx_r - s * h_xx_i, c * h_xx_i + s * h_xx_r);
-    grad_grad_psi[psiIndex][1] = ComplexT(c * h_xy_r - s * h_xy_i, c * h_xy_i + s * h_xy_r);
-    grad_grad_psi[psiIndex][2] = ComplexT(c * h_xz_r - s * h_xz_i, c * h_xz_i + s * h_xz_r);
-    grad_grad_psi[psiIndex][3] = ComplexT(c * h_xy_r - s * h_xy_i, c * h_xy_i + s * h_xy_r);
-    grad_grad_psi[psiIndex][4] = ComplexT(c * h_yy_r - s * h_yy_i, c * h_yy_i + s * h_yy_r);
-    grad_grad_psi[psiIndex][5] = ComplexT(c * h_yz_r - s * h_yz_i, c * h_yz_i + s * h_yz_r);
-    grad_grad_psi[psiIndex][6] = ComplexT(c * h_xz_r - s * h_xz_i, c * h_xz_i + s * h_xz_r);
-    grad_grad_psi[psiIndex][7] = ComplexT(c * h_yz_r - s * h_yz_i, c * h_yz_i + s * h_yz_r);
-    grad_grad_psi[psiIndex][8] = ComplexT(c * h_zz_r - s * h_zz_i, c * h_zz_i + s * h_zz_r);
+    grad_grad_psi[j][0] = ComplexT(c * h_xx_r - s * h_xx_i, c * h_xx_i + s * h_xx_r);
+    grad_grad_psi[j][1] = ComplexT(c * h_xy_r - s * h_xy_i, c * h_xy_i + s * h_xy_r);
+    grad_grad_psi[j][2] = ComplexT(c * h_xz_r - s * h_xz_i, c * h_xz_i + s * h_xz_r);
+    grad_grad_psi[j][3] = ComplexT(c * h_xy_r - s * h_xy_i, c * h_xy_i + s * h_xy_r);
+    grad_grad_psi[j][4] = ComplexT(c * h_yy_r - s * h_yy_i, c * h_yy_i + s * h_yy_r);
+    grad_grad_psi[j][5] = ComplexT(c * h_yz_r - s * h_yz_i, c * h_yz_i + s * h_yz_r);
+    grad_grad_psi[j][6] = ComplexT(c * h_xz_r - s * h_xz_i, c * h_xz_i + s * h_xz_r);
+    grad_grad_psi[j][7] = ComplexT(c * h_yz_r - s * h_yz_i, c * h_yz_i + s * h_yz_r);
+    grad_grad_psi[j][8] = ComplexT(c * h_zz_r - s * h_zz_i, c * h_zz_i + s * h_zz_r);
 
     //These are the real and imaginary components of the third SPO derivative.  _xxx denotes
     // third derivative w.r.t. x, _xyz, a derivative with resepect to x,y, and z, and so on.
@@ -740,36 +736,36 @@ void SplineC2C<ST>::assign_vghgh(const PointType& r,
     const ST gh_zzz_r = f3_zzz_r + 3 * kZ * f_zz_i - 3 * kZ * kZ * dZ_r - kZ * kZ * kZ * val_i;
     const ST gh_zzz_i = f3_zzz_i - 3 * kZ * f_zz_r - 3 * kZ * kZ * dZ_i + kZ * kZ * kZ * val_r;
 
-    grad_grad_grad_psi[psiIndex][0][0] = ComplexT(c * gh_xxx_r - s * gh_xxx_i, c * gh_xxx_i + s * gh_xxx_r);
-    grad_grad_grad_psi[psiIndex][0][1] = ComplexT(c * gh_xxy_r - s * gh_xxy_i, c * gh_xxy_i + s * gh_xxy_r);
-    grad_grad_grad_psi[psiIndex][0][2] = ComplexT(c * gh_xxz_r - s * gh_xxz_i, c * gh_xxz_i + s * gh_xxz_r);
-    grad_grad_grad_psi[psiIndex][0][3] = ComplexT(c * gh_xxy_r - s * gh_xxy_i, c * gh_xxy_i + s * gh_xxy_r);
-    grad_grad_grad_psi[psiIndex][0][4] = ComplexT(c * gh_xyy_r - s * gh_xyy_i, c * gh_xyy_i + s * gh_xyy_r);
-    grad_grad_grad_psi[psiIndex][0][5] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
-    grad_grad_grad_psi[psiIndex][0][6] = ComplexT(c * gh_xxz_r - s * gh_xxz_i, c * gh_xxz_i + s * gh_xxz_r);
-    grad_grad_grad_psi[psiIndex][0][7] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
-    grad_grad_grad_psi[psiIndex][0][8] = ComplexT(c * gh_xzz_r - s * gh_xzz_i, c * gh_xzz_i + s * gh_xzz_r);
+    grad_grad_grad_psi[j][0][0] = ComplexT(c * gh_xxx_r - s * gh_xxx_i, c * gh_xxx_i + s * gh_xxx_r);
+    grad_grad_grad_psi[j][0][1] = ComplexT(c * gh_xxy_r - s * gh_xxy_i, c * gh_xxy_i + s * gh_xxy_r);
+    grad_grad_grad_psi[j][0][2] = ComplexT(c * gh_xxz_r - s * gh_xxz_i, c * gh_xxz_i + s * gh_xxz_r);
+    grad_grad_grad_psi[j][0][3] = ComplexT(c * gh_xxy_r - s * gh_xxy_i, c * gh_xxy_i + s * gh_xxy_r);
+    grad_grad_grad_psi[j][0][4] = ComplexT(c * gh_xyy_r - s * gh_xyy_i, c * gh_xyy_i + s * gh_xyy_r);
+    grad_grad_grad_psi[j][0][5] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
+    grad_grad_grad_psi[j][0][6] = ComplexT(c * gh_xxz_r - s * gh_xxz_i, c * gh_xxz_i + s * gh_xxz_r);
+    grad_grad_grad_psi[j][0][7] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
+    grad_grad_grad_psi[j][0][8] = ComplexT(c * gh_xzz_r - s * gh_xzz_i, c * gh_xzz_i + s * gh_xzz_r);
 
-    grad_grad_grad_psi[psiIndex][1][0] = ComplexT(c * gh_xxy_r - s * gh_xxy_i, c * gh_xxy_i + s * gh_xxy_r);
-    grad_grad_grad_psi[psiIndex][1][1] = ComplexT(c * gh_xyy_r - s * gh_xyy_i, c * gh_xyy_i + s * gh_xyy_r);
-    grad_grad_grad_psi[psiIndex][1][2] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
-    grad_grad_grad_psi[psiIndex][1][3] = ComplexT(c * gh_xyy_r - s * gh_xyy_i, c * gh_xyy_i + s * gh_xyy_r);
-    grad_grad_grad_psi[psiIndex][1][4] = ComplexT(c * gh_yyy_r - s * gh_yyy_i, c * gh_yyy_i + s * gh_yyy_r);
-    grad_grad_grad_psi[psiIndex][1][5] = ComplexT(c * gh_yyz_r - s * gh_yyz_i, c * gh_yyz_i + s * gh_yyz_r);
-    grad_grad_grad_psi[psiIndex][1][6] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
-    grad_grad_grad_psi[psiIndex][1][7] = ComplexT(c * gh_yyz_r - s * gh_yyz_i, c * gh_yyz_i + s * gh_yyz_r);
-    grad_grad_grad_psi[psiIndex][1][8] = ComplexT(c * gh_yzz_r - s * gh_yzz_i, c * gh_yzz_i + s * gh_yzz_r);
+    grad_grad_grad_psi[j][1][0] = ComplexT(c * gh_xxy_r - s * gh_xxy_i, c * gh_xxy_i + s * gh_xxy_r);
+    grad_grad_grad_psi[j][1][1] = ComplexT(c * gh_xyy_r - s * gh_xyy_i, c * gh_xyy_i + s * gh_xyy_r);
+    grad_grad_grad_psi[j][1][2] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
+    grad_grad_grad_psi[j][1][3] = ComplexT(c * gh_xyy_r - s * gh_xyy_i, c * gh_xyy_i + s * gh_xyy_r);
+    grad_grad_grad_psi[j][1][4] = ComplexT(c * gh_yyy_r - s * gh_yyy_i, c * gh_yyy_i + s * gh_yyy_r);
+    grad_grad_grad_psi[j][1][5] = ComplexT(c * gh_yyz_r - s * gh_yyz_i, c * gh_yyz_i + s * gh_yyz_r);
+    grad_grad_grad_psi[j][1][6] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
+    grad_grad_grad_psi[j][1][7] = ComplexT(c * gh_yyz_r - s * gh_yyz_i, c * gh_yyz_i + s * gh_yyz_r);
+    grad_grad_grad_psi[j][1][8] = ComplexT(c * gh_yzz_r - s * gh_yzz_i, c * gh_yzz_i + s * gh_yzz_r);
 
 
-    grad_grad_grad_psi[psiIndex][2][0] = ComplexT(c * gh_xxz_r - s * gh_xxz_i, c * gh_xxz_i + s * gh_xxz_r);
-    grad_grad_grad_psi[psiIndex][2][1] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
-    grad_grad_grad_psi[psiIndex][2][2] = ComplexT(c * gh_xzz_r - s * gh_xzz_i, c * gh_xzz_i + s * gh_xzz_r);
-    grad_grad_grad_psi[psiIndex][2][3] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
-    grad_grad_grad_psi[psiIndex][2][4] = ComplexT(c * gh_yyz_r - s * gh_yyz_i, c * gh_yyz_i + s * gh_yyz_r);
-    grad_grad_grad_psi[psiIndex][2][5] = ComplexT(c * gh_yzz_r - s * gh_yzz_i, c * gh_yzz_i + s * gh_yzz_r);
-    grad_grad_grad_psi[psiIndex][2][6] = ComplexT(c * gh_xzz_r - s * gh_xzz_i, c * gh_xzz_i + s * gh_xzz_r);
-    grad_grad_grad_psi[psiIndex][2][7] = ComplexT(c * gh_yzz_r - s * gh_yzz_i, c * gh_yzz_i + s * gh_yzz_r);
-    grad_grad_grad_psi[psiIndex][2][8] = ComplexT(c * gh_zzz_r - s * gh_zzz_i, c * gh_zzz_i + s * gh_zzz_r);
+    grad_grad_grad_psi[j][2][0] = ComplexT(c * gh_xxz_r - s * gh_xxz_i, c * gh_xxz_i + s * gh_xxz_r);
+    grad_grad_grad_psi[j][2][1] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
+    grad_grad_grad_psi[j][2][2] = ComplexT(c * gh_xzz_r - s * gh_xzz_i, c * gh_xzz_i + s * gh_xzz_r);
+    grad_grad_grad_psi[j][2][3] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
+    grad_grad_grad_psi[j][2][4] = ComplexT(c * gh_yyz_r - s * gh_yyz_i, c * gh_yyz_i + s * gh_yyz_r);
+    grad_grad_grad_psi[j][2][5] = ComplexT(c * gh_yzz_r - s * gh_yzz_i, c * gh_yzz_i + s * gh_yzz_r);
+    grad_grad_grad_psi[j][2][6] = ComplexT(c * gh_xzz_r - s * gh_xzz_i, c * gh_xzz_i + s * gh_xzz_r);
+    grad_grad_grad_psi[j][2][7] = ComplexT(c * gh_yzz_r - s * gh_yzz_i, c * gh_yzz_i + s * gh_yzz_r);
+    grad_grad_grad_psi[j][2][8] = ComplexT(c * gh_zzz_r - s * gh_zzz_i, c * gh_zzz_i + s * gh_zzz_r);
   }
 }
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -124,7 +124,7 @@ inline void SplineC2COMPTarget<ST>::assign_v(const PointType& r,
     const ST val_r = myV[2 * j];
     const ST val_i = myV[2 * j + 1];
     omptarget::sincos(-(x * kx[j] + y * ky[j] + z * kz[j]), &s, &c);
-    psi[j + first_spo] = ComplexT(val_r * c - val_i * s, val_i * c + val_r * s);
+    psi[j] = ComplexT(val_r * c - val_i * s, val_i * c + val_r * s);
   }
 }
 
@@ -187,7 +187,6 @@ void SplineC2COMPTarget<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
   auto* myKcart_ptr              = myKcart->data();
   auto* psiinv_ptr               = psiinv_pos_copy.data();
   auto* ratios_private_ptr       = ratios_private.data();
-  const size_t first_spo_local   = first_spo;
   const auto orb_size            = psiinv.size();
 
   {
@@ -219,7 +218,7 @@ void SplineC2COMPTarget<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = first_cplx; index < last_cplx; index++)
           C2C::assign_v(ST(pos_scratch[iat * 6]), ST(pos_scratch[iat * 6 + 1]), ST(pos_scratch[iat * 6 + 2]),
-                        psi_iat_ptr, offload_scratch_iat_ptr, myKcart_ptr, myKcart_padded_size, first_spo_local, index);
+                        psi_iat_ptr, offload_scratch_iat_ptr, myKcart_ptr, myKcart_padded_size, index);
 
         ComplexT sum(0);
         PRAGMA_OFFLOAD("omp parallel for simd reduction(+:sum)")
@@ -307,7 +306,6 @@ void SplineC2COMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
   auto* myKcart_ptr              = myKcart->data();
   auto* buffer_H2D_ptr           = det_ratios_buffer_H2D.data();
   auto* ratios_private_ptr       = mw_ratios_private.data();
-  const size_t first_spo_local   = first_spo;
 
   {
     ScopedTimer offload(offload_timer_);
@@ -340,7 +338,7 @@ void SplineC2COMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = first_cplx; index < last_cplx; index++)
           C2C::assign_v(pos_scratch[iat * 6], pos_scratch[iat * 6 + 1], pos_scratch[iat * 6 + 2], psi_iat_ptr,
-                        offload_scratch_iat_ptr, myKcart_ptr, myKcart_padded_size, first_spo_local, index);
+                        offload_scratch_iat_ptr, myKcart_ptr, myKcart_padded_size, index);
 
         ComplexT sum(0);
         PRAGMA_OFFLOAD("omp parallel for simd reduction(+:sum)")
@@ -384,9 +382,8 @@ inline void SplineC2COMPTarget<ST>::assign_vgl_from_l(const PointType& r,
   const ST* restrict g2 = myG.data(2);
 
   const size_t last_cplx = OrbitalSetSize > psi.size() ? psi.size() : OrbitalSetSize;
-  const size_t N         = last_cplx - first_spo;
 #pragma omp simd
-  for (size_t j = 0; j < N; ++j)
+  for (size_t j = 0; j < last_cplx; ++j)
   {
     const size_t jr = j << 1;
     const size_t ji = jr + 1;
@@ -421,12 +418,11 @@ inline void SplineC2COMPTarget<ST>::assign_vgl_from_l(const PointType& r,
     const ST lap_r = myL[jr] + (*mKK)[j] * val_r + two * (kX * dX_i + kY * dY_i + kZ * dZ_i);
     const ST lap_i = myL[ji] + (*mKK)[j] * val_i - two * (kX * dX_r + kY * dY_r + kZ * dZ_r);
 
-    const size_t psiIndex = j + first_spo;
-    psi[psiIndex]         = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
-    dpsi[psiIndex][0]     = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
-    dpsi[psiIndex][1]     = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
-    dpsi[psiIndex][2]     = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
-    d2psi[psiIndex]       = ComplexT(c * lap_r - s * lap_i, c * lap_i + s * lap_r);
+    psi[j]     = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
+    dpsi[j][0] = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
+    dpsi[j][1] = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
+    dpsi[j][2] = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
+    d2psi[j]   = ComplexT(c * lap_r - s * lap_i, c * lap_i + s * lap_r);
   }
 }
 
@@ -460,7 +456,6 @@ void SplineC2COMPTarget<ST>::evaluateVGL(const ParticleSet& P,
   auto* GGt_ptr                  = GGt_offload->data();
   auto* prim_lattice_G_ptr       = prim_lattice_G_offload->data();
   auto* myKcart_ptr              = myKcart->data();
-  const size_t first_spo_local   = first_spo;
   const auto orb_size            = psi.size();
 
   {
@@ -502,7 +497,7 @@ void SplineC2COMPTarget<ST>::evaluateVGL(const ParticleSet& P,
       PRAGMA_OFFLOAD("omp parallel for")
       for (int index = first_cplx; index < last_cplx; index++)
         C2C::assign_vgl(x, y, z, results_scratch_ptr, sposet_padded_size, mKK_ptr, offload_scratch_ptr,
-                        spline_padded_size, G, myKcart_ptr, myKcart_padded_size, first_spo_local, index);
+                        spline_padded_size, G, myKcart_ptr, myKcart_padded_size, index);
     }
   }
 
@@ -544,7 +539,6 @@ void SplineC2COMPTarget<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedA
   auto* GGt_ptr                  = GGt_offload->data();
   auto* prim_lattice_G_ptr       = prim_lattice_G_offload->data();
   auto* myKcart_ptr              = myKcart->data();
-  const size_t first_spo_local   = first_spo;
 
   {
     ScopedTimer offload(offload_timer_);
@@ -592,7 +586,7 @@ void SplineC2COMPTarget<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedA
         for (int index = first_cplx; index < last_cplx; index++)
           C2C::assign_vgl(pos_copy_ptr[iw * 6], pos_copy_ptr[iw * 6 + 1], pos_copy_ptr[iw * 6 + 2], psi_iw_ptr,
                           sposet_padded_size, mKK_ptr, offload_scratch_iw_ptr, spline_padded_size, G, myKcart_ptr,
-                          myKcart_padded_size, first_spo_local, index);
+                          myKcart_padded_size, index);
       }
   }
 
@@ -709,7 +703,6 @@ void SplineC2COMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
   auto* phi_vgl_ptr              = phi_vgl_v.data();
   auto* rg_private_ptr           = rg_private.data();
   const size_t buffer_H2D_stride = buffer_H2D.cols();
-  const size_t first_spo_local   = first_spo;
   const size_t phi_vgl_stride    = num_pos * orb_size;
 
   {
@@ -760,8 +753,7 @@ void SplineC2COMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = first_cplx; index < last_cplx; index++)
           C2C::assign_vgl(pos_iw_ptr[0], pos_iw_ptr[1], pos_iw_ptr[2], psi_iw_ptr, sposet_padded_size, mKK_ptr,
-                          offload_scratch_iw_ptr, spline_padded_size, G, myKcart_ptr, myKcart_padded_size,
-                          first_spo_local, index);
+                          offload_scratch_iw_ptr, spline_padded_size, G, myKcart_ptr, myKcart_padded_size, index);
 
         ValueType* restrict psi    = psi_iw_ptr;
         ValueType* restrict dpsi_x = psi_iw_ptr + sposet_padded_size;
@@ -779,18 +771,16 @@ void SplineC2COMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
         PRAGMA_OFFLOAD("omp parallel for reduction(+: ratio, grad_x, grad_y, grad_z)")
         for (int j = first_cplx; j < last_cplx; j++)
         {
-          const size_t psiIndex = first_spo_local + j;
+          out_phi[j]    = psi[j];
+          out_dphi_x[j] = dpsi_x[j];
+          out_dphi_y[j] = dpsi_y[j];
+          out_dphi_z[j] = dpsi_z[j];
+          out_d2phi[j]  = d2psi[j];
 
-          out_phi[psiIndex]    = psi[psiIndex];
-          out_dphi_x[psiIndex] = dpsi_x[psiIndex];
-          out_dphi_y[psiIndex] = dpsi_y[psiIndex];
-          out_dphi_z[psiIndex] = dpsi_z[psiIndex];
-          out_d2phi[psiIndex]  = d2psi[psiIndex];
-
-          ratio += psi[psiIndex] * invRow_iw_ptr[psiIndex];
-          grad_x += dpsi_x[psiIndex] * invRow_iw_ptr[psiIndex];
-          grad_y += dpsi_y[psiIndex] * invRow_iw_ptr[psiIndex];
-          grad_z += dpsi_z[psiIndex] * invRow_iw_ptr[psiIndex];
+          ratio += psi[j] * invRow_iw_ptr[j];
+          grad_x += dpsi_x[j] * invRow_iw_ptr[j];
+          grad_y += dpsi_y[j] * invRow_iw_ptr[j];
+          grad_z += dpsi_z[j] * invRow_iw_ptr[j];
         }
 
         rg_private_ptr[(iw * NumTeams + team_id) * 4]     = ratio;
@@ -881,11 +871,10 @@ void SplineC2COMPTarget<ST>::assign_vgh(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    const size_t psiIndex = j + first_spo;
-    psi[psiIndex]         = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
-    dpsi[psiIndex][0]     = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
-    dpsi[psiIndex][1]     = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
-    dpsi[psiIndex][2]     = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
+    psi[j]     = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
+    dpsi[j][0] = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
+    dpsi[j][1] = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
+    dpsi[j][2] = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
 
     const ST h_xx_r =
         v_m_v(h00[jr], h01[jr], h02[jr], h11[jr], h12[jr], h22[jr], g00, g01, g02, g00, g01, g02) + kX * (gX_i + dX_i);
@@ -925,15 +914,15 @@ void SplineC2COMPTarget<ST>::assign_vgh(const PointType& r,
     const ST h_zz_i =
         v_m_v(h00[ji], h01[ji], h02[ji], h11[ji], h12[ji], h22[ji], g20, g21, g22, g20, g21, g22) - kZ * (gZ_r + dZ_r);
 
-    grad_grad_psi[psiIndex][0] = ComplexT(c * h_xx_r - s * h_xx_i, c * h_xx_i + s * h_xx_r);
-    grad_grad_psi[psiIndex][1] = ComplexT(c * h_xy_r - s * h_xy_i, c * h_xy_i + s * h_xy_r);
-    grad_grad_psi[psiIndex][2] = ComplexT(c * h_xz_r - s * h_xz_i, c * h_xz_i + s * h_xz_r);
-    grad_grad_psi[psiIndex][3] = ComplexT(c * h_yx_r - s * h_yx_i, c * h_yx_i + s * h_yx_r);
-    grad_grad_psi[psiIndex][4] = ComplexT(c * h_yy_r - s * h_yy_i, c * h_yy_i + s * h_yy_r);
-    grad_grad_psi[psiIndex][5] = ComplexT(c * h_yz_r - s * h_yz_i, c * h_yz_i + s * h_yz_r);
-    grad_grad_psi[psiIndex][6] = ComplexT(c * h_zx_r - s * h_zx_i, c * h_zx_i + s * h_zx_r);
-    grad_grad_psi[psiIndex][7] = ComplexT(c * h_zy_r - s * h_zy_i, c * h_zy_i + s * h_zy_r);
-    grad_grad_psi[psiIndex][8] = ComplexT(c * h_zz_r - s * h_zz_i, c * h_zz_i + s * h_zz_r);
+    grad_grad_psi[j][0] = ComplexT(c * h_xx_r - s * h_xx_i, c * h_xx_i + s * h_xx_r);
+    grad_grad_psi[j][1] = ComplexT(c * h_xy_r - s * h_xy_i, c * h_xy_i + s * h_xy_r);
+    grad_grad_psi[j][2] = ComplexT(c * h_xz_r - s * h_xz_i, c * h_xz_i + s * h_xz_r);
+    grad_grad_psi[j][3] = ComplexT(c * h_yx_r - s * h_yx_i, c * h_yx_i + s * h_yx_r);
+    grad_grad_psi[j][4] = ComplexT(c * h_yy_r - s * h_yy_i, c * h_yy_i + s * h_yy_r);
+    grad_grad_psi[j][5] = ComplexT(c * h_yz_r - s * h_yz_i, c * h_yz_i + s * h_yz_r);
+    grad_grad_psi[j][6] = ComplexT(c * h_zx_r - s * h_zx_i, c * h_zx_i + s * h_zx_r);
+    grad_grad_psi[j][7] = ComplexT(c * h_zy_r - s * h_zy_i, c * h_zy_i + s * h_zy_r);
+    grad_grad_psi[j][8] = ComplexT(c * h_zz_r - s * h_zz_i, c * h_zz_i + s * h_zz_r);
   }
 }
 
@@ -1035,11 +1024,10 @@ void SplineC2COMPTarget<ST>::assign_vghgh(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    const size_t psiIndex = j + first_spo;
-    psi[psiIndex]         = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
-    dpsi[psiIndex][0]     = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
-    dpsi[psiIndex][1]     = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
-    dpsi[psiIndex][2]     = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
+    psi[j]     = ComplexT(c * val_r - s * val_i, c * val_i + s * val_r);
+    dpsi[j][0] = ComplexT(c * gX_r - s * gX_i, c * gX_i + s * gX_r);
+    dpsi[j][1] = ComplexT(c * gY_r - s * gY_i, c * gY_i + s * gY_r);
+    dpsi[j][2] = ComplexT(c * gZ_r - s * gZ_i, c * gZ_i + s * gZ_r);
 
     //intermediates for computation of hessian. \partial_i \partial_j phi in cartesian coordinates.
     const ST f_xx_r = v_m_v(h00[jr], h01[jr], h02[jr], h11[jr], h12[jr], h22[jr], g00, g01, g02, g00, g01, g02);
@@ -1070,15 +1058,15 @@ void SplineC2COMPTarget<ST>::assign_vghgh(const PointType& r,
     const ST h_yz_i = f_yz_i - (kZ * dY_r + kY * dZ_r) - kZ * kY * val_i;
     const ST h_zz_i = f_zz_i - 2 * kZ * dZ_r - kZ * kZ * val_i;
 
-    grad_grad_psi[psiIndex][0] = ComplexT(c * h_xx_r - s * h_xx_i, c * h_xx_i + s * h_xx_r);
-    grad_grad_psi[psiIndex][1] = ComplexT(c * h_xy_r - s * h_xy_i, c * h_xy_i + s * h_xy_r);
-    grad_grad_psi[psiIndex][2] = ComplexT(c * h_xz_r - s * h_xz_i, c * h_xz_i + s * h_xz_r);
-    grad_grad_psi[psiIndex][3] = ComplexT(c * h_xy_r - s * h_xy_i, c * h_xy_i + s * h_xy_r);
-    grad_grad_psi[psiIndex][4] = ComplexT(c * h_yy_r - s * h_yy_i, c * h_yy_i + s * h_yy_r);
-    grad_grad_psi[psiIndex][5] = ComplexT(c * h_yz_r - s * h_yz_i, c * h_yz_i + s * h_yz_r);
-    grad_grad_psi[psiIndex][6] = ComplexT(c * h_xz_r - s * h_xz_i, c * h_xz_i + s * h_xz_r);
-    grad_grad_psi[psiIndex][7] = ComplexT(c * h_yz_r - s * h_yz_i, c * h_yz_i + s * h_yz_r);
-    grad_grad_psi[psiIndex][8] = ComplexT(c * h_zz_r - s * h_zz_i, c * h_zz_i + s * h_zz_r);
+    grad_grad_psi[j][0] = ComplexT(c * h_xx_r - s * h_xx_i, c * h_xx_i + s * h_xx_r);
+    grad_grad_psi[j][1] = ComplexT(c * h_xy_r - s * h_xy_i, c * h_xy_i + s * h_xy_r);
+    grad_grad_psi[j][2] = ComplexT(c * h_xz_r - s * h_xz_i, c * h_xz_i + s * h_xz_r);
+    grad_grad_psi[j][3] = ComplexT(c * h_xy_r - s * h_xy_i, c * h_xy_i + s * h_xy_r);
+    grad_grad_psi[j][4] = ComplexT(c * h_yy_r - s * h_yy_i, c * h_yy_i + s * h_yy_r);
+    grad_grad_psi[j][5] = ComplexT(c * h_yz_r - s * h_yz_i, c * h_yz_i + s * h_yz_r);
+    grad_grad_psi[j][6] = ComplexT(c * h_xz_r - s * h_xz_i, c * h_xz_i + s * h_xz_r);
+    grad_grad_psi[j][7] = ComplexT(c * h_yz_r - s * h_yz_i, c * h_yz_i + s * h_yz_r);
+    grad_grad_psi[j][8] = ComplexT(c * h_zz_r - s * h_zz_i, c * h_zz_i + s * h_zz_r);
 
     //These are the real and imaginary components of the third SPO derivative.  _xxx denotes
     // third derivative w.r.t. x, _xyz, a derivative with resepect to x,y, and z, and so on.
@@ -1161,36 +1149,36 @@ void SplineC2COMPTarget<ST>::assign_vghgh(const PointType& r,
     const ST gh_zzz_r = f3_zzz_r + 3 * kZ * f_zz_i - 3 * kZ * kZ * dZ_r - kZ * kZ * kZ * val_i;
     const ST gh_zzz_i = f3_zzz_i - 3 * kZ * f_zz_r - 3 * kZ * kZ * dZ_i + kZ * kZ * kZ * val_r;
 
-    grad_grad_grad_psi[psiIndex][0][0] = ComplexT(c * gh_xxx_r - s * gh_xxx_i, c * gh_xxx_i + s * gh_xxx_r);
-    grad_grad_grad_psi[psiIndex][0][1] = ComplexT(c * gh_xxy_r - s * gh_xxy_i, c * gh_xxy_i + s * gh_xxy_r);
-    grad_grad_grad_psi[psiIndex][0][2] = ComplexT(c * gh_xxz_r - s * gh_xxz_i, c * gh_xxz_i + s * gh_xxz_r);
-    grad_grad_grad_psi[psiIndex][0][3] = ComplexT(c * gh_xxy_r - s * gh_xxy_i, c * gh_xxy_i + s * gh_xxy_r);
-    grad_grad_grad_psi[psiIndex][0][4] = ComplexT(c * gh_xyy_r - s * gh_xyy_i, c * gh_xyy_i + s * gh_xyy_r);
-    grad_grad_grad_psi[psiIndex][0][5] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
-    grad_grad_grad_psi[psiIndex][0][6] = ComplexT(c * gh_xxz_r - s * gh_xxz_i, c * gh_xxz_i + s * gh_xxz_r);
-    grad_grad_grad_psi[psiIndex][0][7] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
-    grad_grad_grad_psi[psiIndex][0][8] = ComplexT(c * gh_xzz_r - s * gh_xzz_i, c * gh_xzz_i + s * gh_xzz_r);
+    grad_grad_grad_psi[j][0][0] = ComplexT(c * gh_xxx_r - s * gh_xxx_i, c * gh_xxx_i + s * gh_xxx_r);
+    grad_grad_grad_psi[j][0][1] = ComplexT(c * gh_xxy_r - s * gh_xxy_i, c * gh_xxy_i + s * gh_xxy_r);
+    grad_grad_grad_psi[j][0][2] = ComplexT(c * gh_xxz_r - s * gh_xxz_i, c * gh_xxz_i + s * gh_xxz_r);
+    grad_grad_grad_psi[j][0][3] = ComplexT(c * gh_xxy_r - s * gh_xxy_i, c * gh_xxy_i + s * gh_xxy_r);
+    grad_grad_grad_psi[j][0][4] = ComplexT(c * gh_xyy_r - s * gh_xyy_i, c * gh_xyy_i + s * gh_xyy_r);
+    grad_grad_grad_psi[j][0][5] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
+    grad_grad_grad_psi[j][0][6] = ComplexT(c * gh_xxz_r - s * gh_xxz_i, c * gh_xxz_i + s * gh_xxz_r);
+    grad_grad_grad_psi[j][0][7] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
+    grad_grad_grad_psi[j][0][8] = ComplexT(c * gh_xzz_r - s * gh_xzz_i, c * gh_xzz_i + s * gh_xzz_r);
 
-    grad_grad_grad_psi[psiIndex][1][0] = ComplexT(c * gh_xxy_r - s * gh_xxy_i, c * gh_xxy_i + s * gh_xxy_r);
-    grad_grad_grad_psi[psiIndex][1][1] = ComplexT(c * gh_xyy_r - s * gh_xyy_i, c * gh_xyy_i + s * gh_xyy_r);
-    grad_grad_grad_psi[psiIndex][1][2] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
-    grad_grad_grad_psi[psiIndex][1][3] = ComplexT(c * gh_xyy_r - s * gh_xyy_i, c * gh_xyy_i + s * gh_xyy_r);
-    grad_grad_grad_psi[psiIndex][1][4] = ComplexT(c * gh_yyy_r - s * gh_yyy_i, c * gh_yyy_i + s * gh_yyy_r);
-    grad_grad_grad_psi[psiIndex][1][5] = ComplexT(c * gh_yyz_r - s * gh_yyz_i, c * gh_yyz_i + s * gh_yyz_r);
-    grad_grad_grad_psi[psiIndex][1][6] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
-    grad_grad_grad_psi[psiIndex][1][7] = ComplexT(c * gh_yyz_r - s * gh_yyz_i, c * gh_yyz_i + s * gh_yyz_r);
-    grad_grad_grad_psi[psiIndex][1][8] = ComplexT(c * gh_yzz_r - s * gh_yzz_i, c * gh_yzz_i + s * gh_yzz_r);
+    grad_grad_grad_psi[j][1][0] = ComplexT(c * gh_xxy_r - s * gh_xxy_i, c * gh_xxy_i + s * gh_xxy_r);
+    grad_grad_grad_psi[j][1][1] = ComplexT(c * gh_xyy_r - s * gh_xyy_i, c * gh_xyy_i + s * gh_xyy_r);
+    grad_grad_grad_psi[j][1][2] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
+    grad_grad_grad_psi[j][1][3] = ComplexT(c * gh_xyy_r - s * gh_xyy_i, c * gh_xyy_i + s * gh_xyy_r);
+    grad_grad_grad_psi[j][1][4] = ComplexT(c * gh_yyy_r - s * gh_yyy_i, c * gh_yyy_i + s * gh_yyy_r);
+    grad_grad_grad_psi[j][1][5] = ComplexT(c * gh_yyz_r - s * gh_yyz_i, c * gh_yyz_i + s * gh_yyz_r);
+    grad_grad_grad_psi[j][1][6] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
+    grad_grad_grad_psi[j][1][7] = ComplexT(c * gh_yyz_r - s * gh_yyz_i, c * gh_yyz_i + s * gh_yyz_r);
+    grad_grad_grad_psi[j][1][8] = ComplexT(c * gh_yzz_r - s * gh_yzz_i, c * gh_yzz_i + s * gh_yzz_r);
 
 
-    grad_grad_grad_psi[psiIndex][2][0] = ComplexT(c * gh_xxz_r - s * gh_xxz_i, c * gh_xxz_i + s * gh_xxz_r);
-    grad_grad_grad_psi[psiIndex][2][1] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
-    grad_grad_grad_psi[psiIndex][2][2] = ComplexT(c * gh_xzz_r - s * gh_xzz_i, c * gh_xzz_i + s * gh_xzz_r);
-    grad_grad_grad_psi[psiIndex][2][3] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
-    grad_grad_grad_psi[psiIndex][2][4] = ComplexT(c * gh_yyz_r - s * gh_yyz_i, c * gh_yyz_i + s * gh_yyz_r);
-    grad_grad_grad_psi[psiIndex][2][5] = ComplexT(c * gh_yzz_r - s * gh_yzz_i, c * gh_yzz_i + s * gh_yzz_r);
-    grad_grad_grad_psi[psiIndex][2][6] = ComplexT(c * gh_xzz_r - s * gh_xzz_i, c * gh_xzz_i + s * gh_xzz_r);
-    grad_grad_grad_psi[psiIndex][2][7] = ComplexT(c * gh_yzz_r - s * gh_yzz_i, c * gh_yzz_i + s * gh_yzz_r);
-    grad_grad_grad_psi[psiIndex][2][8] = ComplexT(c * gh_zzz_r - s * gh_zzz_i, c * gh_zzz_i + s * gh_zzz_r);
+    grad_grad_grad_psi[j][2][0] = ComplexT(c * gh_xxz_r - s * gh_xxz_i, c * gh_xxz_i + s * gh_xxz_r);
+    grad_grad_grad_psi[j][2][1] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
+    grad_grad_grad_psi[j][2][2] = ComplexT(c * gh_xzz_r - s * gh_xzz_i, c * gh_xzz_i + s * gh_xzz_r);
+    grad_grad_grad_psi[j][2][3] = ComplexT(c * gh_xyz_r - s * gh_xyz_i, c * gh_xyz_i + s * gh_xyz_r);
+    grad_grad_grad_psi[j][2][4] = ComplexT(c * gh_yyz_r - s * gh_yyz_i, c * gh_yyz_i + s * gh_yyz_r);
+    grad_grad_grad_psi[j][2][5] = ComplexT(c * gh_yzz_r - s * gh_yzz_i, c * gh_yzz_i + s * gh_yzz_r);
+    grad_grad_grad_psi[j][2][6] = ComplexT(c * gh_xzz_r - s * gh_xzz_i, c * gh_xzz_i + s * gh_xzz_r);
+    grad_grad_grad_psi[j][2][7] = ComplexT(c * gh_yzz_r - s * gh_yzz_i, c * gh_yzz_i + s * gh_yzz_r);
+    grad_grad_grad_psi[j][2][8] = ComplexT(c * gh_zzz_r - s * gh_zzz_i, c * gh_zzz_i + s * gh_zzz_r);
   }
 }
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -383,7 +383,7 @@ inline void SplineC2COMPTarget<ST>::assign_vgl_from_l(const PointType& r,
   const ST* restrict g1 = myG.data(1);
   const ST* restrict g2 = myG.data(2);
 
-  const size_t last_cplx = last_spo > psi.size() ? psi.size() : last_spo;
+  const size_t last_cplx = OrbitalSetSize > psi.size() ? psi.size() : OrbitalSetSize;
   const size_t N         = last_cplx - first_spo;
 #pragma omp simd
   for (size_t j = 0; j < N; ++j)

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2R.cpp
@@ -52,7 +52,7 @@ inline void SplineC2R<ST>::assign_v(const PointType& r,
   const ST* restrict ky = myKcart.data(1);
   const ST* restrict kz = myKcart.data(2);
 
-  TT* restrict psi_s              = psi.data() + first_spo;
+  TT* restrict psi_s              = psi.data();
   const size_t requested_orb_size = psi.size();
 #pragma omp simd
   for (size_t j = first; j < std::min(nComplexBands, last); j++)
@@ -229,22 +229,21 @@ inline void SplineC2R<ST>::assign_vgl(const PointType& r,
     const ST lap_r   = lcart_r + mKK[j] * val_r + two * (kX * dX_i + kY * dY_i + kZ * dZ_i);
     const ST lap_i   = lcart_i + mKK[j] * val_i - two * (kX * dX_r + kY * dY_r + kZ * dZ_r);
 
-    const size_t psiIndex = first_spo + jr;
-    if (psiIndex < requested_orb_size)
+    if (jr < requested_orb_size)
     {
-      psi[psiIndex]     = c * val_r - s * val_i;
-      dpsi[psiIndex][0] = c * gX_r - s * gX_i;
-      dpsi[psiIndex][1] = c * gY_r - s * gY_i;
-      dpsi[psiIndex][2] = c * gZ_r - s * gZ_i;
-      d2psi[psiIndex]   = c * lap_r - s * lap_i;
+      psi[jr]     = c * val_r - s * val_i;
+      dpsi[jr][0] = c * gX_r - s * gX_i;
+      dpsi[jr][1] = c * gY_r - s * gY_i;
+      dpsi[jr][2] = c * gZ_r - s * gZ_i;
+      d2psi[jr]   = c * lap_r - s * lap_i;
     }
-    if (psiIndex + 1 < requested_orb_size)
+    if (ji < requested_orb_size)
     {
-      psi[psiIndex + 1]     = c * val_i + s * val_r;
-      dpsi[psiIndex + 1][0] = c * gX_i + s * gX_r;
-      dpsi[psiIndex + 1][1] = c * gY_i + s * gY_r;
-      dpsi[psiIndex + 1][2] = c * gZ_i + s * gZ_r;
-      d2psi[psiIndex + 1]   = c * lap_i + s * lap_r;
+      psi[ji]     = c * val_i + s * val_r;
+      dpsi[ji][0] = c * gX_i + s * gX_r;
+      dpsi[ji][1] = c * gY_i + s * gY_r;
+      dpsi[ji][2] = c * gZ_i + s * gZ_r;
+      d2psi[ji]   = c * lap_i + s * lap_r;
     }
   }
 
@@ -281,7 +280,7 @@ inline void SplineC2R<ST>::assign_vgl(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    if (const size_t psiIndex = first_spo + nComplexBands + j; psiIndex < requested_orb_size)
+    if (const size_t psiIndex = nComplexBands + j; psiIndex < requested_orb_size)
     {
       psi[psiIndex]     = c * val_r - s * val_i;
       dpsi[psiIndex][0] = c * gX_r - s * gX_i;
@@ -358,22 +357,21 @@ inline void SplineC2R<ST>::assign_vgl_from_l(const PointType& r, ValueVector& ps
     const ST lap_r = myL[jr] + mKK[j] * val_r + two * (kX * dX_i + kY * dY_i + kZ * dZ_i);
     const ST lap_i = myL[ji] + mKK[j] * val_i - two * (kX * dX_r + kY * dY_r + kZ * dZ_r);
 
-    const size_t psiIndex = first_spo + jr;
-    if (psiIndex < requested_orb_size)
+    if (jr < requested_orb_size)
     {
-      psi[psiIndex]     = c * val_r - s * val_i;
-      d2psi[psiIndex]   = c * lap_r - s * lap_i;
-      dpsi[psiIndex][0] = c * gX_r - s * gX_i;
-      dpsi[psiIndex][1] = c * gY_r - s * gY_i;
-      dpsi[psiIndex][2] = c * gZ_r - s * gZ_i;
+      psi[jr]     = c * val_r - s * val_i;
+      d2psi[jr]   = c * lap_r - s * lap_i;
+      dpsi[jr][0] = c * gX_r - s * gX_i;
+      dpsi[jr][1] = c * gY_r - s * gY_i;
+      dpsi[jr][2] = c * gZ_r - s * gZ_i;
     }
-    if (psiIndex + 1 < requested_orb_size)
+    if (ji < requested_orb_size)
     {
-      psi[psiIndex + 1]     = c * val_i + s * val_r;
-      d2psi[psiIndex + 1]   = c * lap_i + s * lap_r;
-      dpsi[psiIndex + 1][0] = c * gX_i + s * gX_r;
-      dpsi[psiIndex + 1][1] = c * gY_i + s * gY_r;
-      dpsi[psiIndex + 1][2] = c * gZ_i + s * gZ_r;
+      psi[ji]     = c * val_i + s * val_r;
+      d2psi[ji]   = c * lap_i + s * lap_r;
+      dpsi[ji][0] = c * gX_i + s * gX_r;
+      dpsi[ji][1] = c * gY_i + s * gY_r;
+      dpsi[ji][2] = c * gZ_i + s * gZ_r;
     }
   }
 
@@ -409,7 +407,7 @@ inline void SplineC2R<ST>::assign_vgl_from_l(const PointType& r, ValueVector& ps
     const ST gX_i = dX_i - val_r * kX;
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
-    if (const size_t psiIndex = first_spo + nComplexBands + j; psiIndex < requested_orb_size)
+    if (const size_t psiIndex = nComplexBands + j; psiIndex < requested_orb_size)
     {
       psi[psiIndex]     = c * val_r - s * val_i;
       dpsi[psiIndex][0] = c * gX_r - s * gX_i;
@@ -507,20 +505,19 @@ void SplineC2R<ST>::assign_vgh(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    const size_t psiIndex = first_spo + jr;
-    if (psiIndex < requested_orb_size)
+    if (jr < requested_orb_size)
     {
-      psi[psiIndex]     = c * val_r - s * val_i;
-      dpsi[psiIndex][0] = c * gX_r - s * gX_i;
-      dpsi[psiIndex][1] = c * gY_r - s * gY_i;
-      dpsi[psiIndex][2] = c * gZ_r - s * gZ_i;
+      psi[jr]     = c * val_r - s * val_i;
+      dpsi[jr][0] = c * gX_r - s * gX_i;
+      dpsi[jr][1] = c * gY_r - s * gY_i;
+      dpsi[jr][2] = c * gZ_r - s * gZ_i;
     }
-    if (psiIndex + 1 < requested_orb_size)
+    if (ji < requested_orb_size)
     {
-      psi[psiIndex + 1]     = c * val_i + s * val_r;
-      dpsi[psiIndex + 1][0] = c * gX_i + s * gX_r;
-      dpsi[psiIndex + 1][1] = c * gY_i + s * gY_r;
-      dpsi[psiIndex + 1][2] = c * gZ_i + s * gZ_r;
+      psi[ji]     = c * val_i + s * val_r;
+      dpsi[ji][0] = c * gX_i + s * gX_r;
+      dpsi[ji][1] = c * gY_i + s * gY_r;
+      dpsi[ji][2] = c * gZ_i + s * gZ_r;
     }
 
     const ST h_xx_r =
@@ -561,29 +558,29 @@ void SplineC2R<ST>::assign_vgh(const PointType& r,
     const ST h_zz_i =
         v_m_v(h00[ji], h01[ji], h02[ji], h11[ji], h12[ji], h22[ji], g20, g21, g22, g20, g21, g22) - kZ * (gZ_r + dZ_r);
 
-    if (psiIndex < requested_orb_size)
+    if (jr < requested_orb_size)
     {
-      grad_grad_psi[psiIndex][0] = c * h_xx_r - s * h_xx_i;
-      grad_grad_psi[psiIndex][1] = c * h_xy_r - s * h_xy_i;
-      grad_grad_psi[psiIndex][2] = c * h_xz_r - s * h_xz_i;
-      grad_grad_psi[psiIndex][3] = c * h_yx_r - s * h_yx_i;
-      grad_grad_psi[psiIndex][4] = c * h_yy_r - s * h_yy_i;
-      grad_grad_psi[psiIndex][5] = c * h_yz_r - s * h_yz_i;
-      grad_grad_psi[psiIndex][6] = c * h_zx_r - s * h_zx_i;
-      grad_grad_psi[psiIndex][7] = c * h_zy_r - s * h_zy_i;
-      grad_grad_psi[psiIndex][8] = c * h_zz_r - s * h_zz_i;
+      grad_grad_psi[jr][0] = c * h_xx_r - s * h_xx_i;
+      grad_grad_psi[jr][1] = c * h_xy_r - s * h_xy_i;
+      grad_grad_psi[jr][2] = c * h_xz_r - s * h_xz_i;
+      grad_grad_psi[jr][3] = c * h_yx_r - s * h_yx_i;
+      grad_grad_psi[jr][4] = c * h_yy_r - s * h_yy_i;
+      grad_grad_psi[jr][5] = c * h_yz_r - s * h_yz_i;
+      grad_grad_psi[jr][6] = c * h_zx_r - s * h_zx_i;
+      grad_grad_psi[jr][7] = c * h_zy_r - s * h_zy_i;
+      grad_grad_psi[jr][8] = c * h_zz_r - s * h_zz_i;
     }
-    if (psiIndex + 1 < requested_orb_size)
+    if (ji < requested_orb_size)
     {
-      grad_grad_psi[psiIndex + 1][0] = c * h_xx_i + s * h_xx_r;
-      grad_grad_psi[psiIndex + 1][1] = c * h_xy_i + s * h_xy_r;
-      grad_grad_psi[psiIndex + 1][2] = c * h_xz_i + s * h_xz_r;
-      grad_grad_psi[psiIndex + 1][3] = c * h_yx_i + s * h_yx_r;
-      grad_grad_psi[psiIndex + 1][4] = c * h_yy_i + s * h_yy_r;
-      grad_grad_psi[psiIndex + 1][5] = c * h_yz_i + s * h_yz_r;
-      grad_grad_psi[psiIndex + 1][6] = c * h_zx_i + s * h_zx_r;
-      grad_grad_psi[psiIndex + 1][7] = c * h_zy_i + s * h_zy_r;
-      grad_grad_psi[psiIndex + 1][8] = c * h_zz_i + s * h_zz_r;
+      grad_grad_psi[ji][0] = c * h_xx_i + s * h_xx_r;
+      grad_grad_psi[ji][1] = c * h_xy_i + s * h_xy_r;
+      grad_grad_psi[ji][2] = c * h_xz_i + s * h_xz_r;
+      grad_grad_psi[ji][3] = c * h_yx_i + s * h_yx_r;
+      grad_grad_psi[ji][4] = c * h_yy_i + s * h_yy_r;
+      grad_grad_psi[ji][5] = c * h_yz_i + s * h_yz_r;
+      grad_grad_psi[ji][6] = c * h_zx_i + s * h_zx_r;
+      grad_grad_psi[ji][7] = c * h_zy_i + s * h_zy_r;
+      grad_grad_psi[ji][8] = c * h_zz_i + s * h_zz_r;
     }
   }
 
@@ -620,7 +617,7 @@ void SplineC2R<ST>::assign_vgh(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    if (const size_t psiIndex = first_spo + nComplexBands + j; psiIndex < requested_orb_size)
+    if (const size_t psiIndex = nComplexBands + j; psiIndex < requested_orb_size)
     {
       psi[psiIndex]     = c * val_r - s * val_i;
       dpsi[psiIndex][0] = c * gX_r - s * gX_i;
@@ -774,20 +771,19 @@ void SplineC2R<ST>::assign_vghgh(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    const size_t psiIndex = first_spo + jr;
-    if (psiIndex < requested_orb_size)
+    if (jr < requested_orb_size)
     {
-      psi[psiIndex]     = c * val_r - s * val_i;
-      dpsi[psiIndex][0] = c * gX_r - s * gX_i;
-      dpsi[psiIndex][1] = c * gY_r - s * gY_i;
-      dpsi[psiIndex][2] = c * gZ_r - s * gZ_i;
+      psi[jr]     = c * val_r - s * val_i;
+      dpsi[jr][0] = c * gX_r - s * gX_i;
+      dpsi[jr][1] = c * gY_r - s * gY_i;
+      dpsi[jr][2] = c * gZ_r - s * gZ_i;
     }
-    if (psiIndex + 1 < requested_orb_size)
+    if (ji < requested_orb_size)
     {
-      psi[psiIndex + 1]     = c * val_i + s * val_r;
-      dpsi[psiIndex + 1][0] = c * gX_i + s * gX_r;
-      dpsi[psiIndex + 1][1] = c * gY_i + s * gY_r;
-      dpsi[psiIndex + 1][2] = c * gZ_i + s * gZ_r;
+      psi[ji]     = c * val_i + s * val_r;
+      dpsi[ji][0] = c * gX_i + s * gX_r;
+      dpsi[ji][1] = c * gY_i + s * gY_r;
+      dpsi[ji][2] = c * gZ_i + s * gZ_r;
     }
 
     //intermediates for computation of hessian. \partial_i \partial_j phi in cartesian coordinates.
@@ -819,30 +815,30 @@ void SplineC2R<ST>::assign_vghgh(const PointType& r,
     const ST h_yz_i = f_yz_i - (kZ * dY_r + kY * dZ_r) - kZ * kY * val_i;
     const ST h_zz_i = f_zz_i - 2 * kZ * dZ_r - kZ * kZ * val_i;
 
-    if (psiIndex < requested_orb_size)
+    if (jr < requested_orb_size)
     {
-      grad_grad_psi[psiIndex][0] = c * h_xx_r - s * h_xx_i;
-      grad_grad_psi[psiIndex][1] = c * h_xy_r - s * h_xy_i;
-      grad_grad_psi[psiIndex][2] = c * h_xz_r - s * h_xz_i;
-      grad_grad_psi[psiIndex][3] = c * h_xy_r - s * h_xy_i;
-      grad_grad_psi[psiIndex][4] = c * h_yy_r - s * h_yy_i;
-      grad_grad_psi[psiIndex][5] = c * h_yz_r - s * h_yz_i;
-      grad_grad_psi[psiIndex][6] = c * h_xz_r - s * h_xz_i;
-      grad_grad_psi[psiIndex][7] = c * h_yz_r - s * h_yz_i;
-      grad_grad_psi[psiIndex][8] = c * h_zz_r - s * h_zz_i;
+      grad_grad_psi[jr][0] = c * h_xx_r - s * h_xx_i;
+      grad_grad_psi[jr][1] = c * h_xy_r - s * h_xy_i;
+      grad_grad_psi[jr][2] = c * h_xz_r - s * h_xz_i;
+      grad_grad_psi[jr][3] = c * h_xy_r - s * h_xy_i;
+      grad_grad_psi[jr][4] = c * h_yy_r - s * h_yy_i;
+      grad_grad_psi[jr][5] = c * h_yz_r - s * h_yz_i;
+      grad_grad_psi[jr][6] = c * h_xz_r - s * h_xz_i;
+      grad_grad_psi[jr][7] = c * h_yz_r - s * h_yz_i;
+      grad_grad_psi[jr][8] = c * h_zz_r - s * h_zz_i;
     }
 
-    if (psiIndex + 1 < requested_orb_size)
+    if (ji < requested_orb_size)
     {
-      grad_grad_psi[psiIndex + 1][0] = c * h_xx_i + s * h_xx_r;
-      grad_grad_psi[psiIndex + 1][1] = c * h_xy_i + s * h_xy_r;
-      grad_grad_psi[psiIndex + 1][2] = c * h_xz_i + s * h_xz_r;
-      grad_grad_psi[psiIndex + 1][3] = c * h_xy_i + s * h_xy_r;
-      grad_grad_psi[psiIndex + 1][4] = c * h_yy_i + s * h_yy_r;
-      grad_grad_psi[psiIndex + 1][5] = c * h_yz_i + s * h_yz_r;
-      grad_grad_psi[psiIndex + 1][6] = c * h_xz_i + s * h_xz_r;
-      grad_grad_psi[psiIndex + 1][7] = c * h_yz_i + s * h_yz_r;
-      grad_grad_psi[psiIndex + 1][8] = c * h_zz_i + s * h_zz_r;
+      grad_grad_psi[ji][0] = c * h_xx_i + s * h_xx_r;
+      grad_grad_psi[ji][1] = c * h_xy_i + s * h_xy_r;
+      grad_grad_psi[ji][2] = c * h_xz_i + s * h_xz_r;
+      grad_grad_psi[ji][3] = c * h_xy_i + s * h_xy_r;
+      grad_grad_psi[ji][4] = c * h_yy_i + s * h_yy_r;
+      grad_grad_psi[ji][5] = c * h_yz_i + s * h_yz_r;
+      grad_grad_psi[ji][6] = c * h_xz_i + s * h_xz_r;
+      grad_grad_psi[ji][7] = c * h_yz_i + s * h_yz_r;
+      grad_grad_psi[ji][8] = c * h_zz_i + s * h_zz_r;
     }
 
     //These are the real and imaginary components of the third SPO derivative.  _xxx denotes
@@ -926,70 +922,70 @@ void SplineC2R<ST>::assign_vghgh(const PointType& r,
     const ST gh_zzz_r = f3_zzz_r + 3 * kZ * f_zz_i - 3 * kZ * kZ * dZ_r - kZ * kZ * kZ * val_i;
     const ST gh_zzz_i = f3_zzz_i - 3 * kZ * f_zz_r - 3 * kZ * kZ * dZ_i + kZ * kZ * kZ * val_r;
 
-    if (psiIndex < requested_orb_size)
+    if (jr < requested_orb_size)
     {
-      grad_grad_grad_psi[psiIndex][0][0] = c * gh_xxx_r - s * gh_xxx_i;
-      grad_grad_grad_psi[psiIndex][0][1] = c * gh_xxy_r - s * gh_xxy_i;
-      grad_grad_grad_psi[psiIndex][0][2] = c * gh_xxz_r - s * gh_xxz_i;
-      grad_grad_grad_psi[psiIndex][0][3] = c * gh_xxy_r - s * gh_xxy_i;
-      grad_grad_grad_psi[psiIndex][0][4] = c * gh_xyy_r - s * gh_xyy_i;
-      grad_grad_grad_psi[psiIndex][0][5] = c * gh_xyz_r - s * gh_xyz_i;
-      grad_grad_grad_psi[psiIndex][0][6] = c * gh_xxz_r - s * gh_xxz_i;
-      grad_grad_grad_psi[psiIndex][0][7] = c * gh_xyz_r - s * gh_xyz_i;
-      grad_grad_grad_psi[psiIndex][0][8] = c * gh_xzz_r - s * gh_xzz_i;
+      grad_grad_grad_psi[jr][0][0] = c * gh_xxx_r - s * gh_xxx_i;
+      grad_grad_grad_psi[jr][0][1] = c * gh_xxy_r - s * gh_xxy_i;
+      grad_grad_grad_psi[jr][0][2] = c * gh_xxz_r - s * gh_xxz_i;
+      grad_grad_grad_psi[jr][0][3] = c * gh_xxy_r - s * gh_xxy_i;
+      grad_grad_grad_psi[jr][0][4] = c * gh_xyy_r - s * gh_xyy_i;
+      grad_grad_grad_psi[jr][0][5] = c * gh_xyz_r - s * gh_xyz_i;
+      grad_grad_grad_psi[jr][0][6] = c * gh_xxz_r - s * gh_xxz_i;
+      grad_grad_grad_psi[jr][0][7] = c * gh_xyz_r - s * gh_xyz_i;
+      grad_grad_grad_psi[jr][0][8] = c * gh_xzz_r - s * gh_xzz_i;
 
-      grad_grad_grad_psi[psiIndex][1][0] = c * gh_xxy_r - s * gh_xxy_i;
-      grad_grad_grad_psi[psiIndex][1][1] = c * gh_xyy_r - s * gh_xyy_i;
-      grad_grad_grad_psi[psiIndex][1][2] = c * gh_xyz_r - s * gh_xyz_i;
-      grad_grad_grad_psi[psiIndex][1][3] = c * gh_xyy_r - s * gh_xyy_i;
-      grad_grad_grad_psi[psiIndex][1][4] = c * gh_yyy_r - s * gh_yyy_i;
-      grad_grad_grad_psi[psiIndex][1][5] = c * gh_yyz_r - s * gh_yyz_i;
-      grad_grad_grad_psi[psiIndex][1][6] = c * gh_xyz_r - s * gh_xyz_i;
-      grad_grad_grad_psi[psiIndex][1][7] = c * gh_yyz_r - s * gh_yyz_i;
-      grad_grad_grad_psi[psiIndex][1][8] = c * gh_yzz_r - s * gh_yzz_i;
+      grad_grad_grad_psi[jr][1][0] = c * gh_xxy_r - s * gh_xxy_i;
+      grad_grad_grad_psi[jr][1][1] = c * gh_xyy_r - s * gh_xyy_i;
+      grad_grad_grad_psi[jr][1][2] = c * gh_xyz_r - s * gh_xyz_i;
+      grad_grad_grad_psi[jr][1][3] = c * gh_xyy_r - s * gh_xyy_i;
+      grad_grad_grad_psi[jr][1][4] = c * gh_yyy_r - s * gh_yyy_i;
+      grad_grad_grad_psi[jr][1][5] = c * gh_yyz_r - s * gh_yyz_i;
+      grad_grad_grad_psi[jr][1][6] = c * gh_xyz_r - s * gh_xyz_i;
+      grad_grad_grad_psi[jr][1][7] = c * gh_yyz_r - s * gh_yyz_i;
+      grad_grad_grad_psi[jr][1][8] = c * gh_yzz_r - s * gh_yzz_i;
 
-      grad_grad_grad_psi[psiIndex][2][0] = c * gh_xxz_r - s * gh_xxz_i;
-      grad_grad_grad_psi[psiIndex][2][1] = c * gh_xyz_r - s * gh_xyz_i;
-      grad_grad_grad_psi[psiIndex][2][2] = c * gh_xzz_r - s * gh_xzz_i;
-      grad_grad_grad_psi[psiIndex][2][3] = c * gh_xyz_r - s * gh_xyz_i;
-      grad_grad_grad_psi[psiIndex][2][4] = c * gh_yyz_r - s * gh_yyz_i;
-      grad_grad_grad_psi[psiIndex][2][5] = c * gh_yzz_r - s * gh_yzz_i;
-      grad_grad_grad_psi[psiIndex][2][6] = c * gh_xzz_r - s * gh_xzz_i;
-      grad_grad_grad_psi[psiIndex][2][7] = c * gh_yzz_r - s * gh_yzz_i;
-      grad_grad_grad_psi[psiIndex][2][8] = c * gh_zzz_r - s * gh_zzz_i;
+      grad_grad_grad_psi[jr][2][0] = c * gh_xxz_r - s * gh_xxz_i;
+      grad_grad_grad_psi[jr][2][1] = c * gh_xyz_r - s * gh_xyz_i;
+      grad_grad_grad_psi[jr][2][2] = c * gh_xzz_r - s * gh_xzz_i;
+      grad_grad_grad_psi[jr][2][3] = c * gh_xyz_r - s * gh_xyz_i;
+      grad_grad_grad_psi[jr][2][4] = c * gh_yyz_r - s * gh_yyz_i;
+      grad_grad_grad_psi[jr][2][5] = c * gh_yzz_r - s * gh_yzz_i;
+      grad_grad_grad_psi[jr][2][6] = c * gh_xzz_r - s * gh_xzz_i;
+      grad_grad_grad_psi[jr][2][7] = c * gh_yzz_r - s * gh_yzz_i;
+      grad_grad_grad_psi[jr][2][8] = c * gh_zzz_r - s * gh_zzz_i;
     }
 
-    if (psiIndex + 1 < requested_orb_size)
+    if (ji < requested_orb_size)
     {
-      grad_grad_grad_psi[psiIndex + 1][0][0] = c * gh_xxx_i + s * gh_xxx_r;
-      grad_grad_grad_psi[psiIndex + 1][0][1] = c * gh_xxy_i + s * gh_xxy_r;
-      grad_grad_grad_psi[psiIndex + 1][0][2] = c * gh_xxz_i + s * gh_xxz_r;
-      grad_grad_grad_psi[psiIndex + 1][0][3] = c * gh_xxy_i + s * gh_xxy_r;
-      grad_grad_grad_psi[psiIndex + 1][0][4] = c * gh_xyy_i + s * gh_xyy_r;
-      grad_grad_grad_psi[psiIndex + 1][0][5] = c * gh_xyz_i + s * gh_xyz_r;
-      grad_grad_grad_psi[psiIndex + 1][0][6] = c * gh_xxz_i + s * gh_xxz_r;
-      grad_grad_grad_psi[psiIndex + 1][0][7] = c * gh_xyz_i + s * gh_xyz_r;
-      grad_grad_grad_psi[psiIndex + 1][0][8] = c * gh_xzz_i + s * gh_xzz_r;
+      grad_grad_grad_psi[ji][0][0] = c * gh_xxx_i + s * gh_xxx_r;
+      grad_grad_grad_psi[ji][0][1] = c * gh_xxy_i + s * gh_xxy_r;
+      grad_grad_grad_psi[ji][0][2] = c * gh_xxz_i + s * gh_xxz_r;
+      grad_grad_grad_psi[ji][0][3] = c * gh_xxy_i + s * gh_xxy_r;
+      grad_grad_grad_psi[ji][0][4] = c * gh_xyy_i + s * gh_xyy_r;
+      grad_grad_grad_psi[ji][0][5] = c * gh_xyz_i + s * gh_xyz_r;
+      grad_grad_grad_psi[ji][0][6] = c * gh_xxz_i + s * gh_xxz_r;
+      grad_grad_grad_psi[ji][0][7] = c * gh_xyz_i + s * gh_xyz_r;
+      grad_grad_grad_psi[ji][0][8] = c * gh_xzz_i + s * gh_xzz_r;
 
-      grad_grad_grad_psi[psiIndex + 1][1][0] = c * gh_xxy_i + s * gh_xxy_r;
-      grad_grad_grad_psi[psiIndex + 1][1][1] = c * gh_xyy_i + s * gh_xyy_r;
-      grad_grad_grad_psi[psiIndex + 1][1][2] = c * gh_xyz_i + s * gh_xyz_r;
-      grad_grad_grad_psi[psiIndex + 1][1][3] = c * gh_xyy_i + s * gh_xyy_r;
-      grad_grad_grad_psi[psiIndex + 1][1][4] = c * gh_yyy_i + s * gh_yyy_r;
-      grad_grad_grad_psi[psiIndex + 1][1][5] = c * gh_yyz_i + s * gh_yyz_r;
-      grad_grad_grad_psi[psiIndex + 1][1][6] = c * gh_xyz_i + s * gh_xyz_r;
-      grad_grad_grad_psi[psiIndex + 1][1][7] = c * gh_yyz_i + s * gh_yyz_r;
-      grad_grad_grad_psi[psiIndex + 1][1][8] = c * gh_yzz_i + s * gh_yzz_r;
+      grad_grad_grad_psi[ji][1][0] = c * gh_xxy_i + s * gh_xxy_r;
+      grad_grad_grad_psi[ji][1][1] = c * gh_xyy_i + s * gh_xyy_r;
+      grad_grad_grad_psi[ji][1][2] = c * gh_xyz_i + s * gh_xyz_r;
+      grad_grad_grad_psi[ji][1][3] = c * gh_xyy_i + s * gh_xyy_r;
+      grad_grad_grad_psi[ji][1][4] = c * gh_yyy_i + s * gh_yyy_r;
+      grad_grad_grad_psi[ji][1][5] = c * gh_yyz_i + s * gh_yyz_r;
+      grad_grad_grad_psi[ji][1][6] = c * gh_xyz_i + s * gh_xyz_r;
+      grad_grad_grad_psi[ji][1][7] = c * gh_yyz_i + s * gh_yyz_r;
+      grad_grad_grad_psi[ji][1][8] = c * gh_yzz_i + s * gh_yzz_r;
 
-      grad_grad_grad_psi[psiIndex + 1][2][0] = c * gh_xxz_i + s * gh_xxz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][1] = c * gh_xyz_i + s * gh_xyz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][2] = c * gh_xzz_i + s * gh_xzz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][3] = c * gh_xyz_i + s * gh_xyz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][4] = c * gh_yyz_i + s * gh_yyz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][5] = c * gh_yzz_i + s * gh_yzz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][6] = c * gh_xzz_i + s * gh_xzz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][7] = c * gh_yzz_i + s * gh_yzz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][8] = c * gh_zzz_i + s * gh_zzz_r;
+      grad_grad_grad_psi[ji][2][0] = c * gh_xxz_i + s * gh_xxz_r;
+      grad_grad_grad_psi[ji][2][1] = c * gh_xyz_i + s * gh_xyz_r;
+      grad_grad_grad_psi[ji][2][2] = c * gh_xzz_i + s * gh_xzz_r;
+      grad_grad_grad_psi[ji][2][3] = c * gh_xyz_i + s * gh_xyz_r;
+      grad_grad_grad_psi[ji][2][4] = c * gh_yyz_i + s * gh_yyz_r;
+      grad_grad_grad_psi[ji][2][5] = c * gh_yzz_i + s * gh_yzz_r;
+      grad_grad_grad_psi[ji][2][6] = c * gh_xzz_i + s * gh_xzz_r;
+      grad_grad_grad_psi[ji][2][7] = c * gh_yzz_i + s * gh_yzz_r;
+      grad_grad_grad_psi[ji][2][8] = c * gh_zzz_i + s * gh_zzz_r;
     }
   }
 #pragma omp simd
@@ -1025,7 +1021,7 @@ void SplineC2R<ST>::assign_vghgh(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    if (const size_t psiIndex = first_spo + nComplexBands + j; psiIndex < requested_orb_size)
+    if (const size_t psiIndex = nComplexBands + j; psiIndex < requested_orb_size)
     {
       psi[psiIndex]     = c * val_r - s * val_i;
       dpsi[psiIndex][0] = c * gX_r - s * gX_i;

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
@@ -49,7 +49,7 @@ inline void SplineC2ROMPTarget<ST>::assign_v(const PointType& r,
   const ST* restrict ky = myKcart->data(1);
   const ST* restrict kz = myKcart->data(2);
 
-  TT* restrict psi_s              = psi.data() + first_spo;
+  TT* restrict psi_s              = psi.data();
   const size_t requested_orb_size = psi.size();
 #pragma omp simd
   for (size_t j = first; j < std::min(nComplexBands, last); j++)
@@ -115,7 +115,6 @@ void SplineC2ROMPTarget<ST>::evaluateValue(const ParticleSet& P, const int iat, 
     const auto rux = ru[0], ruy = ru[1], ruz = ru[2];
     const auto myKcart_padded_size   = myKcart->capacity();
     auto* myKcart_ptr                = myKcart->data();
-    const size_t first_spo_local     = first_spo;
     const size_t nComplexBands_local = nComplexBands;
     const auto requested_orb_size    = psi.size();
     const auto num_complex_splines   = kPoints.size();
@@ -142,7 +141,7 @@ void SplineC2ROMPTarget<ST>::evaluateValue(const ParticleSet& P, const int iat, 
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = first_cplx; index < last_cplx; index++)
           C2R::assign_v(x, y, z, results_scratch_ptr, offload_scratch_ptr, myKcart_ptr, myKcart_padded_size,
-                        first_spo_local, nComplexBands_local, index);
+                        nComplexBands_local, index);
       }
 
       for (size_t i = 0; i < requested_orb_size; i++)
@@ -193,7 +192,6 @@ void SplineC2ROMPTarget<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
   auto* myKcart_ptr                = myKcart->data();
   auto* psiinv_ptr                 = psiinv_pos_copy.data();
   auto* ratios_private_ptr         = ratios_private.data();
-  const size_t first_spo_local     = first_spo;
   const size_t nComplexBands_local = nComplexBands;
   const auto requested_orb_size    = psiinv.size();
   const auto num_complex_splines   = kPoints.size();
@@ -227,8 +225,8 @@ void SplineC2ROMPTarget<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = first_cplx; index < last_cplx; index++)
           C2R::assign_v(ST(pos_scratch[iat * 6]), ST(pos_scratch[iat * 6 + 1]), ST(pos_scratch[iat * 6 + 2]),
-                        psi_iat_ptr, offload_scratch_iat_ptr, myKcart_ptr, myKcart_padded_size, first_spo_local,
-                        nComplexBands_local, index);
+                        psi_iat_ptr, offload_scratch_iat_ptr, myKcart_ptr, myKcart_padded_size, nComplexBands_local,
+                        index);
 
         const size_t first_real = first_cplx + omptarget::min(nComplexBands_local, first_cplx);
         const size_t last_real =
@@ -319,7 +317,6 @@ void SplineC2ROMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
   auto* myKcart_ptr                = myKcart->data();
   auto* buffer_H2D_ptr             = det_ratios_buffer_H2D.data();
   auto* ratios_private_ptr         = mw_ratios_private.data();
-  const size_t first_spo_local     = first_spo;
   const size_t nComplexBands_local = nComplexBands;
   const auto num_complex_splines   = kPoints.size();
 
@@ -354,8 +351,7 @@ void SplineC2ROMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = first_cplx; index < last_cplx; index++)
           C2R::assign_v(pos_scratch[iat * 6], pos_scratch[iat * 6 + 1], pos_scratch[iat * 6 + 2], psi_iat_ptr,
-                        offload_scratch_iat_ptr, myKcart_ptr, myKcart_padded_size, first_spo_local, nComplexBands_local,
-                        index);
+                        offload_scratch_iat_ptr, myKcart_ptr, myKcart_padded_size, nComplexBands_local, index);
 
         const size_t first_real = first_cplx + omptarget::min(nComplexBands_local, first_cplx);
         const size_t last_real =
@@ -446,22 +442,21 @@ inline void SplineC2ROMPTarget<ST>::assign_vgl_from_l(const PointType& r,
     const ST lap_r = myL[jr] + (*mKK)[j] * val_r + two * (kX * dX_i + kY * dY_i + kZ * dZ_i);
     const ST lap_i = myL[ji] + (*mKK)[j] * val_i - two * (kX * dX_r + kY * dY_r + kZ * dZ_r);
 
-    const size_t psiIndex = first_spo + jr;
-    if (psiIndex < requested_orb_size)
+    if (jr < requested_orb_size)
     {
-      psi[psiIndex]     = c * val_r - s * val_i;
-      d2psi[psiIndex]   = c * lap_r - s * lap_i;
-      dpsi[psiIndex][0] = c * gX_r - s * gX_i;
-      dpsi[psiIndex][1] = c * gY_r - s * gY_i;
-      dpsi[psiIndex][2] = c * gZ_r - s * gZ_i;
+      psi[jr]     = c * val_r - s * val_i;
+      d2psi[jr]   = c * lap_r - s * lap_i;
+      dpsi[jr][0] = c * gX_r - s * gX_i;
+      dpsi[jr][1] = c * gY_r - s * gY_i;
+      dpsi[jr][2] = c * gZ_r - s * gZ_i;
     }
-    if (psiIndex + 1 < requested_orb_size)
+    if (ji < requested_orb_size)
     {
-      psi[psiIndex + 1]     = c * val_i + s * val_r;
-      d2psi[psiIndex + 1]   = c * lap_i + s * lap_r;
-      dpsi[psiIndex + 1][0] = c * gX_i + s * gX_r;
-      dpsi[psiIndex + 1][1] = c * gY_i + s * gY_r;
-      dpsi[psiIndex + 1][2] = c * gZ_i + s * gZ_r;
+      psi[ji]     = c * val_i + s * val_r;
+      d2psi[ji]   = c * lap_i + s * lap_r;
+      dpsi[ji][0] = c * gX_i + s * gX_r;
+      dpsi[ji][1] = c * gY_i + s * gY_r;
+      dpsi[ji][2] = c * gZ_i + s * gZ_r;
     }
   }
 
@@ -497,7 +492,7 @@ inline void SplineC2ROMPTarget<ST>::assign_vgl_from_l(const PointType& r,
     const ST gX_i = dX_i - val_r * kX;
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
-    if (const size_t psiIndex = first_spo + nComplexBands + j; psiIndex < requested_orb_size)
+    if (const size_t psiIndex = nComplexBands + j; psiIndex < requested_orb_size)
     {
       psi[psiIndex]     = c * val_r - s * val_i;
       dpsi[psiIndex][0] = c * gX_r - s * gX_i;
@@ -542,7 +537,6 @@ void SplineC2ROMPTarget<ST>::evaluateVGL(const ParticleSet& P,
   auto* GGt_ptr                    = GGt_offload->data();
   auto* prim_lattice_G_ptr         = prim_lattice_G_offload->data();
   auto* myKcart_ptr                = myKcart->data();
-  const size_t first_spo_local     = first_spo;
   const size_t nComplexBands_local = nComplexBands;
   const auto requested_orb_size    = psi.size();
   const auto num_complex_splines   = kPoints.size();
@@ -585,8 +579,7 @@ void SplineC2ROMPTarget<ST>::evaluateVGL(const ParticleSet& P,
       PRAGMA_OFFLOAD("omp parallel for")
       for (int index = first_cplx; index < last_cplx; index++)
         C2R::assign_vgl(x, y, z, results_scratch_ptr, sposet_padded_size, mKK_ptr, offload_scratch_ptr,
-                        spline_padded_size, G, myKcart_ptr, myKcart_padded_size, first_spo_local, nComplexBands_local,
-                        index);
+                        spline_padded_size, G, myKcart_ptr, myKcart_padded_size, nComplexBands_local, index);
     }
   }
 
@@ -628,7 +621,6 @@ void SplineC2ROMPTarget<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedA
   auto* GGt_ptr                    = GGt_offload->data();
   auto* prim_lattice_G_ptr         = prim_lattice_G_offload->data();
   auto* myKcart_ptr                = myKcart->data();
-  const size_t first_spo_local     = first_spo;
   const size_t nComplexBands_local = nComplexBands;
   const auto requested_orb_size    = psi_v_list[0].get().size();
   const auto num_complex_splines   = kPoints.size();
@@ -678,7 +670,7 @@ void SplineC2ROMPTarget<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedA
         for (int index = first_cplx; index < last_cplx; index++)
           C2R::assign_vgl(pos_copy_ptr[iw * 6], pos_copy_ptr[iw * 6 + 1], pos_copy_ptr[iw * 6 + 2], psi_iw_ptr,
                           sposet_padded_size, mKK_ptr, offload_scratch_iw_ptr, spline_padded_size, G, myKcart_ptr,
-                          myKcart_padded_size, first_spo_local, nComplexBands_local, index);
+                          myKcart_padded_size, nComplexBands_local, index);
       }
   }
 
@@ -795,7 +787,6 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
   auto* phi_vgl_ptr                = phi_vgl_v.data();
   auto* rg_private_ptr             = rg_private.data();
   const size_t buffer_H2D_stride   = buffer_H2D.cols();
-  const size_t first_spo_local     = first_spo;
   const auto requested_orb_size    = phi_vgl_v.size(2);
   const size_t phi_vgl_stride      = num_pos * requested_orb_size;
   const size_t nComplexBands_local = nComplexBands;
@@ -849,7 +840,7 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
         for (int index = first_cplx; index < last_cplx; index++)
           C2R::assign_vgl(pos_iw_ptr[0], pos_iw_ptr[1], pos_iw_ptr[2], psi_iw_ptr, sposet_padded_size, mKK_ptr,
                           offload_scratch_iw_ptr, spline_padded_size, G, myKcart_ptr, myKcart_padded_size,
-                          first_spo_local, nComplexBands_local, index);
+                          nComplexBands_local, index);
 
         ValueType* restrict psi    = psi_iw_ptr;
         ValueType* restrict dpsi_x = psi_iw_ptr + sposet_padded_size;
@@ -971,22 +962,20 @@ void SplineC2ROMPTarget<ST>::assign_vgh(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    const size_t psiIndex = first_spo + jr;
-
-    if (psiIndex < requested_orb_size)
+    if (jr < requested_orb_size)
     {
-      psi[psiIndex]     = c * val_r - s * val_i;
-      dpsi[psiIndex][0] = c * gX_r - s * gX_i;
-      dpsi[psiIndex][1] = c * gY_r - s * gY_i;
-      dpsi[psiIndex][2] = c * gZ_r - s * gZ_i;
+      psi[jr]     = c * val_r - s * val_i;
+      dpsi[jr][0] = c * gX_r - s * gX_i;
+      dpsi[jr][1] = c * gY_r - s * gY_i;
+      dpsi[jr][2] = c * gZ_r - s * gZ_i;
     }
 
-    if (psiIndex + 1 < requested_orb_size)
+    if (ji < requested_orb_size)
     {
-      psi[psiIndex + 1]     = c * val_i + s * val_r;
-      dpsi[psiIndex + 1][0] = c * gX_i + s * gX_r;
-      dpsi[psiIndex + 1][1] = c * gY_i + s * gY_r;
-      dpsi[psiIndex + 1][2] = c * gZ_i + s * gZ_r;
+      psi[ji]     = c * val_i + s * val_r;
+      dpsi[ji][0] = c * gX_i + s * gX_r;
+      dpsi[ji][1] = c * gY_i + s * gY_r;
+      dpsi[ji][2] = c * gZ_i + s * gZ_r;
     }
 
     const ST h_xx_r =
@@ -1027,30 +1016,30 @@ void SplineC2ROMPTarget<ST>::assign_vgh(const PointType& r,
     const ST h_zz_i =
         v_m_v(h00[ji], h01[ji], h02[ji], h11[ji], h12[ji], h22[ji], g20, g21, g22, g20, g21, g22) - kZ * (gZ_r + dZ_r);
 
-    if (psiIndex < requested_orb_size)
+    if (jr < requested_orb_size)
     {
-      grad_grad_psi[psiIndex][0] = c * h_xx_r - s * h_xx_i;
-      grad_grad_psi[psiIndex][1] = c * h_xy_r - s * h_xy_i;
-      grad_grad_psi[psiIndex][2] = c * h_xz_r - s * h_xz_i;
-      grad_grad_psi[psiIndex][3] = c * h_yx_r - s * h_yx_i;
-      grad_grad_psi[psiIndex][4] = c * h_yy_r - s * h_yy_i;
-      grad_grad_psi[psiIndex][5] = c * h_yz_r - s * h_yz_i;
-      grad_grad_psi[psiIndex][6] = c * h_zx_r - s * h_zx_i;
-      grad_grad_psi[psiIndex][7] = c * h_zy_r - s * h_zy_i;
-      grad_grad_psi[psiIndex][8] = c * h_zz_r - s * h_zz_i;
+      grad_grad_psi[jr][0] = c * h_xx_r - s * h_xx_i;
+      grad_grad_psi[jr][1] = c * h_xy_r - s * h_xy_i;
+      grad_grad_psi[jr][2] = c * h_xz_r - s * h_xz_i;
+      grad_grad_psi[jr][3] = c * h_yx_r - s * h_yx_i;
+      grad_grad_psi[jr][4] = c * h_yy_r - s * h_yy_i;
+      grad_grad_psi[jr][5] = c * h_yz_r - s * h_yz_i;
+      grad_grad_psi[jr][6] = c * h_zx_r - s * h_zx_i;
+      grad_grad_psi[jr][7] = c * h_zy_r - s * h_zy_i;
+      grad_grad_psi[jr][8] = c * h_zz_r - s * h_zz_i;
     }
 
-    if (psiIndex + 1 < requested_orb_size)
+    if (ji < requested_orb_size)
     {
-      grad_grad_psi[psiIndex + 1][0] = c * h_xx_i + s * h_xx_r;
-      grad_grad_psi[psiIndex + 1][1] = c * h_xy_i + s * h_xy_r;
-      grad_grad_psi[psiIndex + 1][2] = c * h_xz_i + s * h_xz_r;
-      grad_grad_psi[psiIndex + 1][3] = c * h_yx_i + s * h_yx_r;
-      grad_grad_psi[psiIndex + 1][4] = c * h_yy_i + s * h_yy_r;
-      grad_grad_psi[psiIndex + 1][5] = c * h_yz_i + s * h_yz_r;
-      grad_grad_psi[psiIndex + 1][6] = c * h_zx_i + s * h_zx_r;
-      grad_grad_psi[psiIndex + 1][7] = c * h_zy_i + s * h_zy_r;
-      grad_grad_psi[psiIndex + 1][8] = c * h_zz_i + s * h_zz_r;
+      grad_grad_psi[ji][0] = c * h_xx_i + s * h_xx_r;
+      grad_grad_psi[ji][1] = c * h_xy_i + s * h_xy_r;
+      grad_grad_psi[ji][2] = c * h_xz_i + s * h_xz_r;
+      grad_grad_psi[ji][3] = c * h_yx_i + s * h_yx_r;
+      grad_grad_psi[ji][4] = c * h_yy_i + s * h_yy_r;
+      grad_grad_psi[ji][5] = c * h_yz_i + s * h_yz_r;
+      grad_grad_psi[ji][6] = c * h_zx_i + s * h_zx_r;
+      grad_grad_psi[ji][7] = c * h_zy_i + s * h_zy_r;
+      grad_grad_psi[ji][8] = c * h_zz_i + s * h_zz_r;
     }
   }
 
@@ -1087,7 +1076,7 @@ void SplineC2ROMPTarget<ST>::assign_vgh(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    if (const size_t psiIndex = first_spo + nComplexBands + j; psiIndex < requested_orb_size)
+    if (const size_t psiIndex = nComplexBands + j; psiIndex < requested_orb_size)
     {
       psi[psiIndex]     = c * val_r - s * val_i;
       dpsi[psiIndex][0] = c * gX_r - s * gX_i;
@@ -1241,22 +1230,20 @@ void SplineC2ROMPTarget<ST>::assign_vghgh(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    const size_t psiIndex = first_spo + jr;
-
-    if (psiIndex < requested_orb_size)
+    if (jr < requested_orb_size)
     {
-      psi[psiIndex]     = c * val_r - s * val_i;
-      dpsi[psiIndex][0] = c * gX_r - s * gX_i;
-      dpsi[psiIndex][1] = c * gY_r - s * gY_i;
-      dpsi[psiIndex][2] = c * gZ_r - s * gZ_i;
+      psi[jr]     = c * val_r - s * val_i;
+      dpsi[jr][0] = c * gX_r - s * gX_i;
+      dpsi[jr][1] = c * gY_r - s * gY_i;
+      dpsi[jr][2] = c * gZ_r - s * gZ_i;
     }
 
-    if (psiIndex + 1 < requested_orb_size)
+    if (ji < requested_orb_size)
     {
-      psi[psiIndex + 1]     = c * val_i + s * val_r;
-      dpsi[psiIndex + 1][0] = c * gX_i + s * gX_r;
-      dpsi[psiIndex + 1][1] = c * gY_i + s * gY_r;
-      dpsi[psiIndex + 1][2] = c * gZ_i + s * gZ_r;
+      psi[ji]     = c * val_i + s * val_r;
+      dpsi[ji][0] = c * gX_i + s * gX_r;
+      dpsi[ji][1] = c * gY_i + s * gY_r;
+      dpsi[ji][2] = c * gZ_i + s * gZ_r;
     }
 
     //intermediates for computation of hessian. \partial_i \partial_j phi in cartesian coordinates.
@@ -1288,30 +1275,30 @@ void SplineC2ROMPTarget<ST>::assign_vghgh(const PointType& r,
     const ST h_yz_i = f_yz_i - (kZ * dY_r + kY * dZ_r) - kZ * kY * val_i;
     const ST h_zz_i = f_zz_i - 2 * kZ * dZ_r - kZ * kZ * val_i;
 
-    if (psiIndex < requested_orb_size)
+    if (jr < requested_orb_size)
     {
-      grad_grad_psi[psiIndex][0] = c * h_xx_r - s * h_xx_i;
-      grad_grad_psi[psiIndex][1] = c * h_xy_r - s * h_xy_i;
-      grad_grad_psi[psiIndex][2] = c * h_xz_r - s * h_xz_i;
-      grad_grad_psi[psiIndex][3] = c * h_xy_r - s * h_xy_i;
-      grad_grad_psi[psiIndex][4] = c * h_yy_r - s * h_yy_i;
-      grad_grad_psi[psiIndex][5] = c * h_yz_r - s * h_yz_i;
-      grad_grad_psi[psiIndex][6] = c * h_xz_r - s * h_xz_i;
-      grad_grad_psi[psiIndex][7] = c * h_yz_r - s * h_yz_i;
-      grad_grad_psi[psiIndex][8] = c * h_zz_r - s * h_zz_i;
+      grad_grad_psi[jr][0] = c * h_xx_r - s * h_xx_i;
+      grad_grad_psi[jr][1] = c * h_xy_r - s * h_xy_i;
+      grad_grad_psi[jr][2] = c * h_xz_r - s * h_xz_i;
+      grad_grad_psi[jr][3] = c * h_xy_r - s * h_xy_i;
+      grad_grad_psi[jr][4] = c * h_yy_r - s * h_yy_i;
+      grad_grad_psi[jr][5] = c * h_yz_r - s * h_yz_i;
+      grad_grad_psi[jr][6] = c * h_xz_r - s * h_xz_i;
+      grad_grad_psi[jr][7] = c * h_yz_r - s * h_yz_i;
+      grad_grad_psi[jr][8] = c * h_zz_r - s * h_zz_i;
     }
 
-    if (psiIndex + 1 < requested_orb_size)
+    if (ji < requested_orb_size)
     {
-      grad_grad_psi[psiIndex + 1][0] = c * h_xx_i + s * h_xx_r;
-      grad_grad_psi[psiIndex + 1][1] = c * h_xy_i + s * h_xy_r;
-      grad_grad_psi[psiIndex + 1][2] = c * h_xz_i + s * h_xz_r;
-      grad_grad_psi[psiIndex + 1][3] = c * h_xy_i + s * h_xy_r;
-      grad_grad_psi[psiIndex + 1][4] = c * h_yy_i + s * h_yy_r;
-      grad_grad_psi[psiIndex + 1][5] = c * h_yz_i + s * h_yz_r;
-      grad_grad_psi[psiIndex + 1][6] = c * h_xz_i + s * h_xz_r;
-      grad_grad_psi[psiIndex + 1][7] = c * h_yz_i + s * h_yz_r;
-      grad_grad_psi[psiIndex + 1][8] = c * h_zz_i + s * h_zz_r;
+      grad_grad_psi[ji][0] = c * h_xx_i + s * h_xx_r;
+      grad_grad_psi[ji][1] = c * h_xy_i + s * h_xy_r;
+      grad_grad_psi[ji][2] = c * h_xz_i + s * h_xz_r;
+      grad_grad_psi[ji][3] = c * h_xy_i + s * h_xy_r;
+      grad_grad_psi[ji][4] = c * h_yy_i + s * h_yy_r;
+      grad_grad_psi[ji][5] = c * h_yz_i + s * h_yz_r;
+      grad_grad_psi[ji][6] = c * h_xz_i + s * h_xz_r;
+      grad_grad_psi[ji][7] = c * h_yz_i + s * h_yz_r;
+      grad_grad_psi[ji][8] = c * h_zz_i + s * h_zz_r;
     }
 
     //These are the real and imaginary components of the third SPO derivative.  _xxx denotes
@@ -1395,70 +1382,70 @@ void SplineC2ROMPTarget<ST>::assign_vghgh(const PointType& r,
     const ST gh_zzz_r = f3_zzz_r + 3 * kZ * f_zz_i - 3 * kZ * kZ * dZ_r - kZ * kZ * kZ * val_i;
     const ST gh_zzz_i = f3_zzz_i - 3 * kZ * f_zz_r - 3 * kZ * kZ * dZ_i + kZ * kZ * kZ * val_r;
 
-    if (psiIndex < requested_orb_size)
+    if (jr < requested_orb_size)
     {
-      grad_grad_grad_psi[psiIndex][0][0] = c * gh_xxx_r - s * gh_xxx_i;
-      grad_grad_grad_psi[psiIndex][0][1] = c * gh_xxy_r - s * gh_xxy_i;
-      grad_grad_grad_psi[psiIndex][0][2] = c * gh_xxz_r - s * gh_xxz_i;
-      grad_grad_grad_psi[psiIndex][0][3] = c * gh_xxy_r - s * gh_xxy_i;
-      grad_grad_grad_psi[psiIndex][0][4] = c * gh_xyy_r - s * gh_xyy_i;
-      grad_grad_grad_psi[psiIndex][0][5] = c * gh_xyz_r - s * gh_xyz_i;
-      grad_grad_grad_psi[psiIndex][0][6] = c * gh_xxz_r - s * gh_xxz_i;
-      grad_grad_grad_psi[psiIndex][0][7] = c * gh_xyz_r - s * gh_xyz_i;
-      grad_grad_grad_psi[psiIndex][0][8] = c * gh_xzz_r - s * gh_xzz_i;
+      grad_grad_grad_psi[jr][0][0] = c * gh_xxx_r - s * gh_xxx_i;
+      grad_grad_grad_psi[jr][0][1] = c * gh_xxy_r - s * gh_xxy_i;
+      grad_grad_grad_psi[jr][0][2] = c * gh_xxz_r - s * gh_xxz_i;
+      grad_grad_grad_psi[jr][0][3] = c * gh_xxy_r - s * gh_xxy_i;
+      grad_grad_grad_psi[jr][0][4] = c * gh_xyy_r - s * gh_xyy_i;
+      grad_grad_grad_psi[jr][0][5] = c * gh_xyz_r - s * gh_xyz_i;
+      grad_grad_grad_psi[jr][0][6] = c * gh_xxz_r - s * gh_xxz_i;
+      grad_grad_grad_psi[jr][0][7] = c * gh_xyz_r - s * gh_xyz_i;
+      grad_grad_grad_psi[jr][0][8] = c * gh_xzz_r - s * gh_xzz_i;
 
-      grad_grad_grad_psi[psiIndex][1][0] = c * gh_xxy_r - s * gh_xxy_i;
-      grad_grad_grad_psi[psiIndex][1][1] = c * gh_xyy_r - s * gh_xyy_i;
-      grad_grad_grad_psi[psiIndex][1][2] = c * gh_xyz_r - s * gh_xyz_i;
-      grad_grad_grad_psi[psiIndex][1][3] = c * gh_xyy_r - s * gh_xyy_i;
-      grad_grad_grad_psi[psiIndex][1][4] = c * gh_yyy_r - s * gh_yyy_i;
-      grad_grad_grad_psi[psiIndex][1][5] = c * gh_yyz_r - s * gh_yyz_i;
-      grad_grad_grad_psi[psiIndex][1][6] = c * gh_xyz_r - s * gh_xyz_i;
-      grad_grad_grad_psi[psiIndex][1][7] = c * gh_yyz_r - s * gh_yyz_i;
-      grad_grad_grad_psi[psiIndex][1][8] = c * gh_yzz_r - s * gh_yzz_i;
+      grad_grad_grad_psi[jr][1][0] = c * gh_xxy_r - s * gh_xxy_i;
+      grad_grad_grad_psi[jr][1][1] = c * gh_xyy_r - s * gh_xyy_i;
+      grad_grad_grad_psi[jr][1][2] = c * gh_xyz_r - s * gh_xyz_i;
+      grad_grad_grad_psi[jr][1][3] = c * gh_xyy_r - s * gh_xyy_i;
+      grad_grad_grad_psi[jr][1][4] = c * gh_yyy_r - s * gh_yyy_i;
+      grad_grad_grad_psi[jr][1][5] = c * gh_yyz_r - s * gh_yyz_i;
+      grad_grad_grad_psi[jr][1][6] = c * gh_xyz_r - s * gh_xyz_i;
+      grad_grad_grad_psi[jr][1][7] = c * gh_yyz_r - s * gh_yyz_i;
+      grad_grad_grad_psi[jr][1][8] = c * gh_yzz_r - s * gh_yzz_i;
 
-      grad_grad_grad_psi[psiIndex][2][0] = c * gh_xxz_r - s * gh_xxz_i;
-      grad_grad_grad_psi[psiIndex][2][1] = c * gh_xyz_r - s * gh_xyz_i;
-      grad_grad_grad_psi[psiIndex][2][2] = c * gh_xzz_r - s * gh_xzz_i;
-      grad_grad_grad_psi[psiIndex][2][3] = c * gh_xyz_r - s * gh_xyz_i;
-      grad_grad_grad_psi[psiIndex][2][4] = c * gh_yyz_r - s * gh_yyz_i;
-      grad_grad_grad_psi[psiIndex][2][5] = c * gh_yzz_r - s * gh_yzz_i;
-      grad_grad_grad_psi[psiIndex][2][6] = c * gh_xzz_r - s * gh_xzz_i;
-      grad_grad_grad_psi[psiIndex][2][7] = c * gh_yzz_r - s * gh_yzz_i;
-      grad_grad_grad_psi[psiIndex][2][8] = c * gh_zzz_r - s * gh_zzz_i;
+      grad_grad_grad_psi[jr][2][0] = c * gh_xxz_r - s * gh_xxz_i;
+      grad_grad_grad_psi[jr][2][1] = c * gh_xyz_r - s * gh_xyz_i;
+      grad_grad_grad_psi[jr][2][2] = c * gh_xzz_r - s * gh_xzz_i;
+      grad_grad_grad_psi[jr][2][3] = c * gh_xyz_r - s * gh_xyz_i;
+      grad_grad_grad_psi[jr][2][4] = c * gh_yyz_r - s * gh_yyz_i;
+      grad_grad_grad_psi[jr][2][5] = c * gh_yzz_r - s * gh_yzz_i;
+      grad_grad_grad_psi[jr][2][6] = c * gh_xzz_r - s * gh_xzz_i;
+      grad_grad_grad_psi[jr][2][7] = c * gh_yzz_r - s * gh_yzz_i;
+      grad_grad_grad_psi[jr][2][8] = c * gh_zzz_r - s * gh_zzz_i;
     }
 
-    if (psiIndex + 1 < requested_orb_size)
+    if (ji < requested_orb_size)
     {
-      grad_grad_grad_psi[psiIndex + 1][0][0] = c * gh_xxx_i + s * gh_xxx_r;
-      grad_grad_grad_psi[psiIndex + 1][0][1] = c * gh_xxy_i + s * gh_xxy_r;
-      grad_grad_grad_psi[psiIndex + 1][0][2] = c * gh_xxz_i + s * gh_xxz_r;
-      grad_grad_grad_psi[psiIndex + 1][0][3] = c * gh_xxy_i + s * gh_xxy_r;
-      grad_grad_grad_psi[psiIndex + 1][0][4] = c * gh_xyy_i + s * gh_xyy_r;
-      grad_grad_grad_psi[psiIndex + 1][0][5] = c * gh_xyz_i + s * gh_xyz_r;
-      grad_grad_grad_psi[psiIndex + 1][0][6] = c * gh_xxz_i + s * gh_xxz_r;
-      grad_grad_grad_psi[psiIndex + 1][0][7] = c * gh_xyz_i + s * gh_xyz_r;
-      grad_grad_grad_psi[psiIndex + 1][0][8] = c * gh_xzz_i + s * gh_xzz_r;
+      grad_grad_grad_psi[ji][0][0] = c * gh_xxx_i + s * gh_xxx_r;
+      grad_grad_grad_psi[ji][0][1] = c * gh_xxy_i + s * gh_xxy_r;
+      grad_grad_grad_psi[ji][0][2] = c * gh_xxz_i + s * gh_xxz_r;
+      grad_grad_grad_psi[ji][0][3] = c * gh_xxy_i + s * gh_xxy_r;
+      grad_grad_grad_psi[ji][0][4] = c * gh_xyy_i + s * gh_xyy_r;
+      grad_grad_grad_psi[ji][0][5] = c * gh_xyz_i + s * gh_xyz_r;
+      grad_grad_grad_psi[ji][0][6] = c * gh_xxz_i + s * gh_xxz_r;
+      grad_grad_grad_psi[ji][0][7] = c * gh_xyz_i + s * gh_xyz_r;
+      grad_grad_grad_psi[ji][0][8] = c * gh_xzz_i + s * gh_xzz_r;
 
-      grad_grad_grad_psi[psiIndex + 1][1][0] = c * gh_xxy_i + s * gh_xxy_r;
-      grad_grad_grad_psi[psiIndex + 1][1][1] = c * gh_xyy_i + s * gh_xyy_r;
-      grad_grad_grad_psi[psiIndex + 1][1][2] = c * gh_xyz_i + s * gh_xyz_r;
-      grad_grad_grad_psi[psiIndex + 1][1][3] = c * gh_xyy_i + s * gh_xyy_r;
-      grad_grad_grad_psi[psiIndex + 1][1][4] = c * gh_yyy_i + s * gh_yyy_r;
-      grad_grad_grad_psi[psiIndex + 1][1][5] = c * gh_yyz_i + s * gh_yyz_r;
-      grad_grad_grad_psi[psiIndex + 1][1][6] = c * gh_xyz_i + s * gh_xyz_r;
-      grad_grad_grad_psi[psiIndex + 1][1][7] = c * gh_yyz_i + s * gh_yyz_r;
-      grad_grad_grad_psi[psiIndex + 1][1][8] = c * gh_yzz_i + s * gh_yzz_r;
+      grad_grad_grad_psi[ji][1][0] = c * gh_xxy_i + s * gh_xxy_r;
+      grad_grad_grad_psi[ji][1][1] = c * gh_xyy_i + s * gh_xyy_r;
+      grad_grad_grad_psi[ji][1][2] = c * gh_xyz_i + s * gh_xyz_r;
+      grad_grad_grad_psi[ji][1][3] = c * gh_xyy_i + s * gh_xyy_r;
+      grad_grad_grad_psi[ji][1][4] = c * gh_yyy_i + s * gh_yyy_r;
+      grad_grad_grad_psi[ji][1][5] = c * gh_yyz_i + s * gh_yyz_r;
+      grad_grad_grad_psi[ji][1][6] = c * gh_xyz_i + s * gh_xyz_r;
+      grad_grad_grad_psi[ji][1][7] = c * gh_yyz_i + s * gh_yyz_r;
+      grad_grad_grad_psi[ji][1][8] = c * gh_yzz_i + s * gh_yzz_r;
 
-      grad_grad_grad_psi[psiIndex + 1][2][0] = c * gh_xxz_i + s * gh_xxz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][1] = c * gh_xyz_i + s * gh_xyz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][2] = c * gh_xzz_i + s * gh_xzz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][3] = c * gh_xyz_i + s * gh_xyz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][4] = c * gh_yyz_i + s * gh_yyz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][5] = c * gh_yzz_i + s * gh_yzz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][6] = c * gh_xzz_i + s * gh_xzz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][7] = c * gh_yzz_i + s * gh_yzz_r;
-      grad_grad_grad_psi[psiIndex + 1][2][8] = c * gh_zzz_i + s * gh_zzz_r;
+      grad_grad_grad_psi[ji][2][0] = c * gh_xxz_i + s * gh_xxz_r;
+      grad_grad_grad_psi[ji][2][1] = c * gh_xyz_i + s * gh_xyz_r;
+      grad_grad_grad_psi[ji][2][2] = c * gh_xzz_i + s * gh_xzz_r;
+      grad_grad_grad_psi[ji][2][3] = c * gh_xyz_i + s * gh_xyz_r;
+      grad_grad_grad_psi[ji][2][4] = c * gh_yyz_i + s * gh_yyz_r;
+      grad_grad_grad_psi[ji][2][5] = c * gh_yzz_i + s * gh_yzz_r;
+      grad_grad_grad_psi[ji][2][6] = c * gh_xzz_i + s * gh_xzz_r;
+      grad_grad_grad_psi[ji][2][7] = c * gh_yzz_i + s * gh_yzz_r;
+      grad_grad_grad_psi[ji][2][8] = c * gh_zzz_i + s * gh_zzz_r;
     }
   }
 #pragma omp simd
@@ -1494,7 +1481,7 @@ void SplineC2ROMPTarget<ST>::assign_vghgh(const PointType& r,
     const ST gY_i = dY_i - val_r * kY;
     const ST gZ_i = dZ_i - val_r * kZ;
 
-    if (const size_t psiIndex = first_spo + nComplexBands + j; psiIndex < requested_orb_size)
+    if (const size_t psiIndex = nComplexBands + j; psiIndex < requested_orb_size)
     {
       psi[psiIndex]     = c * val_r - s * val_i;
       dpsi[psiIndex][0] = c * gX_r - s * gX_i;

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
@@ -182,7 +182,7 @@ inline void SplineR2R<ST>::assign_v(int bc_sign, const vContainer_type& myV, Val
   const ST signed_one = (bc_sign & 1) ? -1 : 1;
 #pragma omp simd
   for (size_t j = first; j < last; ++j)
-    psi[first_spo + j] = signed_one * myV[j];
+    psi[j] = signed_one * myV[j];
 }
 
 template<typename ST>
@@ -311,11 +311,10 @@ void SplineR2R<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOSet>& spo_
   mw_offload_scratch.resize(spline_padded_size * mw_nVP);
 
   // Ye: need to extract sizes and pointers before entering target region
-  const auto* spline_ptr       = SplineInst->getSplinePtr();
-  auto* offload_scratch_ptr    = mw_offload_scratch.data();
-  auto* buffer_H2D_ptr         = det_ratios_buffer_H2D.data();
-  auto* ratios_private_ptr     = mw_ratios_private.data();
-  const size_t first_spo_local = first_spo;
+  const auto* spline_ptr    = SplineInst->getSplinePtr();
+  auto* offload_scratch_ptr = mw_offload_scratch.data();
+  auto* buffer_H2D_ptr      = det_ratios_buffer_H2D.data();
+  auto* ratios_private_ptr  = mw_ratios_private.data();
 
   {
     ScopedTimer offload(offload_timer_);
@@ -411,12 +410,11 @@ inline void SplineR2R<ST>::assign_vgl(int bc_sign,
 #pragma omp simd
   for (size_t j = first; j < last; ++j)
   {
-    const size_t psiIndex = first_spo + j;
-    psi[psiIndex]         = signed_one * myV[j];
-    dpsi[psiIndex][0]     = signed_one * (g00 * g0[j] + g01 * g1[j] + g02 * g2[j]);
-    dpsi[psiIndex][1]     = signed_one * (g10 * g0[j] + g11 * g1[j] + g12 * g2[j]);
-    dpsi[psiIndex][2]     = signed_one * (g20 * g0[j] + g21 * g1[j] + g22 * g2[j]);
-    d2psi[psiIndex]       = signed_one * SymTrace(h00[j], h01[j], h02[j], h11[j], h12[j], h22[j], symGG);
+    psi[j]     = signed_one * myV[j];
+    dpsi[j][0] = signed_one * (g00 * g0[j] + g01 * g1[j] + g02 * g2[j]);
+    dpsi[j][1] = signed_one * (g10 * g0[j] + g11 * g1[j] + g12 * g2[j]);
+    dpsi[j][2] = signed_one * (g20 * g0[j] + g21 * g1[j] + g22 * g2[j]);
+    d2psi[j]   = signed_one * SymTrace(h00[j], h01[j], h02[j], h11[j], h12[j], h22[j], symGG);
   }
 }
 
@@ -432,14 +430,13 @@ inline void SplineR2R<ST>::assign_vgl_from_l(int bc_sign, ValueVector& psi, Grad
 
   const size_t last_real = OrbitalSetSize > psi.size() ? psi.size() : OrbitalSetSize;
 #pragma omp simd
-  for (int psiIndex = first_spo; psiIndex < last_real; ++psiIndex)
+  for (int j = 0; j < last_real; ++j)
   {
-    const size_t j    = psiIndex - first_spo;
-    psi[psiIndex]     = signed_one * myV[j];
-    dpsi[psiIndex][0] = signed_one * g0[j];
-    dpsi[psiIndex][1] = signed_one * g1[j];
-    dpsi[psiIndex][2] = signed_one * g2[j];
-    d2psi[psiIndex]   = signed_one * myL[j];
+    psi[j]     = signed_one * myV[j];
+    dpsi[j][0] = signed_one * g0[j];
+    dpsi[j][1] = signed_one * g1[j];
+    dpsi[j][2] = signed_one * g2[j];
+    d2psi[j]   = signed_one * myL[j];
   }
 }
 
@@ -523,7 +520,6 @@ void SplineR2R<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithLeader<SPO
   auto* phi_vgl_ptr              = phi_vgl_v.data();
   auto* rg_private_ptr           = rg_private.data();
   const size_t buffer_H2D_stride = buffer_H2D.cols();
-  const size_t first_spo_local   = first_spo;
   const auto requested_orb_size  = phi_vgl_v.size(2);
   const size_t phi_vgl_stride    = num_pos * requested_orb_size;
 
@@ -597,17 +593,16 @@ void SplineR2R<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithLeader<SPO
         {
           lcart[index] = SymTrace(h00[index], h01[index], h02[index], h11[index], h12[index], h22[index], symGGt);
 
-          const size_t psiIndex = first_spo_local + index;
-          out_phi[psiIndex]     = pos_iw_ptr[0] * val[index];
-          out_dphi_x[psiIndex]  = pos_iw_ptr[0] * (G[0] * g0[index] + G[1] * g1[index] + G[2] * g2[index]);
-          out_dphi_y[psiIndex]  = pos_iw_ptr[0] * (G[3] * g0[index] + G[4] * g1[index] + G[5] * g2[index]);
-          out_dphi_z[psiIndex]  = pos_iw_ptr[0] * (G[6] * g0[index] + G[7] * g1[index] + G[8] * g2[index]);
-          out_d2phi[psiIndex]   = pos_iw_ptr[0] * lcart[index];
+          out_phi[index]    = pos_iw_ptr[0] * val[index];
+          out_dphi_x[index] = pos_iw_ptr[0] * (G[0] * g0[index] + G[1] * g1[index] + G[2] * g2[index]);
+          out_dphi_y[index] = pos_iw_ptr[0] * (G[3] * g0[index] + G[4] * g1[index] + G[5] * g2[index]);
+          out_dphi_z[index] = pos_iw_ptr[0] * (G[6] * g0[index] + G[7] * g1[index] + G[8] * g2[index]);
+          out_d2phi[index]  = pos_iw_ptr[0] * lcart[index];
 
-          ratio += out_phi[psiIndex] * invRow_iw_ptr[psiIndex];
-          grad_x += out_dphi_x[psiIndex] * invRow_iw_ptr[psiIndex];
-          grad_y += out_dphi_y[psiIndex] * invRow_iw_ptr[psiIndex];
-          grad_z += out_dphi_z[psiIndex] * invRow_iw_ptr[psiIndex];
+          ratio += out_phi[index] * invRow_iw_ptr[index];
+          grad_x += out_dphi_x[index] * invRow_iw_ptr[index];
+          grad_y += out_dphi_y[index] * invRow_iw_ptr[index];
+          grad_z += out_dphi_z[index] * invRow_iw_ptr[index];
         }
 
 
@@ -672,11 +667,10 @@ void SplineR2R<ST>::assign_vgh(int bc_sign,
     const ST dY_r = g10 * g0[j] + g11 * g1[j] + g12 * g2[j];
     const ST dZ_r = g20 * g0[j] + g21 * g1[j] + g22 * g2[j];
 
-    const size_t psiIndex = j + first_spo;
-    psi[psiIndex]         = signed_one * myV[j];
-    dpsi[psiIndex][0]     = signed_one * dX_r;
-    dpsi[psiIndex][1]     = signed_one * dY_r;
-    dpsi[psiIndex][2]     = signed_one * dZ_r;
+    psi[j]     = signed_one * myV[j];
+    dpsi[j][0] = signed_one * dX_r;
+    dpsi[j][1] = signed_one * dY_r;
+    dpsi[j][2] = signed_one * dZ_r;
 
     const ST h_xx_r = v_m_v(h00[j], h01[j], h02[j], h11[j], h12[j], h22[j], g00, g01, g02, g00, g01, g02);
     const ST h_xy_r = v_m_v(h00[j], h01[j], h02[j], h11[j], h12[j], h22[j], g00, g01, g02, g10, g11, g12);
@@ -688,15 +682,15 @@ void SplineR2R<ST>::assign_vgh(int bc_sign,
     const ST h_zy_r = v_m_v(h00[j], h01[j], h02[j], h11[j], h12[j], h22[j], g20, g21, g22, g10, g11, g12);
     const ST h_zz_r = v_m_v(h00[j], h01[j], h02[j], h11[j], h12[j], h22[j], g20, g21, g22, g20, g21, g22);
 
-    grad_grad_psi[psiIndex][0] = signed_one * h_xx_r;
-    grad_grad_psi[psiIndex][1] = signed_one * h_xy_r;
-    grad_grad_psi[psiIndex][2] = signed_one * h_xz_r;
-    grad_grad_psi[psiIndex][3] = signed_one * h_yx_r;
-    grad_grad_psi[psiIndex][4] = signed_one * h_yy_r;
-    grad_grad_psi[psiIndex][5] = signed_one * h_yz_r;
-    grad_grad_psi[psiIndex][6] = signed_one * h_zx_r;
-    grad_grad_psi[psiIndex][7] = signed_one * h_zy_r;
-    grad_grad_psi[psiIndex][8] = signed_one * h_zz_r;
+    grad_grad_psi[j][0] = signed_one * h_xx_r;
+    grad_grad_psi[j][1] = signed_one * h_xy_r;
+    grad_grad_psi[j][2] = signed_one * h_xz_r;
+    grad_grad_psi[j][3] = signed_one * h_yx_r;
+    grad_grad_psi[j][4] = signed_one * h_yy_r;
+    grad_grad_psi[j][5] = signed_one * h_yz_r;
+    grad_grad_psi[j][6] = signed_one * h_zx_r;
+    grad_grad_psi[j][7] = signed_one * h_zy_r;
+    grad_grad_psi[j][8] = signed_one * h_zz_r;
   }
 }
 
@@ -772,11 +766,10 @@ void SplineR2R<ST>::assign_vghgh(int bc_sign,
     const ST dY_r = g10 * g0[j] + g11 * g1[j] + g12 * g2[j];
     const ST dZ_r = g20 * g0[j] + g21 * g1[j] + g22 * g2[j];
 
-    const size_t psiIndex = j + first_spo;
-    psi[psiIndex]         = signed_one * val_r;
-    dpsi[psiIndex][0]     = signed_one * dX_r;
-    dpsi[psiIndex][1]     = signed_one * dY_r;
-    dpsi[psiIndex][2]     = signed_one * dZ_r;
+    psi[j]     = signed_one * val_r;
+    dpsi[j][0] = signed_one * dX_r;
+    dpsi[j][1] = signed_one * dY_r;
+    dpsi[j][2] = signed_one * dZ_r;
 
     //intermediates for computation of hessian. \partial_i \partial_j phi in cartesian coordinates.
     const ST f_xx_r = v_m_v(h00[j], h01[j], h02[j], h11[j], h12[j], h22[j], g00, g01, g02, g00, g01, g02);
@@ -793,17 +786,17 @@ void SplineR2R<ST>::assign_vghgh(int bc_sign,
       const ST h_yz_r=f_yz_r+(kY*dZ_i+kZ*dY_i)-kY*kZ*val_r;
       const ST h_zz_r=f_zz_r+2*kZ*dZ_i-kZ*kZ*val_r; */
 
-    grad_grad_psi[psiIndex][0] = f_xx_r * signed_one;
-    grad_grad_psi[psiIndex][1] = f_xy_r * signed_one;
-    grad_grad_psi[psiIndex][2] = f_xz_r * signed_one;
-    grad_grad_psi[psiIndex][4] = f_yy_r * signed_one;
-    grad_grad_psi[psiIndex][5] = f_yz_r * signed_one;
-    grad_grad_psi[psiIndex][8] = f_zz_r * signed_one;
+    grad_grad_psi[j][0] = f_xx_r * signed_one;
+    grad_grad_psi[j][1] = f_xy_r * signed_one;
+    grad_grad_psi[j][2] = f_xz_r * signed_one;
+    grad_grad_psi[j][4] = f_yy_r * signed_one;
+    grad_grad_psi[j][5] = f_yz_r * signed_one;
+    grad_grad_psi[j][8] = f_zz_r * signed_one;
 
     //symmetry:
-    grad_grad_psi[psiIndex][3] = grad_grad_psi[psiIndex][1];
-    grad_grad_psi[psiIndex][6] = grad_grad_psi[psiIndex][2];
-    grad_grad_psi[psiIndex][7] = grad_grad_psi[psiIndex][5];
+    grad_grad_psi[j][3] = grad_grad_psi[j][1];
+    grad_grad_psi[j][6] = grad_grad_psi[j][2];
+    grad_grad_psi[j][7] = grad_grad_psi[j][5];
     //These are the real and imaginary components of the third SPO derivative.  _xxx denotes
     // third derivative w.r.t. x, _xyz, a derivative with resepect to x,y, and z, and so on.
 
@@ -840,41 +833,41 @@ void SplineR2R<ST>::assign_vghgh(int bc_sign,
       const ST gh_yzz_r= f3_yzz_r +(2*kZ*f_yz_i+kY*f_zz_i) - (2*kY*kZ*dZ_r+kZ*kZ*dY_r)-kY*kZ*kZ*val_i;
       const ST gh_zzz_r= f3_zzz_r + 3*kZ*f_zz_i - 3*kZ*kZ*dZ_r - kZ*kZ*kZ*val_i;*/
     //[x][xx] //These are the unique entries
-    grad_grad_grad_psi[psiIndex][0][0] = signed_one * f3_xxx_r;
-    grad_grad_grad_psi[psiIndex][0][1] = signed_one * f3_xxy_r;
-    grad_grad_grad_psi[psiIndex][0][2] = signed_one * f3_xxz_r;
-    grad_grad_grad_psi[psiIndex][0][4] = signed_one * f3_xyy_r;
-    grad_grad_grad_psi[psiIndex][0][5] = signed_one * f3_xyz_r;
-    grad_grad_grad_psi[psiIndex][0][8] = signed_one * f3_xzz_r;
+    grad_grad_grad_psi[j][0][0] = signed_one * f3_xxx_r;
+    grad_grad_grad_psi[j][0][1] = signed_one * f3_xxy_r;
+    grad_grad_grad_psi[j][0][2] = signed_one * f3_xxz_r;
+    grad_grad_grad_psi[j][0][4] = signed_one * f3_xyy_r;
+    grad_grad_grad_psi[j][0][5] = signed_one * f3_xyz_r;
+    grad_grad_grad_psi[j][0][8] = signed_one * f3_xzz_r;
 
     //filling in the symmetric terms.  Filling out the xij terms
-    grad_grad_grad_psi[psiIndex][0][3] = grad_grad_grad_psi[psiIndex][0][1];
-    grad_grad_grad_psi[psiIndex][0][6] = grad_grad_grad_psi[psiIndex][0][2];
-    grad_grad_grad_psi[psiIndex][0][7] = grad_grad_grad_psi[psiIndex][0][5];
+    grad_grad_grad_psi[j][0][3] = grad_grad_grad_psi[j][0][1];
+    grad_grad_grad_psi[j][0][6] = grad_grad_grad_psi[j][0][2];
+    grad_grad_grad_psi[j][0][7] = grad_grad_grad_psi[j][0][5];
 
     //Now for everything that's a permutation of the above:
-    grad_grad_grad_psi[psiIndex][1][0] = grad_grad_grad_psi[psiIndex][0][1];
-    grad_grad_grad_psi[psiIndex][1][1] = grad_grad_grad_psi[psiIndex][0][4];
-    grad_grad_grad_psi[psiIndex][1][2] = grad_grad_grad_psi[psiIndex][0][5];
-    grad_grad_grad_psi[psiIndex][1][3] = grad_grad_grad_psi[psiIndex][0][4];
-    grad_grad_grad_psi[psiIndex][1][6] = grad_grad_grad_psi[psiIndex][0][5];
+    grad_grad_grad_psi[j][1][0] = grad_grad_grad_psi[j][0][1];
+    grad_grad_grad_psi[j][1][1] = grad_grad_grad_psi[j][0][4];
+    grad_grad_grad_psi[j][1][2] = grad_grad_grad_psi[j][0][5];
+    grad_grad_grad_psi[j][1][3] = grad_grad_grad_psi[j][0][4];
+    grad_grad_grad_psi[j][1][6] = grad_grad_grad_psi[j][0][5];
 
-    grad_grad_grad_psi[psiIndex][2][0] = grad_grad_grad_psi[psiIndex][0][2];
-    grad_grad_grad_psi[psiIndex][2][1] = grad_grad_grad_psi[psiIndex][0][5];
-    grad_grad_grad_psi[psiIndex][2][2] = grad_grad_grad_psi[psiIndex][0][8];
-    grad_grad_grad_psi[psiIndex][2][3] = grad_grad_grad_psi[psiIndex][0][5];
-    grad_grad_grad_psi[psiIndex][2][6] = grad_grad_grad_psi[psiIndex][0][8];
+    grad_grad_grad_psi[j][2][0] = grad_grad_grad_psi[j][0][2];
+    grad_grad_grad_psi[j][2][1] = grad_grad_grad_psi[j][0][5];
+    grad_grad_grad_psi[j][2][2] = grad_grad_grad_psi[j][0][8];
+    grad_grad_grad_psi[j][2][3] = grad_grad_grad_psi[j][0][5];
+    grad_grad_grad_psi[j][2][6] = grad_grad_grad_psi[j][0][8];
 
-    grad_grad_grad_psi[psiIndex][1][4] = signed_one * f3_yyy_r;
-    grad_grad_grad_psi[psiIndex][1][5] = signed_one * f3_yyz_r;
-    grad_grad_grad_psi[psiIndex][1][8] = signed_one * f3_yzz_r;
+    grad_grad_grad_psi[j][1][4] = signed_one * f3_yyy_r;
+    grad_grad_grad_psi[j][1][5] = signed_one * f3_yyz_r;
+    grad_grad_grad_psi[j][1][8] = signed_one * f3_yzz_r;
 
-    grad_grad_grad_psi[psiIndex][1][7] = grad_grad_grad_psi[psiIndex][1][5];
-    grad_grad_grad_psi[psiIndex][2][4] = grad_grad_grad_psi[psiIndex][1][5];
-    grad_grad_grad_psi[psiIndex][2][5] = grad_grad_grad_psi[psiIndex][1][8];
-    grad_grad_grad_psi[psiIndex][2][7] = grad_grad_grad_psi[psiIndex][1][8];
+    grad_grad_grad_psi[j][1][7] = grad_grad_grad_psi[j][1][5];
+    grad_grad_grad_psi[j][2][4] = grad_grad_grad_psi[j][1][5];
+    grad_grad_grad_psi[j][2][5] = grad_grad_grad_psi[j][1][8];
+    grad_grad_grad_psi[j][2][7] = grad_grad_grad_psi[j][1][8];
 
-    grad_grad_grad_psi[psiIndex][2][8] = signed_one * f3_zzz_r;
+    grad_grad_grad_psi[j][2][8] = signed_one * f3_zzz_r;
   }
 }
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
@@ -430,7 +430,7 @@ inline void SplineR2R<ST>::assign_vgl_from_l(int bc_sign, ValueVector& psi, Grad
   const ST* restrict g1 = myG.data(1);
   const ST* restrict g2 = myG.data(2);
 
-  const size_t last_real = last_spo > psi.size() ? psi.size() : last_spo;
+  const size_t last_real = OrbitalSetSize > psi.size() ? psi.size() : OrbitalSetSize;
 #pragma omp simd
   for (int psiIndex = first_spo; psiIndex < last_real; ++psiIndex)
   {


### PR DESCRIPTION
## Proposed changes
1. This feature was never activated nor tested. calls to selectBands always set relative=false.
2. It should not be implemented in the current way even if this feature is needed. Thus remove first_spo and last_spo.
3. Remove unused selectBands variants.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
