### PR TITLE
Adjust coverage build compiler wrappers

### DIFF
--- a/CMake/GNUCompilers.cmake
+++ b/CMake/GNUCompilers.cmake
@@ -156,6 +156,6 @@ endif(QMC_BUILD_STATIC)
 # Coverage
 if(ENABLE_GCOV)
   set(GCOV_SUPPORTED TRUE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -O0 -fno-inline -fno-inline-small-functions -fno-default-inline")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -O0 -fno-inline -fno-inline-small-functions -fno-default-inline")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -O0 -fno-inline -fno-inline-small-functions -fno-default-inline -fprofile-dir=coverage.%p")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -O0 -fno-inline -fno-inline-small-functions -fno-default-inline -fprofile-dir=coverage.%p")
 endif(ENABLE_GCOV)

--- a/CMake/GNUCompilers.cmake
+++ b/CMake/GNUCompilers.cmake
@@ -156,6 +156,6 @@ endif(QMC_BUILD_STATIC)
 # Coverage
 if(ENABLE_GCOV)
   set(GCOV_SUPPORTED TRUE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -O0 -fno-inline -fno-inline-small-functions -fno-default-inline -fprofile-dir=coverage.%p")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -O0 -fno-inline -fno-inline-small-functions -fno-default-inline -fprofile-dir=coverage.%p")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -O0 -fno-inline -fno-inline-small-functions -fno-default-inline")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -O0 -fno-inline -fno-inline-small-functions -fno-default-inline")
 endif(ENABLE_GCOV)

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -163,9 +163,17 @@ case "$1" in
       ;;
       *"GCC"*"-Gcov"*)
         echo 'Configure for code coverage with gcc and gcovr -DENABLE_GCOV=TRUE and upload reports to Codecov'
+
+        # For consistency with other compiler usage, while usually the default, specify gcc to OpenMPI wrappers.
+        export OMPI_CC=gcc
+        export OMPI_CXX=g++
+        # Make current environment variables available to subsequent steps
+        echo "OMPI_CC=gcc" >> $GITHUB_ENV
+        echo "OMPI_CXX=g++" >> $GITHUB_ENV
+
         cmake -GNinja $CMAKE_OPTIONS \
-              -DMPI_C_COMPILER=mpicc \
-              -DMPI_CXX_COMPILER=mpicxx \
+              -DCMAKE_C_COMPILER=mpicc \
+              -DCMAKE_CXX_COMPILER=mpicxx \
               -DENABLE_GCOV=TRUE \
               -DENABLE_PYCOV=TRUE \
               ${GITHUB_WORKSPACE}


### PR DESCRIPTION
## Proposed changes

Use the standard way to build QMCPACK with MPI for the coverage builds. Current builds display our cmake warning for use of MPI_C/CXX_COMPILER.

~Try -fprofile-dir=coverage.%p to avoid corrupt gcda files in parallel runs. (Untested and only a theory; output of gcovr must be checked)~

## What type(s) of changes does this code introduce?

- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None. Must be checked.

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
