### PR TITLE
Reduce LMYengine exposure in optimizer drivers

### DIFF
--- a/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunction.cpp
+++ b/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunction.cpp
@@ -32,16 +32,16 @@ size_t QMCCostFunction::total_samples()
 /// \brief  Computes the cost function using the LMYEngine
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-QMCCostFunction::Return_rt QMCCostFunction::LMYEngineCost_detail(cqmc::engine::LMYEngine<ValueType>* EngineObj)
+QMCCostFunction::Return_rt QMCCostFunction::LMYEngineCost_detail(cqmc::engine::LMYEngine<ValueType>& EngineObj)
 {
   // get total number of samples
   const size_t m = this->total_samples();
 
   // reset Engine object
-  EngineObj->reset();
+  EngineObj.reset();
 
   // turn off wavefunction update mode
-  EngineObj->turn_off_update();
+  EngineObj.turn_off_update();
 
   //for (int ip = 0, j = 0; ip < NumThreads; ip++) {
 #pragma omp parallel
@@ -61,22 +61,22 @@ QMCCostFunction::Return_rt QMCCostFunction::LMYEngineCost_detail(cqmc::engine::L
       //lce_vec.at(j) = saved[ENERGY_NEW];
 
       // take sample
-      EngineObj->take_sample(saved[ENERGY_NEW], 1.0, saved[REWEIGHT] / SumValue[SUM_WGT]);
+      EngineObj.take_sample(saved[ENERGY_NEW], 1.0, saved[REWEIGHT] / SumValue[SUM_WGT]);
     }
   }
   //}
   // finish taking sample
-  EngineObj->sample_finish();
+  EngineObj.sample_finish();
 
   // compute energy and target relevant quantities
-  EngineObj->energy_target_compute();
+  EngineObj.energy_target_compute();
 
   // prepare variables to hold the output of the engine call
-  double energy_avg  = EngineObj->energy_mean();
-  double energy_sdev = EngineObj->energy_sdev();
-  double energy_serr = EngineObj->energy_statistical_err();
-  double target_avg  = EngineObj->target_value();
-  double target_serr = EngineObj->target_statistical_err();
+  double energy_avg  = EngineObj.energy_mean();
+  double energy_sdev = EngineObj.energy_sdev();
+  double energy_serr = EngineObj.energy_statistical_err();
+  double target_avg  = EngineObj.target_value();
+  double target_serr = EngineObj.target_statistical_err();
 
   // prepare a stream to hold engine printout
   //std::stringstream engine_out;

--- a/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunctionBatched.cpp
@@ -26,15 +26,15 @@ size_t QMCCostFunctionBatched::total_samples() { return samples_.getNumSamples()
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::LMYEngineCost_detail(
-    cqmc::engine::LMYEngine<Return_t>* EngineObj)
+    cqmc::engine::LMYEngine<Return_t>& EngineObj)
 {
   // get total number of samples
   const size_t m = this->total_samples();
   // reset Engine object
-  EngineObj->reset();
+  EngineObj.reset();
 
   // turn off wavefunction update mode
-  EngineObj->turn_off_update();
+  EngineObj.turn_off_update();
 
 #pragma omp parallel
   {
@@ -47,22 +47,22 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::LMYEngineCost_detail(
       const Return_rt* restrict saved = RecordsOnNode_[iw];
 
       // take sample
-      EngineObj->take_sample(saved[ENERGY_NEW], 1.0, saved[REWEIGHT] / SumValue[SUM_WGT]);
+      EngineObj.take_sample(saved[ENERGY_NEW], 1.0, saved[REWEIGHT] / SumValue[SUM_WGT]);
     }
   }
   //}
   // finish taking sample
-  EngineObj->sample_finish();
+  EngineObj.sample_finish();
 
   // compute energy and target relevant quantities
-  EngineObj->energy_target_compute();
+  EngineObj.energy_target_compute();
 
   // prepare variables to hold the output of the engine call
-  double energy_avg  = EngineObj->energy_mean();
-  double energy_sdev = EngineObj->energy_sdev();
-  double energy_serr = EngineObj->energy_statistical_err();
-  double target_avg  = EngineObj->target_value();
-  double target_serr = EngineObj->target_statistical_err();
+  double energy_avg  = EngineObj.energy_mean();
+  double energy_sdev = EngineObj.energy_sdev();
+  double energy_serr = EngineObj.energy_statistical_err();
+  double target_avg  = EngineObj.target_value();
+  double target_serr = EngineObj.target_statistical_err();
 
 
   // return the cost function value (target function if we are targeting excited states and energy if we are doing groud state calculations)

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
@@ -233,8 +233,8 @@ void QMCCostFunction::getConfigurations(const std::string& aroot)
 void QMCCostFunction::checkConfigurations(EngineHandle& handle)
 {
   const auto num_opt_vars = opt_vars.size();
-  RealType et_tot = 0.0;
-  RealType e2_tot = 0.0;
+  RealType et_tot         = 0.0;
+  RealType e2_tot         = 0.0;
 #pragma omp parallel reduction(+ : et_tot, e2_tot)
   {
     int ip = omp_get_thread_num();
@@ -345,7 +345,7 @@ void QMCCostFunction::checkConfigurations(EngineHandle& handle)
 /** evaluate everything before optimization
  *In future, both the LM and descent engines should be children of some parent engine base class.
  * */
-void QMCCostFunction::engine_checkConfigurations(cqmc::engine::LMYEngine<Return_t>* EngineObj,
+void QMCCostFunction::engine_checkConfigurations(cqmc::engine::LMYEngine<Return_t>& EngineObj,
                                                  DescentEngine& descentEngineObj,
                                                  const std::string& MinMethod)
 {
@@ -429,7 +429,7 @@ void QMCCostFunction::engine_checkConfigurations(cqmc::engine::LMYEngine<Return_
         if (MinMethod == "adaptive")
         {
           // pass into engine
-          EngineObj->take_sample(der_rat_samp, le_der_samp, le_der_samp, 1.0, saved[REWEIGHT]);
+          EngineObj.take_sample(der_rat_samp, le_der_samp, le_der_samp, 1.0, saved[REWEIGHT]);
         }
         else if (MinMethod == "descent")
         {
@@ -478,7 +478,7 @@ void QMCCostFunction::engine_checkConfigurations(cqmc::engine::LMYEngine<Return_
 #ifdef HAVE_LMY_ENGINE
   // engine finish taking samples
   if (MinMethod == "adaptive")
-    EngineObj->sample_finish();
+    EngineObj.sample_finish();
   else if (MinMethod == "descent")
     descentEngineObj.sample_finish();
 #endif

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.h
@@ -40,7 +40,7 @@ public:
   void getConfigurations(const std::string& aroot) override;
   void checkConfigurations(EngineHandle& handle) override;
 #ifdef HAVE_LMY_ENGINE
-  void engine_checkConfigurations(cqmc::engine::LMYEngine<Return_t>* EngineObj,
+  void engine_checkConfigurations(cqmc::engine::LMYEngine<Return_t>& EngineObj,
                                   DescentEngine& descentEngineObj,
                                   const std::string& MinMethod) override;
 #endif
@@ -64,7 +64,7 @@ protected:
 
 #ifdef HAVE_LMY_ENGINE
   size_t total_samples();
-  Return_rt LMYEngineCost_detail(cqmc::engine::LMYEngine<Return_t>* EngineObj) override;
+  Return_rt LMYEngineCost_detail(cqmc::engine::LMYEngine<Return_t>& EngineObj) override;
 #endif
 
   NewTimer& fill_timer_;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -131,19 +131,13 @@ QMCCostFunctionBase::Return_rt QMCCostFunctionBase::Cost(bool needGrad)
 }
 
 QMCCostFunctionBase::Return_rt QMCCostFunctionBase::fillHamVec(std::vector<Return_rt>& ham)
-{
-  throw std::runtime_error("Need to implement fillHamVec");
-}
+{ throw std::runtime_error("Need to implement fillHamVec"); }
 
 void QMCCostFunctionBase::calcOvlParmVec(const std::vector<Return_rt>& param, std::vector<Return_rt>& ovlParmVec)
-{
-  throw std::runtime_error("Need to implement calcOvlParmVec");
-}
+{ throw std::runtime_error("Need to implement calcOvlParmVec"); }
 
 void QMCCostFunctionBase::checkConfigurationsSR(EngineHandle& handle)
-{
-  throw std::runtime_error("Need to implement checkConfigurationsSR");
-}
+{ throw std::runtime_error("Need to implement checkConfigurationsSR"); }
 
 void QMCCostFunctionBase::printEstimates()
 {
@@ -393,12 +387,11 @@ bool QMCCostFunctionBase::put(xmlNodePtr q)
   InitVariables = opt_vars;
   //get the indices
   Psi.checkOutVariables(opt_vars);
-  
+
   if (const auto num_opt_vars = opt_vars.size(); num_opt_vars == 0)
     throw UniformCommunicateError("QMCCostFunctionBase::put No valid optimizable variables are found.");
   else
-    app_log() << " In total " << num_opt_vars << " parameters being optimized after applying constraints."
-              << std::endl;
+    app_log() << " In total " << num_opt_vars << " parameters being optimized after applying constraints." << std::endl;
   //     app_log() << "<active-optimizables> " << std::endl;
   //     opt_vars.print(app_log());
   //     app_log() << "</active-optimizables>" << std::endl;
@@ -1025,7 +1018,7 @@ void QMCCostFunctionBase::resetOptimizableObjects(TrialWaveFunction& psi, const 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #ifdef HAVE_LMY_ENGINE
 QMCCostFunctionBase::Return_rt QMCCostFunctionBase::LMYEngineCost(const bool needDeriv,
-                                                                  cqmc::engine::LMYEngine<Return_t>* EngineObj)
+                                                                  cqmc::engine::LMYEngine<Return_t>& EngineObj)
 {
   // prepare local energies, weights, and possibly derivative vectors, and compute standard cost
   const Return_rt standardCost = this->Cost(needDeriv);

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -147,7 +147,7 @@ public:
   virtual void calcOvlParmVec(const std::vector<Return_rt>& param, std::vector<Return_rt>& ovlParmVec);
 
 #ifdef HAVE_LMY_ENGINE
-  Return_rt LMYEngineCost(const bool needDeriv, cqmc::engine::LMYEngine<Return_t>* EngineObj);
+  Return_rt LMYEngineCost(const bool needDeriv, cqmc::engine::LMYEngine<Return_t>& EngineObj);
 #endif
 
   virtual void getConfigurations(const std::string& aroot) = 0;
@@ -158,7 +158,7 @@ public:
   //for SR method
   virtual void checkConfigurationsSR(EngineHandle& handle);
 #ifdef HAVE_LMY_ENGINE
-  virtual void engine_checkConfigurations(cqmc::engine::LMYEngine<Return_t>* EngineObj,
+  virtual void engine_checkConfigurations(cqmc::engine::LMYEngine<Return_t>& EngineObj,
                                           DescentEngine& descentEngineObj,
                                           const std::string& MinMethod) = 0;
 
@@ -314,7 +314,7 @@ protected:
   void resetOptimizableObjects(TrialWaveFunction& psi, const OptVariables& opt_variables) const;
 
 #ifdef HAVE_LMY_ENGINE
-  virtual Return_rt LMYEngineCost_detail(cqmc::engine::LMYEngine<Return_t>* EngineObj)
+  virtual Return_rt LMYEngineCost_detail(cqmc::engine::LMYEngine<Return_t>& EngineObj)
   {
     APP_ABORT("NOT IMPLEMENTED");
     return 0;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -40,9 +40,7 @@ QMCCostFunctionBatched::QMCCostFunctionBatched(ParticleSet& w,
       corr_sampling_timer_(createGlobalTimer("QMCCostFunctionBatched::correlatedSampling", timer_level_medium)),
       fill_timer_(createGlobalTimer("QMCCostFunctionBatched::fillOverlapHamiltonianMatrices", timer_level_medium))
 
-{
-  app_log() << " Using QMCCostFunctionBatched::QMCCostFunctionBatched" << std::endl;
-}
+{ app_log() << " Using QMCCostFunctionBatched::QMCCostFunctionBatched" << std::endl; }
 
 
 /** Clean up the vector */
@@ -628,12 +626,10 @@ void QMCCostFunctionBatched::checkConfigurationsSR(EngineHandle& handle)
 }
 
 #ifdef HAVE_LMY_ENGINE
-void QMCCostFunctionBatched::engine_checkConfigurations(cqmc::engine::LMYEngine<Return_t>* EngineObj,
+void QMCCostFunctionBatched::engine_checkConfigurations(cqmc::engine::LMYEngine<Return_t>& EngineObj,
                                                         DescentEngine& descentEngineObj,
                                                         const std::string& MinMethod)
-{
-  APP_ABORT("LMYEngine not implemented with batch optimization");
-}
+{ APP_ABORT("LMYEngine not implemented with batch optimization"); }
 #endif
 
 
@@ -794,7 +790,7 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
               vmc_or_dmc, needGrad);
 
   // Sum weights over crowds
-  Return_rt wgt_tot = 0.0;
+  Return_rt wgt_tot       = 0.0;
   Return_rt inv_n_samples = 1.0 / (samples_.getNumSamples() * myComm->size());
   for (int i = 0; i < opt_eval.size(); i++)
     wgt_tot += opt_eval[i]->get_wgt() * inv_n_samples;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
@@ -54,7 +54,7 @@ public:
   void checkConfigurations(EngineHandle& handle) override;
   void checkConfigurationsSR(EngineHandle& handle) override;
 #ifdef HAVE_LMY_ENGINE
-  void engine_checkConfigurations(cqmc::engine::LMYEngine<Return_t>* EngineObj,
+  void engine_checkConfigurations(cqmc::engine::LMYEngine<Return_t>& EngineObj,
                                   DescentEngine& descentEngineObj,
                                   const std::string& MinMethod) override;
 #endif
@@ -94,7 +94,7 @@ protected:
 
 #ifdef HAVE_LMY_ENGINE
   size_t total_samples();
-  Return_rt LMYEngineCost_detail(cqmc::engine::LMYEngine<Return_t>* EngineObj) override;
+  Return_rt LMYEngineCost_detail(cqmc::engine::LMYEngine<Return_t>& EngineObj) override;
 #endif
 
   friend testing::LinearMethodTestSupport;

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -125,67 +125,9 @@ QMCFixedSampleLinearOptimize::QMCFixedSampleLinearOptimize(const ProjectData& pr
   m_param.add(cost_increase_tol, "cost_increase_tol");
   m_param.add(target_shift_i, "target_shift_i");
   m_param.add(param_tol, "alloweddifference");
-
-#ifdef HAVE_LMY_ENGINE
-  //app_log() << "construct QMCFixedSampleLinearOptimize" << endl;
-  std::vector<double> shift_scales(3, 1.0);
-  EngineObj = new cqmc::engine::LMYEngine<ValueType>(&vdeps,
-                                                     false, // exact sampling
-                                                     true,  // ground state?
-                                                     false, // variance correct,
-                                                     true,
-                                                     true,  // print matrices,
-                                                     true,  // build matrices
-                                                     false, // spam
-                                                     false, // use var deps?
-                                                     true,  // chase lowest
-                                                     false, // chase closest
-                                                     false, // eom
-                                                     false,
-                                                     false,  // eom related
-                                                     false,  // eom related
-                                                     false,  // use block?
-                                                     120000, // number of samples
-                                                     0,      // number of parameters
-                                                     60,     // max krylov iter
-                                                     0,      // max spam inner iter
-                                                     1,      // spam appro degree
-                                                     0,      // eom related
-                                                     0,      // eom related
-                                                     0,      // eom related
-                                                     0.0,    // omega
-                                                     0.0,    // var weight
-                                                     1.0e-6, // convergence threshold
-                                                     0.99,   // minimum S singular val
-                                                     0.0, 0.0,
-                                                     10.0, // max change allowed
-                                                     1.00, // identity shift
-                                                     1.00, // overlap shift
-                                                     0.3,  // max parameter change
-                                                     shift_scales, app_log());
-#endif
-
-
-  //   stale parameters
-  //   m_param.add(eigCG,"eigcg");
-  //   m_param.add(TotalCGSteps,"cgsteps");
-  //   m_param.add(w_beta,"beta");
-  //   quadstep=-1.0;
-  //   m_param.add(quadstep,"quadstep");
-  //   m_param.add(stepsize,"stepsize");
-  //   m_param.add(exp1,"exp1");
-  //   m_param.add(StabilizerMethod,"StabilizerMethod");
-  //   m_param.add(LambdaMax,"LambdaMax");
-  //Set parameters for line minimization:
 }
 
-/** Clean up the vector */
-QMCFixedSampleLinearOptimize::~QMCFixedSampleLinearOptimize()
-{
-#ifdef HAVE_LMY_ENGINE
-  delete EngineObj;
-#endif
-}
+QMCFixedSampleLinearOptimize::~QMCFixedSampleLinearOptimize() = default;
 
 QMCFixedSampleLinearOptimize::RealType QMCFixedSampleLinearOptimize::Func(RealType dl)
 {
@@ -572,19 +514,56 @@ bool QMCFixedSampleLinearOptimize::processOptXML(xmlNodePtr opt_xml, const std::
   previous_optimizer_type_ = current_optimizer_type_;
   current_optimizer_type_  = OptimizerNames.at(MinMethod);
 
+#ifdef HAVE_LMY_ENGINE
+  if (!EngineObj &&
+      (current_optimizer_type_ == OptimizerType::DESCENT || current_optimizer_type_ == OptimizerType::ADAPTIVE))
+  {
+    //app_log() << "construct QMCFixedSampleLinearOptimize" << endl;
+    std::vector<double> shift_scales(3, 1.0);
+    EngineObj = std::make_unique<cqmc::engine::LMYEngine<ValueType>>(&vdeps,
+                                                                     false, // exact sampling
+                                                                     true,  // ground state?
+                                                                     false, // variance correct,
+                                                                     true,
+                                                                     true,  // print matrices,
+                                                                     true,  // build matrices
+                                                                     false, // spam
+                                                                     false, // use var deps?
+                                                                     true,  // chase lowest
+                                                                     false, // chase closest
+                                                                     false, // eom
+                                                                     false,
+                                                                     false,  // eom related
+                                                                     false,  // eom related
+                                                                     false,  // use block?
+                                                                     120000, // number of samples
+                                                                     0,      // number of parameters
+                                                                     60,     // max krylov iter
+                                                                     0,      // max spam inner iter
+                                                                     1,      // spam appro degree
+                                                                     0,      // eom related
+                                                                     0,      // eom related
+                                                                     0,      // eom related
+                                                                     0.0,    // omega
+                                                                     0.0,    // var weight
+                                                                     1.0e-6, // convergence threshold
+                                                                     0.99,   // minimum S singular val
+                                                                     0.0, 0.0,
+                                                                     10.0, // max change allowed
+                                                                     1.00, // identity shift
+                                                                     1.00, // overlap shift
+                                                                     0.3,  // max parameter change
+                                                                     shift_scales, app_log());
+  }
+#endif
+
   if (current_optimizer_type_ == OptimizerType::DESCENT)
   {
     if (!descentEngineObj)
-    {
       descentEngineObj = std::make_unique<DescentEngine>(myComm, opt_xml);
-    }
-
     else
-    {
       descentEngineObj->processXML(opt_xml);
-    }
   }
-
 
   // sanity check
   if (targetExcited && current_optimizer_type_ != OptimizerType::ADAPTIVE &&
@@ -1002,7 +981,7 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
   EngineObj->reset();
 
   // generate samples and compute weights, local energies, and derivative vectors
-  engine_start(EngineObj, *descentEngineObj, MinMethod);
+  engine_start(*EngineObj, *descentEngineObj, MinMethod);
 
   // get dimension of the linear method matrices
   size_t N = numParams + 1;
@@ -1039,7 +1018,7 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
     finish();
 
     // take sample
-    engine_start(EngineObj, *descentEngineObj, MinMethod);
+    engine_start(*EngineObj, *descentEngineObj, MinMethod);
   }
 
   // say what we are doing
@@ -1135,7 +1114,7 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
   for (int i = 0; i < numParams; i++)
     optTarget->Params(i) = currParams.at(i) - parameterDirections.at(central_index).at(i + 1);
   optTarget->IsValid      = true;
-  const RealType initCost = optTarget->LMYEngineCost(false, EngineObj);
+  const RealType initCost = optTarget->LMYEngineCost(false, *EngineObj);
 
   // compute the update directions for the smaller and larger shifts relative to that of the middle shift
   for (int i = 0; i < numParams; i++)
@@ -1156,7 +1135,7 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
     for (int i = 0; i < numParams; i++)
       optTarget->Params(i) = currParams.at(i) + (k == central_index ? 0.0 : parameterDirections.at(k).at(i + 1));
     optTarget->IsValid = true;
-    costValues.at(k)   = optTarget->LMYEngineCost(false, EngineObj);
+    costValues.at(k)   = optTarget->LMYEngineCost(false, *EngineObj);
     good_update.at(k) =
         (good_update.at(k) && std::abs((initCost - costValues.at(k)) / initCost) < max_relative_cost_change);
     if (!good_update.at(k))
@@ -1417,8 +1396,7 @@ bool QMCFixedSampleLinearOptimize::descent_run()
   optTarget->setneedGrads(true);
 
   //Compute Lagrangian derivatives needed for parameter updates with engine_checkConfigurations, which is called inside engine_start
-  engine_start(EngineObj, *descentEngineObj, MinMethod);
-
+  engine_start(*EngineObj, *descentEngineObj, MinMethod);
 
   int descent_num = descentEngineObj->getDescentNum();
 
@@ -1540,7 +1518,7 @@ void QMCFixedSampleLinearOptimize::start()
 }
 
 #ifdef HAVE_LMY_ENGINE
-void QMCFixedSampleLinearOptimize::engine_start(cqmc::engine::LMYEngine<ValueType>* EngineObj,
+void QMCFixedSampleLinearOptimize::engine_start(cqmc::engine::LMYEngine<ValueType>& EngineObj,
                                                 DescentEngine& descentEngineObj,
                                                 std::string MinMethod)
 {

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
@@ -109,7 +109,7 @@ private:
 
 #ifdef HAVE_LMY_ENGINE
   formic::VarDeps vdeps;
-  cqmc::engine::LMYEngine<ValueType>* EngineObj;
+  std::unique_ptr<cqmc::engine::LMYEngine<ValueType>> EngineObj;
 #endif
 
   //engine for running various gradient descent based algorithms for optimization
@@ -233,7 +233,7 @@ private:
   ///common operation to start optimization, used by the derived classes
   void start();
 #ifdef HAVE_LMY_ENGINE
-  void engine_start(cqmc::engine::LMYEngine<ValueType>* EngineObj,
+  void engine_start(cqmc::engine::LMYEngine<ValueType>& EngineObj,
                     DescentEngine& descentEngineObj,
                     std::string MinMethod);
 #endif

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -135,55 +135,10 @@ QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(
   m_param.add(options_LMY_.ratio_threshold, "deriv_threshold");
   m_param.add(options_LMY_.store_samples, "store_samples");
   m_param.add(options_LMY_.filter_info, "filter_info");
-
-
-#ifdef HAVE_LMY_ENGINE
-  //app_log() << "construct QMCFixedSampleLinearOptimizeBatched" << endl;
-  std::vector<double> shift_scales(3, 1.0);
-  EngineObj = new cqmc::engine::LMYEngine<ValueType>(&vdeps,
-                                                     false, // exact sampling
-                                                     true,  // ground state?
-                                                     false, // variance correct,
-                                                     true,
-                                                     true,  // print matrices,
-                                                     true,  // build matrices
-                                                     false, // spam
-                                                     false, // use var deps?
-                                                     true,  // chase lowest
-                                                     false, // chase closest
-                                                     false, // eom
-                                                     false,
-                                                     false,  // eom related
-                                                     false,  // eom related
-                                                     false,  // use block?
-                                                     120000, // number of samples
-                                                     0,      // number of parameters
-                                                     60,     // max krylov iter
-                                                     0,      // max spam inner iter
-                                                     1,      // spam appro degree
-                                                     0,      // eom related
-                                                     0,      // eom related
-                                                     0,      // eom related
-                                                     0.0,    // omega
-                                                     0.0,    // var weight
-                                                     1.0e-6, // convergence threshold
-                                                     0.99,   // minimum S singular val
-                                                     0.0, 0.0,
-                                                     10.0, // max change allowed
-                                                     1.00, // identity shift
-                                                     1.00, // overlap shift
-                                                     0.3,  // max parameter change
-                                                     shift_scales, app_log());
-#endif
 }
 
 /** Clean up the vector */
-QMCFixedSampleLinearOptimizeBatched::~QMCFixedSampleLinearOptimizeBatched()
-{
-#ifdef HAVE_LMY_ENGINE
-  delete EngineObj;
-#endif
-}
+QMCFixedSampleLinearOptimizeBatched::~QMCFixedSampleLinearOptimizeBatched() = default;
 
 QMCFixedSampleLinearOptimizeBatched::RealType QMCFixedSampleLinearOptimizeBatched::costFunc(RealType dl)
 {
@@ -222,7 +177,7 @@ void QMCFixedSampleLinearOptimizeBatched::start()
 }
 
 #ifdef HAVE_LMY_ENGINE
-void QMCFixedSampleLinearOptimizeBatched::engine_start(cqmc::engine::LMYEngine<ValueType>* EngineObj,
+void QMCFixedSampleLinearOptimizeBatched::engine_start(cqmc::engine::LMYEngine<ValueType>& EngineObj,
                                                        DescentEngine& descentEngineObj,
                                                        std::string MinMethod)
 {
@@ -232,7 +187,7 @@ void QMCFixedSampleLinearOptimizeBatched::engine_start(cqmc::engine::LMYEngine<V
   if (MinMethod == "descent")
     handle = std::make_unique<DescentEngineHandle>(descentEngineObj);
   else if (MinMethod == "adaptive")
-    handle = std::make_unique<LMYEngineHandle>(*EngineObj);
+    handle = std::make_unique<LMYEngineHandle>(EngineObj);
   else
     handle = std::make_unique<NullEngineHandle>();
 
@@ -672,6 +627,50 @@ bool QMCFixedSampleLinearOptimizeBatched::processOptXML(xmlNodePtr opt_xml,
     throw std::runtime_error("Unknown MinMethod!\n");
   options_LMY_.previous_optimizer_type = options_LMY_.current_optimizer_type;
   options_LMY_.current_optimizer_type  = OptimizerNames.at(MinMethod);
+
+#ifdef HAVE_LMY_ENGINE
+  if (!EngineObj &&
+      (options_LMY_.current_optimizer_type == OptimizerType::DESCENT ||
+       options_LMY_.current_optimizer_type == OptimizerType::ADAPTIVE))
+  {
+    // app_log() << "construct QMCFixedSampleLinearOptimizeBatched" << endl;
+    std::vector<double> shift_scales(3, 1.0);
+    EngineObj = std::make_unique<cqmc::engine::LMYEngine<ValueType>>(&vdeps,
+                                                                     false, // exact sampling
+                                                                     true,  // ground state?
+                                                                     false, // variance correct,
+                                                                     true,
+                                                                     true,  // print matrices,
+                                                                     true,  // build matrices
+                                                                     false, // spam
+                                                                     false, // use var deps?
+                                                                     true,  // chase lowest
+                                                                     false, // chase closest
+                                                                     false, // eom
+                                                                     false,
+                                                                     false,  // eom related
+                                                                     false,  // eom related
+                                                                     false,  // use block?
+                                                                     120000, // number of samples
+                                                                     0,      // number of parameters
+                                                                     60,     // max krylov iter
+                                                                     0,      // max spam inner iter
+                                                                     1,      // spam appro degree
+                                                                     0,      // eom related
+                                                                     0,      // eom related
+                                                                     0,      // eom related
+                                                                     0.0,    // omega
+                                                                     0.0,    // var weight
+                                                                     1.0e-6, // convergence threshold
+                                                                     0.99,   // minimum S singular val
+                                                                     0.0, 0.0,
+                                                                     10.0, // max change allowed
+                                                                     1.00, // identity shift
+                                                                     1.00, // overlap shift
+                                                                     0.3,  // max parameter change
+                                                                     shift_scales, app_log());
+  }
+#endif
 
   if (options_LMY_.current_optimizer_type == OptimizerType::DESCENT && !descentEngineObj)
     descentEngineObj = std::make_unique<DescentEngine>(myComm, opt_xml);
@@ -1177,7 +1176,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
   EngineObj->reset();
 
   // generate samples and compute weights, local energies, and derivative vectors
-  engine_start(EngineObj, *descentEngineObj, MinMethod);
+  engine_start(*EngineObj, *descentEngineObj, MinMethod);
 
   int new_num = 0;
 
@@ -1321,7 +1320,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
       finish();
 
       // take sample
-      engine_start(EngineObj, *descentEngineObj, MinMethod);
+      engine_start(*EngineObj, *descentEngineObj, MinMethod);
     }
     else
     {
@@ -1332,12 +1331,12 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
 
       if (options_LMY_.filter_param)
       {
-        engine_start(EngineObj, *descentEngineObj, MinMethod);
+        engine_start(*EngineObj, *descentEngineObj, MinMethod);
         EngineObj->buildMatricesFromDerivatives();
       }
       else
       {
-        engine_start(EngineObj, *descentEngineObj, MinMethod);
+        engine_start(*EngineObj, *descentEngineObj, MinMethod);
         app_log() << "Should be building matrices from stored samples" << std::endl;
         EngineObj->buildMatricesFromDerivatives();
       }
@@ -1478,7 +1477,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
   for (int i = 0; i < numParams; i++)
     optTarget->Params(i) = currParams.at(i) - parameterDirections.at(central_index).at(i + 1);
   optTarget->IsValid      = true;
-  const RealType initCost = optTarget->LMYEngineCost(false, EngineObj);
+  const RealType initCost = optTarget->LMYEngineCost(false, *EngineObj);
 
   // compute the update directions for the smaller and larger shifts relative to that of the middle shift
   for (int i = 0; i < numParams; i++)
@@ -1499,7 +1498,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
     for (int i = 0; i < numParams; i++)
       optTarget->Params(i) = currParams.at(i) + (k == central_index ? 0.0 : parameterDirections.at(k).at(i + 1));
     optTarget->IsValid = true;
-    costValues.at(k)   = optTarget->LMYEngineCost(false, EngineObj);
+    costValues.at(k)   = optTarget->LMYEngineCost(false, *EngineObj);
     good_update.at(k)  = (good_update.at(k) &&
                           std::abs((initCost - costValues.at(k)) / initCost) < options_LMY_.max_relative_cost_change);
     if (!good_update.at(k))
@@ -1943,7 +1942,7 @@ bool QMCFixedSampleLinearOptimizeBatched::stochastic_reconfiguration_conjugate_g
 bool QMCFixedSampleLinearOptimizeBatched::descent_run()
 {
   //Compute Lagrangian derivatives needed for parameter updates with engine_checkConfigurations, which is called inside engine_start
-  engine_start(EngineObj, *descentEngineObj, MinMethod);
+  engine_start(*EngineObj, *descentEngineObj, MinMethod);
 
   int descent_num = descentEngineObj->getDescentNum();
 

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -81,7 +81,7 @@ public:
 
 #ifdef HAVE_LMY_ENGINE
   using ValueType = QMCTraits::ValueType;
-  void engine_start(cqmc::engine::LMYEngine<ValueType>* EngineObj,
+  void engine_start(cqmc::engine::LMYEngine<ValueType>& EngineObj,
                     DescentEngine& descentEngineObj,
                     std::string MinMethod);
 #endif
@@ -144,7 +144,7 @@ private:
 
 #ifdef HAVE_LMY_ENGINE
   formic::VarDeps vdeps;
-  cqmc::engine::LMYEngine<ValueType>* EngineObj;
+  std::unique_ptr<cqmc::engine::LMYEngine<ValueType>> EngineObj;
 #endif
 
   //engine for running various gradient descent based algorithms for optimization

--- a/src/QMCTools/ppconvert/src/common/IOASCII.cc
+++ b/src/QMCTools/ppconvert/src/common/IOASCII.cc
@@ -506,7 +506,7 @@ namespace IO {
 
 
   IOVarBase *NewASCIIVar (std::string name, IODataType newType, int ndim,
-			  Array<int,1> dims)
+			  const Array<int,1>& dims)
   {
     if (ndim == 0) {
       if (newType == DOUBLE_TYPE)


### PR DESCRIPTION
## Proposed changes
The buggy LMYengine is no longer initialized unconditionally.
Also fix gcc warning in ppconvert.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
