### PR TITLE
Change Nexus workflow to use `apt` and `brew` to install GraphViz

### DIFF
--- a/.github/workflows/ci-github-actions-nexus.yaml
+++ b/.github/workflows/ci-github-actions-nexus.yaml
@@ -5,26 +5,60 @@ on:
     branches:
       - develop
       - main
+      - nexus-workflow-graphviz
   pull_request:
     branches:
       - develop
       - main
 
 jobs:
-  build:
+  linux:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.14"]
-    runs-on: ${{ matrix.os }}
+
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout Action
       uses: actions/checkout@v6
 
     - name: Setup Graphviz
-      uses: ts-graphviz/setup-graphviz@v2
+      run: sudo apt-get install graphviz
+
+    - name: Install uv and Setup Python ${{ matrix.python-version }}
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: "0.11.6"
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Project and All Dependencies
+      run: uv sync --locked --all-extras --dev
+      working-directory: ./nexus
+
+    - name: Switch to Numpy == 1.22.0
+      if: contains(matrix.python-version, '3.10')
+      run: uv pip install numpy==1.22.0
+      working-directory: ./nexus
+
+    - name: Run Nexus Tests
+      run: uv run pytest nexus/tests/
+      working-directory: ./nexus
+
+  macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.14"]
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout Action
+      uses: actions/checkout@v6
+
+    - name: Setup Graphviz
+      run: brew upgrade || brew install graphviz
 
     - name: Install uv and Setup Python ${{ matrix.python-version }}
       uses: astral-sh/setup-uv@v7

--- a/.github/workflows/ci-github-actions-nexus.yaml
+++ b/.github/workflows/ci-github-actions-nexus.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
       - main
-      - nexus-workflow-graphviz
   pull_request:
     branches:
       - develop
@@ -37,7 +36,7 @@ jobs:
       run: uv sync --locked --all-extras --dev
       working-directory: ./nexus
 
-    - name: Switch to Numpy == 1.22.0
+    - name: Use Numpy 1.22.0 (Python 3.10 only)
       if: contains(matrix.python-version, '3.10')
       run: uv pip install numpy==1.22.0
       working-directory: ./nexus
@@ -70,7 +69,7 @@ jobs:
       run: uv sync --locked --all-extras --dev
       working-directory: ./nexus
 
-    - name: Switch to Numpy == 1.22.0
+    - name: Use Numpy 1.22.0 (Python 3.10 only)
       if: contains(matrix.python-version, '3.10')
       run: uv pip install numpy==1.22.0
       working-directory: ./nexus

--- a/.github/workflows/ci-github-actions-nexus.yaml
+++ b/.github/workflows/ci-github-actions-nexus.yaml
@@ -58,9 +58,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Setup Graphviz
-      run: |
-        brew update
-        brew install graphviz
+      run: brew install graphviz
 
     - name: Install uv and Setup Python ${{ matrix.python-version }}
       uses: astral-sh/setup-uv@v7

--- a/.github/workflows/ci-github-actions-nexus.yaml
+++ b/.github/workflows/ci-github-actions-nexus.yaml
@@ -58,7 +58,9 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Setup Graphviz
-      run: brew upgrade || brew install graphviz
+      run: |
+        brew update
+        brew install graphviz
 
     - name: Install uv and Setup Python ${{ matrix.python-version }}
       uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Proposed changes

The action that I used to install GraphViz originally was doing okay, but doesn't seem to be entirely maintained and had a bit of a performance hit due to a `brew upgrade` step in the action on MacOS. This PR switches the workflow to just run `brew install graphviz` for MacOS, and `sudo apt-get install graphviz` for Linux. The time improvements on Linux are minimal, if any, but preliminary testing indicates the MacOS jobs are ~30-45s faster.

The additional benefit is that we are less reliant on external actions and can use more trusted installation routes for the workflows.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

[My fork of QMCPACK](https://github.com/brockdyer03/qmcpack/actions/runs/24756066981)

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'