### PR TITLE
Reporting of NLPP values to estimators does not require special relations between joblist and walkers

### DIFF
--- a/src/QMCHamiltonians/NLPPJob.h
+++ b/src/QMCHamiltonians/NLPPJob.h
@@ -31,7 +31,7 @@ struct NLPPJob
   const int electron_id;
   const RealType ion_elec_dist;
   const PosType ion_elec_displ;
-
+  int walker_index = -1;
   /** This allows construction using emplace back
    *  could be a way to pull it off with aggregate initialization
    *  but it is nontrivial
@@ -39,11 +39,13 @@ struct NLPPJob
   NLPPJob(const int ion_id_in,
           const int electron_id_in,
           const RealType ion_elec_dist_in,
-          const PosType& ion_elec_displ_in)
+          const PosType& ion_elec_displ_in,
+          int walker_index)
       : ion_id(ion_id_in),
         electron_id(electron_id_in),
         ion_elec_dist(ion_elec_dist_in),
-        ion_elec_displ(ion_elec_displ_in)
+        ion_elec_displ(ion_elec_displ_in),
+        walker_index(walker_index)
   {}
 };
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -297,7 +297,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
           if (O.PP[iat] != nullptr && dist[iat] < O.PP[iat]->getRmax())
           {
             O.neighbor_lists.addElecIonPair(jel, iat);
-            joblist.emplace_back(iat, jel, dist[iat], -displ[iat]);
+            joblist.emplace_back(iat, jel, dist[iat], -displ[iat], iw);
           }
       }
     }
@@ -388,9 +388,6 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
                                                                  : std::nullopt,
                                                  O_leader.use_DLA);
 
-      // Right now this is just over walker but could and probably should be over a set
-      // larger than the walker count.  The easiest way to not complicate the per particle
-      // reporting code would be to add the crowd walker index to the nlpp job meta data.
       for (size_t j = 0; j < ecp_potential_list.size(); j++)
       {
         NonLocalECPotential& ecp = ecp_potential_list[j];
@@ -400,8 +397,9 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
         {
           auto& ve_samples = O_leader.mw_res_handle_.getResource().ve_samples;
           auto& vi_samples = O_leader.mw_res_handle_.getResource().vi_samples;
-          // CAUTION! This may not be so simple in the future
-          int iw = j;
+          // This is not the walker_id but rather its index in the
+          // crowd.
+          int iw = batch_list[j].get().walker_index;
           ve_samples(iw, batch_list[j].get().electron_id) += 0.5 * pairpots[j];
           vi_samples(iw, batch_list[j].get().ion_id) += 0.5 * pairpots[j];
         }

--- a/src/QMCHamiltonians/SOECPotential.cpp
+++ b/src/QMCHamiltonians/SOECPotential.cpp
@@ -40,10 +40,7 @@ struct SOECPotential::SOECPotentialMultiWalkerResource : public Resource
  *\param els electronic poitions
  *\param psi Trial wave function
 */
-SOECPotential::SOECPotential(ParticleSet& ions,
-                             ParticleSet& els,
-                             bool use_exact_spin,
-                             bool use_VP)
+SOECPotential::SOECPotential(ParticleSet& ions, ParticleSet& els, bool use_exact_spin, bool use_VP)
     : my_rng_(nullptr),
       ion_config_(ions),
       vp_(use_VP ? std::make_unique<VirtualParticleSet>(els) : nullptr),
@@ -200,7 +197,7 @@ void SOECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase>& o_l
         const auto& displ = ble.getDisplRow(jel);
         for (size_t iat = 0; iat < O.pp_.size(); iat++)
           if (O.pp_[iat] != nullptr && dist[iat] < O.pp_[iat]->getRmax())
-            joblist.emplace_back(iat, jel, dist[iat], -displ[iat]);
+            joblist.emplace_back(iat, jel, dist[iat], -displ[iat], iw);
       }
     }
     O.value_ = 0.0;

--- a/src/QMCWaveFunctions/tests/test_J1_bspline.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1_bspline.cpp
@@ -409,10 +409,10 @@ void test_J1_spline(const DynamicCoordinateKind kind_selected)
   const int ei_table_index = elec_.addTable(ions_);
   const auto& ei_table1    = elec_.getDistTableAB(ei_table_index);
   // make virtual move of elec 0, reference ion 1
-  NLPPJob<RealType> job1(1, 0, ei_table1.getDistances()[0][1], -ei_table1.getDisplacements()[0][1]);
+  NLPPJob<RealType> job1(1, 0, ei_table1.getDistances()[0][1], -ei_table1.getDisplacements()[0][1], 0);
   const auto& ei_table2 = elec_clone.getDistTableAB(ei_table_index);
   // make virtual move of elec 1, reference ion 3
-  NLPPJob<RealType> job2(3, 1, ei_table2.getDistances()[1][3], -ei_table2.getDisplacements()[1][3]);
+  NLPPJob<RealType> job2(3, 1, ei_table2.getDistances()[1][3], -ei_table2.getDisplacements()[1][3], 1);
 
   std::vector<PosType> deltaV1{{0.1, 0.2, 0.3}, {0.1, 0.3, 0.2}, {0.2, 0.1, 0.3}};
   std::vector<PosType> deltaV2{{0.02, 0.01, 0.03}, {0.02, 0.03, 0.01}, {0.03, 0.01, 0.02}};

--- a/src/QMCWaveFunctions/tests/test_LCAO_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_LCAO_diamondC_2x1x1.cpp
@@ -355,9 +355,9 @@ void test_LCAO_DiamondC_2x1x1_real(const bool useOffload)
     const auto& ei_table_  = elec_.getDistTableAB(ei_table_index);
     const auto& ei_table_2 = elec_2.getDistTableAB(ei_table_index);
     // make virtual move of elec 0, reference ion 1
-    NLPPJob<SPOSet::RealType> job_(1, 0, ei_table_.getDistances()[0][1], -ei_table_.getDisplacements()[0][1]);
+    NLPPJob<SPOSet::RealType> job_(1, 0, ei_table_.getDistances()[0][1], -ei_table_.getDisplacements()[0][1], 0);
     // make virtual move of elec 1, reference ion 3
-    NLPPJob<SPOSet::RealType> job_2(3, 1, ei_table_2.getDistances()[1][3], -ei_table_2.getDisplacements()[1][3]);
+    NLPPJob<SPOSet::RealType> job_2(3, 1, ei_table_2.getDistances()[1][3], -ei_table_2.getDisplacements()[1][3], 1);
 
     // make VP refvec
     RefVectorWithLeader<VirtualParticleSet> vp_list(VP_, {VP_, VP_2});
@@ -803,9 +803,9 @@ void test_LCAO_DiamondC_2x1x1_cplx(const bool useOffload)
     const auto& ei_table_  = elec_.getDistTableAB(ei_table_index);
     const auto& ei_table_2 = elec_2.getDistTableAB(ei_table_index);
     // make virtual move of elec 0, reference ion 1
-    NLPPJob<SPOSet::RealType> job_(1, 0, ei_table_.getDistances()[0][1], -ei_table_.getDisplacements()[0][1]);
+    NLPPJob<SPOSet::RealType> job_(1, 0, ei_table_.getDistances()[0][1], -ei_table_.getDisplacements()[0][1], 0);
     // make virtual move of elec 1, reference ion 3
-    NLPPJob<SPOSet::RealType> job_2(3, 1, ei_table_2.getDistances()[1][3], -ei_table_2.getDisplacements()[1][3]);
+    NLPPJob<SPOSet::RealType> job_2(3, 1, ei_table_2.getDistances()[1][3], -ei_table_2.getDisplacements()[1][3], 1);
 
     // make VP refvec
     RefVectorWithLeader<VirtualParticleSet> vp_list(VP_, {VP_, VP_2});

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -536,11 +536,12 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
   ResourceCollectionTeamLock<VirtualParticleSet> mw_vp_lock(vp_res, vp_list);
 
   const auto& ei_table1 = elec_.getDistTableAB(ei_table_index);
+
   // make virtual move of elec 0, reference ion 1
-  NLPPJob<RealType> job1(1, 0, ei_table1.getDistances()[0][1], -ei_table1.getDisplacements()[0][1]);
+  NLPPJob<RealType> job1(1, 0, ei_table1.getDistances()[0][1], -ei_table1.getDisplacements()[0][1], 0);
   const auto& ei_table2 = elec_clone.getDistTableAB(ei_table_index);
   // make virtual move of elec 1, reference ion 3
-  NLPPJob<RealType> job2(3, 1, ei_table2.getDistances()[1][3], -ei_table2.getDisplacements()[1][3]);
+  NLPPJob<RealType> job2(3, 1, ei_table2.getDistances()[1][3], -ei_table2.getDisplacements()[1][3], 1);
 
   std::vector<PosType> deltaV1{{0.1, 0.2, 0.3}, {0.1, 0.3, 0.2}, {0.2, 0.1, 0.3}};
   std::vector<PosType> deltaV2{{0.02, 0.01, 0.03}, {0.02, 0.03, 0.01}, {0.03, 0.01, 0.02}};

--- a/src/QMCWaveFunctions/tests/test_einset_LiH.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_LiH.cpp
@@ -253,9 +253,9 @@ void test_einset_LiH_x(bool use_offload)
     const auto& ei_table_  = elec_.getDistTableAB(ei_table_index);
     const auto& ei_table_2 = elec_2.getDistTableAB(ei_table_index);
     // make virtual move of elec 0, reference ion 1
-    NLPPJob<SPOSet::RealType> job_(1, 0, ei_table_.getDistances()[0][1], -ei_table_.getDisplacements()[0][1]);
+    NLPPJob<SPOSet::RealType> job_(1, 0, ei_table_.getDistances()[0][1], -ei_table_.getDisplacements()[0][1], 0);
     // make virtual move of elec 1, reference ion 0
-    NLPPJob<SPOSet::RealType> job_2(0, 1, ei_table_2.getDistances()[1][0], -ei_table_2.getDisplacements()[1][0]);
+    NLPPJob<SPOSet::RealType> job_2(0, 1, ei_table_2.getDistances()[1][0], -ei_table_2.getDisplacements()[1][0], 1);
 
     // make VP refvec
     RefVectorWithLeader<VirtualParticleSet> vp_list(VP_, {VP_, VP_2});

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -675,13 +675,13 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
   inv_row = {0.1, 0.2, 0.3};
   inv_row.updateTo();
   std::vector<const SPOSet::ValueType*> inv_row_ptr(2, spo->isOMPoffload() ? inv_row.device_data() : inv_row.data());
-  const auto& ei_table1    = elec_.getDistTableAB(elec_.addTable(ions_));
-  const auto& ei_table2     = elec_2.getDistTableAB(elec_2.addTable(ions_));
+  const auto& ei_table1 = elec_.getDistTableAB(elec_.addTable(ions_));
+  const auto& ei_table2 = elec_2.getDistTableAB(elec_2.addTable(ions_));
   ParticleSet::mw_update(p_list);
   for (int iat = 0; iat < 3; iat++)
   {
-    NLPPJob<RealType> job1(0, iat, ei_table1.getDistances()[iat][0], -ei_table1.getDisplacements()[iat][0]);
-    NLPPJob<RealType> job2(0, iat, ei_table2.getDistances()[iat][0], -ei_table2.getDisplacements()[iat][0]);
+    NLPPJob<RealType> job1(0, iat, ei_table1.getDistances()[iat][0], -ei_table1.getDisplacements()[iat][0], 0);
+    NLPPJob<RealType> job2(0, iat, ei_table2.getDistances()[iat][0], -ei_table2.getDisplacements()[iat][0], 1);
 
     std::vector<ParticleSet::PosType> deltaV1{{-dR[iat][0], -dR[iat][1], -dR[iat][2]}};
     std::vector<ParticleSet::PosType> deltaV2{{-dR[iat][0], -dR[iat][1], -dR[iat][2]}};

--- a/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
@@ -370,10 +370,10 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
   const int ei_table_index = elec_.addTable(ions_);
   const auto& ei_table1    = elec_.getDistTableAB(ei_table_index);
   // make virtual move of elec 0, reference ion 1
-  NLPPJob<RealType> job1(1, 0, ei_table1.getDistances()[0][1], -ei_table1.getDisplacements()[0][1]);
+  NLPPJob<RealType> job1(1, 0, ei_table1.getDistances()[0][1], -ei_table1.getDisplacements()[0][1], 0);
   const auto& ei_table2 = elec_clone.getDistTableAB(ei_table_index);
   // make virtual move of elec 1, reference ion 3
-  NLPPJob<RealType> job2(3, 1, ei_table2.getDistances()[1][3], -ei_table2.getDisplacements()[1][3]);
+  NLPPJob<RealType> job2(3, 1, ei_table2.getDistances()[1][3], -ei_table2.getDisplacements()[1][3], 1);
 
   std::vector<PosType> deltaV1{{0.1, 0.2, 0.3}, {0.1, 0.3, 0.2}, {0.2, 0.1, 0.3}};
   std::vector<PosType> deltaV2{{0.02, 0.01, 0.03}, {0.02, 0.03, 0.01}, {0.03, 0.01, 0.02}};


### PR DESCRIPTION
## Proposed changes
There is no guarantee that NLPP jobs will always be have a particular relation to the number of walkers and they are not processed on a per walker basis, so we should actually require capture the walker's index in the crowd for the purposes of reporting to estimators. This avoids having to reason out the exact relations between NLPPjob multiplicity and across numerous call boundaries.  And should allow NLPP jobs to be refactored more freely.

This should result in no functional change to anything except the EnergyDensityEstimator values and at this point does not change them.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)
- Documentation or build script changes
- Other (please describe):

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
a30four
## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [ ] I have read the pull request guidance and develop docs
* * [ ] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
