### PR TITLE
Remove/reduce pytest packages from centos CI and complete Dockerfiles

### DIFF
--- a/config/docker/dependencies/centos10/Dockerfile
+++ b/config/docker/dependencies/centos10/Dockerfile
@@ -11,9 +11,7 @@ RUN dnf install -y ninja-build
 RUN dnf install -y rsync # Nexus hard requirement
 RUN dnf install -y python3-numpy
 RUN dnf install -y python3-h5py
-RUN dnf install -y python3-pytest
-RUN dnf install -y python3-pytest-cov
-RUN dnf install -y python3-pytest-order
+#RUN dnf install -y python3-pytest # Ensure build works without pytest available.
 
 ## Add a user different from root for OpenMPI
 RUN adduser -u 1000 -d /home/user -s /bin/bash user

--- a/tests/test_automation/containers/Dockerfile_gcc_mpi_develop_complete
+++ b/tests/test_automation/containers/Dockerfile_gcc_mpi_develop_complete
@@ -29,7 +29,7 @@ RUN apt-get install -y --no-install-recommends \
     ca-certificates make ninja-build git cmake wget bzip2 rsync  g++ gfortran openmpi-bin libopenmpi-dev libboost-dev \
     libopenblas-openmp-dev libhdf5-dev libxml2-dev libfftw3-dev \
     python3-numpy python3-scipy python3-pandas python3-h5py python3-matplotlib \
-    python3-pytest python3-pytest-cov python3-pytest-order
+    python3-pytest
 
 # Convenience feature to setup certificates for behind firewall builds.
 # * Copy any provided certificates into the container and update the SSL config


### PR DESCRIPTION
## Proposed changes

Review before Nexus testing updates

Ensure we have a CI configuration (centos) without pytest available to ensure that the builds work as expected without pytest available. The ubuntu-based CI containers have pytest and extras.

Remove the pytest "extras" from the complete dockerfile to hopefully allow it to build

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
