### PR TITLE
Update Dockerfiles for upcoming Pytest changes

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -172,7 +172,7 @@ jobs:
         run: |
           brew upgrade || brew link --overwrite python@3.12
           brew install gcc@14 ninja hdf5 fftw boost
-          python3 -m pip install numpy h5py
+          python3 -m pip install numpy h5py pytest pytest-cov pytest-order
 
       - name: Configure
         run: tests/test_automation/github-actions/ci/run_step.sh configure

--- a/config/docker/dependencies/centos10/Dockerfile
+++ b/config/docker/dependencies/centos10/Dockerfile
@@ -11,6 +11,9 @@ RUN dnf install -y ninja-build
 RUN dnf install -y rsync # Nexus hard requirement
 RUN dnf install -y python3-numpy
 RUN dnf install -y python3-h5py
+RUN dnf install -y python3-pytest
+RUN dnf install -y python3-pytest-cov
+RUN dnf install -y python3-pytest-order
 
 ## Add a user different from root for OpenMPI
 RUN adduser -u 1000 -d /home/user -s /bin/bash user

--- a/config/docker/dependencies/ubuntu22/clang/Dockerfile
+++ b/config/docker/dependencies/ubuntu22/clang/Dockerfile
@@ -24,6 +24,7 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
     sudo \
     curl \
     rsync \
+    python3-numpy python3-pytest python3-pytest-cov python3-pytest-order \
     wget \
     software-properties-common \
     vim \

--- a/config/docker/dependencies/ubuntu22/openmpi/Dockerfile
+++ b/config/docker/dependencies/ubuntu22/openmpi/Dockerfile
@@ -45,6 +45,8 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
     python3-pandas \
     python3-coverage \
     python3-pytest \
+    python3-pytest-cov \
+    python3-pytest-order \
     python3-pip \
     -y
 

--- a/config/docker/dependencies/ubuntu22/serial/Dockerfile
+++ b/config/docker/dependencies/ubuntu22/serial/Dockerfile
@@ -43,6 +43,8 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
     python3-pandas \
     python3-coverage \
     python3-pytest \
+    python3-pytest-cov \
+    python3-pytest-order \
     python3-pip \
     -y
 

--- a/nexus/nexus/tests/CMakeLists.txt
+++ b/nexus/nexus/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 include("${PROJECT_SOURCE_DIR}/CMake/test_labels.cmake")
 include("${PROJECT_SOURCE_DIR}/CMake/python.cmake")
 
-check_python_reqs("numpy;pytest;pytest_cov;pytest_order" "nexus base" ADD_TEST)
+check_python_reqs(numpy "nexus base" ADD_TEST)
 
 if(ADD_TEST)
   file(TIMESTAMP ${qmcpack_SOURCE_DIR}/nexus/nexus/bin/nxs-test NEXUS_TESTLIST_TIMESTAMP)

--- a/nexus/nexus/tests/CMakeLists.txt
+++ b/nexus/nexus/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 include("${PROJECT_SOURCE_DIR}/CMake/test_labels.cmake")
 include("${PROJECT_SOURCE_DIR}/CMake/python.cmake")
 
-check_python_reqs(numpy "nexus base" ADD_TEST)
+check_python_reqs("numpy;pytest;pytest_cov;pytest_order" "nexus base" ADD_TEST)
 
 if(ADD_TEST)
   file(TIMESTAMP ${qmcpack_SOURCE_DIR}/nexus/nexus/bin/nxs-test NEXUS_TESTLIST_TIMESTAMP)

--- a/nexus/pyproject.toml
+++ b/nexus/pyproject.toml
@@ -26,6 +26,8 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "coverage[toml]>=7.13.5; python-version < '3.11'",
+    "coverage>=7.13.5; python-version >= '3.11'",
     "pytest-cov>=7.0.0",
 ]
 

--- a/tests/test_automation/containers/Dockerfile_gcc_mpi_develop_complete
+++ b/tests/test_automation/containers/Dockerfile_gcc_mpi_develop_complete
@@ -28,7 +28,8 @@ RUN groupadd --gid $USER_GID $USERNAME \
 RUN apt-get install -y --no-install-recommends \
     ca-certificates make ninja-build git cmake wget bzip2 rsync  g++ gfortran openmpi-bin libopenmpi-dev libboost-dev \
     libopenblas-openmp-dev libhdf5-dev libxml2-dev libfftw3-dev \
-    python3-numpy python3-scipy python3-pandas python3-h5py python3-matplotlib
+    python3-numpy python3-scipy python3-pandas python3-h5py python3-matplotlib \
+    python3-pytest python3-pytest-cov python3-pytest-order
 
 # Convenience feature to setup certificates for behind firewall builds.
 # * Copy any provided certificates into the container and update the SSL config


### PR DESCRIPTION
## Proposed changes

This updates the various Dockerfiles for the upcoming migration to Pytest.

- [x] Add Pytest packages to Clang Dockerfiles

## What type(s) of changes does this code introduce?

- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- Potentially

## What systems has this change been tested on?

Desktop, Fedora 43 KDE Plasma, Python 3.14.3

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'