### PR TITLE
Test NESpaceGrid normalization

### DIFF
--- a/src/Estimators/NESpaceGrid.cpp
+++ b/src/Estimators/NESpaceGrid.cpp
@@ -731,8 +731,6 @@ void NESpaceGrid<REAL>::collect(NESpaceGrid& reduction_grid, const RefVector<NES
 template<typename REAL>
 void NESpaceGrid<REAL>::normalize(REAL invToWgt)
 {
-  // normalize everything but the weights
-  // convention that value 0 is always the weight.
   std::transform(data_.begin() + buffer_offset_, data_.end(), data_.begin() + buffer_offset_,
                  [invToWgt](REAL value) { return value * invToWgt; });
 }

--- a/src/Estimators/NESpaceGrid.cpp
+++ b/src/Estimators/NESpaceGrid.cpp
@@ -578,7 +578,6 @@ void NESpaceGrid<REAL>::accumulate(const ParticlePos& R,
   int nparticles = values.size1();
   int nvalues    = values.size2();
   int iu[OHMMS_DIM];
-  int buf_index;
   const Real o2pi = 1.0 / (2.0 * M_PI);
   using CoordForm = SpaceGridInput::CoordForm;
   auto& agr       = input_.get_axis_grids();
@@ -620,11 +619,13 @@ void NESpaceGrid<REAL>::accumulate(const ParticlePos& R,
           for (int d = 0; d < OHMMS_DIM; ++d)
             error << gmapIndex(d, u) << ",  umin: " << umin_[d] << "  umax: " << umax_[d] << "  odu: " << odu_[d]
                   << '\n';
-          error << "which falls outside of the cell, for a period system all particle positions must be in the cell!\n";
+          error
+              << "which falls outside of the cell, for a periodic system all particle positions must be in the cell!\n";
           error << "It is very likely you have not set up your space grid correctly.\n";
           std::throw_with_nested(std::runtime_error(error.str()));
         }
-        buf_index = buffer_offset_;
+        // This should always be 0
+        int buf_index = buffer_offset_;
         for (int d = 0; d < OHMMS_DIM; ++d)
           buf_index += nvalues * dm_[d] * iu[d];
         for (v = 0; v < nvalues; v++, buf_index++)
@@ -667,7 +668,7 @@ void NESpaceGrid<REAL>::accumulate(const ParticlePos& R,
         iu[0]                = gmap_[0][floor((u[0] - umin_[0]) * odu_[0])];
         iu[1]                = gmap_[1][floor((u[1] - umin_[1]) * odu_[1])];
         iu[2]                = gmap_[2][floor((u[2] - umin_[2]) * odu_[2])];
-        buf_index            = buffer_offset_ + nvalues * (dm_[0] * iu[0] + dm_[1] * iu[1] + dm_[2] * iu[2]);
+        int buf_index        = buffer_offset_ + nvalues * (dm_[0] * iu[0] + dm_[1] * iu[1] + dm_[2] * iu[2]);
         for (v = 0; v < nvalues; v++, buf_index++)
           data_[buf_index] += values(p, v);
       }
@@ -688,7 +689,7 @@ void NESpaceGrid<REAL>::accumulate(const ParticlePos& R,
         iu[0]                = gmap_[0][floor((u[0] - umin_[0]) * odu_[0])];
         iu[1]                = gmap_[1][floor((u[1] - umin_[1]) * odu_[1])];
         iu[2]                = gmap_[2][floor((u[2] - umin_[2]) * odu_[2])];
-        buf_index            = buffer_offset_ + nvalues * (dm_[0] * iu[0] + dm_[1] * iu[1] + dm_[2] * iu[2]);
+        int buf_index        = buffer_offset_ + nvalues * (dm_[0] * iu[0] + dm_[1] * iu[1] + dm_[2] * iu[2]);
         for (v = 0; v < nvalues; v++, buf_index++)
           data_[buf_index] += values(p, v);
       }

--- a/src/Estimators/NESpaceGrid.cpp
+++ b/src/Estimators/NESpaceGrid.cpp
@@ -731,8 +731,10 @@ void NESpaceGrid<REAL>::collect(NESpaceGrid& reduction_grid, const RefVector<NES
 template<typename REAL>
 void NESpaceGrid<REAL>::normalize(REAL invToWgt)
 {
-  std::transform(data_.begin(), data_.end(), data_.begin(),
-                 std::bind(std::multiplies<REAL>(), std::placeholders::_1, invToWgt));
+  // normalize everything but the weights
+  // convention that value 0 is always the weight.
+  std::transform(data_.begin() + buffer_offset_, data_.end(), data_.begin() + buffer_offset_,
+                 [invToWgt](REAL value) { return value * invToWgt; });
 }
 
 template<typename REAL>

--- a/src/Estimators/tests/test_NESpaceGrid.cpp
+++ b/src/Estimators/tests/test_NESpaceGrid.cpp
@@ -199,6 +199,7 @@ TEST_CASE("SpaceGrid::Basic", "[estimators]")
   CHECK(tensorAccessor(grid_data, 17, 12, 9, 0) == Approx(5.0));
   CHECK(tensorAccessor(grid_data, 17, 12, 9, 1) == Approx(5.1));
   CHECK(tensorAccessor(grid_data, 17, 12, 9, 2) == Approx(5.2));
+
   // new pset R's
   // check again
   auto min_R =
@@ -258,6 +259,13 @@ TEST_CASE("SpaceGrid::Basic", "[estimators]")
   CHECK(tensorAccessor(grid_data, 17, 12, 9, 0) == Approx(5.0));
   CHECK(tensorAccessor(grid_data, 17, 12, 9, 1) == Approx(5.1));
   CHECK(tensorAccessor(grid_data, 17, 12, 9, 2) == Approx(5.2));
+
+  // Test normalization
+  Vector<Real> ohmms_vector(grid_data.size());
+  std::copy(grid_data.begin(), grid_data.end(), ohmms_vector.begin());
+  space_grid.normalize(0.5);
+  ohmms_vector *= 0.5;
+  checkVector(ohmms_vector, grid_data, true);
 }
 
 TEST_CASE("SpaceGrid::Accumulate::outside", "[estimators]")


### PR DESCRIPTION
## Proposed changes

There is currently no test of the normalization behavior of NESpaceGrid, this is potentially prone to confusion because the different way in which this works from the legacy grids, which carried a particle count per cell and also did not own there data. 

I also fixed a typo in a comment and localized an indexing variable.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
a30four
## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
