### PR TITLE
More robust CI scripts when using oneapi

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -242,6 +242,7 @@ case "$1" in
              "need built-from-source OpenBLAS due to bug in rpm"
         
         source /opt/intel/oneapi/setvars.sh
+        unset CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH LIBRARY_PATH
 
         export OMPI_CC=/opt/intel/oneapi/compiler/2023.0.0/linux/bin/intel64/icc
         export OMPI_CXX=/opt/intel/oneapi/compiler/2023.0.0/linux/bin/intel64/icpc

--- a/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-1.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-1.sh
@@ -53,6 +53,7 @@ case "$1" in
         echo 'Configure for building with GCC and Intel MKL'
 
         source /opt/intel/oneapi/setvars.sh
+        unset CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH LIBRARY_PATH
 
         cmake -GNinja \
               -DCMAKE_C_COMPILER=/usr/lib64/openmpi/bin/mpicc \


### PR DESCRIPTION
## Proposed changes
Fixes #5940 
Unset environment variables set by setvars.sh and force CMake record explicit paths in the generated build recipe.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
