### PR TITLE
insure `Matrix` zeroing via unit test

### DIFF
--- a/src/Containers/OhmmsPETE/tests/CMakeLists.txt
+++ b/src/Containers/OhmmsPETE/tests/CMakeLists.txt
@@ -13,6 +13,6 @@ set(UTEST_EXE test_containers_ohmmspete)
 set(UTEST_NAME deterministic-unit_${UTEST_EXE})
 
 add_executable(${UTEST_EXE} test_Vector.cpp test_Matrix.cpp test_Array.cpp test_TinyVector.cpp)
-target_link_libraries(${UTEST_EXE} catch_main containers)
+target_link_libraries(${UTEST_EXE} catch_main containers utilities_for_test)
 
 add_unit_test(${UTEST_NAME} 1 1 $<TARGET_FILE:${UTEST_EXE}>)

--- a/src/Containers/OhmmsPETE/tests/test_Matrix.cpp
+++ b/src/Containers/OhmmsPETE/tests/test_Matrix.cpp
@@ -17,6 +17,7 @@
 
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "config.h"
+#include <checkMatrix.hpp>
 
 using std::string;
 
@@ -53,13 +54,27 @@ TEST_CASE("matrix", "[OhmmsPETE]")
     CHECK(*ia == Approx(3.1));
   }
 
-  REQUIRE( A == A);
-  REQUIRE( A != C);
+  REQUIRE(A == A);
+  REQUIRE(A != C);
 
   // copy constructor and copy method
   Mat D(C);
   CHECK(D.rows() == 3);
   CHECK(D.cols() == 3);
+
+  // Check that the zeroing behavior on construction and resize
+  // follows assumptions about zeroing.
+  Mat E(2, 2);
+  Mat E_expected(2, 2);
+  E_expected        = 0.0;
+  auto check_matrix = checkMatrix(E, E_expected);
+  CHECKED_ELSE(check_matrix.result) { FAIL(check_matrix.result_message); }
+
+  E.resize(5, 5);
+  Mat E2_expected(5, 5);
+  E2_expected  = 0.0;
+  check_matrix = checkMatrix(E, E2_expected);
+  CHECKED_ELSE(check_matrix.result) { FAIL(check_matrix.result_message); }
 
   // swap_rows
   A(0, 0) = 0.0;
@@ -81,8 +96,8 @@ TEST_CASE("matrix", "[OhmmsPETE]")
 
 TEST_CASE("matrix converting assignment", "[OhmmsPETE]")
 {
-  Matrix<double> mat_A(3,3);
-  Matrix<float> mat_B(3,3);
+  Matrix<double> mat_A(3, 3);
+  Matrix<float> mat_B(3, 3);
 
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
@@ -90,40 +105,40 @@ TEST_CASE("matrix converting assignment", "[OhmmsPETE]")
 
   mat_B = mat_A;
 
-  CHECK(mat_B(0,0) == Approx(0));
-  CHECK(mat_B(1,1) == Approx(4.2));
+  CHECK(mat_B(0, 0) == Approx(0));
+  CHECK(mat_B(1, 1) == Approx(4.2));
 
-  Matrix<float> mat_C(2,2);
+  Matrix<float> mat_C(2, 2);
   for (int i = 0; i < 2; i++)
     for (int j = 0; j < 2; j++)
       mat_C(i, j) = (i + j) * 2.2;
 
   mat_A.assignUpperLeft(mat_C);
-  CHECK(mat_A(1,0) == Approx(2.2));
-  CHECK(mat_A(1,2) == Approx(6.3));
+  CHECK(mat_A(1, 0) == Approx(2.2));
+  CHECK(mat_A(1, 2) == Approx(6.3));
 
-  Matrix<float> mat_D(4,4);
+  Matrix<float> mat_D(4, 4);
   for (int i = 0; i < 4; i++)
     for (int j = 0; j < 4; j++)
       mat_D(i, j) = (i + j) * 2.3;
 
   mat_A.assignUpperLeft(mat_D);
-  CHECK(mat_A(1,0) == Approx(2.3));
-  CHECK(mat_A(1,2) == Approx(6.9));
+  CHECK(mat_A(1, 0) == Approx(2.3));
+  CHECK(mat_A(1, 2) == Approx(6.9));
 
-  Matrix<float> mat_too_small(2,2);
+  Matrix<float> mat_too_small(2, 2);
   CHECK_THROWS(mat_too_small = mat_A);
-  
-  Matrix<double> mat_too_small_but_larger_value_type(2,2);
+
+  Matrix<double> mat_too_small_but_larger_value_type(2, 2);
   mat_too_small_but_larger_value_type = mat_B;
   CHECK(mat_too_small_but_larger_value_type.rows() == 3);
   CHECK(mat_too_small_but_larger_value_type.cols() == 3);
-  CHECK(mat_too_small_but_larger_value_type(1,1) == Approx(mat_B(1,1)));
-  Matrix<double> too_small_but_same(2,2);
+  CHECK(mat_too_small_but_larger_value_type(1, 1) == Approx(mat_B(1, 1)));
+  Matrix<double> too_small_but_same(2, 2);
   too_small_but_same = mat_A;
   CHECK(too_small_but_same.rows() == 3);
   CHECK(too_small_but_same.cols() == 3);
-  CHECK(too_small_but_same(1,1) == Approx(mat_A(1,1)));  
+  CHECK(too_small_but_same(1, 1) == Approx(mat_A(1, 1)));
 }
 
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes

Various code depend's on Matrix zeroing on construction but unit tests do not insure this behavior is maintained. Now the unit tests do.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
a30four, sdgx-server

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
