### PR TITLE
Updated nightly testing spack configuration and scripts

### DIFF
--- a/tests/test_automation/nightly_test_scripts/nightly_ornl.sh
+++ b/tests/test_automation/nightly_test_scripts/nightly_ornl.sh
@@ -78,9 +78,13 @@ case "$ourhostname" in
 		clangoffloadnompi_offloadcuda_mixed_complex \
                 clangoffloadnompi_offloadcuda_debug \
                 clangoffloadnompi_offloadcuda_complex_debug \
+                clangoffloadnompi_offloadcpu \				    
+                clangnewmpi clangnewmpi_mixed clangnewmpi_complex clangnewmpi_mixed_complex \
+		clangnewnompi_debug clangnewnompi_debug_asan \
                 gccnewnompi_debug_asan gccnewnompi_debug_ubsan \
-                gccnewmpi_mkl clangnewmpi gccnewnompi gccnewmpi gccoldmpi clangnewmpi_complex gccnewnompi_complex gccnewmpi_complex \
-                clangnewmpi_mixed gccnewnompi_mixed gccnewmpi_mixed clangnewmpi_mixed_complex gccnewnompi_mixed_complex gccnewmpi_mixed_complex"
+                gccnewmpi gccnewmpi_mkl gccnewnompi gccnewnompi_complex gccnewmpi_complex \
+                gccnewnompi_mixed gccnewmpi_mixed gccnewnompi_mixed_complex gccnewmpi_mixed_complex \
+                gccoldmpi"
 	else
 	    buildsys="gccnewmpi_mkl clangnewmpi gccnewmpi clangnewmpi_complex clangnewmpi_mixed clangnewmpi_mixed_complex clangoffloadmpi_offloadcuda"
 	fi
@@ -88,14 +92,16 @@ case "$ourhostname" in
 	;;
     nitrogen2 )
 	if [[ $jobtype == "nightly" ]]; then
-	    buildsys="amdclangnompi_offloadhip_complex \
-		amdclangnompi_offloadhip amdclangnompi_offloadhip_debug \
-		amdclangnompi_offloadhip_complex_debug \
-		amdclangnompi_offloadhip_mixed amdclangnompi_offloadhip_mixed_debug \
-		amdclangnompi_offloadhip_mixed_complex amdclangnompi_offloadhip_mixed_complex_debug \
-                gccnewnompi gccnewnompi_aocl gccnewnompi_complex gccnewnompi_debug gccnewnompi_complex_debug \
-                gccnewnompi_mixed_debug gccnewnompi_mixed_complex_debug gccnewnompi_aocl_mixed_complex_debug gccnewmpi gccnewmpi_aocl clangnewmpi \
-		amdclangnompi amdclangnompi_debug"
+	    buildsys="gccoldmpi_aocl gccoldnompi_aocl_mixed_complex_debug gccoldnompi gccoldnompi_debug \
+		      amdclangnompi_offloadhip_complex \
+		      amdclangnompi_offloadhip amdclangnompi_offloadhip_debug \
+		      amdclangnompi_offloadhip_complex_debug \
+		      amdclangnompi_offloadhip_mixed amdclangnompi_offloadhip_mixed_debug \
+		      amdclangnompi_offloadhip_mixed_complex amdclangnompi_offloadhip_mixed_complex_debug \
+                      gccnewnompi gccnewnompi_complex gccnewnompi_debug gccnewnompi_complex_debug \
+                      gccnewnompi_mixed_debug gccnewnompi_mixed_complex_debug gccnewmpi \
+                      clangnewmpi \
+		      amdclangnompi amdclangnompi_debug"
 	else
 	    buildsys="gccnewmpi gccnewmpi_aocl amdclangnompi gccnewnompi gccnewnompi_aocl clangnewmpi amdclangnompi_offloadhip"
 	fi
@@ -179,7 +185,7 @@ module() { eval `/usr/bin/modulecmd bash $*`; }
 
 export SPACK_USER_CONFIG_PATH=$HOME/apps/spack_user_config  # Avoid using $HOME/.spack
 export SPACK_ROOT=$HOME/apps/spack
-export PATH=$SPACK_ROOT/bin:$PATH
+#export PATH=$SPACK_ROOT/bin:$PATH
 . $SPACK_ROOT/share/spack/setup-env.sh
 
 
@@ -216,7 +222,8 @@ fi
 # Sanity check cmake config file present
 if [ -e qmcpack/CMakeLists.txt ]; then
 
-export PYTHONPATH=${test_dir}/qmcpack/nexus
+# TODO: Update PYTHONPATH for modern tool location
+#export PYTHONPATH=${test_dir}/qmcpack/nexus/lib
 echo --- PYTHONPATH=$PYTHONPATH
 
 echo --- Starting test builds and tests
@@ -242,29 +249,33 @@ cd build_$sys
 ourenv=env${syscompilermpi}
 echo --- Activating environment $ourenv
 spack env activate $ourenv
-echo --- Sourcing environment $ourenv
-if [ ! -e $HOME/apps/spack/var/spack/environments/$ourenv/loads ]; then
-    echo Loads file missing for environment $ourenv
-    exit 1
-fi
-source $HOME/apps/spack/var/spack/environments/$ourenv/loads    
+#MAR26retcode=$?
+#MAR26if (( rc != 0 )); then
+#MAR26  echo "FAILED to activate $ourenv (exit code $rc)"
+#MAR26  break
+#MAR26else
+#MAR26  echo "Successfully activated $ourenv"
+#MAR26fi
+#MAR26 TODO: Verify views work
+#MAR26echo --- Sourcing environment $ourenv
+#MAR26if [ ! -e $HOME/apps/spack/var/spack/environments/$ourenv/loads ]; then
+#MAR26    echo Loads file missing for environment $ourenv
+#MAR26    exit 1
+#MAR26fi
+#MAR26 source $HOME/apps/spack/var/spack/environments/$ourenv/loads    
 # Compiler sanity check:
-which gcc
-which clang
-which mpicc
+echo "gcc is `which gcc`"
+echo "clang is `which clang`"
+echo "mpicc is `which mpicc`"
 # Extra configuration for this build
 # All base sw should be available via the environments
 
 # Ensure GNU C++ library available. Problem symptoms:
 # $ bin/qmcpack
 # bin/qmcpack: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by bin/qmcpack)
-
-echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`which gcc|sed 's/bin\/gcc/lib64/g'`
-echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH
-
-
-
+#MAR26#echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+#MAR26#export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`which gcc|sed 's/bin\/gcc/lib64/g'`
+#MAR26#echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 # Setup additional python paths when gccnew and therefore pyscf available. TO DO: test for module availability
 case "$sys" in
@@ -364,13 +375,20 @@ if [[ $sys == *"clang"* ]]; then
     
 # Clang OpenMP offload CUDA builds. Setup here due to clang specific arguments
     if [[ $sys == *"offloadcuda"* ]]; then
-        QMCPACK_TEST_SUBMIT_NAME=${QMCPACK_TEST_SUBMIT_NAME}-NVGPU
+	# Default OpenMP offload with CUDA support
+        QMCPACK_TEST_SUBMIT_NAME=${QMCPACK_TEST_SUBMIT_NAME}-Offload-NVGPU
         CMCFG="$CMCFG -DCMAKE_CXX_FLAGS=-Wno-unknown-cuda-version"
 	QMC_OPTIONS="${QMC_OPTIONS};-DQMC_GPU_ARCHS=sm_70"
     fi
     if [[ $sys == *"offloadhip"* ]]; then
-        QMCPACK_TEST_SUBMIT_NAME=${QMCPACK_TEST_SUBMIT_NAME}-AMDGPU
+	# Default OpenMP offload with ROCm/HIP support
+        QMCPACK_TEST_SUBMIT_NAME=${QMCPACK_TEST_SUBMIT_NAME}-Offload-AMDGPU
 	QMC_OPTIONS="${QMC_OPTIONS};-DQMC_GPU_ARCHS=$amdgpuarch"
+    fi
+    if [[ $sys == *"offloadcpu"* ]]; then
+	# Pure OpenMP offload to host cpu (i.e. no GPU required)
+        QMCPACK_TEST_SUBMIT_NAME=${QMCPACK_TEST_SUBMIT_NAME}-Offload-CPU
+	QMC_OPTIONS="${QMC_OPTIONS};-DQMC_GPU=openmp;-DOFFLOAD_TARGET=x86_64-pc-linux-gnu"
     fi
 fi
 
@@ -441,6 +459,16 @@ else
 	export QMC_OPTIONS="${QMC_OPTIONS};-DBLA_VENDOR=OpenBLAS"
     fi
 fi
+
+# END of compiler setup
+if [[ $sys == *"nompi"* ]]; then
+echo MPI is disabled
+else
+    echo MPI is enabled
+    echo OMPI_CC=$OMPI_CC
+    echo OMPI_CXX=$OMPI_CXX
+fi
+
 
 # Complex
 if [[ $sys == *"complex"* ]]; then

--- a/tests/test_automation/nightly_test_scripts/ornl_setup.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_setup.sh
@@ -45,9 +45,6 @@ ourhostname=`hostname|sed 's/\..*//g'`
 echo --- Host is $ourhostname
 
 export SPACK_ROOT=$HOME/apps/spack
-if [ -e $SPACK_ROOT ]; then
-    rm -r -f $SPACK_ROOT
-fi
 export SPACK_USER_CONFIG_PATH=$HOME/apps/spack_user_config  # Avoid using $HOME/.spack
 if [ ! -e $SPACK_USER_CONFIG_PATH ]; then
     mkdir $SPACK_USER_CONFIG_PATH
@@ -58,6 +55,26 @@ fi
 if [ -e $HOME/.spack ]; then
     rm -r -f $HOME/.spack 
 fi
+
+
+# Pin the version of the package repository for reproducibility
+# Docs: https://spack.readthedocs.io/en/latest/repositories.html#updating-and-pinning
+# The package repo will be at something like ~/.spack/package_repos/fncqgg4/
+
+cat >>$SPACK_USER_CONFIG_PATH/repos.yaml<<EOF
+repos:
+  builtin:
+    commit: ba81a382694253e885f2f3012992ed8d7df2fe08
+
+#commit ba81a382694253e885f2f3012992ed8d7df2fe08 (HEAD -> develop, origin/develop)
+#Author: Alec Scott <scott112@llnl.gov>
+#Date:   Wed Apr 8 16:29:47 2026 -0700
+#
+#    helm: new package (#4179)
+#
+#    Signed-off-by: Alec Scott <alec@llnl.gov>
+EOF
+
 
 # Setup build multiplicity and preferred directories for spack
 # Choose the fastest filesytem. Don't abuse shared nodes.
@@ -85,7 +102,6 @@ packages:
         externals:
         - spec: openssl@1.1.1k
           prefix: /usr
-          buildable: False
 EOF
 ;;
     nitrogen )
@@ -111,7 +127,6 @@ packages:
         externals:
         - spec: openssl@1.1.1k
           prefix: /usr
-          buildable: False
 EOF
 ;;
     sulfur )
@@ -137,7 +152,6 @@ packages:
         externals:
         - spec: openssl@1.1.1k
           prefix: /usr
-          buildable: False
 EOF
 	;;
     *)
@@ -178,30 +192,35 @@ fi
 
 cd $HOME/apps
 
-if [ -e $HOME/apps/spack ]; then
-    rm -r -f $HOME/apps/spack
+if [ -e spack ]; then
+    cd spack
+    echo -- Resetting existing spack git repo
+    git checkout -f
+    git clean -fd
+    git checkout develop
+    git pull
+    cd ..
+else
+    git clone https://github.com/spack/spack.git
 fi
-
-git clone https://github.com/spack/spack.git
 
 if [ ! -e spack/CHANGELOG.md ]; then
     echo "--- FAILED TO FIND spack/CHANGELOG.md . BAD CLONE or I/O PROBLEMS. ABORTING"
     exit 1	 
 fi
 
-cd $HOME/apps/spack
-
+cd $SPACK_ROOT
 # For reproducibility, use a specific version of Spack
 # Prefer to use tagged releases https://github.com/spack/spack/releases
-git checkout b8c31b22a5d1619d0137bc3fc69e24389ca436fb
-#commit b8c31b22a5d1619d0137bc3fc69e24389ca436fb (HEAD -> develop, origin/develop, origin/HEAD)
+git checkout 45b9069e4997f4b453b2770886b1e8ba790980f4
+#commit 45b9069e4997f4b453b2770886b1e8ba790980f4 (HEAD -> develop, origin/develop, origin/HEAD)
 #Author: Harmen Stoppels <me@harmenstoppels.nl>
-#Date:   Fri May 16 12:09:20 2025 +0200
+#Date:   Wed Apr 8 14:38:32 2026 +0200
 #
-#    builtin: crlf -> lf (#50505)
+#    new_installer.py: sub_process < /dev/null (#52221)
 
 # Limit overly strong rmg boost dependency to allow concretizer:unify:true
-sed -ibak 's/boost@1.61.0:1.82.0/boost@1.61.0:1.82.0", when="@:6.1.2/g' var/spack/repos/spack_repo/builtin/packages/rmgdft/package.py
+#sed -ibak 's/boost@1.61.0:1.82.0/boost@1.61.0:1.82.0", when="@:6.1.2/g' var/spack/repos/spack_repo/builtin/packages/rmgdft/package.py
 
 echo --- Git version and last log entry
 git log -1
@@ -213,70 +232,107 @@ cd bin
 # Consider using a GCC toolset on Red Hat systems to use
 # recent compilers with better architecture support.
 # e.g. dnf install gcc-toolset-14
-if [ -e /opt/rh/gcc-toolset-14/enable ]; then
-    echo --- Using gcc-toolset-14 for newer compilers
-    source /opt/rh/gcc-toolset-14/enable 
-fi
+#if [ -e /opt/rh/gcc-toolset-14/enable ]; then
+#    echo --- Using gcc-toolset-14 for newer compilers
+#    source /opt/rh/gcc-toolset-14/enable 
+#fi
 
 export DISPLAY="" 
-export SPACK_ROOT=$HOME/apps/spack
-export SPACK_USER_CONFIG_PATH=$HOME/apps/spack_user_config  # Avoid using $HOME/.spack
+# SPACK_ROOT & SPACK_USER_CONFIG_PATH already set
 export PATH=$SPACK_ROOT/bin:$PATH
 . $SPACK_ROOT/share/spack/setup-env.sh
 echo --- Bootstrap
 spack bootstrap now
+spack gpg init
+
+echo --- Setup/use mirror in /scratch/$USER/spack_mirror
+if [ ! -e /scratch/$USER/spack_mirror ];then
+    mkdir /scratch/$USER/spack_mirror
+    #spack mirror create -d /scratch/$USER/spack_mirror #  Will error due to no packages
+else
+    echo --- Mirror already exists. Carefully consider if refresh needed after major spack updates.
+    du -ksh /scratch/$USER/spack_mirror
+fi
+spack mirror add localmirror /scratch/$USER/spack_mirror
+spack buildcache update-index /scratch/$USER/spack_mirror
+spack mirror set --autopush localmirror  # enable automatic push for an existing mirror
+spack mirror set --unsigned localmirror  # disable signing and verification
 
 echo --- Spack list
 spack find
+echo --- Spack compilers
+spack compilers
+echo --- Spack compiler find
+spack compiler find
+echo --- Spack compilers
+spack compilers
 echo --- Modules list
 module list
 echo --- End listings
 
-echo --- gcc@${gcc_vnew} `date`
-spack install gcc@${gcc_vnew}
-echo --- load gcc@${gcc_vnew}
-spack load gcc@${gcc_vnew}
-module list
-spack compiler find
-spack unload gcc@${gcc_vnew}
-echo --- gcc@${gcc_vold}  `date`
-spack install gcc@${gcc_vold}
-echo --- load gcc@${gcc_vold}
-spack load gcc@${gcc_vold}
-module list
-spack compiler find
-spack unload gcc@${gcc_vold}
-echo --- gcc@${gcc_vcuda}
-spack install gcc@${gcc_vcuda}
-spack load gcc@${gcc_vcuda}
-spack compiler find
-spack unload gcc@${gcc_vcuda}
-if [ "$ourplatform" == "Intel" ]; then
-echo --- gcc@${gcc_vintel}  `date`
-spack install gcc@${gcc_vintel}
-spack load gcc@${gcc_vintel}
-spack compiler find
-spack unload gcc@${gcc_vintel}
-fi
-echo --- gcc@${gcc_vnvhpc}  `date`
-spack install gcc@${gcc_vnvhpc}
-spack load gcc@${gcc_vnvhpc}
-spack compiler find
-spack unload gcc@${gcc_vnvhpc}
-echo --- llvm@${llvm_vnew}  `date`
-spack install llvm@${llvm_vnew}
-spack load llvm@${llvm_vnew}
-spack compiler find
-spack unload llvm@${llvm_vnew}
+#DEBUGecho --- Screen llvm compilations
+#DEBUGecho --- Trying without cuda_arch
+#DEBUGecho --- llvm@22 for offload  `date`
+#DEBUGspack spec llvm@22 +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+#DEBUGspack install llvm@22 +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+#DEBUGspack load llvm@22 +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+#DEBUGspack unload llvm
+#DEBUGecho --- llvm@21 for offload  `date`
+#DEBUGspack spec llvm@21 +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+#DEBUGspack install llvm@21 +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+#DEBUGspack load llvm@21 +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+#DEBUGspack unload llvm
+#DEBUGecho --- llvm@20 for offload  `date`
+#DEBUGspack spec llvm@20 +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+#DEBUGspack install llvm@20 +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+#DEBUGspack load llvm@20 +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+#DEBUGspack unload llvm
+#DEBUGecho --- llvm@19 for offload  `date`
+#DEBUGspack spec llvm@19 +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+#DEBUGspack install llvm@19 +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+#DEBUGspack load llvm@19 +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+#DEBUGspack unload llvm
+
+# 2026-03-28: Install LLVM first. Will use system gcc and avoid problems/spack bugs with newer gcc, binutils etc.
 echo --- llvm@${llvm_voffload} for offload  `date`
-spack install gcc@${gcc_vllvmoffload}
-spack install cuda@${cuda_voffload} +allow-unsupported-compilers
-spack load cuda@${cuda_voffload} +allow-unsupported-compilers
-spack install llvm@${llvm_voffload} targets=all ^gcc@${gcc_vllvmoffload}
-spack load llvm@${llvm_voffload}  targets=all  ^gcc@${gcc_vllvmoffload}
-spack compiler find
-spack unload llvm@${llvm_voffload}
-spack unload cuda@${cuda_voffload}
+
+spack spec llvm@${llvm_voffload} openmp=project +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+spack install llvm@${llvm_voffload} openmp=project +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+spack load llvm@${llvm_voffload} openmp=project +libomptarget +libomptarget_debug ^cuda@${cuda_voffload} +allow-unsupported-compilers
+spack unload llvm
+
+echo --- llvm@${llvm_vnew}  `date`
+if [ "${llvm_vnew}" == "${llvm_voffload}" ]; then
+    echo Skipping: Offload and New LLVM versions are identical
+else
+    spack install llvm@${llvm_vnew} openmp=project
+    spack load llvm@${llvm_vnew} openmp=project
+    spack compiler find
+    spack unload llvm@${llvm_vnew}
+fi
+
+echo --- gcc@${gcc_vold}  `date`
+if [ "${gcc_vllvmoffload}" == "${gcc_vold}" ]; then
+    echo Skipping: Already available via offload version
+else
+    spack install gcc@${gcc_vold}
+    spack load gcc@${gcc_vold}
+    module list
+    spack compiler find
+    spack unload gcc@${gcc_vold}
+fi
+
+echo --- gcc@${gcc_vnew} `date`
+if [ "${gcc_vllvmoffload}" == "${gcc_vnew}" ] || [ "${gcc_vold}" == "${gcc_vnew}" ] ; then
+    echo Skipping: Already available via offload or old versions
+else
+    spack install gcc@${gcc_vnew}
+    spack load gcc@${gcc_vnew}
+    module list
+    spack compiler find
+    spack unload gcc@${gcc_vnew}
+fi
+
 echo --- Spack compilers  `date`
 spack compilers
 echo --- Modules list

--- a/tests/test_automation/nightly_test_scripts/ornl_setup_environments.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_setup_environments.sh
@@ -2,12 +2,15 @@
 
 echo --- START environment setup `date`
 
+command -v spack >/dev/null 2>&1 || { echo "Error: spack not found on PATH." >&2; exit 1; }
+
 # serial   : single install
 # 8up      : 8 installs
 # par48    : install -j 48 
 # makefile : make -j
 
 parallelmode=par48
+#parallelmode=makefile
 
 install_environment () {
 case "$parallelmode" in
@@ -34,7 +37,7 @@ case "$parallelmode" in
 	echo --- Install via parallel make
 	spack concretize
 	spack env depfile >Makefile
-	make -j
+	make -j 48 SPACK_COLOR=always --output-sync=recurse
 	;;
     * )
 	echo Unknown parallelmode
@@ -76,45 +79,63 @@ echo --- Host is $ourhostname
 echo --- Using spack `which spack`
 echo --- SPACK_USER_CONFIG_PATH=$SPACK_USER_CONFIG_PATH
 
-theenv=envgccnewmpi
+for havempi in mpi nompi
+do	       
+
+theenv=envgccnew${havempi}
 echo --- Setting up $theenv `date`
 spack env create $theenv
-#spack -e $theenv config add "concretizer:unify:when_possible"
 spack -e $theenv config add "concretizer:unify:true"
 spack env activate $theenv
 
 spack add gcc@${gcc_vnew}
+spack add hwloc
 spack add git
 spack add ninja
-spack add cmake@${cmake_vnew}
-spack add libxml2@${libxml2_v}^gcc@${gcc_vnew}
+spack add cmake@${cmake_vnew}^gcc@${gcc_vnew}
+spack add libxml2
 spack add boost@${boost_vnew}^gcc@${gcc_vnew}
 spack add util-linux-uuid^gcc@${gcc_vnew}
 spack add python^gcc@${gcc_vnew}
-spack add openmpi@${ompi_vnew}^gcc@${gcc_vnew}
-spack add hdf5@${hdf5_vnew} +fortran +hl +mpi 
-spack add fftw@${fftw_vnew} -mpi #Avoid MPI for simplicity
-spack add openblas threads=openmp
-if [ "$ourplatform" == "AMD" ]; then
-spack add amdblis; spack add amdlibflame; #spack add amd-aocl
+if [ "$havempi" == "mpi" ]; then
+    spack add openmpi@${ompi_vnew}^gcc@${gcc_vnew}
 fi
+
+if [ "$havempi" == "mpi" ]; then
+    spack add hdf5@${hdf5_vnew} +fortran +hl +mpi ^gcc@${gcc_vnew}
+else
+    spack add hdf5@${hdf5_vnew} +fortran +hl ~mpi ^gcc@${gcc_vnew}
+fi
+
+spack add fftw@${fftw_vnew} -mpi ^gcc@${gcc_vnew} #Avoid MPI for simplicity
+spack add openblas threads=openmp ^gcc@${gcc_vnew} 
+#PK: amdlibflame@5.2 will fail with gcc 15.2.0 as of 2026-03-24.f Link error
+#if [ "$ourplatform" == "AMD" ]; then
+#spack add amdblis; spack add amdlibflame; #spack add amd-aocl
+#fi
 if [ "$ourplatform" == "Intel" ]; then
 spack add intel-oneapi-mkl
 fi
 
-
 spack add py-lxml
 spack add py-matplotlib
 spack add py-pandas
-spack add py-mpi4py
+if [ "$havempi" == "mpi" ]; then
+    spack add py-mpi4py
+fi
+
 spack add py-numpy@${numpy_vnew}
 spack add py-scipy
 spack add py-h5py ^hdf5@${hdf5_vnew}
+
+if [ "$havempi" == "mpi" ]; then
+# Complete install only for MPI environments:
 spack add quantum-espresso +mpi +qmcpack
 export CMAKE_BUILD_PARALLEL_LEVEL=8 # For PySCF
-spack add py-pyscf
-spack add dftd4
-spack add rmgdft
+#spack add py-pyscf  # Does not work with gccnew=15.2
+#spack add dftd4
+#spack add rmgdft@develop # Use develop version to avoid vendored SCALPACK compilation bugs (20250324)
+#spack add rmgdft
 
 #Luxury options for actual science use:
 spack add py-requests # for pseudo helper
@@ -127,29 +148,44 @@ spack add py-pydot    # NEXUS optional
 #spack add py-seekpath # NEXUS optional
 #spack add py-pycifrw  # NEXUS optional
 #NOT IN SPACK spack add py-cif2cell # NEXUS optional
+fi
 
 install_environment
 unset CMAKE_BUILD_PARALLEL_LEVEL
 spack env deactivate
 
-theenv=envgccnewnompi
+done
+
+for havempi in mpi nompi
+do	       
+
+theenv=envgccold${havempi}
 echo --- Setting up $theenv `date`
 spack env create $theenv
-spack -e $theenv config add "concretizer:unify:when_possible"
-#spack -e $theenv config add "concretizer:unify:true"
+spack -e $theenv config add "concretizer:unify:true"
 spack env activate $theenv
 
-spack add gcc@${gcc_vnew}
+spack add gcc@${gcc_vold}
+spack add hwloc
 spack add git
 spack add ninja
-spack add cmake@${cmake_vnew}
-spack add libxml2@${libxml2_v}^gcc@${gcc_vnew}
-spack add boost@${boost_vnew}^gcc@${gcc_vnew}
-spack add util-linux-uuid^gcc@${gcc_vnew}
-spack add python^gcc@${gcc_vnew}
-spack add hdf5@${hdf5_vnew} +fortran +hl ~mpi
-spack add fftw@${fftw_vnew} -mpi #Avoid MPI for simplicity
-spack add openblas threads=openmp
+spack add cmake@${cmake_vold}^gcc@${gcc_vold}
+spack add libxml2
+spack add boost@${boost_vold}^gcc@${gcc_vold}
+spack add util-linux-uuid^gcc@${gcc_vold}
+spack add python^gcc@${gcc_vold}
+if [ "$havempi" == "mpi" ]; then
+    spack add openmpi@${ompi_vnew}^gcc@${gcc_vold}
+fi
+
+if [ "$havempi" == "mpi" ]; then
+    spack add hdf5@${hdf5_vold} +fortran +hl +mpi ^gcc@${gcc_vold}
+else
+    spack add hdf5@${hdf5_vold} +fortran +hl ~mpi ^gcc@${gcc_vold}
+fi
+
+spack add fftw@${fftw_vold} -mpi ^gcc@${gcc_vold} #Avoid MPI for simplicity
+spack add openblas threads=openmp ^gcc@${gcc_vold}
 if [ "$ourplatform" == "AMD" ]; then
 spack add amdblis; spack add amdlibflame; #spack add amd-aocl
 fi
@@ -157,76 +193,25 @@ if [ "$ourplatform" == "Intel" ]; then
 spack add intel-oneapi-mkl
 fi
 
-
 spack add py-lxml
 spack add py-matplotlib
 spack add py-pandas
-spack add py-numpy@${numpy_vnew}
-spack add py-scipy
-spack add py-h5py ^hdf5@${hdf5_vnew}
+if [ "$havempi" == "mpi" ]; then
+    spack add py-mpi4py
+fi
 
-install_environment
-spack env deactivate
-
-theenv=envgccoldnompi
-echo --- Setting up $theenv `date`
-spack env create $theenv
-#spack -e $theenv config add "concretizer:unify:when_possible"
-spack -e $theenv config add "concretizer:unify:true"
-spack env activate $theenv
-
-spack add gcc@${gcc_vold}
-spack add cmake@${cmake_vold}^gcc@${gcc_vold}
-spack add libxml2@${libxml2_v}^gcc@${gcc_vold}
-spack add boost@${boost_vold}^gcc@${gcc_vold}
-spack add util-linux-uuid^gcc@${gcc_vold}
-spack add python^gcc@${gcc_vold}
-spack add hdf5@${hdf5_vold} +fortran +hl ~mpi
-spack add fftw@${fftw_vold} -mpi #Avoid MPI for simplicity
-spack add openblas threads=openmp
-spack add git
-spack add ninja
-
-spack add py-lxml
-spack add py-matplotlib
-spack add py-pandas
 spack add py-numpy@${numpy_vold}
 spack add py-scipy
 spack add py-h5py ^hdf5@${hdf5_vnew}
-install_environment
-spack env deactivate
 
-theenv=envgccoldmpi
-echo --- Setting up $theenv `date`
-spack env create $theenv
-#spack -e $theenv config add "concretizer:unify:when_possible"
-spack -e $theenv config add "concretizer:unify:true"
-spack env activate $theenv
-
-spack add gcc@${gcc_vold}
-spack add cmake@${cmake_vold}^gcc@${gcc_vold}
-spack add libxml2@${libxml2_v}^gcc@${gcc_vold}
-spack add boost@${boost_vold}^gcc@${gcc_vold}
-spack add util-linux-uuid^gcc@${gcc_vold}
-spack add python^gcc@${gcc_vold}
-spack add openmpi@${ompi_vnew}^gcc@${gcc_vold}
-spack add hdf5@${hdf5_vold} +fortran +hl +mpi
-spack add fftw@${fftw_vold} -mpi #Avoid MPI for simplicity
-spack add openblas threads=openmp
-spack add git
-spack add ninja
-
-spack add py-lxml
-spack add py-matplotlib
-spack add py-pandas
-spack add py-mpi4py
-spack add py-numpy@${numpy_vold}
-spack add py-scipy
-spack add py-h5py ^hdf5@${hdf5_vnew}
-#spack add quantum-espresso +mpi +qmcpack # Skip QE, will crash GCC 12.4.0
+if [ "$havempi" == "mpi" ]; then
+# Complete install only for MPI environments:
+spack add quantum-espresso +mpi +qmcpack
 export CMAKE_BUILD_PARALLEL_LEVEL=8 # For PySCF
 spack add py-pyscf
-spack add rmgdft
+#spack add dftd4
+#spack add rmgdft@develop # Use develop version to avoid vendored SCALPACK compilation bugs (20250324)
+#spack add rmgdft
 
 #Luxury options for actual science use:
 spack add py-requests # for pseudo helper
@@ -234,159 +219,140 @@ spack add py-ase      # full Atomic Simulation Environment
 spack add libffi
 spack add graphviz +pangocairo # NEXUS requires optional PNG support in dot
 spack add py-pydot    # NEXUS optional
+
 #spack add py-spglib   # NEXUS optional 
 #spack add py-seekpath # NEXUS optional
 #spack add py-pycifrw  # NEXUS optional
 #NOT IN SPACK spack add py-cif2cell # NEXUS optional
+fi
 
 install_environment
 unset CMAKE_BUILD_PARALLEL_LEVEL
 spack env deactivate
+done
 
- theenv=envclangnewmpi
- echo --- Setting up $theenv `date`
- spack env create $theenv
- #spack -e $theenv config add "concretizer:unify:when_possible"
- spack -e $theenv config add "concretizer:unify:true"
- spack env activate $theenv
- 
- spack add llvm@${llvm_vnew}
- spack add gcc@${gcc_vnew}
- spack add git
- spack add ninja
- spack add cmake@${cmake_vnew}
- spack add libxml2@${libxml2_v}^gcc@${gcc_vnew}
- spack add boost@${boost_vnew}^gcc@${gcc_vnew}
- spack add util-linux-uuid^gcc@${gcc_vnew}
- spack add python^gcc@${gcc_vnew}
- spack add openmpi@${ompi_vnew}^gcc@${gcc_vnew}
- spack add hdf5@${hdf5_vnew} +fortran +hl +mpi
- spack add fftw@${fftw_vnew} -mpi #Avoid MPI for simplicity
- spack add openblas threads=openmp
- if [ "$ourplatform" == "AMD" ]; then
- spack add amdblis; spack add amdlibflame; #spack add amd-aocl
- fi
- if [ "$ourplatform" == "Intel" ]; then
- spack add intel-oneapi-mkl
- fi
- 
- spack add py-lxml
- spack add py-matplotlib
- spack add py-pandas
- spack add py-mpi4py
- spack add py-numpy@${numpy_vold}
- spack add py-scipy
- spack add py-h5py ^hdf5@${hdf5_vnew}
- install_environment
- spack env deactivate
- 
- theenv=envclangnewnompi
- echo --- Setting up $theenv `date`
- spack env create $theenv
- #spack -e $theenv config add "concretizer:unify:when_possible"
- spack -e $theenv config add "concretizer:unify:true"
- spack env activate $theenv
- 
- spack add llvm@${llvm_vnew}^gcc@${gcc_vnew}
- spack add gcc@${gcc_vnew}
- spack add git
- spack add ninja
- spack add cmake@${cmake_vnew}
- spack add libxml2@${libxml2_v}^gcc@${gcc_vnew}
- spack add boost@${boost_vnew}^gcc@${gcc_vnew}
- spack add util-linux-uuid^gcc@${gcc_vnew}
- spack add python^gcc@${gcc_vnew}
- spack add hdf5@${hdf5_vnew} +fortran +hl ~mpi
- spack add fftw@${fftw_vnew} -mpi #Avoid MPI for simplicity
- spack add openblas threads=openmp
- if [ "$ourplatform" == "AMD" ]; then
- spack add amdblis; spack add amdlibflame; #spack add amd-aocl
- fi
- if [ "$ourplatform" == "Intel" ]; then
- spack add intel-oneapi-mkl
- fi
- 
- spack add py-lxml
- spack add py-matplotlib
- spack add py-pandas
- spack add py-numpy@${numpy_vold}
- spack add py-scipy
- spack add py-h5py ^hdf5@${hdf5_vnew}
- install_environment
- spack env deactivate
- 
- 
-# TO DO: Match chosen cuda with version installed on system
-theenv=envclangoffloadmpi
+for havempi in mpi nompi
+do	    
+
+theenv=envclangnew${havempi}
 echo --- Setting up $theenv `date`
 spack env create $theenv
-#spack -e $theenv config add "concretizer:unify:when_possible"
+spack -e $theenv config add "concretizer:unify:true"
+spack env activate $theenv
+
+spack add llvm@${llvm_vnew}
+#spack add gcc@${gcc_vold}
+spack add hwloc
+spack add git
+spack add ninja
+#spack add cmake@${cmake_vnew}^gcc@${gcc_vold}
+spack add cmake@${cmake_vnew}
+spack add libxml2
+#spack add boost@${boost_vnew}^gcc@${gcc_vold}
+spack add boost@${boost_vnew}
+#spack add util-linux-uuid^gcc@${gcc_vold}
+spack add util-linux-uuid
+#spack add python^gcc@${gcc_vold}
+spack add python
+if [ "$havempi" == "mpi" ]; then
+#spack add openmpi@${ompi_vnew}^gcc@${gcc_vold}
+spack add openmpi@${ompi_vnew}
+fi
+
+if [ "$havempi" == "mpi" ]; then
+#spack add hdf5@${hdf5_vnew} +fortran +hl +mpi ^gcc@${gcc_vold}
+spack add hdf5@${hdf5_vnew} +fortran +hl +mpi 
+else
+#spack add hdf5@${hdf5_vnew} +fortran +hl ~mpi ^gcc@${gcc_vold}
+spack add hdf5@${hdf5_vnew} +fortran +hl ~mpi 
+fi
+#spack add fftw@${fftw_vnew} -mpi ^gcc@${gcc_vold} #Avoid MPI for simplicity
+spack add fftw@${fftw_vnew} -mpi  #Avoid MPI for simplicity
+#spack add openblas threads=openmp ^gcc@${gcc_vold}
+spack add openblas threads=openmp 
+#PK: amdlibflame@5.2 will fail as of 2026-03-24
+#if [ "$ourplatform" == "AMD" ]; then
+#spack add amdblis; spack add amdlibflame; #spack add amd-aocl
+#fi
+if [ "$ourplatform" == "Intel" ]; then
+spack add intel-oneapi-mkl
+fi
+ 
+spack add py-lxml
+spack add py-matplotlib
+spack add py-pandas
+if [ "$havempi" == "mpi" ]; then
+	spack add py-mpi4py
+fi
+spack add py-numpy@${numpy_vold}
+spack add py-scipy
+spack add py-h5py ^hdf5@${hdf5_vnew}
+install_environment
+spack env deactivate
+done
+
+# Build LLVM offload with preferred GCC since CUDA may not support new GCC
+# Build with new CMake
+# TO DO: Match chosen cuda with version installed on system
+for havempi in mpi nompi
+do	      
+theenv=envclangoffload${havempi}
+echo --- Setting up $theenv `date`
+spack env create $theenv
 spack -e $theenv config add "concretizer:unify:true"
 spack env activate $theenv
 
 spack add gcc@${gcc_vllvmoffload}
 spack add cuda@${cuda_voffload} +allow-unsupported-compilers
-spack add llvm@${llvm_voffload}
+spack add llvm@${llvm_voffload} openmp=project +libomptarget +libomptarget_debug ^cuda@${cuda_voffload}
 
+spack add hwloc # Try hwloc to solve duplicate 2026-03-24
 spack add git
 spack add ninja
-spack add cmake@${cmake_vnew}
-spack add libxml2@${libxml2_v}^gcc@${gcc_vllvmoffload}
+spack add cmake@${cmake_vnew}^gcc@${gcc_vllvmoffload}
+spack add libxml2
 spack add boost@${boost_vold}^gcc@${gcc_vllvmoffload}
 spack add util-linux-uuid^gcc@${gcc_vllvmoffload}
 spack add python^gcc@${gcc_vllvmoffload}
 spack add openmpi@${ompi_vnew}^gcc@${gcc_vllvmoffload}
-spack add hdf5@${hdf5_vold} +fortran +hl +mpi
-spack add fftw@${fftw_vold} -mpi #Avoid MPI for simplicity
-spack add openblas threads=openmp
+if [ "$havempi" == "mpi" ]; then
+spack add hdf5@${hdf5_vold} +fortran +hl +mpi ^gcc@${gcc_vllvmoffload}
+else
+spack add hdf5@${hdf5_vold} +fortran +hl ~mpi ^gcc@${gcc_vllvmoffload}
+fi
+spack add fftw@${fftw_vold} -mpi ^gcc@${gcc_vllvmoffload} #Avoid MPI for simplicity
+spack add openblas threads=openmp ^gcc@${gcc_vllvmoffload}
+#PK: amdlibflame@5.2 will fail 2026-03-24. Link error
+#if [ "$ourplatform" == "AMD" ]; then
+#spack add amdblis; spack add amdlibflame; #spack add amd-aocl
+#fi
+if [ "$ourplatform" == "Intel" ]; then
+spack add intel-oneapi-mkl
+fi
 
 spack add py-lxml
 spack add py-matplotlib
 spack add py-pandas
+
+if [ "$havempi" == "mpi" ]; then
 spack add py-mpi4py
+fi
+
 spack add py-numpy@${numpy_vold}
 spack add py-scipy
 spack add py-h5py ^hdf5@${hdf5_vold}
 install_environment
 spack env deactivate
-
-theenv=envclangoffloadnompi
-echo --- Setting up $theenv `date`
-spack env create $theenv
-#spack -e $theenv config add "concretizer:unify:when_possible"
-spack -e $theenv config add "concretizer:unify:true"
-spack env activate $theenv
-
-spack add gcc@${gcc_vllvmoffload}
-spack add cuda@${cuda_voffload} +allow-unsupported-compilers
-spack add llvm@${llvm_voffload} targets=all
-
-spack add git
-spack add ninja
-spack add cmake@${cmake_vnew}
-spack add libxml2@${libxml2_v}^gcc@${gcc_vllvmoffload}
-spack add boost@${boost_vold}^gcc@${gcc_vllvmoffload}
-spack add util-linux-uuid^gcc@${gcc_vllvmoffload}
-spack add python^gcc@${gcc_vllvmoffload}
-spack add hdf5@${hdf5_vold} +fortran +hl ~mpi
-spack add fftw@${fftw_vold} -mpi #Avoid MPI for simplicity
-spack add openblas threads=openmp
-
-spack add py-lxml
-spack add py-matplotlib
-spack add py-pandas
-spack add py-numpy@${numpy_vold}
-spack add py-scipy
-spack add py-h5py ^hdf5@${hdf5_vold}
-install_environment
-spack env deactivate
-
+done
 
 if [ "$ourplatform" == "AMD" ]; then
-theenv=envamdclangmpi
+
+for havempi in mpi nompi
+do	      
+
+theenv=envamdclang${havempi}
 echo --- Setting up $theenv `date`
 spack env create $theenv
-#spack -e $theenv config add "concretizer:unify:when_possible"
 spack -e $theenv config add "concretizer:unify:true"
 spack env activate $theenv
 
@@ -395,126 +361,108 @@ spack add gcc@${gcc_vllvmoffload}
 spack add git
 spack add ninja
 spack add cmake@${cmake_vnew}
-spack add libxml2@${libxml2_v}^gcc@${gcc_vllvmoffload}
+spack add libxml2
 spack add boost@${boost_vold}^gcc@${gcc_vllvmoffload}
 spack add util-linux-uuid^gcc@${gcc_vllvmoffload}
 spack add python^gcc@${gcc_vllvmoffload}
+
+if [ "$havempi" == "mpi" ]; then
 spack add openmpi@${ompi_vnew}^gcc@${gcc_vllvmoffload}
+fi
+#spack add hdf5@${hdf5_vold}%gcc@${gcc_vllvmoffload} +fortran +hl +mpi
+if [ "$havempi" == "mpi" ]; then
 spack add hdf5@${hdf5_vold} +fortran +hl +mpi
-spack add fftw@${fftw_vold} -mpi #Avoid MPI for simplicity
-spack add openblas threads=openmp
-spack add amdblis; spack add amdlibflame; #spack add amd-aocl
-
-spack add py-lxml
-spack add py-matplotlib
-spack add py-pandas
-spack add py-mpi4py
-spack add py-numpy@${numpy_vold}
-spack add py-scipy
-spack add py-h5py ^hdf5@${hdf5_vold}
-spack add quantum-espresso +mpi +qmcpack
-spack add rmgdft@develop # Use develop version to avoid vendored SCALPACK compilation bugs (20250324)
-install_environment
-spack env deactivate
-
-theenv=envamdclangnompi
-echo --- Setting up $theenv `date`
-spack env create $theenv
-#spack -e $theenv config add "concretizer:unify:when_possible"
-spack -e $theenv config add "concretizer:unify:true"
-spack env activate $theenv
-
-spack add gcc@${gcc_vllvmoffload}
-spack add git
-spack add ninja
-spack add cmake@${cmake_vnew}
-spack add libxml2@${libxml2_v}^gcc@${gcc_vllvmoffload}
-spack add boost@${boost_vold}^gcc@${gcc_vllvmoffload}
-spack add util-linux-uuid^gcc@${gcc_vllvmoffload}
-spack add python^gcc@${gcc_vllvmoffload}
+else
 spack add hdf5@${hdf5_vold} +fortran +hl ~mpi
-spack add fftw@${fftw_vold} -mpi #Avoid MPI for simplicity
-spack add openblas threads=openmp
-spack add amdblis; spack add amdlibflame; #spack add amd-aocl
+fi
+spack add fftw@${fftw_vold} -mpi ^gcc@${gcc_vllvmoffload} #Avoid MPI for simplicity
+spack add openblas threads=openmp ^gcc@${gcc_vllvmoffload}
+#MAR26spack add amdblis^gcc@${gcc_vold}; spack add amdlibflame^gcc@${gcc_vold}; #spack add amd-aocl
 
 spack add py-lxml
 spack add py-matplotlib
 spack add py-pandas
+if [ "$havempi" == "mpi" ]; then
+spack add py-mpi4py
+fi
 spack add py-numpy@${numpy_vold}
 spack add py-scipy
 spack add py-h5py ^hdf5@${hdf5_vold}
+if [ "$havempi" == "mpi" ]; then
+spack add quantum-espresso +mpi +qmcpack
+fi
 install_environment
 spack env deactivate
+done
 fi
 
-
-#if [ "$ourplatform" == "Intel" ]; then
-#theenv=envinteloneapinompi
-#echo --- Setting up $theenv `date`
-#spack env create $theenv
-##spack -e $theenv config add "concretizer:unify:when_possible"
-#spack -e $theenv config add "concretizer:unify:true"
-#spack env activate $theenv
-#
-#spack add gcc@${gcc_vintel}
-#spack add git
-#spack add ninja
-#spack add cmake@${cmake_vnew}
-#spack add libxml2@${libxml2_v}%gcc@${gcc_vintel}
-#spack add boost@${boost_vnew}%gcc@${gcc_vintel}
-#spack add util-linux-uuid%gcc@${gcc_vintel}
-#spack add python%gcc@${gcc_vintel}
-#spack add hdf5@${hdf5_vnew}%gcc@${gcc_vintel} +fortran +hl ~mpi
-#spack add fftw@${fftw_vnew}%gcc@${gcc_vintel} -mpi #Avoid MPI for simplicity
-#
-#spack add py-lxml
-#spack add py-matplotlib
-#spack add py-pandas
-#spack add py-numpy@${numpy_vold}
-#spack add py-scipy
-#spack add py-h5py ^hdf5@${hdf5_vnew}%gcc@${gcc_vintel} +fortran +hl ~mpi
-#install_environment
-#spack env deactivate
-#
-#theenv=envinteloneapimpi
-#echo --- Setting up $theenv `date`
-#spack env create $theenv
-##spack -e $theenv config add "concretizer:unify:when_possible"
-#spack -e $theenv config add "concretizer:unify:true"
-#spack env activate $theenv
-#
-#spack add gcc@${gcc_vintel}
-#spack add git
-#spack add ninja
-#spack add cmake@${cmake_vnew}
-#spack add libxml2@${libxml2_v}%gcc@${gcc_vintel}
-#spack add boost@${boost_vnew}%gcc@${gcc_vintel}
-#spack add util-linux-uuid%gcc@${gcc_vintel}
-#spack add python%gcc@${gcc_vintel}
-#spack add hdf5@${hdf5_vnew}%gcc@${gcc_vintel} +fortran +hl ~mpi
-#spack add fftw@${fftw_vnew}%gcc@${gcc_vintel} -mpi #Avoid MPI for simplicity
-#
-#spack add py-lxml
-#spack add py-matplotlib
-#spack add py-pandas
-#spack add py-numpy@${numpy_vold}
-#spack add py-scipy
-#spack add py-h5py ^hdf5@${hdf5_vnew}%gcc@${gcc_vintel} +fortran +hl ~mpi
-#install_environment
-#spack env deactivate
-#fi
-
-# CAUTION: Removing build deps reveals which spack packages do not have correct runtime deps specified and may result in breakage
-#echo --- Removing build deps
-#for f in `spack env list`
-#do
-#    spack env activate $f
-#    spack gc --yes-to-all
-#    echo --- Software for environment $f
-#    spack env status
-#    spack find
-#    spack env deactivate
-#done
+#MAR26#if [ "$ourplatform" == "Intel" ]; then
+#MAR26#theenv=envinteloneapinompi
+#MAR26#echo --- Setting up $theenv `date`
+#MAR26#spack env create $theenv
+#MAR26##spack -e $theenv config add "concretizer:unify:when_possible"
+#MAR26#spack -e $theenv config add "concretizer:unify:true"
+#MAR26#spack env activate $theenv
+#MAR26#
+#MAR26#spack add gcc@${gcc_vintel}
+#MAR26#spack add git
+#MAR26#spack add ninja
+#MAR26#spack add cmake@${cmake_vnew}
+#MAR26#spack add libxml2%gcc@${gcc_vintel}
+#MAR26#spack add boost@${boost_vnew}%gcc@${gcc_vintel}
+#MAR26#spack add util-linux-uuid%gcc@${gcc_vintel}
+#MAR26#spack add python%gcc@${gcc_vintel}
+#MAR26#spack add hdf5@${hdf5_vnew}%gcc@${gcc_vintel} +fortran +hl ~mpi
+#MAR26#spack add fftw@${fftw_vnew}%gcc@${gcc_vintel} -mpi #Avoid MPI for simplicity
+#MAR26#
+#MAR26#spack add py-lxml
+#MAR26#spack add py-matplotlib
+#MAR26#spack add py-pandas
+#MAR26#spack add py-numpy@${numpy_vold}
+#MAR26#spack add py-scipy
+#MAR26#spack add py-h5py ^hdf5@${hdf5_vnew}%gcc@${gcc_vintel} +fortran +hl ~mpi
+#MAR26#install_environment
+#MAR26#spack env deactivate
+#MAR26#
+#MAR26#theenv=envinteloneapimpi
+#MAR26#echo --- Setting up $theenv `date`
+#MAR26#spack env create $theenv
+#MAR26##spack -e $theenv config add "concretizer:unify:when_possible"
+#MAR26#spack -e $theenv config add "concretizer:unify:true"
+#MAR26#spack env activate $theenv
+#MAR26#
+#MAR26#spack add gcc@${gcc_vintel}
+#MAR26#spack add git
+#MAR26#spack add ninja
+#MAR26#spack add cmake@${cmake_vnew}
+#MAR26#spack add libxml2%gcc@${gcc_vintel}
+#MAR26#spack add boost@${boost_vnew}%gcc@${gcc_vintel}
+#MAR26#spack add util-linux-uuid%gcc@${gcc_vintel}
+#MAR26#spack add python%gcc@${gcc_vintel}
+#MAR26#spack add hdf5@${hdf5_vnew}%gcc@${gcc_vintel} +fortran +hl ~mpi
+#MAR26#spack add fftw@${fftw_vnew}%gcc@${gcc_vintel} -mpi #Avoid MPI for simplicity
+#MAR26#
+#MAR26#spack add py-lxml
+#MAR26#spack add py-matplotlib
+#MAR26#spack add py-pandas
+#MAR26#spack add py-numpy@${numpy_vold}
+#MAR26#spack add py-scipy
+#MAR26#spack add py-h5py ^hdf5@${hdf5_vnew}%gcc@${gcc_vintel} +fortran +hl ~mpi
+#MAR26#install_environment
+#MAR26#spack env deactivate
+#MAR26#fi
+#MAR26
+#MAR26# CAUTION: Removing build deps reveals which spack packages do not have correct runtime deps specified and may result in breakage
+#MAR26#echo --- Removing build deps
+#MAR26#for f in `spack env list`
+#MAR26#do
+#MAR26#    spack env activate $f
+#MAR26#    spack gc --yes-to-all
+#MAR26#    echo --- Software for environment $f
+#MAR26#    spack env status
+#MAR26#    spack find
+#MAR26#    spack env deactivate
+#MAR26#done
 
 echo --- Making loads files
 for f in `spack env list`

--- a/tests/test_automation/nightly_test_scripts/ornl_versions.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_versions.sh
@@ -4,41 +4,36 @@
 
 # GCC
 # Dates at https://gcc.gnu.org/releases.html
-#gcc_vnew=15.1.0 # Released 2025-04-25  # Too ambituous 2025-05-02
-gcc_vnew=14.2.0 # Released 2024-08-01
-gcc_vold=12.4.0 # Released 2024-06-20
+gcc_vnew=15.2.0 # Released 2025-08-08
+gcc_vold=13.4.0 # Released 2025-06-06
 
-gcc_vcuda=${gcc_vold}
-gcc_vintel=${gcc_vold}
-gcc_vnvhpc=${gcc_vold}
-gcc_vllvmoffload=${gcc_vold}
+# Verify vs cuda_voffload release notes e.g.
+#  https://docs.nvidia.com/cuda/archive/12.9.0/cuda-installation-guide-linux/index.html#host-compiler-support-policy
+#gcc_vllvmoffload=13.4.0
+gcc_vllvmoffload=11.5.0 # Must match RHEL system supplied gcc
 
 # LLVM 
 # Dates at https://releases.llvm.org/
-llvm_vnew=20.1.4 # Released 2025-05-02
-llvm_voffload=${llvm_vnew}
-cuda_voffload=12.6.0 # https://releases.llvm.org/20.1.0/tools/clang/docs/ReleaseNotes.html#cuda-support #12.6 is limit for LLVM 20.1.0
+llvm_vnew=22.1.2 # Released 2026-03-25
+llvm_voffload=21.1.8 # 22.1.1 not working as of 2026-04-03
+cuda_voffload=12.6.0 # Same as system installed version
 
 # HDF5
 # Dates at https://portal.hdfgroup.org/display/support/Downloads
-#hdf5_vnew=1.14.6 # Released 2025-02-05
-hdf5_vnew=1.14.5
+hdf5_vnew=1.14.6 # Released 2025-02-05
+#hdf5_vnew=1.14.5
 hdf5_vold=${hdf5_vnew}
 
 # CMake 
 # Dates at https://cmake.org/files/
 #cmake_vnew=3.30.8 # Try older version for py-pyscf build
-cmake_vnew=3.31.6
-cmake_vold=${cmake_vnew}
+cmake_vnew=4.2.3
+cmake_vold=3.27.9
 
 # OpenMPI
 # Dates at https://www.open-mpi.org/software/ompi/v5.0/
-ompi_vnew=5.0.6 # Released 2024-11-15
-#ompi_vnew=5.0.7 # Released 2025-02-014
+ompi_vnew=5.0.10 # Released 2026-02-23
 ompi_vold=${ompi_vold}
-
-# Libxml2
-libxml2_v=2.13.5 # Released 2024-11-12 See https://gitlab.gnome.org/GNOME/libxml2/-/releases
 
 # FFTW
 # Dates at http://www.fftw.org/release-notes.html
@@ -47,14 +42,15 @@ fftw_vold=${fftw_vnew} # Released 2018-05-28
 
 # BOOST
 # Dates at https://www.boost.org/users/history/
-boost_vnew=1.88.0 # Released 2025-04-10
-boost_vold=1.82.0 # Released 2023-08-11
+boost_vnew=1.90.0 # Released 2025-12-10
+boost_vold=1.84.0 # Released 2023-12-06
 
 # Python
 # Use a single version to reduce dependencies. Ideally the spack prefered version.
-python_version=3.13.2
+python_version=3.14.3
 
-numpy_vnew=2.2.5
-numpy_vold=2.2.5
-#numpy_vold=1.26.4
+#numpy_vnew=2.4.3
+#numpy_vold=2.4.3
+numpy_vnew=2.3.5 # PySCF < v2.12.1 is incompatible with >=2.4.0
+numpy_vold=2.3.5 
 


### PR DESCRIPTION
## Proposed changes

The installation and nightly scripts have been significantly updated for the modern era of spack where compilers mostly work as dependencies, environments are more functional, and the package repository is separate.

Note that the compilers must be installed ahead of attempted use, so we install those first, relying on the system compiler being good enough.

Several bugs are worked around, e.g. compilers are generally built with the system gcc. spack currently fails to inject newer binutils dependencies consistently so installing llvm using a spack built gcc is prone to failure. [ Solution to that is in progress in https://github.com/spack/spack-packages/pull/3880 + linked issues/PRs ]

I was not able to make a working llvm v22.1.1 for offload. v21 is used for now (NV, host CPU).

Several packages need updating before we can make more use of them e.g. to avoid build failures with gcc@15

For easier maintenance, mpi and nompi environments are now made in loops with if[] exclusions where needed.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

nitrogen, nitrogen2, sulfur

## Checklist

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
