### PR TITLE
Restore working C++ coverage via large threshold for suspicious hits in gcovr coverage reports

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -363,7 +363,7 @@ case "$1" in
     cd ${GITHUB_WORKSPACE}/../qmcpack-build
     # filter unreachable branches with gcovr
     # see https://gcovr.com/en/stable/faq.html#why-does-c-code-have-so-many-uncovered-branches
-    gcovr --exclude-unreachable-branches --exclude-throw-branches --root=${GITHUB_WORKSPACE}/.. --xml-pretty -o coverage.xml
+    gcovr --exclude-unreachable-branches --exclude-throw-branches --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --root=${GITHUB_WORKSPACE}/.. --xml-pretty -o coverage.xml
     du -hs coverage.xml
     #cat coverage.xml
     python3-coverage combine nexus/nexus/tests/.coverage*

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -363,7 +363,9 @@ case "$1" in
     cd ${GITHUB_WORKSPACE}/../qmcpack-build
     # filter unreachable branches with gcovr
     # see https://gcovr.com/en/stable/faq.html#why-does-c-code-have-so-many-uncovered-branches
-    gcovr --exclude-unreachable-branches --exclude-throw-branches --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --root=${GITHUB_WORKSPACE}/.. --xml-pretty -o coverage.xml
+    # set suspicious hits threshold=2^40
+    # see https://gcovr.com/en/stable/manpage.html#gcov-options
+    gcovr --exclude-unreachable-branches --exclude-throw-branches --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --gcov-suspicious-hits-threshold=1099511627776 --root=${GITHUB_WORKSPACE}/.. --xml-pretty -o coverage.xml
     du -hs coverage.xml
     #cat coverage.xml
     python3-coverage combine nexus/nexus/tests/.coverage*


### PR DESCRIPTION
## Proposed changes

~Experiment to see if this gets workable coverage. Most likely we have some concurrency issues as well.~

Restore working C++ coverage. Set a large threshold for reporting of suspicious hits. These occur in overloaded operators that are naturally called large numbers of times across the entire test set.

A similar problem was noted in the comments on https://github.com/gcovr/gcovr/pull/903

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None. CI result must be checked: does any C++ coverage reappear?

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
