### PR TITLE
Raise CUDA minimal version to 12.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -684,7 +684,7 @@ if(ENABLE_CUDA AND NOT QMC_CUDA2HIP)
   if(ENABLE_CUDA)
     include(TestCUDAHostCompatibility)
   endif()
-  find_package(CUDAToolkit 11.0 REQUIRED)
+  find_package(CUDAToolkit 12.3 REQUIRED)
   if(NOT TARGET CUDA::cublas)
     message(
       FATAL_ERROR


### PR DESCRIPTION
## Proposed changes
12.3 is a good version based on an old issue https://github.com/QMCPACK/qmcpack/issues/3922
CUDA Toolkit 12.3 was officially released by NVIDIA on October 19, 2023. Over two years old.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
