### PR TITLE
Update Nexus test `CMakeLists.txt` to not explicitly set source for coverage

### DIFF
--- a/nexus/nexus/tests/CMakeLists.txt
+++ b/nexus/nexus/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ if(ADD_TEST)
   if(ENABLE_PYCOV)
     add_test(NAME ntest_nexus_coverage_all
              COMMAND ${Python3_EXECUTABLE} -m ${NTEST} ${qmcpack_SOURCE_DIR}/nexus/nexus/tests -c ${qmcpack_SOURCE_DIR}/nexus/pyproject.toml
-                                                                                   --cov=nexus
+                                                                                   --cov
                                                                                    --cov-report=xml
                                                                                    --cov-config=${qmcpack_SOURCE_DIR}/nexus/pyproject.toml
     )


### PR DESCRIPTION
## Proposed changes

Some strange behavior when running `pytest` through `ctest` versus running on the command line led to coverage not being gathered for user examples in Nexus. It seems that the source is due to the explicit specification `--cov=nexus` which apparently made `pytest` only search for importable modules starting at the `nexus/nexus` directory. This meant that the user examples, which don't contain an `__init__.py` file at each step would not be considered importable, and thus not covered. Hopefully this fix will... fix that.

## What type(s) of changes does this code introduce?

- Bugfix
- Testing changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora 43 KDE Plasma
Python 3.14.4
uv 0.11.8
Numpy 2.4.4
Pytest 9.0.3
CMake 3.31.11
CTest 3.31.11

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'