### PR TITLE
Nexus: Update `qmcpack_analyzer.py`/`qmcpack_input.py` to accept `pathlib.Path` objects

### DIFF
--- a/nexus/nexus/qmcpack_analyzer.py
+++ b/nexus/nexus/qmcpack_analyzer.py
@@ -25,6 +25,7 @@
 import os
 import sys
 import traceback
+from pathlib import Path
 import numpy as np
 #custom library imports
 from .developer import obj, unavailable
@@ -117,7 +118,7 @@ class QmcpackAnalysisRequest(QAobject):
                  output=set(['averages','samples']),
                  ndmc_blocks=1000,equilibration=None,group_num=None,
                  traces=False,dm_settings=None):
-        self.source          = source          
+        self.source          = source if not isinstance(source, Path) else str(source.resolve())
         self.destination     = destination     
         self.savefile        = str(savefile)
         self.output          = set(output)
@@ -241,7 +242,7 @@ class QmcpackAnalyzer(SimulationAnalyzer,QAanalyzer):
             #end if
         elif isinstance(arg0,QmcpackAnalysisRequest):
             request = arg0
-        elif isinstance(arg0,str):
+        elif isinstance(arg0, (str, Path)):
             kwargs['source']=arg0
             request = QmcpackAnalysisRequest(**kwargs)
         else:

--- a/nexus/nexus/qmcpack_input.py
+++ b/nexus/nexus/qmcpack_input.py
@@ -134,6 +134,7 @@
 
 
 import os
+from pathlib import Path
 import inspect
 import keyword
 import numpy as np
@@ -3166,7 +3167,7 @@ class QmcpackInput(SimulationInput,Names):
         element  = None
         if arg0 is None and arg1 is None:
             None
-        elif isinstance(arg0,str) and arg1 is None:
+        elif isinstance(arg0,(str, Path)) and arg1 is None:
             filepath = arg0
         elif isinstance(arg0,QIxml) and arg1 is None:
             element = arg0


### PR DESCRIPTION
## Proposed changes

Add a simple check in `QmcpackAnalysisRequest` for `pathlib.Path` objects, resolving and converting to `str` if true.

Add a simple check in `QmcpackInput` for `pathlib.Path` objects.

Contributes toward #5881

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora 43 KDE Plasma
Python 3.14.4
uv 0.11.8
Numpy 2.4.4
Pytest 9.0.3

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'