### PR TITLE
Nexus: Suppress warnings from `spglib` and `PyCifRW`

### DIFF
--- a/nexus/pyproject.toml
+++ b/nexus/pyproject.toml
@@ -70,6 +70,8 @@ omit = [
 #addopts = ["--cov=nexus", "--cov-report=xml"]
 filterwarnings = [
     "ignore::UserWarning",
+    "ignore::DeprecationWarning:spglib.*",
+    "ignore:::.*.CifFile",
 ]
 testpaths = ["nexus/tests"]
 xfail_strict = true


### PR DESCRIPTION
## Proposed changes

This is a pretty minimal PR that just disables warnings from `spglib` and `PyCifRW`. Specifically in `spglib` there are a number of `DeprecationWarning`, and in `PyCifRW` (which is really `CifFile`) there is a `SyntaxWarning`.

These aren't our responsibility, and can end up masking warnings that are actually important.

## What type(s) of changes does this code introduce?

- Bugfix
- Testing changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora 43 KDE Plasma
Python 3.14.4
Numpy 2.4.4
`spglib` 2.7.0
`pycifrw` 4.4.6
`pytest` 9.0.2

AND

Python 3.10.19
Numpy 2.2.6
`spglib` 2.7.0
`pycifrw` 4.4.6
`pytest` 6.2.4

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'