### PR TITLE
Nexus: Clean up testing imports and unused code

### DIFF
--- a/nexus/nexus/tests/test_basisset.py
+++ b/nexus/nexus/tests/test_basisset.py
@@ -8,7 +8,7 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import value_eq,object_eq
+from ..testing import object_eq
 from ..testing import divert_nexus_log,restore_nexus_log
 
 

--- a/nexus/nexus/tests/test_bundle.py
+++ b/nexus/nexus/tests/test_bundle.py
@@ -9,7 +9,7 @@ except ImportError:
 
 from .. import testing
 from ..testing import failed,FailedTest
-from ..testing import value_eq,object_eq
+from ..testing import object_eq
 
 
 def test_import():

--- a/nexus/nexus/tests/test_gamess_analyzer.py
+++ b/nexus/nexus/tests/test_gamess_analyzer.py
@@ -8,7 +8,7 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import value_eq,object_eq,text_eq
+from ..testing import object_eq
 
 
 def test_import():
@@ -26,7 +26,7 @@ def test_empty_init():
 
 def test_analyze():
     import os
-    from numpy import array,ndarray
+    from numpy import array
     from ..developer import obj
     from ..gamess_analyzer import GamessAnalyzer
 

--- a/nexus/nexus/tests/test_gamess_input.py
+++ b/nexus/nexus/tests/test_gamess_input.py
@@ -8,9 +8,9 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import divert_nexus,restore_nexus
+from ..testing import restore_nexus
 from ..testing import divert_nexus_log,restore_nexus_log
-from ..testing import value_eq,object_eq
+from ..testing import object_eq
 
 
 associated_files = dict()

--- a/nexus/nexus/tests/test_gamess_simulation.py
+++ b/nexus/nexus/tests/test_gamess_simulation.py
@@ -8,9 +8,9 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import divert_nexus,restore_nexus
+from ..testing import restore_nexus
 from ..testing import failed,FailedTest
-from ..testing import value_eq,object_eq,text_eq
+from ..testing import object_eq
 
 
 def clear_all_sims():
@@ -78,7 +78,6 @@ def test_minimal_init():
 
 
 def test_check_result():
-    tpath = testing.setup_unit_test_output_directory('gamess_simulation','test_check_result')
 
     sim = get_gamess_sim('rhf')
     
@@ -145,10 +144,8 @@ def test_get_result():
 
 
 def test_incorporate_result():
-    import os
-    from ..developer import NexusError, obj
 
-    tpath = testing.setup_unit_test_output_directory('gamess_simulation','test_incorporate_result')
+    from ..developer import NexusError, obj
 
     sim = get_gamess_sim('rhf')
 
@@ -188,7 +185,6 @@ def test_incorporate_result():
 
 def test_check_sim_status():
     import os
-    from ..developer import NexusError, obj
     from ..nexus_base import nexus_core
 
     tpath = testing.setup_unit_test_output_directory('gamess_simulation','test_check_sim_status',divert=True)

--- a/nexus/nexus/tests/test_generic.py
+++ b/nexus/nexus/tests/test_generic.py
@@ -10,10 +10,10 @@ except ImportError:
 from .. import testing
 from ..testing import failed,FailedTest
 from ..testing import divert_nexus_log,restore_nexus_log,FakeLog
-from ..testing import value_eq,object_eq,object_neq
+from ..testing import object_eq,object_neq
 
 def test_logging():
-    from ..generic import log,message,warn,error
+    from ..generic import log,warn,error
     from ..generic import generic_settings,NexusError
 
     # send messages to object rather than stdout

--- a/nexus/nexus/tests/test_grid_functions.py
+++ b/nexus/nexus/tests/test_grid_functions.py
@@ -500,7 +500,7 @@ def get_props():
 
 def test_grid_initialization():
     import numpy as np
-    from ..testing import object_eq,value_eq
+    from ..testing import value_eq
     from ..grid_functions import Grid,StructuredGrid,StructuredGridWithAxes
     from ..grid_functions import ParallelotopeGrid
     from ..grid_functions import SpheroidGrid
@@ -662,7 +662,6 @@ def test_grid_reset():
 
 def test_grid_set_operations():
     import numpy as np
-    from ..developer import obj
     from ..testing import value_eq
     from .. import numpy_extensions as npe
 
@@ -1030,7 +1029,7 @@ def test_grid_inside():
 
 def test_grid_project():
     import numpy as np
-    from ..testing import value_eq,object_eq
+    from ..testing import object_eq
     from .. import numpy_extensions as npe
     
     def make_1d(x):
@@ -1314,9 +1313,6 @@ def test_grid_function_initialization():
     import numpy as np
     from ..testing import object_eq
     from ..grid_functions import unit_grid_points
-    from ..grid_functions import ParallelotopeGrid
-    from ..grid_functions import SpheroidGrid
-    from ..grid_functions import SpheroidSurfaceGrid
     from ..grid_functions import GridFunction
     from ..grid_functions import StructuredGridFunction
     from ..grid_functions import StructuredGridFunctionWithAxes

--- a/nexus/nexus/tests/test_hdfreader.py
+++ b/nexus/nexus/tests/test_hdfreader.py
@@ -9,7 +9,7 @@ except ImportError:
 
 from nexus.versions import h5py_available
 from .. import testing
-from ..testing import value_eq,object_eq
+from ..testing import value_eq
 
 
 def test_import():

--- a/nexus/nexus/tests/test_machines.py
+++ b/nexus/nexus/tests/test_machines.py
@@ -8,7 +8,7 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import value_eq,object_eq,failed,FailedTest
+from ..testing import object_eq,object_diff,failed,FailedTest
 from ..testing import divert_nexus_log,restore_nexus_log
 
 

--- a/nexus/nexus/tests/test_nexus_base.py
+++ b/nexus/nexus/tests/test_nexus_base.py
@@ -8,7 +8,7 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import value_eq,object_eq
+from ..testing import object_eq
 from ..testing import divert_nexus_log,restore_nexus_log
 
 

--- a/nexus/nexus/tests/test_numerics.py
+++ b/nexus/nexus/tests/test_numerics.py
@@ -283,7 +283,6 @@ if scipy_available:
 
     def test_convex_hull():
         import numpy as np
-        from ..testing import value_eq
         from ..numerics import convex_hull
 
         points = [
@@ -402,7 +401,6 @@ def test_equilibration_length():
 
 if scipy_available:
     def test_ttest():
-        import numpy as np
         from ..testing import value_eq
         from ..numerics import ttest
 
@@ -440,10 +438,9 @@ def test_morse():
     from ..unit_converter import convert
     from ..numerics import morse,morse_re,morse_a,morse_De,morse_Einf,morse_width
     from ..numerics import morse_depth,morse_Ee,morse_k,morse_params
-    from ..numerics import morse_reduced_mass,morse_freq,morse_w,morse_wX
+    from ..numerics import morse_reduced_mass,morse_freq,morse_w
     from ..numerics import morse_E0,morse_En,morse_zero_point,morse_harmfreq
-    from ..numerics import morse_harmonic_potential,morse_spect_fit
-    from ..numerics import morse_rDw_fit,morse_fit,morse_fit_fine
+    from ..numerics import morse_rDw_fit
 
     rm = morse_reduced_mass('Ti','O')
     assert(value_eq(rm, 21858.453534035318))
@@ -563,7 +560,7 @@ def test_eos():
     import numpy as np
     from ..testing import value_eq
     from ..unit_converter import convert
-    from ..numerics import eos_fit,eos_eval,eos_param
+    from ..numerics import eos_eval,eos_param
 
     data = np.array([
             [0.875, -83.31851261], 
@@ -610,7 +607,7 @@ if scipy_available:
         import numpy as np
         from ..testing import value_eq
         from ..unit_converter import convert
-        from ..numerics import eos_fit,eos_eval,eos_param
+        from ..numerics import eos_fit,eos_eval
 
         data = np.array([
                 [0.875, -83.31851261], 

--- a/nexus/nexus/tests/test_nxs_sim.py
+++ b/nexus/nexus/tests/test_nxs_sim.py
@@ -9,7 +9,7 @@ except ImportError:
 
 import sys
 from .. import testing
-from ..testing import divert_nexus,restore_nexus,clear_all_sims
+from ..testing import restore_nexus,clear_all_sims
 from ..testing import execute,text_eq
 
 

--- a/nexus/nexus/tests/test_observables.py
+++ b/nexus/nexus/tests/test_observables.py
@@ -7,8 +7,7 @@ try:
 except ImportError:
     pass
 
-from .. import testing
-from ..testing import value_eq,object_eq,text_eq,check_object_eq
+from ..testing import check_object_eq
 from ..testing import FailedTest,failed
 
 

--- a/nexus/nexus/tests/test_periodic_table.py
+++ b/nexus/nexus/tests/test_periodic_table.py
@@ -16,7 +16,6 @@ def test_import():
 
 
 def test_periodic_table():
-    from ..testing import value_eq
     from ..periodic_table import Elements
 
     ref_element_symbols = (

--- a/nexus/nexus/tests/test_physical_system.py
+++ b/nexus/nexus/tests/test_physical_system.py
@@ -10,7 +10,7 @@ except ImportError:
 
 import numpy as np
 from .. import testing
-from ..testing import value_eq,object_eq,object_diff,print_diff
+from ..testing import value_eq,object_eq
 
 from .test_structure import structure_same
 
@@ -45,9 +45,7 @@ def test_import():
 
 
 def test_particle_initialization():
-    from ..developer import obj
     from ..physical_system import Matter,Particle,Ion,PseudoIon,Particles
-    from ..physical_system import PhysicalSystem,generate_physical_system
 
     # empty initialization
     Matter()

--- a/nexus/nexus/tests/test_project_manager.py
+++ b/nexus/nexus/tests/test_project_manager.py
@@ -8,7 +8,7 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import value_eq,object_eq
+from ..testing import value_eq
 from ..testing import failed,FailedTest
 from ..testing import divert_nexus_log,restore_nexus_log
 from ..testing import divert_nexus,restore_nexus
@@ -196,7 +196,6 @@ def test_resolve_file_collisions():
 
 
 def test_propagate_blockages():
-    from ..developer import NexusError
     from ..simulation import Simulation
     from ..project_manager import ProjectManager
 

--- a/nexus/nexus/tests/test_pwscf_analyzer.py
+++ b/nexus/nexus/tests/test_pwscf_analyzer.py
@@ -8,7 +8,7 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import value_eq,object_eq,text_eq
+from ..testing import object_eq
 
 
 def test_import():
@@ -27,7 +27,7 @@ def test_empty_init():
 
 def test_analyze():
     import os
-    from numpy import array,ndarray
+    from numpy import array
     from ..developer import obj
     from ..pwscf_analyzer import PwscfAnalyzer
 

--- a/nexus/nexus/tests/test_pwscf_input.py
+++ b/nexus/nexus/tests/test_pwscf_input.py
@@ -10,7 +10,7 @@ except ImportError:
 from .. import testing
 from ..testing import failed
 from ..testing import divert_nexus_log,restore_nexus_log
-from ..testing import value_eq,object_eq,object_diff
+from ..testing import object_eq,object_diff
 
 
 associated_files = dict()
@@ -60,7 +60,6 @@ def test_input():
     # imports
     import os
     import numpy as np
-    from .. import pwscf_input as pwi
     from ..developer import obj
     from ..structure import read_structure
     from ..physical_system import generate_physical_system

--- a/nexus/nexus/tests/test_pwscf_postprocessor_analyzers.py
+++ b/nexus/nexus/tests/test_pwscf_postprocessor_analyzers.py
@@ -8,7 +8,7 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import value_eq,object_eq,text_eq
+from ..testing import object_eq,text_eq
 
 
 

--- a/nexus/nexus/tests/test_pwscf_postprocessor_input.py
+++ b/nexus/nexus/tests/test_pwscf_postprocessor_input.py
@@ -8,7 +8,7 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import value_eq,object_eq,text_eq
+from ..testing import object_eq
 
 
 projwfc_in = '''&projwfc

--- a/nexus/nexus/tests/test_pwscf_postprocessor_simulations.py
+++ b/nexus/nexus/tests/test_pwscf_postprocessor_simulations.py
@@ -7,10 +7,8 @@ try:
 except ImportError:
     pass
 
-from .. import testing
-from ..testing import divert_nexus,restore_nexus,clear_all_sims
+from ..testing import clear_all_sims
 from ..testing import failed,FailedTest
-from ..testing import value_eq,object_eq,text_eq
 
 
 def get_class_generators():

--- a/nexus/nexus/tests/test_pwscf_simulation.py
+++ b/nexus/nexus/tests/test_pwscf_simulation.py
@@ -8,9 +8,9 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import divert_nexus,restore_nexus,clear_all_sims
+from ..testing import restore_nexus,clear_all_sims
 from ..testing import failed,FailedTest
-from ..testing import value_eq,object_eq,text_eq
+from ..testing import value_eq,object_eq
 
 
 

--- a/nexus/nexus/tests/test_pyscf_input.py
+++ b/nexus/nexus/tests/test_pyscf_input.py
@@ -8,7 +8,7 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import value_eq,object_eq,text_eq
+from ..testing import object_eq,text_eq
 
 
 mno_poscar = '''MnO Crystal

--- a/nexus/nexus/tests/test_pyscf_simulation.py
+++ b/nexus/nexus/tests/test_pyscf_simulation.py
@@ -8,9 +8,8 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import divert_nexus,restore_nexus,clear_all_sims
+from ..testing import restore_nexus,clear_all_sims
 from ..testing import failed,FailedTest
-from ..testing import value_eq,object_eq,text_eq
 
 
 def get_pyscf_sim(**kwargs):
@@ -77,7 +76,7 @@ def test_check_result():
 
 def test_get_result():
     import os
-    from ..developer import NexusError, obj
+    from ..developer import NexusError
     from ..nexus_base import nexus_core
 
     tpath = testing.setup_unit_test_output_directory('pyscf_simulation','test_get_result',divert=True)

--- a/nexus/nexus/tests/test_qmcpack_analyzer.py
+++ b/nexus/nexus/tests/test_qmcpack_analyzer.py
@@ -10,7 +10,7 @@ except ImportError:
 from .. import versions
 from .. import testing
 from ..testing import divert_nexus_log,restore_nexus_log
-from ..testing import value_eq,object_eq,text_eq,print_diff
+from ..testing import value_eq,object_eq,text_eq
 
 
 def test_import():
@@ -446,7 +446,6 @@ if versions.h5py_available:
     def test_density_analysis():
         import os
         from numpy import array
-        from ..developer import obj
         from ..qmcpack_analyzer import QmcpackAnalyzer
 
         tpath = testing.setup_unit_test_output_directory(

--- a/nexus/nexus/tests/test_qmcpack_converter_input.py
+++ b/nexus/nexus/tests/test_qmcpack_converter_input.py
@@ -8,7 +8,7 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import value_eq,object_eq,text_eq
+from ..testing import value_eq,object_eq
 
 
 

--- a/nexus/nexus/tests/test_qmcpack_converter_simulations.py
+++ b/nexus/nexus/tests/test_qmcpack_converter_simulations.py
@@ -8,9 +8,9 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import divert_nexus,restore_nexus,clear_all_sims
+from ..testing import restore_nexus,clear_all_sims
 from ..testing import failed,FailedTest
-from ..testing import value_eq,object_eq,text_eq
+from ..testing import object_eq
 
 
 #====================================================================#
@@ -97,7 +97,7 @@ def test_pw2qmcpack_get_result():
 
 
 def test_pw2qmcpack_incorporate_result():
-    from ..developer import NexusError, obj
+    from ..developer import NexusError
     from ..simulation import Simulation
     from .test_pwscf_simulation import pseudo_inputs,get_pwscf_sim
 
@@ -111,7 +111,7 @@ def test_pw2qmcpack_incorporate_result():
 
     try:
         sim.incorporate_result('unknown',None,other)
-        raise TestFailed
+        raise FailedTest
     except NexusError:
         None
     except FailedTest:
@@ -130,7 +130,6 @@ def test_pw2qmcpack_incorporate_result():
 
 def test_pw2qmcpack_check_sim_status():
     import os
-    from ..developer import NexusError, obj
     from ..nexus_base import nexus_core
 
     tpath = testing.setup_unit_test_output_directory('qmcpack_converter_simulations','test_pw2qmcpack_check_sim_status',divert=True)
@@ -281,7 +280,6 @@ def test_convert4qmc_incorporate_result():
     from ..developer import NexusError, obj
     from ..simulation import Simulation
     from ..gamess import Gamess
-    from ..pyscf_sim import Pyscf
     from ..quantum_package import QuantumPackage
     from .test_gamess_simulation import get_gamess_sim
     from .test_pyscf_simulation import get_pyscf_sim
@@ -316,7 +314,7 @@ def test_convert4qmc_incorporate_result():
     sim = sim_start.copy()
     try:
         sim.incorporate_result('unknown',None,other)
-        raise TestFailed
+        raise FailedTest
     except NexusError:
         None
     except FailedTest:
@@ -368,7 +366,6 @@ def test_convert4qmc_incorporate_result():
 
 def test_convert4qmc_check_sim_status():
     import os
-    from ..developer import NexusError, obj
     from ..nexus_base import nexus_core
 
     tpath = testing.setup_unit_test_output_directory('qmcpack_converter_simulations','test_convert4qmc_check_sim_status',divert=True)
@@ -525,7 +522,7 @@ def test_pyscf_to_afqmc_incorporate_result():
 
     try:
         sim.incorporate_result('unknown',None,other)
-        raise TestFailed
+        raise FailedTest
     except NexusError:
         None
     except FailedTest:
@@ -551,7 +548,6 @@ def test_pyscf_to_afqmc_incorporate_result():
 
 def test_pyscf_to_afqmc_check_sim_status():
     import os
-    from ..developer import NexusError, obj
     from ..nexus_base import nexus_core
 
     tpath = testing.setup_unit_test_output_directory('qmcpack_converter_simulations','test_pyscf_to_afqmc_check_sim_status',divert=True)

--- a/nexus/nexus/tests/test_qmcpack_simulation.py
+++ b/nexus/nexus/tests/test_qmcpack_simulation.py
@@ -8,9 +8,9 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import divert_nexus,restore_nexus,clear_all_sims
+from ..testing import restore_nexus,clear_all_sims
 from ..testing import failed,FailedTest
-from ..testing import value_eq,object_eq,text_eq
+from ..testing import value_eq,text_eq
 
 
 
@@ -200,7 +200,7 @@ def test_incorporate_result():
     import shutil
     from subprocess import Popen,PIPE
     from numpy import array
-    from ..developer import NexusError, obj
+    from ..developer import obj
     from ..nexus_base import nexus_core
     from .test_vasp_simulation import setup_vasp_sim as get_vasp_sim
     from .test_vasp_simulation import pseudo_inputs as vasp_pseudo_inputs

--- a/nexus/nexus/tests/test_quantum_package_input.py
+++ b/nexus/nexus/tests/test_quantum_package_input.py
@@ -8,7 +8,7 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import value_eq,object_eq,text_eq,check_object_eq
+from ..testing import object_eq
 
 
 def format_value(v):
@@ -259,7 +259,6 @@ def test_import():
 
 def test_empty_init():
     from ..quantum_package_input import QuantumPackageInput
-    from ..quantum_package_input import generate_quantum_package_input
 
     qi = QuantumPackageInput()
 
@@ -284,7 +283,6 @@ def test_read():
 
 def test_generate():
     import os
-    from ..developer import obj
     from ..physical_system import generate_physical_system
     from ..quantum_package_input import generate_quantum_package_input
 

--- a/nexus/nexus/tests/test_quantum_package_simulation.py
+++ b/nexus/nexus/tests/test_quantum_package_simulation.py
@@ -8,9 +8,9 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import divert_nexus,restore_nexus
+from ..testing import restore_nexus
 from ..testing import failed,FailedTest
-from ..testing import value_eq,object_eq,text_eq
+from ..testing import object_eq
 
 
 def clear_all_sims():
@@ -113,7 +113,7 @@ def test_get_result():
 
 
 def test_incorporate_result():
-    from ..developer import NexusError, obj
+    from ..developer import NexusError
     from ..machines import job
     from ..simulation import Simulation
     from ..gamess import generate_gamess,Gamess
@@ -159,7 +159,6 @@ def test_incorporate_result():
 
 def test_check_sim_status():
     import os
-    from ..developer import NexusError, obj
     from ..nexus_base import nexus_core
 
     tpath = testing.setup_unit_test_output_directory('quantum_package_simulation','test_check_sim_status',divert=True)

--- a/nexus/nexus/tests/test_rmg_analyzer.py
+++ b/nexus/nexus/tests/test_rmg_analyzer.py
@@ -7,9 +7,6 @@ try:
 except ImportError:
     pass
 
-from .. import testing
-from ..testing import value_eq,object_eq,text_eq
-
 
 def test_import():
     from ..rmg_analyzer import RmgAnalyzer

--- a/nexus/nexus/tests/test_rmg_input.py
+++ b/nexus/nexus/tests/test_rmg_input.py
@@ -8,9 +8,7 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import failed
-from ..testing import divert_nexus_log,restore_nexus_log
-from ..testing import value_eq,object_eq,check_object_eq
+from ..testing import value_eq,check_object_eq
 from .. import versions
 
 

--- a/nexus/nexus/tests/test_rmg_simulation.py
+++ b/nexus/nexus/tests/test_rmg_simulation.py
@@ -7,11 +7,7 @@ try:
 except ImportError:
     pass
 
-from .. import testing
-from ..testing import divert_nexus,restore_nexus,clear_all_sims
-from ..testing import failed,FailedTest
-from ..testing import value_eq,object_eq,text_eq
-
+from ..testing import clear_all_sims
 
 
 def test_import():

--- a/nexus/nexus/tests/test_simulation_module.py
+++ b/nexus/nexus/tests/test_simulation_module.py
@@ -11,7 +11,7 @@ from .. import testing
 from ..testing import value_eq,object_eq
 from ..testing import FailedTest,failed
 from ..testing import divert_nexus_log,restore_nexus_log
-from ..testing import divert_nexus,restore_nexus
+from ..testing import restore_nexus
 
 from .. import versions
 
@@ -445,7 +445,6 @@ def test_simulation_input():
 
 
 def test_simulation_analyzer():
-    import os
     from ..developer import NexusError
     from ..simulation import SimulationAnalyzer
 
@@ -607,7 +606,7 @@ file2 = "my_file.dat"
 def test_simulation_input_multi_template():
     import os
     from string import Template
-    from ..developer import obj, NexusError
+    from ..developer import obj
     from ..simulation import SimulationInput
     from ..simulation import GenericSimulationInput
     from ..simulation import SimulationInputMultiTemplate

--- a/nexus/nexus/tests/test_structure.py
+++ b/nexus/nexus/tests/test_structure.py
@@ -294,7 +294,6 @@ def test_empty_init():
 
 
 def test_reference_inputs():
-    from ..developer import obj
     ref_in = get_reference_inputs()
     assert(len(ref_in)>0)
 #end def test_reference_inputs

--- a/nexus/nexus/tests/test_testing.py
+++ b/nexus/nexus/tests/test_testing.py
@@ -244,7 +244,6 @@ def test_value_checks():
 
 
 def test_object_checks():
-    import numpy as np
     from ..testing import object_diff,object_eq,object_neq
 
     assert(id(object_diff)==id(object_neq))

--- a/nexus/nexus/tests/test_vasp_analyzer.py
+++ b/nexus/nexus/tests/test_vasp_analyzer.py
@@ -63,7 +63,7 @@ def test_analyze():
     import os
     from numpy import array,ndarray
     from ..developer import obj
-    from ..vasp_analyzer import VaspAnalyzer,VXML,VXMLcoll,OutcarData
+    from ..vasp_analyzer import VaspAnalyzer,VXML,OutcarData
 
     tpath = testing.setup_unit_test_output_directory(
         test      = 'vasp_analyzer',

--- a/nexus/nexus/tests/test_vasp_input.py
+++ b/nexus/nexus/tests/test_vasp_input.py
@@ -8,9 +8,8 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import divert_nexus,restore_nexus
-from ..testing import divert_nexus_log,restore_nexus_log
-from ..testing import value_eq,object_eq
+from ..testing import restore_nexus
+from ..testing import object_eq
 
 
 associated_files = dict()

--- a/nexus/nexus/tests/test_vasp_simulation.py
+++ b/nexus/nexus/tests/test_vasp_simulation.py
@@ -8,9 +8,9 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import divert_nexus,restore_nexus,clear_all_sims
+from ..testing import restore_nexus,clear_all_sims
 from ..testing import failed,FailedTest
-from ..testing import value_eq,object_eq,text_eq,check_object_eq
+from ..testing import value_eq,object_eq,check_object_eq
 
 from .test_vasp_input import c_potcar_text,get_files
 

--- a/nexus/nexus/tests/test_xmlreader.py
+++ b/nexus/nexus/tests/test_xmlreader.py
@@ -8,7 +8,7 @@ except ImportError:
     pass
 
 from .. import testing
-from ..testing import value_eq,object_eq
+from ..testing import object_eq
 
 
 associated_files = dict()


### PR DESCRIPTION
## Proposed changes

This PR removes (hopefully) all of the unused imports from Nexus's test modules, and additionally removes some unused code.

## What type(s) of changes does this code introduce?

- Testing changes
- Other: Code Cleanup

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora 43 KDE Plasma
Python 3.14.4
Numpy 2.4.4
Pytest 9.0.3

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'