### PR TITLE
Nexus: Add `pathlib.Path` support to `basisset.py`

### DIFF
--- a/nexus/nexus/basisset.py
+++ b/nexus/nexus/basisset.py
@@ -4,6 +4,7 @@
 
 
 import os
+from pathlib import Path
 import numpy as np
 from .periodic_table import is_element
 from .developer import DevBase, obj, error, to_str, unavailable
@@ -32,7 +33,7 @@ class BasisSets(DevBase):
         for bs in basissets:
             if isinstance(bs,BasisFile):
                 bss.append(bs)
-            elif isinstance(bs,str):
+            elif isinstance(bs,(str, Path)):
                 bsfiles.append(bs)
             else:
                 self.error('expected BasisFile type or filepath, got '+str(type(bs)),exit=False)
@@ -70,12 +71,13 @@ class BasisSets(DevBase):
         self.log('')
         self.log('  Basissets')
         for filepath in bsfiles:
-            self.log('    reading basis: '+filepath)
-            ext = filepath.split('.')[-1].lower()
+            filepath_str = str(filepath)
+            self.log('    reading basis: '+filepath_str)
+            ext = filepath_str.split('.')[-1].lower()
             if ext=='gms_bas' or ext=='bas':
-                bs = gamessBasisFile(filepath)
+                bs = gamessBasisFile(filepath_str)
             else:
-                bs = BasisFile(filepath)
+                bs = BasisFile(filepath_str)
             #end if
             bss.append(bs)
         #end for
@@ -108,7 +110,7 @@ class BasisFile(DevBase):
         self.location      = None
         if filepath is not None:
             self.filename = os.path.basename(filepath)
-            self.location = os.path.abspath(filepath)
+            self.location = os.path.realpath(filepath)
             elem_label = self.filename.split('.')[0]
             is_elem,symbol = is_element(elem_label,symbol=True)
             if not is_elem:
@@ -123,8 +125,6 @@ class BasisFile(DevBase):
         self.not_implemented()
     #end def cleaned_text
 #end class BasisFile
-
-
 
 
 class gaussBasisFile(BasisFile):
@@ -160,7 +160,6 @@ class gaussBasisFile(BasisFile):
         self.not_implemented()
     #end def read_file
 #end class gaussBasisFile
-
 
 
 class gamessBasisFile(gaussBasisFile):
@@ -203,11 +202,6 @@ class gamessBasisFile(gaussBasisFile):
     #end def read_file
 #end class gamessBasisFile
 
-
-
-
-
- 
 
 def process_gaussian_text(text,format,pp=True,basis=True,preserve_spacing=False):
     if format=='gamess' or format=='gaussian' or format=='atomscf':
@@ -289,8 +283,6 @@ def process_gaussian_text(text,format,pp=True,basis=True,preserve_spacing=False)
         error('must request pp or basis')
     #end if
 #end def process_gaussian_text
-
-
 
 
 class GaussianBasisSet(DevBase):
@@ -433,7 +425,6 @@ class GaussianBasisSet(DevBase):
     #end def read_lines
 
 
-    
     def write_text(self,format=None,occ=None):
         text = ''
         format = format.lower()


### PR DESCRIPTION
## Proposed changes

This adds support to `basisset.py` for `pathlib.Path` objects, does a bit of whitespace cleanup, and additionally changes an instance of `os.path.abspath` to `os.path.realpath`, which is far more likely to *actually* give an absolute file path, unlike `abspath`.

## What type(s) of changes does this code introduce?

- New feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora 43, Python 3.14.2

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'