### PR TITLE
Introduce QMC_DOXYGEN to enable doxygen documentation target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ set(VALID_SANITIZERS "asan" "ubsan" "tsan" "msan" "typesan")
 set(ENABLE_SANITIZER "" CACHE STRING "Valid input: ${VALID_SANITIZERS} or left empty")
 
 option(QMC_INSTALL_NEXUS "Install Nexus alongside QMCPACK" ON)
+option(QMC_DOXYGEN "Enable use of Doxygen documentation generator tool" ON)
 
 ######################################################################
 # Set compiler specific options/flags
@@ -1059,7 +1060,9 @@ message(STATUS "Ready to parse QMCPACK source tree")
 
 add_subdirectory(external_codes)
 add_subdirectory(src)
-add_subdirectory(doxygen)
+if(QMC_DOXYGEN)
+  add_subdirectory(doxygen)
+endif(QMC_DOXYGEN)
 
 if(NOT QMC_BUILD_SANDBOX_ONLY)
   if(NOT QMC_NO_SLOW_CUSTOM_TESTING_COMMANDS)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -351,7 +351,6 @@ the path to the source directory.
                          Also supported: CMAKE_CXX_FLAGS_DEBUG,
                          CMAKE_CXX_FLAGS_RELEASE, and CMAKE_CXX_FLAGS_RELWITHDEBINFO
     CMAKE_INSTALL_PREFIX Set the install location (if using the optional install step)
-    QMC_INSTALL_NEXUS    Install Nexus alongside QMCPACK (if using the optional install step)
 
 - Additional QMCPACK build options
 
@@ -377,6 +376,8 @@ the path to the source directory.
     ENABLE_PPCONVERT       ON/OFF. Enable the ppconvert tool. If requirements are met, it is ON by default.
     USE_OBJECT_TARGET      ON/OFF(default). Use CMake object library targets to workaround linker not being able to handle hybrid
                            binary archives which contain both host and device codes.
+    QMC_INSTALL_NEXUS      ON(default)/OFF. Install Nexus alongside QMCPACK (if using the optional install step).
+    QMC_DOXYGEN            ON(default)/OFF. Enable use of Doxygen documentation generator tool.
 
 - Expert performance fine tuning options
 


### PR DESCRIPTION
## Proposed changes
Tripped by `find_package(Doxygen)` failure caused by a broken doxygen toolchain.
Now at least we have a way to opt it out.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?

- Yes
- No

## What systems has this change been tested on?
laptop

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
