### PR TITLE
Use pip to upgrade `gcovr` to latest (8.6) version to fix line limit bug

### DIFF
--- a/config/docker/dependencies/ubuntu24/openmpi/Dockerfile
+++ b/config/docker/dependencies/ubuntu24/openmpi/Dockerfile
@@ -10,6 +10,7 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
     apt-get install gcc g++ \
     clang clang-format clang-tidy \
     libomp-dev \
+    gcovr \
     python3 \
     cmake \
     ninja-build \

--- a/config/docker/dependencies/ubuntu24/openmpi/Dockerfile
+++ b/config/docker/dependencies/ubuntu24/openmpi/Dockerfile
@@ -10,7 +10,6 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
     apt-get install gcc g++ \
     clang clang-format clang-tidy \
     libomp-dev \
-    gcovr \
     python3 \
     cmake \
     ninja-build \
@@ -46,6 +45,8 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
     python3-pip \
     -y
 
+# Install gcovr from pip since the Ubuntu 24.04 apt version doesn't support files >9999 lines 
+# https://github.com/gcovr/gcovr/pull/883
 RUN export DEBIAN_FRONTEND=noninteractive &&\
     pip3 install --user --break-system-packages gcovr==8.6
 

--- a/config/docker/dependencies/ubuntu24/openmpi/Dockerfile
+++ b/config/docker/dependencies/ubuntu24/openmpi/Dockerfile
@@ -49,7 +49,7 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
 # Install gcovr from pip since the Ubuntu 24.04 apt version doesn't support files >9999 lines 
 # https://github.com/gcovr/gcovr/pull/883
 RUN export DEBIAN_FRONTEND=noninteractive &&\
-    pip3 install --user --break-system-packages gcovr==8.6
+    sudo pip3 install --break-system-packages gcovr==8.6
 
 # must add a user different from root to run MPI executables
 RUN useradd -ms /bin/bash user

--- a/config/docker/dependencies/ubuntu24/openmpi/Dockerfile
+++ b/config/docker/dependencies/ubuntu24/openmpi/Dockerfile
@@ -46,6 +46,9 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
     python3-pip \
     -y
 
+RUN export DEBIAN_FRONTEND=noninteractive &&\
+    pip3 install --user --break-system-packages gcovr==8.6
+
 # must add a user different from root to run MPI executables
 RUN useradd -ms /bin/bash user
 # allow in sudoers to install packages


### PR DESCRIPTION
## Proposed changes

A bug in `gcovr` version 7.0 (which is the version provided by the Ubuntu 24.04 `apt`) means that coverage can not be collected for source files [with more than 9999 lines](https://github.com/gcovr/gcovr/issues/882). To circumvent this, I've added two lines in the Dockerfile that upgrade the version of `gcovr` to the current latest release (8.6).

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Local build of docker.

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'