### PR TITLE
Remove estimator-latdev-free from deterministic tests.

### DIFF
--- a/tests/estimator/CMakeLists.txt
+++ b/tests/estimator/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 check_python_reqs("numpy;h5py" estimator-latdev-free add_tests)
 
 if(add_tests)
-  simple_run_and_check(deterministic-estimator-latdev-free "${qmcpack_SOURCE_DIR}/tests/estimator/latdev/free" two.xml 1 16
+  simple_run_and_check(estimator-latdev-free "${qmcpack_SOURCE_DIR}/tests/estimator/latdev/free" two.xml 1 16
                        flatdev.py)
 endif()
 


### PR DESCRIPTION
## Proposed changes
stabilize CI. remaining issue tracked by #5849

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
