### PR TITLE
[CMake] make ADD_UNIT_TEST working without MPI

### DIFF
--- a/CMake/unit_test.cmake
+++ b/CMake/unit_test.cmake
@@ -40,14 +40,14 @@ function(ADD_UNIT_TEST TESTNAME PROCS THREADS TEST_BINARY)
         APPEND
         PROPERTY ENVIRONMENT "OMP_TARGET_OFFLOAD=mandatory")
     endif()
-  endif()
 
-  set(TEST_LABELS_TEMP "")
-  add_test_labels(${TESTNAME} TEST_LABELS_TEMP)
-  set_property(
-    TEST ${TESTNAME}
-    APPEND
-    PROPERTY LABELS "unit")
+    set(TEST_LABELS_TEMP "")
+    add_test_labels(${TESTNAME} TEST_LABELS_TEMP)
+    set_property(
+      TEST ${TESTNAME}
+      APPEND
+      PROPERTY LABELS "unit")
+  endif()
 endfunction()
 
 # Add a test to see if the target output exists in the desired location in the build directory.


### PR DESCRIPTION
## Proposed changes
It should not need to be protected when not using MPI.

## What type(s) of changes does this code introduce?
- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
