### PR TITLE
Nexus: Update `NexusCore.enter()` to accept `pathlib.Path` objects

### DIFF
--- a/nexus/nexus/nexus_base.py
+++ b/nexus/nexus/nexus_base.py
@@ -220,7 +220,7 @@ _____________________________________________________
         if isinstance(directory, Path):
             directory = str(directory.resolve())
 
-        self.log('    Entering '+directory,msg)
+        self.log('    Entering ' + directory, msg)
         if changedir:
             os.chdir(directory)
         #end if

--- a/nexus/nexus/nexus_base.py
+++ b/nexus/nexus/nexus_base.py
@@ -216,6 +216,19 @@ _____________________________________________________
     #end def tlog
 
     def enter(self, directory: PathLike, changedir: bool = True, msg: str = ''):
+        """Have Nexus enter a directory and change its current working directory.
+        
+        Parameters
+        ----------
+        directory : PathLike
+            Directory to enter. Can be a ``str`` or ``pathlib.Path``
+            object.
+        changedir : bool, default=True
+            Default of ``True`` will change the CWD, setting to ``False``
+            will not change the CWD.
+        msg : str, optional
+            Optional message to pass to the output log.
+        """
         NexusCore.working_directory = os.getcwd()
         if isinstance(directory, Path):
             directory = str(directory.resolve())

--- a/nexus/nexus/nexus_base.py
+++ b/nexus/nexus/nexus_base.py
@@ -27,6 +27,8 @@
 
 import os
 import gc as garbage_collector
+from os import PathLike
+from pathlib import Path
 from .nexus_version import nexus_version
 from .memory import resident
 from .developer import DevBase, obj, log
@@ -213,8 +215,11 @@ _____________________________________________________
         #end if
     #end def tlog
 
-    def enter(self,directory,changedir=True,msg=''):
+    def enter(self, directory: PathLike, changedir: bool = True, msg: str = ''):
         NexusCore.working_directory = os.getcwd()
+        if isinstance(directory, Path):
+            directory = str(directory.resolve())
+
         self.log('    Entering '+directory,msg)
         if changedir:
             os.chdir(directory)


### PR DESCRIPTION
## Proposed changes

Simple change to accept `pathlib.Path` objects in anticipation of Pytest migration effects on temporary directory management (see #5881). Behavior is unchanged for all other object types.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Laptop, Fedora 43 KDE Plasma, Python 3.14.2, Numpy 2.4.4, `uv` 0.11.3, Pytest 9.0.3

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
