### PR TITLE
Nexus: Update `pp_elem_label()` to prevent error without `guard=True`

### DIFF
--- a/nexus/nexus/pseudopotential.py
+++ b/nexus/nexus/pseudopotential.py
@@ -67,11 +67,18 @@ def pp_elem_label(filename,guard=False):
     is_elem, element = Elements.is_element(el, return_element=True)
     if guard: 
         if not is_elem:
-            error('cannot determine element for pseudopotential file: {0}\npseudopotential file names must be prefixed by an atomic symbol or label\n(e.g. Si, Si1, etc)'.format(filename))
+            error(
+                'cannot determine element for pseudopotential file: {0}\n'
+                'pseudopotential file names must be prefixed by an atomic symbol or label\n'
+                '(e.g. Si, Si1, etc)'.format(filename)
+            )
         #end if
         return elem_label, element.symbol
     else:
-        return elem_label, element.symbol, is_elem
+        if isinstance(element, Elements):
+            return elem_label, element.symbol, is_elem
+        else:
+            return elem_label, element, is_elem
     #end if
 #end def pp_elem_label
 


### PR DESCRIPTION
## Proposed changes

Since #5832 using `pp_elem_label()` without `guard=True` meant that if a file was encountered that was not properly prefixed with the atomic symbol/label would result in an error since the element was not found properly.

This fix just checks if the object returned by `Elements.is_element()` is actually a member of the `Elements` enum, and returns the symbol if so, otherwise it just returns the object itself.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora 43 KDE Plasma, Python 3.14.2, Numpy 2.4.4, `uv` 0.11.3

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'