### PR TITLE
Allow spline coefficients being shared across MPI ranks

### DIFF
--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -63,17 +63,19 @@ Communicate::Communicate(mpi3::communicator&& in_comm) : d_groupid(0), d_ngroups
   d_ncontexts = comm.size();
 }
 
-Communicate::Communicate(const Communicate& in_comm, int nparts)
+Communicate::Communicate(const Communicate& in_comm, int nparts, int stripe)
 {
   std::vector<int> nplist(nparts + 1);
-  const int p = FairDivideLow(in_comm.rank(), in_comm.size(), nparts, nplist); //group
+  // group index
+  const int gid = stripe == 0 ? FairDivideLow(in_comm.rank(), in_comm.size(), nparts, nplist) :
+	     in_comm.rank() / stripe % nparts;
   // comm is mutable member
-  comm  = in_comm.comm.split(p, in_comm.rank());
+  comm  = in_comm.comm.split(gid, in_comm.rank());
   myMPI = comm.get();
   // TODO: mpi3 needs to define comm
   d_mycontext = comm.rank();
   d_ncontexts = comm.size();
-  d_groupid   = p;
+  d_groupid   = gid;
   d_ngroups   = nparts;
 
   // create an inter group communicator
@@ -113,7 +115,7 @@ void Communicate::barrier() const {}
 
 void Communicate::cleanupMessage(void*) {}
 
-Communicate::Communicate(const Communicate& in_comm, int nparts)
+Communicate::Communicate(const Communicate& in_comm, int nparts, int stripe)
     : myMPI(MPI_COMM_NULL), d_mycontext(0), d_ncontexts(1), d_groupid(0)
 { inter_group_comm_ = std::make_unique<Communicate>(); }
 #endif // !HAVE_MPI

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -77,6 +77,13 @@ public:
 #endif
 
   /** constructor that splits in_comm
+   * in_comm.size() == 12 ; nparts = 2; stripe = 0
+   *   | group 0      | group 1       |
+   *   |  0 1 2 3 4 5 | 6 7 8 9 10 11 |
+   * in_comm.size() == 12 ; nparts = 2; stripe = 3;
+   *   | group 0 | group 1 |
+   *   |  0 1 2  |  3 4 5  |
+   *   |  6 7 8  | 9 10 11 |
    */
   Communicate(const Communicate& in_comm, int nparts, int stripe = 0);
 

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -78,7 +78,7 @@ public:
 
   /** constructor that splits in_comm
    */
-  Communicate(const Communicate& in_comm, int nparts);
+  Communicate(const Communicate& in_comm, int nparts, int stripe = 0);
 
   /**destructor
    * Call proper finalization of Communication library

--- a/src/Message/tests/CMakeLists.txt
+++ b/src/Message/tests/CMakeLists.txt
@@ -16,7 +16,10 @@ set(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 add_executable(${UTEST_EXE} test_communciate.cpp)
 target_link_libraries(${UTEST_EXE} PUBLIC message catch_main)
 
-add_unit_test(${UTEST_NAME} 1 1 $<TARGET_FILE:${UTEST_EXE}>)
+foreach(NUM_RANKS 1 2 3 6 12)
+  set(UTEST_NAME_MPI ${UTEST_NAME}-r${NUM_RANKS})
+  add_unit_test(${UTEST_NAME_MPI} ${NUM_RANKS} 1 $<TARGET_FILE:${UTEST_EXE}>)
+endforeach()
 
 if(HAVE_MPI)
   set(UTEST_EXE test_${SRC_DIR}_mpi)

--- a/src/Message/tests/test_communciate.cpp
+++ b/src/Message/tests/test_communciate.cpp
@@ -97,4 +97,19 @@ TEST_CASE("test_communicate_split_four", "[message]")
   }
 }
 
+TEST_CASE("test_communicate_split_two_stripe_three", "[message]")
+{
+  Communicate* c = OHMMS::Controller;
+  // For simplicity, only test the case where the number of processes is divisible by 6.
+  if (c->size() % 6 != 0)
+    return;
+
+  auto c2              = std::make_unique<Communicate>(*c, 2, 3);
+  const int group_size = c->size() / 2;
+  const int new_rank   = c->rank() % 3 + c->rank() / 6 * 3;
+  REQUIRE(c2->size() == group_size);
+  REQUIRE(c2->rank() == new_rank);
+  REQUIRE(c2->getGroupID() == (c->rank() / 3 % 2));
+}
+
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineReader.cpp
@@ -93,7 +93,7 @@ void BsplineReader::setCommon(xmlNodePtr cur)
 
 std::unique_ptr<SPOSet> BsplineReader::create_spline_set(const std::string& spo_name,
                                                          int spin,
-                                                         int ndistributed,
+                                                         const std::pair<int, int>& distributed_and_shared_ranks,
                                                          const size_t size)
 {
   if (spo2band.empty())
@@ -115,7 +115,7 @@ std::unique_ptr<SPOSet> BsplineReader::create_spline_set(const std::string& spo_
   vals.myName  = make_bandgroup_name(spo_name, spin, mybuilder->twist_num_, mybuilder->TileMatrix, 0, size);
   vals.selectBands(fullband, 0, size);
 
-  return create_spline_set(spo_name, spin, ndistributed, vals);
+  return create_spline_set(spo_name, spin, distributed_and_shared_ranks, vals);
 }
 
 bool BsplineReader::lookforSplineDataDumpFile(const BandInfoGroup& bandgroup,
@@ -168,7 +168,7 @@ void BsplineReader::readOneOrbitalCoefs(const std::string& s, hdf_archive& h5f, 
 
 std::unique_ptr<SPOSet> BsplineReader::create_spline_set(const std::string& spo_name,
                                                          int spin,
-                                                         int ndistributed,
+                                                         const std::pair<int, int>& distributed_and_shared_ranks,
                                                          SPOSetInputInfo& input_info)
 {
   if (spo2band.empty())
@@ -191,7 +191,7 @@ std::unique_ptr<SPOSet> BsplineReader::create_spline_set(const std::string& spo_
                                      input_info.min_index(), input_info.max_index());
   vals.selectBands(fullband, spo2band[spin][input_info.min_index()], input_info.max_index() - input_info.min_index());
 
-  return create_spline_set(spo_name, spin, ndistributed, vals);
+  return create_spline_set(spo_name, spin, distributed_and_shared_ranks, vals);
 }
 
 /** build index tables to map a state to band with k-point folidng

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineReader.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineReader.h
@@ -43,7 +43,7 @@ class BsplineReader
    */
   virtual std::unique_ptr<SPOSet> create_spline_set(const std::string& my_name,
                                                     int spin,
-                                                    int ndistributed,
+                                                    const std::pair<int, int>& distributed_and_shared_ranks,
                                                     const BandInfoGroup& bandgroup) = 0;
 
   void initialize_spo2band(const std::string& spo_name,
@@ -64,11 +64,14 @@ public:
   /** create the spline after one of the kind is created */
   std::unique_ptr<SPOSet> create_spline_set(const std::string& spo_name,
                                             int spin,
-                                            int ndistributed,
+                                            const std::pair<int, int>& distributed_and_shared_ranks,
                                             SPOSetInputInfo& input_info);
 
   /** create the spline set */
-  std::unique_ptr<SPOSet> create_spline_set(const std::string& spo_name, int spin, int ndistributed, const size_t size);
+  std::unique_ptr<SPOSet> create_spline_set(const std::string& spo_name,
+                                            int spin,
+                                            const std::pair<int, int>& distributed_and_shared_ranks,
+                                            const size_t size);
 
   /** Set the checkNorm variable */
   inline void setCheckNorm(bool new_checknorm) { checkNorm = new_checknorm; };

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder.h
@@ -263,7 +263,7 @@ protected:
    * @param cur the current xml node
    * @return the distribution size
    */
-  static int obtainMemoryAttributes(xmlNodePtr cur);
+  static std::pair<int, int> obtainMemoryAttributes(xmlNodePtr cur);
 
   /** analyze twists of orbitals in h5 and determinine twist_num_
    * @param twist_num_inp twistnum XML input

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
@@ -31,7 +31,6 @@
 #include "BsplineSet.h"
 #include "SplineSetReader.h"
 #include "HybridRepSetReader.h"
-#include "Message/UniformCommunicateError.h"
 
 #include <array>
 #include <string_view>
@@ -125,9 +124,9 @@ std::pair<int, int> EinsplineSetBuilder::obtainMemoryAttributes(const xmlNodePtr
     shared_ranks = 1;
 
   if (auto node_comm_size = OHMMS::Controller->NodeComm().size(); node_comm_size % distributed_ranks * shared_ranks > 0)
-    throw UniformCommunicateError("The number of MPI ranks per node (" + std::to_string(node_comm_size) +
-                                  ") is not divisible by the product of distributed_ranks and shared_ranks (" +
-                                  std::to_string(distributed_ranks * shared_ranks) + ").");
+    throw std::runtime_error("The number of MPI ranks per node (" + std::to_string(node_comm_size) +
+                             ") is not divisible by the product of distributed_ranks and shared_ranks (" +
+                             std::to_string(distributed_ranks * shared_ranks) + ").");
 
   return {distributed_ranks, shared_ranks};
 }

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
@@ -31,6 +31,7 @@
 #include "BsplineSet.h"
 #include "SplineSetReader.h"
 #include "HybridRepSetReader.h"
+#include "Message/UniformCommunicateError.h"
 
 #include <numeric>
 #include <array>
@@ -104,29 +105,32 @@ void EinsplineSetBuilder::set_metadata(int numOrbs,
 }
 
 
-int EinsplineSetBuilder::obtainMemoryAttributes(const xmlNodePtr cur)
+std::pair<int, int> EinsplineSetBuilder::obtainMemoryAttributes(const xmlNodePtr cur)
 {
-  int ndistributed = 0;
+  int distributed_ranks = 0;
+  int shared_ranks      = 0;
   processChildren(cur, [&](const std::string& cname, const xmlNodePtr element) {
     if (cname == "coefs_mem")
     {
       OhmmsAttributeSet mem_attr;
-      mem_attr.add(ndistributed, "distributed");
+      mem_attr.add(distributed_ranks, "distributed_ranks");
+      mem_attr.add(shared_ranks, "shared_ranks");
       mem_attr.put(element);
     }
   });
 
-  if (ndistributed < 1)
-    ndistributed = 1;
+  if (distributed_ranks < 1)
+    distributed_ranks = 1;
 
-  if (auto node_comm_size = OHMMS::Controller->NodeComm().size(); node_comm_size % ndistributed > 0)
-  {
-    ndistributed = std::gcd(node_comm_size, ndistributed);
-    app_warning() << "Overriding the number of distributed memory segments to the greatest common divisor of the "
-                     "\"distributed\" input value and the number of MPI ranks per node : "
-                  << ndistributed << std::endl;
-  }
-  return ndistributed;
+  if (shared_ranks < 1)
+    shared_ranks = 1;
+
+  if (auto node_comm_size = OHMMS::Controller->NodeComm().size(); node_comm_size % distributed_ranks * shared_ranks > 0)
+    throw UniformCommunicateError("The number of MPI ranks per node " + std::to_string(node_comm_size) +
+                                  " is not divisible by the product of distributed_ranks and shared_ranks " +
+                                  std::to_string(distributed_ranks * shared_ranks));
+
+  return {distributed_ranks, shared_ranks};
 }
 
 std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(const xmlNodePtr cur)

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
@@ -126,9 +126,9 @@ std::pair<int, int> EinsplineSetBuilder::obtainMemoryAttributes(const xmlNodePtr
     shared_ranks = 1;
 
   if (auto node_comm_size = OHMMS::Controller->NodeComm().size(); node_comm_size % distributed_ranks * shared_ranks > 0)
-    throw UniformCommunicateError("The number of MPI ranks per node " + std::to_string(node_comm_size) +
-                                  " is not divisible by the product of distributed_ranks and shared_ranks " +
-                                  std::to_string(distributed_ranks * shared_ranks));
+    throw UniformCommunicateError("The number of MPI ranks per node (" + std::to_string(node_comm_size) +
+                                  ") is not divisible by the product of distributed_ranks and shared_ranks (" +
+                                  std::to_string(distributed_ranks * shared_ranks) + ").");
 
   return {distributed_ranks, shared_ranks};
 }

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSetBuilder_createSPOs.cpp
@@ -33,7 +33,6 @@
 #include "HybridRepSetReader.h"
 #include "Message/UniformCommunicateError.h"
 
-#include <numeric>
 #include <array>
 #include <string_view>
 

--- a/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/EinsplineSpinorSetBuilder.cpp
@@ -201,12 +201,12 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
   MixedSplineReader->setRotate(false);
 
   //Make the up spin set.
-  auto bspline_zd_u = MixedSplineReader->create_spline_set(spo_object_name, spinSet, 1, numOrbs);
+  auto bspline_zd_u = MixedSplineReader->create_spline_set(spo_object_name, spinSet, {1, 1}, numOrbs);
   bspline_zd_u->finalizeConstruction();
 
   //Make the down spin set.
   OccupyBands(spinSet2, sortBands, numOrbs, skipChecks);
-  auto bspline_zd_d = MixedSplineReader->create_spline_set(spo_object_name, spinSet2, 1, numOrbs);
+  auto bspline_zd_d = MixedSplineReader->create_spline_set(spo_object_name, spinSet2, {1, 1}, numOrbs);
   bspline_zd_d->finalizeConstruction();
 
   //register with spin set and we're off to the races.

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
@@ -151,10 +151,11 @@ HybridRepSetReader<ST>::HybridRepSetReader(EinsplineSetBuilder* e, bool use_dupl
 {}
 
 template<typename ST>
-std::unique_ptr<SPOSet> HybridRepSetReader<ST>::create_spline_set(const std::string& my_name,
-                                                                  int spin,
-                                                                  int ndistributed,
-                                                                  const BandInfoGroup& bandgroup)
+std::unique_ptr<SPOSet> HybridRepSetReader<ST>::create_spline_set(
+    const std::string& my_name,
+    int spin,
+    const std::pair<int, int>& distributed_and_shared_ranks,
+    const BandInfoGroup& bandgroup)
 {
   const int N = bandgroup.getNumDistinctOrbitals();
 

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.h
@@ -37,7 +37,7 @@ class HybridRepSetReader : public BsplineReader
 
   std::unique_ptr<SPOSet> create_spline_set(const std::string& my_name,
                                             int spin,
-                                            int ndistributed,
+                                            const std::pair<int, int>& distributed_and_shared_ranks,
                                             const BandInfoGroup& bandgroup) override;
 
 public:

--- a/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
@@ -50,23 +50,23 @@ std::unique_ptr<SPOSet> SplineSetReader<ST>::create_spline_set(const std::string
 {
   const int N = bandgroup.getNumDistinctOrbitals();
 
-  auto [ndistributed, shared_ranks] = distributed_and_shared_ranks;
+  auto [distributed_ranks, shared_ranks] = distributed_and_shared_ranks;
 
   if (use_offload)
   {
-    if (ndistributed > 1 || shared_ranks > 1)
+    if (distributed_ranks > 1 || shared_ranks > 1)
       app_warning() << "Offload implemenation doesn't support distributing or sharing the memory of spline "
-                       "coefficients. Overriding ndistributed and shared_ranks to 1."
+                       "coefficients. Overriding distributed_ranks and shared_ranks to 1."
                     << std::endl;
-    ndistributed = 1;
-    shared_ranks = 1;
+    distributed_ranks = 1;
+    shared_ranks      = 1;
   }
 
-  auto dist_comm_ptr = std::make_unique<Communicate>(*myComm, myComm->size() / (ndistributed * shared_ranks));
+  auto dist_comm_ptr = std::make_unique<Communicate>(*myComm, myComm->size() / (distributed_ranks * shared_ranks));
 
   app_log() << "  Using " << (use_duplex_splines_ ? "complex" : "real") << " einspline table." << std::endl;
-  if (ndistributed > 1)
-    app_log() << "  Distributed across " << ndistributed << " MPI ranks." << std::endl;
+  if (distributed_ranks > 1)
+    app_log() << "  Distributed across " << distributed_ranks << " MPI ranks." << std::endl;
   if (shared_ranks > 1)
     app_log() << "  Shared across " << shared_ranks << " MPI ranks." << std::endl;
 
@@ -84,9 +84,9 @@ std::unique_ptr<SPOSet> SplineSetReader<ST>::create_spline_set(const std::string
   if (use_offload)
     multi_splines_ptr = std::make_unique<MultiBsplineOffload<ST>>(xyz_grid, xyz_bc, num_splines);
 #if defined(HAVE_MPI)
-  else if (ndistributed * shared_ranks > 1)
+  else if (distributed_ranks * shared_ranks > 1)
     multi_splines_ptr = std::make_unique<MultiBsplineMPIShared<ST>>(xyz_grid, xyz_bc, num_splines,
-                                                                    std::move(dist_comm_ptr), ndistributed);
+                                                                    std::move(dist_comm_ptr), distributed_ranks);
 #endif
   else
     multi_splines_ptr = std::make_unique<MultiBspline<ST>>(xyz_grid, xyz_bc, num_splines);
@@ -144,13 +144,13 @@ std::unique_ptr<SPOSet> SplineSetReader<ST>::create_spline_set(const std::string
   }
 
   /* create a sub communicator. spline table is shared across MPI ranks with identical subcomm rank id.
-   *  myComm->size() == 12 ; shared_ranks = 2; ndistributed = 3;
+   *  myComm->size() == 12 ; shared_ranks = 2; distributed_ranks = 3;
    *          | group 0 | group 1 |
    *          |  0 1 2  |  3 4 5  |
    *          |  6 7 8  | 9 10 11 |
    */
-  Communicate shared_comm(*myComm, shared_ranks, ndistributed);
-  Communicate dist_comm(shared_comm, shared_comm.size() / ndistributed);
+  Communicate shared_comm(*myComm, shared_ranks, distributed_ranks);
+  Communicate dist_comm(shared_comm, shared_comm.size() / distributed_ranks);
 
   if (!foundspline)
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
@@ -45,26 +45,30 @@ SplineSetReader<ST>::SplineSetReader(EinsplineSetBuilder* e, bool use_duplex_spl
 template<typename ST>
 std::unique_ptr<SPOSet> SplineSetReader<ST>::create_spline_set(const std::string& my_name,
                                                                int spin,
-                                                               int ndistributed,
+                                                               const std::pair<int, int>& distributed_and_shared_ranks,
                                                                const BandInfoGroup& bandgroup)
 {
   const int N = bandgroup.getNumDistinctOrbitals();
 
+  auto [ndistributed, shared_ranks] = distributed_and_shared_ranks;
+
   if (use_offload)
   {
-    if (ndistributed > 1)
-      app_warning()
-          << "Offload implemenation doesn't distribute the memory of spline coefficients. Overriding ndistributed to 1."
-          << std::endl;
+    if (ndistributed > 1 || shared_ranks > 1)
+      app_warning() << "Offload implemenation doesn't support distributing or sharing the memory of spline "
+                       "coefficients. Overriding ndistributed and shared_ranks to 1."
+                    << std::endl;
     ndistributed = 1;
+    shared_ranks = 1;
   }
 
-  auto dist_comm_ptr = std::make_unique<Communicate>(*myComm, myComm->size() / ndistributed);
-  auto& dist_comm(*dist_comm_ptr);
+  auto dist_comm_ptr = std::make_unique<Communicate>(*myComm, myComm->size() / (ndistributed * shared_ranks));
 
   app_log() << "  Using " << (use_duplex_splines_ ? "complex" : "real") << " einspline table." << std::endl;
   if (ndistributed > 1)
     app_log() << "  Distributed across " << ndistributed << " MPI ranks." << std::endl;
+  if (shared_ranks > 1)
+    app_log() << "  Shared across " << shared_ranks << " MPI ranks." << std::endl;
 
   const TinyVector<int, 3> half_g = use_duplex_splines_
       ? TinyVector<int, 3>(0, 0, 0)
@@ -80,9 +84,9 @@ std::unique_ptr<SPOSet> SplineSetReader<ST>::create_spline_set(const std::string
   if (use_offload)
     multi_splines_ptr = std::make_unique<MultiBsplineOffload<ST>>(xyz_grid, xyz_bc, num_splines);
 #if defined(HAVE_MPI)
-  else if (ndistributed > 1)
-    multi_splines_ptr =
-        std::make_unique<MultiBsplineMPIShared<ST>>(xyz_grid, xyz_bc, num_splines, std::move(dist_comm_ptr), ndistributed);
+  else if (ndistributed * shared_ranks > 1)
+    multi_splines_ptr = std::make_unique<MultiBsplineMPIShared<ST>>(xyz_grid, xyz_bc, num_splines,
+                                                                    std::move(dist_comm_ptr), ndistributed);
 #endif
   else
     multi_splines_ptr = std::make_unique<MultiBspline<ST>>(xyz_grid, xyz_bc, num_splines);
@@ -139,13 +143,24 @@ std::unique_ptr<SPOSet> SplineSetReader<ST>::create_spline_set(const std::string
                 << now.elapsed() << " sec." << std::endl;
   }
 
+  /* create a sub communicator. spline table is shared across MPI ranks with identical subcomm rank id.
+   *  myComm->size() == 12 ; shared_ranks = 2; ndistributed = 3;
+   *          | group 0 | group 1 |
+   *          |  0 1 2  |  3 4 5  |
+   *          |  6 7 8  | 9 10 11 |
+   */
+  Communicate shared_comm(*myComm, shared_ranks, ndistributed);
+  Communicate dist_comm(shared_comm, shared_comm.size() / ndistributed);
+
   if (!foundspline)
   {
-    multi_splines.flush_zero(dist_comm.rank());
-
-    Timer now;
-    initialize_spline_pio_gather(spin, bandgroup, half_g, bspline->BandIndexMap, multi_splines, dist_comm);
-    app_log() << "  SplineSetReader initialize_spline_pio " << now.elapsed() << " sec" << std::endl;
+    if (shared_comm.getGroupID() == 0)
+    {
+      multi_splines.flush_zero(dist_comm.rank());
+      Timer now;
+      initialize_spline_pio_gather(spin, bandgroup, half_g, bspline->BandIndexMap, multi_splines, dist_comm);
+      app_log() << "  SplineSetReader initialize_spline_pio " << now.elapsed() << " sec" << std::endl;
+    }
 
     if (saveSplineCoefs && myComm->rank() == 0)
     {
@@ -167,7 +182,8 @@ std::unique_ptr<SPOSet> SplineSetReader<ST>::create_spline_set(const std::string
   {
     myComm->barrier();
     Timer now;
-    SplineUtils<ST>::bcast(multi_splines, dist_comm.rank(), dist_comm.getInterGroupComm());
+    if (shared_comm.getGroupID() == 0)
+      SplineUtils<ST>::bcast(multi_splines, dist_comm.rank(), dist_comm.getInterGroupComm());
     myComm->barrier();
     app_log() << "  Time to bcast the table = " << now.elapsed() << std::endl;
   }

--- a/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.h
@@ -42,7 +42,7 @@ class SplineSetReader : public BsplineReader
 {
   std::unique_ptr<SPOSet> create_spline_set(const std::string& my_name,
                                             int spin,
-                                            int ndistributed,
+                                            const std::pair<int, int>& distributed_and_shared_ranks,
                                             const BandInfoGroup& bandgroup) override;
 
 public:

--- a/src/QMCWaveFunctions/tests/test_einset_diamondC.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_diamondC.cpp
@@ -30,7 +30,7 @@ using std::string;
 
 namespace qmcplusplus
 {
-void test_einset_diamond_1x1x1(bool use_offload)
+void test_einset_diamond_1x1x1(bool use_offload, int distributed_ranks = 1, int shared_ranks = 1)
 {
   Communicate* c = OHMMS::Controller;
 
@@ -72,12 +72,15 @@ void test_einset_diamond_1x1x1(bool use_offload)
   std::string spo_xml = R"XML(
 <sposet_collection type="einspline" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" meshfactor="1.0" precision="float" gpu="omptarget">
     <sposet name="updet" size="8">
-        <coefs_mem distributed="2"/>
+        <coefs_mem distributed_ranks="DISTRIBUTED_RANKS" shared_ranks="SHARED_RANKS"/>
     </sposet>
 </sposet_collection>)XML";
 
   if (!use_offload)
     spo_xml = std::regex_replace(spo_xml, std::regex("omptarget"), "no");
+
+  spo_xml = std::regex_replace(spo_xml, std::regex("DISTRIBUTED_RANKS"), std::to_string(distributed_ranks));
+  spo_xml = std::regex_replace(spo_xml, std::regex("SHARED_RANKS"), std::to_string(shared_ranks));
 
   Libxml2Document doc;
   REQUIRE(doc.parseFromString(spo_xml));
@@ -302,6 +305,21 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
 {
   test_einset_diamond_1x1x1(true);
   test_einset_diamond_1x1x1(false);
+  Communicate* c = OHMMS::Controller;
+  if (c->size() % 2 == 0)
+  {
+    test_einset_diamond_1x1x1(true, 2, 1);
+    test_einset_diamond_1x1x1(false, 2, 1);
+    test_einset_diamond_1x1x1(true, 1, 2);
+    test_einset_diamond_1x1x1(false, 1, 2);
+  }
+  if (c->size() % 6 == 0)
+  {
+    test_einset_diamond_1x1x1(true, 2, 3);
+    test_einset_diamond_1x1x1(false, 2, 3);
+    test_einset_diamond_1x1x1(true, 3, 2);
+    test_einset_diamond_1x1x1(false, 3, 2);
+  }
 }
 
 TEST_CASE("Einspline SPO from HDF diamond_2x1x1 5 electrons", "[wavefunction]")

--- a/src/spline2/MultiBsplineBase.hpp
+++ b/src/spline2/MultiBsplineBase.hpp
@@ -169,7 +169,7 @@ public:
   {
     size_t num_T = 0;
     for (auto spline_m : spline_blocks)
-      num_T += spline_m->coefs_size * sizeof(T);
+      num_T += spline_m->coefs_size;
     return num_T * sizeof(T);
   }
 


### PR DESCRIPTION
## Proposed changes
Baseline run
Node free memory: 1092245 MiB at start, 835475 MiB after VMC warmup. Consumed 256770 MiB

Run with `distributed_ranks=3` and `shared_ranks=2` on one spin channel
Node free memory: 1099349 MiB at start, 910659 MiB after VMC warmup. Consumed 188690 MiB

Saving 68080 MiB that is about 10 (12 - 2) times of 6817MiB, the size of one copy.

`distributed_ranks=3` and `shared_ranks=2` result in
rank 0, 1, 2 owing actual memory with 1/3 each. rank 3, 4, 5 are references to the memory owned by 0, 1, 2 respectively.
rank >= 6 repeat this pattern.
Host side memory consumption is only 1/6 compared to not using this feature.
Full documentation will be added in a later PR.

This PR does
1. Add striping support in Communicate splitting.
2. Add shared_ranks feature to SplineSPOs.

## What type(s) of changes does this code introduce?
- New feature
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server, Aurora

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
