### PR TITLE
Nexus: Ensure all non-dependency-locked tests are in `nxs-test`

### DIFF
--- a/nexus/nexus/bin/nxs-test
+++ b/nexus/nexus/bin/nxs-test
@@ -734,6 +734,7 @@ def periodic_table():
     nunit('representation')
 
     nunit_all()
+#end def periodic_table
 
 
 

--- a/nexus/nexus/bin/nxs-test
+++ b/nexus/nexus/bin/nxs-test
@@ -725,10 +725,15 @@ def periodic_table():
 
     nunit('periodic_table')
 
+    nunit('call_elements')
+
     nunit('is_element')
 
+    nunit('element_set')
+
+    nunit('representation')
+
     nunit_all()
-#end def periodic_table
 
 
 
@@ -746,6 +751,8 @@ def numerics():
     nunit('simstats')
 
     nunit('equilibration_length')
+
+    nunit('jackknife')
 
     nunit('morse')
 
@@ -800,6 +807,8 @@ def grid_functions():
     nunit('grid_cell_volumes')
 
     nunit('grid_unit_metric')
+
+    nunit('grid_function_initialization')
 
     # GridFunction tests
 
@@ -872,6 +881,10 @@ def structure():
     nunit('generate_init')
 
     nunit('crystal_init')
+
+    nunit('change_units')
+
+    nunit('rotate')
 
     nunit('diagonal_tiling')
 
@@ -1330,6 +1343,8 @@ def qmcpack_input():
     nunit('generate_kspace_jastrow')
 
     nunit('excited_state')
+
+    nunit('magnetization_density')
 
     nunit_all()
 #end def qmcpack_input


### PR DESCRIPTION
## Proposed changes

This PR makes sure that any Nexus tests that are not locked behind dependencies (e.g. scipy, h5py, etc.) are included explicitly in `nxs-test` so that, while it remains the testing system, it will cover all necessary tests.

Below I've attached a list of all tests in Nexus, with those that are locked behind dependencies being marked with a `#`, as well as their dependency specified.

[nxs-test-order.txt](https://github.com/user-attachments/files/26439658/nxs-test-order.txt)

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora 43 KDE Plasma, Python 3.14.2, `uv` 0.11.3

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'