### PR TITLE
Add Ubuntu 24.04LTS Docker container for testing

### DIFF
--- a/.github/workflows/update-ghcr-ci-image-ubuntu24-openmpi.yaml
+++ b/.github/workflows/update-ghcr-ci-image-ubuntu24-openmpi.yaml
@@ -1,0 +1,45 @@
+name: Build and Push Ubuntu24 OpenMPI build CI Image to GHCR
+
+on:
+  push:
+    paths:
+      - 'config/docker/dependencies/ubuntu24/openmpi/**'
+    branches:
+      - develop
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    if: github.repository == 'qmcpack/qmcpack'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: config/docker/dependencies/ubuntu24/openmpi/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/qmcpack/ubuntu24-openmpi:latest
+          platforms: linux/amd64
+

--- a/config/docker/dependencies/ubuntu24/openmpi/Dockerfile
+++ b/config/docker/dependencies/ubuntu24/openmpi/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:24.04
+
+RUN export DEBIAN_FRONTEND=noninteractive &&\
+    apt-get clean &&\
+    apt-get update -y &&\
+    apt-get upgrade -y apt-utils &&\
+    apt-get install -y gpg wget
+
+RUN export DEBIAN_FRONTEND=noninteractive &&\
+    apt-get install gcc g++ \
+    clang clang-format clang-tidy \
+    libomp-dev \
+    gcovr \
+    python3 \
+    cmake \
+    ninja-build \
+    libboost-all-dev \
+    git \
+    libopenmpi-dev \
+    libhdf5-openmpi-dev \
+    libhdf5-serial-dev \
+    hdf5-tools \
+    libfftw3-dev \
+    libopenblas-openmp-dev \
+    libxml2-dev \
+    sudo \
+    curl \
+    rsync \
+    wget \
+    software-properties-common \
+    vim \
+    numdiff \
+    -y
+
+# Python packages for tests
+RUN export DEBIAN_FRONTEND=noninteractive &&\
+    apt-get install python3-numpy \
+    python3-h5py \
+    python3-pandas \
+    python3-coverage \
+    python3-pytest \
+    python3-pytest-cov \
+    python3-pytest-order \
+    python3-cif2cell \
+    python3-spglib \
+    python3-pip \
+    -y
+
+# must add a user different from root to run MPI executables
+RUN useradd -ms /bin/bash user
+# allow in sudoers to install packages
+RUN adduser user sudo
+RUN echo "user:user" | chpasswd
+
+USER user
+WORKDIR /home/user


### PR DESCRIPTION
## Proposed changes

This adds a Docker container that uses Ubuntu 24.04 LTS with the intent to use it in a future PR for code coverage tests in GitHub workflows.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Built the image on my laptop running Fedora 43 KDE Plasma, ran `ctest -R ntest -j 8` and got no fails.

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
