### PR TITLE
Update code blocks in QMCPACK docs to use proper syntax highlighting

### DIFF
--- a/docs/LCAO.rst
+++ b/docs/LCAO.rst
@@ -75,7 +75,7 @@ wavefunction can be generated according to the following example for a
 supertwist shifted away from :math:`\Gamma`, leading to a complex
 wavefunction.
 
-.. code-block::
+.. code-block:: python
   :caption: Example PySCF input for single k-point calculation for a :math:`2 \times 1 \times 1` carbon supercell.
   :name: Listing 48
 
@@ -127,7 +127,7 @@ wavefunction.
 
 Note that the last three lines of the file
 
-::
+.. code-block:: python
 
   title="C_diamond-tiled-cplx"
   from PyscfToQmcpack import savetoqmcpack
@@ -153,7 +153,7 @@ https://github.com/QMCPACK/qmcpack_workshop_2019 under
 For the converter in the script to be called properly, you need
 to specify the path to the file in your PYTHONPATH such as
 
-::
+.. code-block:: bash
 
   export PYTHONPATH=QMCPACK_PATH/src/QMCTools:$PYTHONPATH
 
@@ -171,7 +171,7 @@ further modification.
 
 Running convert4qmc will generate 3 input files:
 
-.. code-block::
+.. code-block:: xml
   :caption: C_diamond-tiled-cplx.structure.xml. This file contains the geometry of the system.
   :name: Listing 49
 
@@ -216,7 +216,7 @@ As one can see, for both examples, the two-atom primitive cell has been
 expanded to contain four atoms in a :math:`2 \times 1 \times 1` carbon
 cell.
 
-.. code-block::
+.. code-block:: xml
   :caption: C_diamond-tiled-cplx.wfj.xml. This file contains the trial wavefunction.
   :name: Listing 50
 

--- a/docs/additional_tools.rst
+++ b/docs/additional_tools.rst
@@ -1060,7 +1060,7 @@ Here's a summary of some of the tests provided:
 
    .. code-block:: xml
 
-      <parameter name="ratio">deriv</parameter>}
+      <parameter name="ratio">deriv</parameter>
 
    Computes electron gradients, laplacians, and wave function parameter
    derivatives using implemented calls and compares them to

--- a/docs/additional_tools.rst
+++ b/docs/additional_tools.rst
@@ -177,7 +177,7 @@ prefix ``Mysim`` and output files will be
   the user to modify the ECP name to match the one used to generate
   the wavefunction.
 
-  ::
+  .. code-block:: xml
 
       <?xml version="1.0"?>
     <simulation>
@@ -211,7 +211,7 @@ prefix ``Mysim`` and output files will be
     minimum number of blocks to reproduce the HF/DFT energy used to
     generate the trial wavefunction.
 
-    ::
+    .. code-block:: xml
 
         <qmc method="vmc" move="pbyp" checkpoint="-1">
           <estimator name="LocalEnergy" hdf5="no"/>
@@ -230,7 +230,7 @@ prefix ``Mysim`` and output files will be
   system; however, they need to be updated and optimized for each
   system. The initial values might only be suitable for a small molecule.
 
-  ::
+  .. code-block:: xml
 
       <loop max="4">
         <qmc method="linear" move="pbyp" checkpoint="-1">
@@ -369,7 +369,7 @@ Command line options
 
   This option is to be used when a multideterminant expansion (mainly a CI expansion) is present in an HDF5 file. The trial wavefunction file will not display the full list of multideterminants and will add a path to the HDF5 file as follows (full example for the C2 molecule in qmcpack/tests/molecules/C2_pp).
 
-  ::
+  .. code-block:: xml
 
     <?xml version="1.0"?>
     <qmcsystem>
@@ -404,7 +404,7 @@ Command line options
 
   This option generates the ``*.orbs.h5`` HDF5 file containing the basis set and the orbital coefficients. If the wavefunction contains a multideterminant expansion from QP2, it will also be stored in this file. This option minimizes the size of the ``*.wfj.xml`` file, which points to the HDF file, as in the following example:
 
-  ::
+  .. code-block:: xml
 
       <?xml version="1.0"?>
      <qmcsystem>
@@ -451,7 +451,7 @@ Command line options
   et al. :cite:`Ma2005` When this option is present, the
   wavefunction file has a new set of tags:
 
-  ::
+  .. code-block:: xml
 
     qmcsystem>
      <wavefunction name="psi0" target="e">
@@ -465,7 +465,7 @@ Command line options
   In the “orbitals“ section of the wavefunction file, a new tag
   “cuspInfo” will be added for orbitals spin-up and orbitals spin-down:
 
-  ::
+  .. code-block:: xml
 
       <slaterdeterminant>
            <determinant id="updet" size="2"
@@ -497,7 +497,7 @@ Command line options
 
   QMCPACK builds the wavefunction as a named object. In the vast majority of cases, one wavefunction is simulated at a time, but there may be situations where we want to distinguish different parts of a wavefunction, or even use multiple wavefunctions. This option can change the name for these cases.
 
-  ::
+  .. code-block:: xml
 
      <wavefunction name="psi0" target="e">
 
@@ -505,7 +505,7 @@ Command line options
 
   Although similar to **-psi_tag**, this is used for the type of ions.
 
-  ::
+  .. code-block:: xml
 
     <particleset name="ion0" size="2">
 
@@ -609,7 +609,7 @@ Supported codes
     PySCF script, this path must be added to the PYTHONPATH environment
     variable. For the bash shell, this can be done as follows:
 
-    ::
+    .. code-block:: bash
 
       export PYTHONPATH=/PATH_TO_QMCPACK/qmcpack/src/QMCTools:\$PYTHONPATH
 
@@ -617,7 +617,7 @@ Supported codes
 
     Copy and paste the following code in a file named LiH.py.
 
-    ::
+    .. code-block:: python
 
       #! /usr/bin/env python3
       from pyscf import gto, scf, df
@@ -989,7 +989,7 @@ The QMC code CASINO also makes available its pseudopotentials available at the w
 
 QMCPACK can directly read in the CASINO-formated pseudopotential (``pp.data``), but four parameters found in the pseudopotential summary file must be specified in the pseudo element (``l-local``, ``lmax``, ``nrule``, ``cutoff``)[see :ref:`nlpp` for details]:
 
-.. code-block::
+.. code-block:: xml
   :caption: XML syntax to use CASINO-formatted pseudopotentials in QMCPACK
   :name: Listing 73
 
@@ -1018,7 +1018,7 @@ into optimization, VMC, or DMC runs, as it is a valid <qmc> block.
 
 As an example, the following code generates a random walker configuration and compares the trial wave function ratio computed in two different ways:
 
-.. code-block::
+.. code-block:: xml
   :caption: The following executes the wavefunction ratio test in "wftester"
   :name: Listing 74
 
@@ -1030,7 +1030,7 @@ Here's a summary of some of the tests provided:
 
 -  Ratio Test. Invoked with
 
-   ::
+   .. code-block:: xml
 
       <parameter name="ratio">yes</parameter>
 
@@ -1039,7 +1039,7 @@ Here's a summary of some of the tests provided:
 
 -  Clone Test. Invoked with
 
-   ::
+   .. code-block:: xml
 
       <parameter name="clone">yes</parameter>
 
@@ -1048,7 +1048,7 @@ Here's a summary of some of the tests provided:
 
 -  Elocal Test. Invoked with
 
-   ::
+   .. code-block:: xml
 
       <parameter name="printEloc">yes</parameter>
 
@@ -1058,7 +1058,7 @@ Here's a summary of some of the tests provided:
 
 -  Derivative Test. Invoked with
 
-   ::
+   .. code-block:: xml
 
       <parameter name="ratio">deriv</parameter>}
 
@@ -1068,7 +1068,7 @@ Here's a summary of some of the tests provided:
 
 -  Ion Gradient Test. Invoked with
 
-   ::
+   .. code-block:: xml
 
       <parameter name="source">ion0</parameter>
 
@@ -1077,7 +1077,7 @@ Here's a summary of some of the tests provided:
 
 -  “Basic Test". Invoked with
 
-   ::
+   .. code-block:: xml
 
       <parameter name="basic">yes</parameter>
 

--- a/docs/afqmc.rst
+++ b/docs/afqmc.rst
@@ -28,7 +28,7 @@ For example, in the example, multiple Hamiltonian objects with different
 names can be defined. The one actually used in the calculation is the
 one passed to “execute” as ham.
 
-.. code-block::
+.. code-block:: xml
   :caption: Sample input file for AFQMC.
   :name: Listing 51
 
@@ -820,7 +820,7 @@ The following is a growing list of useful advice for new users, followed by a sa
    parallel implementation. For large calculations, values between 6–12
    for both quantities should be reasonable, depending on architecture.
 
-.. code-block::
+.. code-block:: xml
   :caption: Example of sections of an AFQMC input file for a large calculation.
   :name: Listing 56
 

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -153,9 +153,10 @@ Type and class names
 
 Type and class names should start with a capital letter and have a capital letter for each new word. Underscores (``_``) are not
 allowed. It's redundant to end these names with ``Type`` or ``_t``.
-.. code:: c++
 
-   \\no
+.. code:: cpp
+
+   // no
    using ValueMatrix_t = Matrix<Value>;
    using RealType = double;
 
@@ -185,7 +186,7 @@ Lambda expressions
 
 Named lambda expressions follow the naming convention for functions:
 
-::
+.. code:: cpp
 
   auto myWhatever = [](int i) { return i + 4; };
 
@@ -199,7 +200,7 @@ Test case and test names
 
 Test code files should be named as follows:
 
-::
+.. code:: cpp
 
   class DiracMatrix;
   //leads to
@@ -219,7 +220,7 @@ Use the ``// Comment`` syntax for actual comments.
 
 Use
 
-::
+.. code:: cpp
 
   /** base class for Single-particle orbital sets
    *
@@ -230,7 +231,7 @@ Use
 
 or
 
-::
+.. code:: cpp
 
   ///index in the builder list of sposets
   int builder_index;
@@ -245,7 +246,7 @@ File docs
 
 Do not put the file name after the ``\file`` Doxygen command. Doxygen will fill it in for the file the tag appears in.
 
-::
+.. code:: cpp
 
   /** \file
    *  File level documentation
@@ -266,7 +267,7 @@ For function parameters whose type is non-const reference or pointer to non-cons
 
 Example:
 
-::
+.. code:: cpp
 
   /** Updates foo and computes bar using in_1 .. in_5.
    * \param[in] in_3
@@ -306,7 +307,7 @@ particularly large changes, commit the formatting changes in a separate pull req
 Disable the use of clang-format for sections of code that would be more readable when formatted differently, e.g., for matrices or
 for code blocks where a particular alignment would clearly help readability.
 
-::
+.. code:: cpp
 
   // clang-format off
   Matrix my_matrix = { {1, 2, 3},
@@ -357,7 +358,7 @@ Pointers and references
 
 Pointer or reference operators should go with the type. But understand the compiler reads them from right to left.
 
-::
+.. code:: cpp
 
   Type* var;
   Type& var;
@@ -370,7 +371,7 @@ Templates
 
 The angle brackets of templates should not have any external or internal padding.
 
-::
+.. code:: cpp
 
   template<class C>
   class Class1;
@@ -389,7 +390,7 @@ Variable declarations and definitions
 
 - Avoid declaring multiple variables in the same declaration, especially if they are not fundamental types:
 
-  ::
+  .. code:: cpp
 
     int x, y;                        // Not recommended
     Matrix a("my-matrix"), b(size);  // Not allowed
@@ -402,7 +403,7 @@ Variable declarations and definitions
 
 - Use the following order for keywords and modifiers in  variable declarations:
 
-  ::
+  .. code:: cpp
 
     // General type
     [static] [const/constexpr] Type variable_name;
@@ -429,7 +430,7 @@ on it, in which case one parameter per line aligned with the first parameter sho
 
 Also include the parameter names in the declaration of a function, that is,
 
-::
+.. code:: cpp
 
   // calculates a*b+c
   double function(double a, double b, double c);
@@ -451,7 +452,7 @@ Conditionals
 
 Examples:
 
-::
+.. code:: cpp
 
   if (condition)
     statement;
@@ -478,7 +479,7 @@ Switch statements should always have a default case.
 
 Example:
 
-::
+.. code:: cpp
 
   switch (var)
   {
@@ -502,7 +503,7 @@ Loops
 
 Examples:
 
-::
+.. code:: cpp
 
   for (statement; condition; statement)
     statement;
@@ -537,7 +538,7 @@ Class format
 
 Example:
 
-::
+.. code:: cpp
 
   class Foo : public Bar
   {
@@ -569,7 +570,7 @@ Constructor initializer lists
 
 Examples:
 
-::
+.. code:: cpp
 
   // When everything fits on one line:
   Foo::Foo(int var) : var_(var)
@@ -691,7 +692,7 @@ Pre-increment and pre-decrement
 Use the pre-increment (pre-decrement) operator when a variable is incremented (decremented) and the value of the expression is not
 used. In particular, use the pre-increment (pre-decrement) operator for loop counters where i is not used:
 
-::
+.. code:: cpp
 
   for (int i = 0; i < N; ++i)
   {
@@ -721,7 +722,7 @@ Use of const
 
 - Member functions should be specified const whenever possible.
 
-  ::
+  .. code:: cpp
 
     // Declaration
     int computeFoo(int bar, const Matrix& m)
@@ -798,7 +799,7 @@ Adding and using timers
 In your class header file, add ```#include <NewTimer.h>```. Add a timer enumeration and define the timer names in the
 header file or preferably cpp file. For example, put the following under "protected/private"
 
-::
+.. code:: cpp
 
   enum PSTimers
   {
@@ -812,7 +813,7 @@ header file or preferably cpp file. For example, put the following under "protec
 
 Initialize timers in the constructor:
 
-::
+.. code:: cpp
 
   # if you have many timers;
   const TimerNameList_t<PSTimers>
@@ -827,7 +828,7 @@ Initialize timers in the constructor:
 
 Finally, there are two ways of using the timers. Using the ScopedTimer is required when possible.
 
-::
+.. code:: cpp
 
   // RAII pattern
   {
@@ -976,7 +977,7 @@ interface may change to use functions to set and retrieve positions so
 the SoA transformation of the particle data can happen automatically.
 For now, it is crucial to call ``P.update()`` to populate ``RSoA`` anytime ``P.R`` is changed. Otherwise, the distance tables associated with ``R`` will be uninitialized or out-of-date.
 
-::
+.. code:: cpp
 
   const SimulationCell sc;
   ParticleSet elec(sc), ions(sc);
@@ -1037,7 +1038,7 @@ Looping over particles
 
 Some sample code on how to loop over all the particles in an electron-ion distance table:
 
-::
+.. code:: cpp
 
 
   // d_table is an electron-ion distance table
@@ -1057,7 +1058,7 @@ out of the loop.
 
 An example of the first approach is
 
-::
+.. code:: cpp
 
 
   // P is a ParticleSet
@@ -1069,7 +1070,7 @@ An example of the first approach is
 
 An example of the second approach is
 
-::
+.. code:: cpp
 
   // P is a ParticleSet
   assert(P.IsGrouped == true); // ensure particles are grouped
@@ -1227,7 +1228,7 @@ For particle-by-particle moves, each timestep advance
 The following example shows part of an input block for VMC with
 all-electron moves and drift.
 
-::
+.. code:: xml
 
    <qmc method="vmc" target="e" move="alle">
      <parameter name="use_drift">yes</parameter>
@@ -1244,7 +1245,7 @@ To get the electron-ion distances, add the ion ``ParticleSet`` using
 ``addTable`` and save the returned index. Use that index to get the
 ion-electron distance table.
 
-::
+.. code:: cpp
 
    const int ei_id = elecs.addTable(ions); // in the constructor only
    const auto& ei_table = elecs.getDistTable(ei_id); // when consuming a distance table
@@ -1491,7 +1492,7 @@ value of the determinant is stored during the inversion of the matrix
 :math:`M` (``cgetrf``\ :math:`\rightarrow`\ ``cgetri``). Suppose
 :math:`M=LU`, then :math:`S=\prod\limits_{i=1}^N L_{ii} U_{ii}`.
 
-::
+.. code:: cpp
 
   // In DiracDeterminantWithBackflow::evaluateLog(P,G,L)
   Phi->evaluate(BFTrans->QP, FirstIndex, LastIndex, psiM,dpsiM,grad_grad_psiM);
@@ -1557,7 +1558,7 @@ from the notations of ref. :cite:`Kwon1993backflow`. This
 name change is intended to help the reader associate M with the QMCPACK
 variable ``psiM``.
 
-::
+.. code:: cpp
 
   // In DiracDeterminantWithBackflow::evaluateLog(P,G,L)
   for(int i=0; i<num; i++) // k in above formula
@@ -1614,7 +1615,7 @@ the calculations of :math:`L_i`. The first :math:`BF` term can be
 directly calculated in a loop over quasi-particle coordinates
 :math:`j\alpha`.
 
-::
+.. code:: cpp
 
   // In DiracDeterminantWithBackflow::evaluateLog(P,G,L)
   for(int j=0; j<NumPtcls; j++)
@@ -1646,7 +1647,7 @@ which is simply the outer product of :math:`F\otimes F`. Then the
 :math:`AAFF` term can be calculated by fully contracting :math:`AA` with
 :math:`FF`.
 
-::
+.. code:: cpp
 
   // In DiracDeterminantWithBackflow::evaluateLog(P,G,L)
   for(int j=0; j<NumPtcls; j++)
@@ -1669,7 +1670,7 @@ Finally, define the SPO derivative term:
 then the last term is given by the contraction of :math:`Md2M` (``q_j``)
 with the diagonal of :math:`AA`.
 
-::
+.. code:: cpp
 
   for(int j=0; j<NumPtcls; j++)
   {
@@ -1780,7 +1781,7 @@ Cloning
 
 When ``OpenMP`` threads are spawned, the estimator will be cloned by the ``CloneManager``, which is a parent class of many QMC drivers.
 
-::
+.. code:: cpp
 
   // In CloneManager.cpp
   #pragma omp parallel for shared(w,psi,ham)
@@ -1793,7 +1794,7 @@ When ``OpenMP`` threads are spawned, the estimator will be cloned by the ``Clone
 
 In the preceding snippet, ``ham`` is the reference to the estimator on the master thread. If the implemented estimator does not allocate memory for any array, then the default constructor should suffice for the ``makeClone`` method.
 
-::
+.. code:: cpp
 
   // In SpeciesKineticEnergy.cpp
   OperatorBase* SpeciesKineticEnergy::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
@@ -1803,7 +1804,7 @@ In the preceding snippet, ``ham`` is the reference to the estimator on the maste
 
 If memory is allocated during estimator construction (usually when parsing the XML node in the ``put`` method), then the ``makeClone`` method should perform the same initialization on each thread.
 
-::
+.. code:: cpp
 
   OperatorBase* LatticeDeviationEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
   {
@@ -1817,7 +1818,7 @@ Evaluate
 
 After the observable class (derived class of OperatorBase) is constructed and prepared (by the put() method), it is ready to be used in a QMCDriver. A QMCDriver will call ``H.auxHevaluate(W,thisWalker)`` after every accepted move, where H is the QMCHamiltonian that holds all main and auxiliary Hamiltonian elements, W is a MCWalkerConfiguration, and thisWalker is a pointer to the current walker being worked on. As shown in the following, this function goes through each auxiliary Hamiltonian element and evaluates it using the current walker configuration. Under the hood, observables are calculated and dumped to the main particle set's property list for later collection.
 
-::
+.. code:: cpp
 
   // In QMCHamiltonian.cpp
   // This is more efficient.
@@ -1869,7 +1870,7 @@ The first step is to create a barebone class structure for this simple scalar es
 
 To achieve this, first create a header file "SpeciesKineticEnergy.h" in the QMCHamiltonians folder, with only the required functions declared as follows:
 
-::
+.. code:: cpp
 
   // In SpeciesKineticEnergy.h
   #ifndef QMCPLUSPLUS_SPECIESKINETICENERGY_H
@@ -1910,7 +1911,7 @@ To achieve this, first create a header file "SpeciesKineticEnergy.h" in the QMCH
 
 Notice that a local reference ``tpset`` to the target particle set ``P`` is saved in the constructor. The target particle set carries much information useful for calculating observables. Next, make "SpeciesKineticEnergy.cpp," and make vacuous definitions.
 
-::
+.. code:: cpp
 
   // In SpeciesKineticEnergy.cpp
   #include <QMCHamiltonians/SpeciesKineticEnergy.h>
@@ -1943,7 +1944,7 @@ Notice that a local reference ``tpset`` to the target particle set ``P`` is save
 
 Now, head over to HamiltonianFactory and instantiate this observable if an XML node is found requesting it. Look for "gofr" in HamiltonianFactory.cpp, for example, and follow the if block.
 
-::
+.. code:: cpp
 
   // In HamiltonianFactory.cpp
   #include <QMCHamiltonians/SpeciesKineticEnergy.h>
@@ -1961,7 +1962,7 @@ Evaluate
 
 The evaluate() method is where we perform the calculation of the desired observable. In a first iteration, we will simply hard-code the name and mass of the particles.
 
-::
+.. code:: cpp
 
   // In SpeciesKineticEnergy.cpp
   #include <QMCHamiltonians/BareKineticEnergy.h> // laplaician() defined here
@@ -1998,7 +1999,7 @@ kinetic energy of the up electron (group=“u") or the down electron
 (group=“d"). This is easily achievable using the OhmmsAttributeSet
 class,
 
-::
+.. code:: cpp
 
   // In SpeciesKineticEnergy.cpp
   #include <OhmmsData/AttributeSet.h>
@@ -2020,7 +2021,7 @@ class,
 
 where we may keep "group" and "minus\_over\_2m" as local variables to our specific class.
 
-::
+.. code:: cpp
 
   // In SpeciesKineticEnergy.h
   private:
@@ -2039,7 +2040,7 @@ Make sure the sum of the “ukinetic" and “dkinetic" columns is
 
 For easy reference, a summary of the complete list of changes follows:
 
-::
+.. code:: cpp
 
   // In HamiltonianFactory.cpp
   #include "QMCHamiltonians/SpeciesKineticEnergy.h"
@@ -2050,7 +2051,7 @@ For easy reference, a summary of the complete list of changes follows:
   	targetH->addOperator(apot,potName,false);
   }
 
-::
+.. code:: cpp
 
   // In SpeciesKineticEnergy.h
   #include <Particle/WalkerSetRef.h>
@@ -2092,7 +2093,7 @@ For easy reference, a summary of the complete list of changes follows:
   } // namespace qmcplusplus
   #endif
 
-::
+.. code:: cpp
 
   // In SpeciesKineticEnergy.cpp
   #include <QMCHamiltonians/SpeciesKineticEnergy.h>
@@ -2148,7 +2149,7 @@ Multiple scalars
 
 It is fairly straightforward to create more than one column in the ``scalar.dat`` file with a single observable class. For example, if we want a single SpeciesKineticEnergy estimator to simultaneously record the kinetic energies of all species in the target particle set, we only have to write two new methods: addObservables() and setObservables(), then tweak the behavior of evaluate(). First, we will have to override the default behavior of addObservables() to make room for more than one column in the ``scalar.dat`` file as follows,
 
-::
+.. code:: cpp
 
   // In SpeciesKineticEnergy.cpp
   void SpeciesKineticEnergy::addObservables(PropertySetType& plist, BufferType& collectables)
@@ -2164,7 +2165,7 @@ where “num_species” and “species_name” can be local variables
 initialized in the constructor. We should also initialize some local
 arrays to hold temporary data.
 
-::
+.. code:: cpp
 
   // In SpeciesKineticEnergy.h
   private:
@@ -2191,7 +2192,7 @@ arrays to hold temporary data.
 
 Next, we need to override the default behavior of ``setObservables()`` to transfer multiple values to the property list kept by the main particle set, which eventually goes into the ``scalar.dat`` file.
 
-::
+.. code:: cpp
 
   // In SpeciesKineticEnergy.cpp
   void SpeciesKineticEnergy::setObservables(PropertySetType& plist)
@@ -2202,7 +2203,7 @@ Next, we need to override the default behavior of ``setObservables()`` to transf
 Finally, we need to change the behavior of evaluate() to fill the local
 vector “species_kinetic” with appropriate observable values.
 
-::
+.. code:: cpp
 
   SpeciesKineticEnergy::Return_t SpeciesKineticEnergy::evaluate(ParticleSet& P)
   {
@@ -2226,7 +2227,7 @@ HDF5 output
 
 If we desire an observable that will output hundreds of scalars per simulation step (e.g., SkEstimator), then it is preferred to output to the ``stat.h5`` file instead of the ``scalar.dat`` file for better organization. A large chunk of data to be registered in the ``stat.h5`` file is called a "Collectable" in QMCPACK. In particular, if a OperatorBase object is initialized with ``UpdateMode.set(COLLECTABLE,1)``, then the "Collectables" object carried by the main particle set will be processed and written to the ``stat.h5`` file, where "UpdateMode" is a bit set (i.e., a collection of flags) with the following enumeration:
 
-::
+.. code:: cpp
 
   // In OperatorBase.h
   ///enum for UpdateMode
@@ -2241,7 +2242,7 @@ If we desire an observable that will output hundreds of scalars per simulation s
 
 As a simple example, to put the two columns we produced in the previous section into the ``stat.h5`` file, we will first need to declare that our observable uses "Collectables."
 
-::
+.. code:: cpp
 
   // In constructor add:
   hdf5_out = true;
@@ -2249,7 +2250,7 @@ As a simple example, to put the two columns we produced in the previous section 
 
 Then make some room in the "Collectables" object carried by the target particle set.
 
-::
+.. code:: cpp
 
   // In addObservables(PropertySetType& plist, BufferType& collectables) add:
   if (hdf5_out)
@@ -2261,7 +2262,7 @@ Then make some room in the "Collectables" object carried by the target particle 
 
 Next, make some room in the ``stat.h5`` file by overriding the registerCollectables() method.
 
-::
+.. code:: cpp
 
   // In SpeciesKineticEnergy.cpp
   void SpeciesKineticEnergy::registerCollectables(std::vector<observable_helper>& h5desc, hid_t gid) const
@@ -2278,7 +2279,7 @@ Next, make some room in the ``stat.h5`` file by overriding the registerCollectab
 
 Finally, edit evaluate() to use the space in the "Collectables" object.
 
-::
+.. code:: cpp
 
   // In SpeciesKineticEnergy.cpp
   SpeciesKineticEnergy::Return_t SpeciesKineticEnergy::evaluate(ParticleSet& P)
@@ -2393,7 +2394,7 @@ Collect stage
 
 File output is performed by the master ``EstimatorManager`` owned by ``QMCDriver``. The first 8+ entries in ``EstimatorManagerBase::AverageCache`` will be written to ``scalar.dat``. The remaining entries in ``AverageCache`` will be written to ``stat.h5``. File writing is triggered by ``EstimatorManagerBase`` ``::collectBlockAverages`` inside ``EstimatorManagerBase::stopBlock``.
 
-::
+.. code:: cpp
 
   // In EstimatorManagerBase.cpp::collectBlockAverages
     if(Archive)
@@ -2412,7 +2413,7 @@ File output is performed by the master ``EstimatorManager`` owned by ``QMCDriver
 
 ``EstimatorManagerBase::collectBlockAverages`` is triggered from the master-thread estimator via either ``stopBlock(std::vector)`` or ``stopBlock(RealType, true)``. Notice that file writing is NOT triggered by the slave-thread estimator method ``stopBlock(RealType, false)``.
 
-::
+.. code:: cpp
 
   // In EstimatorManagerBase.cpp
   void EstimatorManagerBase::stopBlock(RealType accept, bool collectall)
@@ -2431,7 +2432,7 @@ File output is performed by the master ``EstimatorManager`` owned by ``QMCDriver
       collectBlockAverages(1);
   }
 
-::
+.. code:: cpp
 
   // In ScalarEstimatorBase.h
   template<typename IT>
@@ -2466,7 +2467,7 @@ should unload a subset of walkers. Thus, the slave estimator should call
 ``SimpleFixedNodeBranch::myEstimator``, should unload data from the
 entire walker ensemble. This is achieved by calling ``accumulate(W)``.
 
-::
+.. code:: cpp
 
   void EstimatorManagerBase::accumulate(MCWalkerConfiguration& W)
   { // intended to be called by master estimator only
@@ -2478,7 +2479,7 @@ entire walker ensemble. This is achieved by calling ``accumulate(W)``.
       Collectables->accumulate_all(W.Collectables,1.0);
   }
 
-::
+.. code:: cpp
 
   void EstimatorManagerBase::accumulate(MCWalkerConfiguration& W
    , MCWalkerConfiguration::iterator it
@@ -2492,7 +2493,7 @@ entire walker ensemble. This is achieved by calling ``accumulate(W)``.
       Collectables->accumulate_all(W.Collectables,1.0);
   }
 
-::
+.. code:: cpp
 
   // In LocalEnergyEstimator.h
   inline void accumulate(const Walker_t& awalker, RealType wgt)
@@ -2507,7 +2508,7 @@ entire walker ensemble. This is achieved by calling ``accumulate(W)``.
       scalars[target](ePtr[source],wwght);
   }
 
-::
+.. code:: cpp
 
   // In CollectablesEstimator.h
   inline void accumulate_all(const MCWalkerConfiguration::Buffer_t& data, RealType wgt)
@@ -2528,7 +2529,7 @@ Load ensemble stage
   ``::KineticEnergy``, and ``::Observables`` must be properly populated
   at the end of the evaluate stage.
 
-::
+.. code:: cpp
 
   // In QMCHamiltonian.h
     template<class IT>
@@ -2552,7 +2553,7 @@ Evaluate stage
   ``QMCHamiltonian::evaluate`` and ``QMCHamiltonian::``
 | ``auxHevaluate``.
 
-::
+.. code:: cpp
 
   // In QMCHamiltonian.cpp
   QMCHamiltonian::Return_t
@@ -2577,7 +2578,7 @@ Evaluate stage
     return LocalEnergy;
   }
 
-::
+.. code:: cpp
 
   // In QMCHamiltonian.cpp
   void QMCHamiltonian::auxHevaluate(ParticleSet& P, Walker_t& ThisWalker)
@@ -2603,7 +2604,7 @@ Estimator use cases
 VMCSingleOMP pseudo code
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-::
+.. code:: cpp
 
   bool VMCSingleOMP::run()
   {
@@ -2634,7 +2635,7 @@ VMCSingleOMP pseudo code
 DMCOMP  pseudo code
 ^^^^^^^^^^^^^^^^^^^
 
-::
+.. code:: cpp
 
   bool DMCOMP::run()
   {

--- a/docs/hamiltonianobservable.rst
+++ b/docs/hamiltonianobservable.rst
@@ -68,7 +68,7 @@ Additional information:
    one hamiltonian component or observable requires the detailed knowledge of the wavefunction that it operates on.
    If the specified value is not an empty string, it must match the ``name`` attribute of a ``wavefunction`` xml node.
 
-.. code-block::
+.. code-block:: xml
   :caption: All electron Hamiltonian XML element.
   :name: Listing 14
 
@@ -79,7 +79,7 @@ Additional information:
   </hamiltonian>
 
 
-.. code-block::
+.. code-block:: xml
   :caption: Pseudopotential Hamiltonian XML element.
   :name: Listing 15
 
@@ -230,19 +230,19 @@ Additional information:
 
 -  **gpu**: When not specified, use the ``gpu`` attribute of ``particleset``.
 
-.. code-block::
+.. code-block:: xml
   :caption: QMCPXML element for Coulomb interaction between electrons.
   :name: Listing 16
 
   <pairpot name="ElecElec" type="coulomb" source="e" target="e"/>
 
-.. code-block::
+.. code-block:: xml
   :caption: QMCPXML element for Coulomb interaction between electrons and ions (all-electron only).
   :name: Listing 17
 
   <pairpot name="ElecIon"  type="coulomb" source="i" target="e"/>
 
-.. code-block::
+.. code-block:: xml
   :caption: QMCPXML element for Coulomb interaction between ions.
   :name: Listing 18
 
@@ -380,13 +380,13 @@ Additional information:
    the structure of the Slater-Jastrow wave function in order to analytically
    perform the spin integral.
 
-.. code-block::
+.. code-block:: xml
   :caption: QMCPXML element for pseudopotential electron-ion interaction (psf files).
   :name: Listing 19
 
     <pairpot name="PseudoPot" type="pseudo"  source="i" format="psf"/>
 
-.. code-block::
+.. code-block:: xml
   :caption: QMCPXML element for pseudopotential electron-ion interaction (xml files). If SOC terms present in xml, they are added to local energy
   :name: Listing 20
 
@@ -395,7 +395,7 @@ Additional information:
       <pseudo elementType="H" href="H.xml"/>
     </pairpot>
 
-.. code-block::
+.. code-block:: xml
   :caption: QMCPXML element for pseudopotential to accumulate the spin-orbit energy, but do not include in local energy
   :name: Listing 21
 
@@ -436,7 +436,7 @@ attributes:
   | ``l-local``:math:`^o`             | integer      |                 |             | Override local channel    |
   +-----------------------------------+--------------+-----------------+-------------+---------------------------+
 
-.. code-block::
+.. code-block:: xml
   :caption: QMCPXML element for pseudopotential of single ionic species.
   :name: Listing 21b
 
@@ -491,7 +491,7 @@ Remarks:
 -  **Developer note:** Currently the ``name`` attribute for the MPC
    interaction is ignored. The name is always reset to ``MPC``.
 
-.. code-block::
+.. code-block:: xml
   :caption: MPC for finite-size postcorrection.
   :name: Listing 22
 
@@ -597,7 +597,7 @@ attributes:
   | ``source``:math:`^o`  | text         | ``particleset.name``   | e           | Identify quantum particles |
   +-----------------------+--------------+------------------------+-------------+----------------------------+
 
-.. code-block::
+.. code-block:: xml
   :caption: "Chiesa" kinetic energy finite-size postcorrection.
   :name: Listing 23
 
@@ -692,7 +692,7 @@ Additional information:
    the cell, and hence the density grid, is defined from :math:`0` to
    :math:`L`).
 
-.. code-block::
+.. code-block:: xml
   :caption: QMCPXML,caption=Density estimator (uniform grid).
   :name: Listing 24
 
@@ -781,7 +781,7 @@ Additional information:
    not specified. Simultaneous use of ``corner`` and ``center`` will
    cause QMCPACK to abort.
 
-.. code-block::
+.. code-block:: xml
   :caption: Spin density estimator (uniform grid).
   :name: Listing 25
 
@@ -789,7 +789,7 @@ Additional information:
     <parameter name="grid"> 40 40 40 </parameter>
   </estimator>
 
-.. code-block::
+.. code-block:: xml
   :caption: Spin density estimator (uniform grid centered about origin).
   :name: Listing 26
 
@@ -911,7 +911,7 @@ Additional information:
    Post-processing tools are provided in Nexus.
 
 
-.. code-block::
+.. code-block:: xml
   :caption: Magnetization density estimator (uniform grid).
   :name: Listing 27
 
@@ -1011,13 +1011,13 @@ Additional information:
    ``gofr_e_0_0``, ``gofr_e_0_1``, and ``gofr_e_1_1`` for up-up,
    up-down, and down-down correlations, respectively.
 
-.. code-block::
+.. code-block:: xml
   :caption: Pair correlation function estimator element.
   :name: Listing 28
 
   <estimator type="gofr" name="gofr" num_bin="200" rmax="3.0" />
 
-.. code-block::
+.. code-block:: xml
   :caption: Pair correlation function estimator element with additional electron-ion correlations.
   :name: Listing 29
 
@@ -1108,13 +1108,13 @@ Additional information:
    ``gofr_e_0_0``, ``gofr_e_0_1``, and ``gofr_e_1_1`` for up-up,
    up-down, and down-down correlations, respectively.
 
-.. code-block::
+.. code-block:: xml
   :caption: Pair correlation function estimator element.
   :name: Listing PCorr 1
 
   <estimator type="PairCorrelation" name="gofr_ee" num_bin="200" rmax="3.0" />
 
-.. code-block::
+.. code-block:: xml
   :caption: Pair correlation function estimator element with additional electron-ion correlations.
   :name: Listing PCorr 2
 
@@ -1181,7 +1181,7 @@ Additional information:
    electronic density, thus meaning it will not accurately measure the
    electron-electron density response.
 
-.. code-block::
+.. code-block:: xml
   :caption: Static structure factor estimator element.
   :name: Listing 30
 
@@ -1241,7 +1241,7 @@ Additional information:
    electronic density, thus meaning it wil not accurately measure the
    electron-electron density response.
 
-.. code-block::
+.. code-block:: xml
   :caption: SkAll estimator element.
   :name: Listing 31
 
@@ -1276,7 +1276,7 @@ attributes:
   | ``hdf5``:math:`^o`  | boolean      | yes/no         | no          | Output to ``stat.h5`` (yes) |
   +---------------------+--------------+----------------+-------------+-----------------------------+
 
-.. code-block::
+.. code-block:: xml
   :caption: Species kinetic energy estimator element.
   :name: Listing 32
 
@@ -1337,7 +1337,7 @@ Additional information:
 -  ``hdf5``: Used to record particle-resolved distances in the h5 file
    if ``gdf5=yes``.
 
-.. code-block::
+.. code-block:: xml
   :caption: Lattice deviation estimator element.
   :name: Listing 33
 
@@ -1442,7 +1442,7 @@ Additional information:
    ``name``.
 - **Important:** in order for the estimator to work, a traces XML input element (<traces array="yes" write="no"/>) must appear following the <qmcsystem/> element and prior to any <qmc/> element.
 
-.. code-block::
+.. code-block:: xml
   :caption: Energy density estimator accumulated on a :math:`20 \times  10 \times 10` grid over the simulation cell.
   :name: Listing 34
 
@@ -1455,7 +1455,7 @@ Additional information:
      </spacegrid>
   </estimator>
 
-.. code-block::
+.. code-block:: xml
   :caption: Energy density estimator accumulated within spheres of radius 6.9 Bohr centered on the first and second atoms in the ion0 particleset.
   :name: Listing 35
 
@@ -1479,7 +1479,7 @@ Additional information:
     </spacegrid>
   </estimator>
 
-.. code-block::
+.. code-block:: xml
   :caption: Energy density estimator accumulated within Voronoi polyhedra centered on the ions.
   :name: Listing 36
 
@@ -1855,7 +1855,7 @@ Additional information:
    any detail here; the interested reader is referred to
    :cite:`Krogel2014`.
 
-.. code-block::
+.. code-block:: xml
   :caption: One body density matrix with uniform grid integration.
   :name: Listing 37
 
@@ -1868,7 +1868,7 @@ Additional information:
     <parameter name="center"       >  0 0 0         </parameter>
   </estimator>
 
-.. code-block::
+.. code-block:: xml
   :caption: One body density matrix with uniform sampling.
   :name: Listing 38
 
@@ -1881,7 +1881,7 @@ Additional information:
     <parameter name="center"       >  0 0 0         </parameter>
   </estimator>
 
-.. code-block::
+.. code-block:: xml
   :caption: One body density matrix with density sampling.
   :name: Listing 39
 
@@ -1894,7 +1894,7 @@ Additional information:
     <parameter name="use_drift"    >  no            </parameter>
   </estimator>
 
-.. code-block::
+.. code-block:: xml
   :caption: Example ``sposet`` initialization for density matrix use.  Occupied and virtual orbital sets are created separately, then joined (``basis="spo_u spo_uv"``).
   :name: Listing 40
 
@@ -1904,7 +1904,7 @@ Additional information:
     <sposet type="bspline" name="spo_uv" group="0" index_min="4" index_max="10"/>
   </sposet_builder>
 
-.. code-block::
+.. code-block:: xml
   :caption: Example ``sposet`` initialization for density matrix use. Density matrix orbital basis created separately (``basis="dm_basis"``).
   :name: Listing 41
 
@@ -2019,7 +2019,7 @@ Additional information:
 
 The following is an example use case.
 
-::
+.. code-block:: xml
 
   <simulationcell>
     ...
@@ -2168,7 +2168,7 @@ Additional information:
 
 The following is an example use case.
 
-::
+.. code-block:: xml
 
   <hamiltonian>
     <estimator name="F" type="Force" mode="acforce" fast_derivatives="yes" spacewarp="no"/>
@@ -2216,7 +2216,7 @@ Additional information:
 
 The following is an example use case.
 
-::
+.. code-block:: xml
 
   <simulationcell>
     ...

--- a/docs/input_overview.rst
+++ b/docs/input_overview.rst
@@ -23,7 +23,7 @@ QMCPACK uses XML to represent structured data in its input file.  Instead of tex
 
 QMCPACK input looks like
 
-::
+.. code-block:: xml
 
   <project id="vmc" series="0">
   </project>
@@ -38,7 +38,7 @@ XML elements start with ``<element_name>``, end with ``</element_name>}``, and c
 
 The overall structure of the input file reflects different aspects of the QMC simulation: the simulation cell, particles, trial wavefunction, Hamiltonian, and QMC run parameters.  A condensed version of the actual input file is shown as follows:
 
-::
+.. code-block:: xml
 
   <?xml version="1.0"?>
   <simulation>
@@ -131,7 +131,7 @@ Random number initialization
 
 The random number generator state is initialized from the ``random`` element using the ``seed`` attribute:
 
-::
+.. code-block:: xml
 
   <random seed="1000"/>
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -900,7 +900,7 @@ Job script example with one MPI rank per GPU. Frontier is configured in low oper
 cores are not available on each node by default. i.e. We use 7 OpenMP CPU threads per MPI rank. The part of the job script that
 makes specific modules available is copied directly from the build script used above.
 
-::
+.. code-block:: bash
 
   #!/bin/bash
   #SBATCH -A MAT151
@@ -952,7 +952,7 @@ Installing on systems with ARMv8-based processors
 
 The following build recipe was verified using the 'Arm Compiler for HPC' on the ANL JLSE Comanche system with Cavium ThunderX2 processors on November 6, 2018.
 
-::
+.. code-block:: bash
 
   # load armclang compiler
   module load Generic-AArch64/RHEL/7/arm-hpc-compiler/18.4
@@ -964,7 +964,7 @@ The following build recipe was verified using the 'Arm Compiler for HPC' on the 
 
 Then using the following command:
 
-::
+.. code-block:: bash
 
   mkdir build_armclang
   cd build_armclang

--- a/docs/intro_wavefunction.rst
+++ b/docs/intro_wavefunction.rst
@@ -39,7 +39,7 @@ where :math:`\textit{A}(\vec{r})`
 is one of the antisymmetric functions: (1) Slater determinant, (2) multislater determinant, or (3) pfaffian and :math:`\textit{J}_k`
 is any of the Jastrow functions (described in :ref:`jastrow`).  The antisymmetric functions are built from a set of single particle orbitals (SPO) ``(sposet)``. QMCPACK implements four different types of ``sposet``, described in the following section. Each ``sposet`` is designed for a different type of calculation, so their definition and generation varies accordingly.
 
-.. code-block::
+.. code-block:: xml
    :caption: wavefunction XML element skeleton.
    :name: wavefunction.skeleton.xml
 
@@ -78,7 +78,7 @@ QMCPACK supports a range of SPOSet types:
 sposet_collection input style
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block::
+.. code-block:: xml
   :caption: SPO XML element framework.
   :name: spo.collection.xml
 
@@ -120,7 +120,7 @@ SPOSet construction related details out of ``determinantset``. This revised
 specification keeps the basis set details separate from information about the
 determinants. 
 
-.. code-block::
+.. code-block:: xml
   :caption: Deprecated input style.
   :name: spo.singledet.old.xml
 
@@ -137,7 +137,7 @@ determinants.
 
 After updating the input style.
 
-.. code-block::
+.. code-block:: xml
   :caption: Updated input style.
   :name: spo.singledet.xml
 
@@ -216,7 +216,7 @@ OpenMP/MPI hybrid QMC.
 The input XML block for the spline SPOs is given in :ref:`spline.spo.xml`. A list of options is given in
 :numref:`table3`.
 
-.. code-block::
+.. code-block:: xml
   :caption: Spline SPO XML element
   :name: spline.spo.xml
 
@@ -344,7 +344,7 @@ In this section we describe the input sections of ``sposet_collection`` for the 
 Here is an :ref:`example <spo.singledet.lcao.xml>` of single determinant with LCAO.
 The input sections for multideterminant trial wavefunctions are described in :ref:`multideterminants`.
 
-.. code-block::
+.. code-block:: xml
   :caption: ``slaterdeterminant`` with an LCAO ``sposet_collection`` example
   :name: spo.singledet.lcao.xml
 
@@ -373,7 +373,7 @@ The input sections for multideterminant trial wavefunctions are described in :re
 Here is the :ref:`basic structure <spo.lcao.xml>` for LCAO ``sposet_collection`` input block.
 A list of options for ``sposet_collection`` is given in :numref:`table4`.
 
-.. code-block::
+.. code-block:: xml
    :caption: Basic input block for ``sposet_collection`` for LCAO.
    :name: spo.lcao.xml
 
@@ -439,7 +439,7 @@ Attribute:
 - cuspCorrection
     Enable (disable) use of the cusp correction algorithm (CASINO REFERENCE) for a ``basisset`` built with GTO functions. The algorithm is implemented as described in (CASINO REFERENCE) and works only with transform="yes" and an input GTO basis set. No further input is needed.
 
-.. code-block::
+.. code-block:: xml
   :caption: Basic input block for ``basisset``.
   :name: Listing 4
 
@@ -608,7 +608,7 @@ Orbitals in region C are computed as the regular B-spline basis described in :re
 
 To enable hybrid orbital representation, the input XML needs to see the tag ``hybridrep="yes"`` shown in :ref:`Listing 6 <Listing 6>`.
 
-.. code-block::
+.. code-block:: xml
   :caption: Hybrid orbital representation input example.
   :name: Listing 6
 
@@ -620,7 +620,7 @@ To enable hybrid orbital representation, the input XML needs to see the tag ``hy
 
 Second, the information describing the atomic regions is required in the particle set, shown in :ref:`Listing 7 <Listing 7>`.
 
-.. code-block::
+.. code-block:: xml
   :caption: particleset elements for ions with information needed by hybrid orbital representation.
   :name: Listing 7
 
@@ -682,7 +682,7 @@ The lowest-energy plane-wave states compatible with the boundary condition are o
 This following example can also be used for Helium simulations by specifying the
 proper pair interaction in the Hamiltonian section and using a bosonic wavefunction.
 
-.. code-block::
+.. code-block:: xml
   :caption: 2D Fermi liquid example: particle specification
   :name: Listing 8
 
@@ -702,7 +702,7 @@ proper pair interaction in the Hamiltonian section and using a bosonic wavefunct
     </group>
   </particleset>
 
-.. code-block::
+.. code-block:: xml
   :caption: 2D Fermi liquid example (Slater Jastrow wavefunction)
   :name: Listing 9
 
@@ -766,7 +766,7 @@ Attribute:
 
 .. centered:: Table 2 Options for the ``slaterdeterminant`` XML-block.
 
-.. code-block::
+.. code-block:: xml
    :caption: Slaterdeterminant set XML element.
    :name: Listing 1
 
@@ -855,7 +855,7 @@ Additional information:
 - When the multideterminant wavefunction is read from an HDF5 file in the ``detlist`` child, the HDF5 dataset must use 64 bit unsigned integers to represent the determinants. The ``utils/determinants_tools.py`` script described in further detail below will check that the determinants are stored using the correct type and correct files that are storing signed 64 bit integers.
 
 
-.. code-block::
+.. code-block:: xml
    :caption: multideterminant set XML element.
    :name: multideterminant.xml
 
@@ -951,7 +951,7 @@ Attribute:
 | ``name``        | Text     |                |         | Name of rotated SPOSet             |
 +-----------------+----------+----------------+---------+------------------------------------+
 
-.. code-block::
+.. code-block:: xml
    :caption: Orbital Rotation XML element.
    :name: Listing 1R
 
@@ -1072,7 +1072,7 @@ Example Use Case
 
 Having specified the general form, we present a general example of one-body and two-body backflow transformations in a hydrogen-helium mixture.  The hydrogen and helium ions have independent backflow transformations, as do the like and unlike-spin two-body terms.  One caveat is in order:  ionic backflow transformations must be listed in the order they appear in the particle set.  If in our example, helium is listed first and hydrogen is listed second, the following example would be correct.  However, switching backflow declaration to hydrogen first then helium, will result in an error.  Outside of this, declaration of one-body blocks and two-body blocks are not sensitive to ordering.
 
-::
+.. code-block:: xml
 
   <backflow>
   <!--The One-Body term with independent e-He and e-H terms. IN THAT ORDER -->
@@ -1106,7 +1106,7 @@ Having specified the general form, we present a general example of one-body and 
 
 Currently, backflow works only with single-Slater determinant wavefunctions.  When a backflow transformation has been declared, it should be placed within the ``<determinantset>`` block, but outside of the ``<slaterdeterminant>`` blocks, like so:
 
-::
+.. code-block:: xml
 
   <determinantset ... >
       <!--basis set declarations go here, if there are any -->
@@ -1410,7 +1410,7 @@ specified, the default cutoff of the Wigner Seitz cell radius is used; this
 Jastrow must be used with a 3D periodic system such as a bulk solid. The name of
 the particleset holding the ionic positions is "i."
 
-::
+.. code-block:: xml
 
   <jastrow name="J1" type="One-Body" function="Bspline" print="yes" source="i">
    <correlation elementType="C" cusp="0.0" size="4">
@@ -1424,7 +1424,7 @@ the ions is labeled as ion0 rather than "i," as in the other example.  Also in t
 the ion is lithium with a coulomb potential, so the cusp condition is satisfied by
 setting cusp="d."
 
-::
+.. code-block:: xml
 
   <jastrow name="J1" type="One-Body" function="Bspline" source="ion0" spin="yes">
     <correlation speciesA="Li" speciesB="u" size="7" rcut="6">
@@ -1517,7 +1517,7 @@ Example use case
 Specify a spin-independent function with independent Jastrow factors for two different species (Li and H).
 The name of the particleset holding the ionic positions is "i."
 
-::
+.. code-block:: xml
 
   <jastrow name="J1" function="pade2" type="One-Body" print="yes" source="i">
     <correlation elementType="Li">
@@ -1572,7 +1572,7 @@ will typically be fixed as the desired cusp condition is known.
 
 To specify this one-body Jastrow factor, use an input section like the following.
 
-::
+.. code-block:: xml
 
   <jastrow name="J1Cusps" type="One-Body" function="shortrangecusp" source="ion0" print="yes">
     <correlation rcut="6" cusp="3" elementType="Li">
@@ -1762,7 +1762,7 @@ Specify a spin-dependent function with four parameters for each channel.  In thi
 a radius of 4.0 bohr (rather than to the default of the Wigner Seitz cell radius).  Also, in this example,
 the coefficients are set to not be optimized during an optimization step.
 
-::
+.. code-block:: xml
 
   <jastrow name="J2" type="Two-Body" function="Bspline" print="yes">
     <correlation speciesA="u" speciesB="u" size="8" rcut="4.0">
@@ -1976,7 +1976,7 @@ Additional information:
 
 -  ``symmetry=none``: Impose no symmetry on the coefficients.
 
-.. code-block::
+.. code-block:: xml
   :caption: k-space Jastrow with one- and two-body terms.
   :name: Listing 10
 
@@ -1991,7 +1991,7 @@ Additional information:
    </correlation>
   </jastrow>
 
-.. code-block::
+.. code-block:: xml
   :caption: k-space Jastrow with one-body term only.
   :name: Listing 11
 
@@ -2002,7 +2002,7 @@ Additional information:
      </correlation>
   </jastrow>
 
-.. code-block::
+.. code-block:: xml
   :caption: k-space Jastrow with two-body term only.
   :name: Listing 12
 
@@ -2127,7 +2127,7 @@ For both the Yukawa and Gaskell RPA Jastrows, the default value for :math:`r_s` 
     | ``kc``:math:`^o`  | kc           | :math:`k_c>0`  | :math:`2\left(\tfrac{9\pi}{4}\right)^{1/3}\tfrac{4\pi N_e}{3\Omega}` | k-space cutoff          |
     +-------------------+--------------+----------------+----------------------------------------------------------------------+-------------------------+
 
-.. code-block::
+.. code-block:: xml
   :caption: Two body RPA Jastrow with long- and short-ranged parts.
   :name: Listing 13
 
@@ -2173,7 +2173,7 @@ Example use case
 Here is an example of H2O molecule. After optimizing one and two body Jastrow factors, add the following block in the wavefunction.
 The coefficients will be filled zero automatically if not given.
 
-::
+.. code-block:: xml
 
   <jastrow name="J3" type="eeI" function="polynomial" source="ion0" print="yes">
     <correlation ispecies="O" especies="u" isize="3" esize="3" rcut="10">
@@ -2248,7 +2248,7 @@ Additional information:
 Example Use Case
 ~~~~~~~~~~~~~~~~
 
-::
+.. code-block:: xml
 
   <qmcsystem>
     <simulationcell>

--- a/docs/lab_advanced_molecules.rst
+++ b/docs/lab_advanced_molecules.rst
@@ -147,7 +147,7 @@ favorite text editor and modify the name of the files that contain the
 ``wavefunction`` and ``particleset`` XML blocks. These files are
 included with the commands:
 
-::
+.. code-block:: xml
 
   <include href=ptcl.xml/>
   <include href=wfs.xml/>
@@ -861,7 +861,7 @@ Useful notes
 Appendix C: Wavefunction optimization XML block
 -----------------------------------------------
 
-.. code-block::
+.. code-block:: xml
   :caption: Sample XML optimization block.
   :name: Listing 60
 
@@ -943,7 +943,7 @@ Recommendations:
 Appendix D: VMC and DMC XML block
 ---------------------------------
 
-.. code-block::
+.. code-block:: xml
   :caption: Sample XML blocks for VMC and DMC calculations.
   :name: Listing 61
 
@@ -1018,7 +1018,7 @@ Options unique to DMC:
 Appendix E: Wavefunction XML block
 ----------------------------------
 
-.. code-block::
+.. code-block:: xml
   :caption: Basic framework for a single-determinant determinantset XML block.
   :name: Listing 62
 
@@ -1076,7 +1076,7 @@ in the determinant block refers to the number of SPOs present while the
 “size” parameter in the coefficient block refers to the number of atomic
 basis functions per SPO.
 
-.. code-block::
+.. code-block:: xml
   :caption: Sample XML block for the single Slater determinant case.
   :name: Listing 63
 
@@ -1109,7 +1109,7 @@ that two sposet sets must be defined, one for each electron spin. The name of ea
 is required in the definition of the multideterminant block. The determinants are defined in
 terms of occupation numbers based on these orbitals.
 
-.. code-block::
+.. code-block:: xml
   :caption: Basic framework for a multideterminant determinantset XML block.
   :name: Listing 64
 
@@ -1184,7 +1184,7 @@ Optimization of individual radial functions can be turned on/off using the “op
 parameter. It can be added to any coefficients block, even though it is currently not
 present in the J1 and J2 blocks.
 
-.. code-block::
+.. code-block:: xml
   :caption: Sample Jastrow XML block.
   :name: Listing 65
 

--- a/docs/lab_condensed_matter.rst
+++ b/docs/lab_condensed_matter.rst
@@ -165,7 +165,7 @@ We will now use Nexus to generate the trial wavefunction for this BCC beryllium.
 
 Fortunately, the Nexus will handle determination of the proper k-vectors given the tiling matrix.  All that is needed is to place the tiling matrix in the ``Be-2at-setup.py`` file.   Now the definition of the physical system is
 
-::
+.. code-block:: python
 
   bcc_Be = generate_physical_system(
       lattice    = 'cubic',
@@ -228,13 +228,13 @@ finite-size effects. To fix this, delete the directory
 ``bcc-beryllium/opt-2at``, change the line near the top of
 ``Be-2at-setup.py`` from
 
-::
+.. code-block:: python
 
   qmcpack    = '/soft/applications/qmcpack/Binaries/qmcpack'
 
 to
 
-::
+.. code-block:: python
 
   qmcpack    = '/soft/applications/qmcpack/Binaries/qmcpack_comp'
 
@@ -370,7 +370,7 @@ variance.
 Finally, edit the file ``graphene-final.py``, which will perform two DMC
 calculations. In the first, (qmc1) replace the following lines:
 
-::
+.. code-block:: python
 
   meshfactor   = xxx,
   precision    = '---',

--- a/docs/lab_excited.rst
+++ b/docs/lab_excited.rst
@@ -203,7 +203,7 @@ In the ``band.py`` script, identification of high-symmetry k-points and band str
 In the script, where the ``dia`` PhysicalSystem object is used as the input structure, ``dia2_structure`` is the standardized primitive cell and ``dia2_kpath`` is the respective k-path around the iBZ.
 ``dia2_kpath`` has a dictionary of the k-path in various coordinate systems; please make sure you are using the right one.
 
-::
+.. code-block:: python
 
   from structure import get_primitive_cell, get_kpath
   dia2_structure   = get_primitive_cell(structure=dia.structure)['structure']
@@ -235,11 +235,11 @@ denote the CBM wavevector in the rest of this document. In ``band.py``
 script, once the band structure calculation is finished, you can use the
 following lines to get the exact location of VBM and CBM using
 
-::
+.. code-block:: python
 
   p = band.load_analyzer_image()
-  print "VBM:\n{0}".format(p.bands.vbm)
-  print "CBM:\n{0}".format(p.bands.cbm)
+  print("VBM:\n{0}".format(p.bands.vbm))
+  print("CBM:\n{0}".format(p.bands.cbm))
 
 Output must be the following:
 
@@ -300,11 +300,11 @@ denote the CBM wavevector in the rest of this document. In script, once
 the band structure calculation is finished, you can use the following
 lines to get the exact location of VBM and CBM using
 
-::
+.. code-block:: python
 
   p = band.load_analyzer_image()
-  print "VBM:\n{0}".format(p.bands.vbm)
-  print "CBM:\n{0}".format(p.bands.cbm)
+  print("VBM:\n{0}".format(p.bands.vbm))
+  print("CBM:\n{0}".format(p.bands.cbm))
 
 Output must be the following:
 
@@ -382,7 +382,7 @@ we use :math:`\Delta'=[1/3, 0., 1/3]`, we could use a
 :math:`\Delta'` can be a good approximation. We can compare the
 eigenvalues using their index numbers:
 
-::
+.. code-block:: python
 
   >>> print p.bands.up[51] ## CBM, $\Delta$ ##
     eigs            = [-3.2076  4.9221  7.5433  7.5433 17.1545 19.7598 28.3242 28.3242]
@@ -454,15 +454,15 @@ transition can be defined as from (0,3) to (4,4).
 
 Alternatively, we can also read the band and twist indexes using PwscfAnalyzer and determine the band/twist indexes on the go:
 
-::
+.. code-block:: python
 
   p = nscf.load_analyzer_image()
-  print 'band information'
-  print p.bands.up
-  print 'twist 0 k-point:',p.bands.up[0].kpoint_rel
-  print 'twist 4 k-point:',p.bands.up[4].kpoint_rel
-  print 'twist 0 band 3 eigenvalue:',p.bands.up[0].eigs[3]
-  print 'twist 4 band 4 eigenvalue:',p.bands.up[4].eigs[4]
+  print('band information')
+  print(p.bands.up)
+  print('twist 0 k-point:',p.bands.up[0].kpoint_rel)
+  print('twist 4 k-point:',p.bands.up[4].kpoint_rel)
+  print('twist 0 band 3 eigenvalue:',p.bands.up[0].eigs[3])
+  print('twist 4 band 4 eigenvalue:',p.bands.up[4].eigs[4])
 
 Giving output:
 
@@ -560,7 +560,7 @@ A typical workflow for a quasiparticle calculation includes the following:
 #. Check the convergence of the quasiparticle gap with respect to the
    simulation cell size.
 
-::
+.. code-block:: xml
 
   <particleset name="e" random="yes">
     <group name="u" size="36" mass="1.0"> ##Change size to 35
@@ -584,7 +584,7 @@ Going back to :eq:`eq77`, we can see that it is essential to include VBM and CBM
 Therefore, the added electron will sit at CBM while the subtracted electron will be removed from VBM.
 However, for the charged cell calculations, we may need to make changes in the input files for the fourth step.  Alternatively, in the quasiparticle.py file, the changes in the QMC input are shown for a negatively charged system:
 
-::
+.. code-block:: python
 
   qmc.input.simulation.qmcsystem.particlesets.e.groups.u.size +=1
   (qmc.input.simulation.qmcsystem.wavefunction.determinantset
@@ -611,7 +611,7 @@ gap calculations. Here, the modified input file is given for the
 :math:`\Gamma\rightarrow\Delta'` transition, which can be compared with
 the ground state input file in the previous section.
 
-::
+.. code-block:: xml
 
   <determinantset>
     <slaterdeterminant>
@@ -652,7 +652,7 @@ And the ``updet.tile_300010003.spin_0.tw_0.g0.bandinfo.dat`` file must be change
 
 Alternatively, the excitations within Nexus can be defined as shown in the ``optical.py`` file:
 
-::
+.. code-block:: python
 
   qmc = generate_qmcpack(
       ...

--- a/docs/lab_qmc_basics.rst
+++ b/docs/lab_qmc_basics.rst
@@ -271,7 +271,7 @@ For this exercise, we will focus on minimizing the variance.
 
 First, we need to update the template particle and wavefunction information in ``O.q0.ptcl.xml`` and ``O.q0.wfs.xml``.  We want to simulate the O atom in open boundary conditions (the default is periodic).  To do this, open ```O.q0.ptcl.xml`` with your favorite text editor (e.g., ``emacs`` or ``vi``) and replace
 
-::
+.. code-block:: xml
 
   <parameter name="bconds">
      p p p
@@ -282,7 +282,7 @@ First, we need to update the template particle and wavefunction information in `
 
 with
 
-::
+.. code-block:: xml
 
   <parameter name="bconds">
      n n n
@@ -290,7 +290,7 @@ with
 
 Next we will select Jastrow factors appropriate for an atom.  In open boundary conditions, the B-spline Jastrow correlation functions should cut off to zero at some distance away from the atom.  Open ``O.q0.wfs.xml`` and add the following cutoffs (``rcut`` in Bohr radii) to the correlation factors:
 
-::
+.. code-block:: xml
 
   ...
   <correlation speciesA="u" speciesB="u" size="8" rcut="10.0">
@@ -310,7 +310,7 @@ parameters, which are just the values of :math:`u` on a uniformly spaced
 grid up to ``rcut``. Initially the parameters (``coefficients``) are set
 to zero:
 
-::
+.. code-block:: xml
 
   <correlation speciesA="u" speciesB="u" size="8" rcut="10.0">
     <coefficients id="uu" type="Array">
@@ -320,7 +320,7 @@ to zero:
 
 Finally, we need to assemble particle, wavefunction, and pseudopotential information into the main QMCPACK input file (``O.q0.opt.in.xml``) and specify inputs for the Jastrow optimization process.  Open ``O.q0.opt.in.xml`` and write in the location of the particle, wavefunction, and pseudopotential files ("``<!-- ... -->``" are comments):
 
-::
+.. code-block:: xml
 
   ...
   <!-- include simulationcell and particle information from pw2qmcpqack -->
@@ -335,7 +335,7 @@ Finally, we need to assemble particle, wavefunction, and pseudopotential informa
 
 The relevant portion of the input describing the linear optimization process is
 
-::
+.. code-block:: xml
 
   <loop max="MAX">
     <qmc method="linear" move="pbyp" checkpoint="-1">
@@ -527,7 +527,7 @@ The DMC algorithm contains two biases in addition to the fixed node and pseudopo
 
 In the same directory you used to perform wavefunction optimization (``oxygen_atom``) you will find a sample DMC input file for the neutral oxygen atom named ``O.q0.dmc.in.xml``.  Open this file in a text editor and note the differences from the optimization case.  Wavefunction information is no longer included from ``pw2qmcpack`` but instead should come from the optimization run:
 
-::
+.. code-block:: xml
 
   <!-- OPT_XML is from optimization, e.g. O.q0.opt.s008.opt.xml -->
   <include href="OPT_XML"/>
@@ -609,7 +609,7 @@ is sufficient for this system.
 
 Choose an initial DMC time step and create a sequence of :math:`N` time steps according to :eq:`eq69`.  Make :math:`N` copies of the DMC XML block in the input file.
 
-::
+.. code-block:: xml
 
   <qmc method="dmc" move="pbyp">
      <parameter name="warmupSteps"         >    DWARMUP         </parameter>
@@ -728,7 +728,7 @@ convenience, the necessary steps are summarized as follows.
   (a) Copy the optimization input (``O.q0.opt.in.xml``) to ``O.q1.opt.in.xml``
   (b) Edit ``O.q1.opt.in.xml`` to match the file prefix used in DFT.
 
-    ::
+    .. code-block:: xml
 
       ...
       <project id="O.q1.opt" series="0">
@@ -740,7 +740,7 @@ convenience, the necessary steps are summarized as follows.
 
   (c) Edit the particle XML file (``O.q1.ptcl.xml``) to have open boundary conditions.
 
-    ::
+    .. code-block:: xml
 
       <parameter name="bconds">
         n n n
@@ -748,7 +748,7 @@ convenience, the necessary steps are summarized as follows.
 
   (d) Add cutoffs to the Jastrow factors in the wavefunction XML file (``O.q1.wfs.xml``)
 
-    ::
+    .. code-block:: xml
 
       ...
       <correlation speciesA="u" speciesB="u" size="8" rcut="10.0">
@@ -766,7 +766,7 @@ convenience, the necessary steps are summarized as follows.
   (a) Copy the DMC input (``O.q0.dmc.in.xml``) to ``O.q1.dmc.in.xml``
   (b) Edit ``O.q1.dmc.in.xml`` to use the DFT prefix and the optimal Jastrow.
 
-    ::
+    .. code-block:: xml
 
       ...
       <project id="O.q1.dmc" series="0">
@@ -826,7 +826,7 @@ The set of automation tools we will be using is known as Nexus :cite:`Krogel2016
 
 Nexus is driven by simple user-defined scripts that resemble keyword-driven input files.  An example Nexus input file that performs a single VMC calculation (with pregenerated orbitals) follows.  Take a moment to read it over and especially note the comments (prefixed with "``\#``") explaining most of the contents.  If the input syntax is unclear you may want to consult portions of :ref:`python-basics`, which gives a condensed summary of Python constructs.  An additional example and details about the inner workings of Nexus can be found in the reference publication :cite:`Krogel2016nexus`.
 
-::
+.. code-block:: python
 
   #! /usr/bin/env python3
 
@@ -897,7 +897,7 @@ Enter the ``oxygen_dimer`` directory.  Copy your BFD pseudopotential from the at
 As in the example in the last section, the oxygen dimer is generated with the ``generate_physical_
 system`` function:
 
-::
+.. code-block:: python
 
   dimer = generate_physical_system(
       type       = 'dimer',
@@ -913,7 +913,7 @@ Similar syntax can be used to generate crystal structures or to specify systems 
 
 Next, objects representing a QE (PWSCF) run and subsequent orbital conversion step are constructed with respective ``generate_*`` functions:
 
-::
+.. code-block:: python
 
   dft = generate_pwscf(
       identifier   = 'dft',
@@ -935,7 +935,7 @@ Note the ``dependencies`` keyword.  This keyword is used to construct workflows 
 
 Objects representing QMCPACK simulations are then constructed with the ``generate_qmcpack`` function:
 
-::
+.. code-block:: python
 
   opt = generate_qmcpack(
       identifier   = 'opt',
@@ -1000,7 +1000,7 @@ Objects representing QMCPACK simulations are then constructed with the ``generat
 
 Shared details such as the run directory, job, pseudopotentials, and orbital file have been omitted (``...``).  The "``opt``" run will optimize a 1-body B-spline Jastrow with 8 knots having a cutoff of 5.0 Bohr and a B-spline Jastrow (for up-up and up-down correlations) with 8 knots and cutoffs of 10.0 Bohr.  The Jastrow list for the DMC run is empty, and the previous use of ``dependencies`` indicates that the DMC run depends on the optimization run for the Jastrow factor.  Nexus will submit the "``opt``" run first, and upon completion it will scan the output, select the optimal set of parameters, pass the Jastrow information to the "``qmc``" run, and then submit the DMC job.  Independent job workflows are submitted in parallel when permitted.  No input files are written or job submissions made until the "``run_project``" function is reached:
 
-::
+.. code-block:: python
 
   run_project(sims)
 
@@ -1008,7 +1008,7 @@ All of the simulation objects have been collected into a list (``sims``) for sub
 
 As written, ``O_dimer.py`` will perform calculations only at the equilibrium separation distance of 1.2074 {\AA} since the list of scaling factors (representing stretching or compressing the dimer)  contains only one value (``scales = [1.00]``).  Modify the file now to perform DMC calculations across a range of separation distances with each DMC run using the Jastrow factor optimized at the equilibrium separation distance.  Specifically, you will want to change the list of scaling factors to include both compression (``scale<1.0``) and stretch (``scale>1.0``):
 
-::
+.. code-block:: python
 
   scales = [1.00,0.90,0.95,1.05,1.10]
 
@@ -1257,7 +1257,7 @@ Before performing production calculations (more than just the initial setup in t
 
 Beyond PPs, all that is required to get started are the atomic positions and the dimensions/shape of the simulation cell.  The Nexus file ``example.py`` illustrates how to set up PWSCF and QMCPACK input files by providing minimal information regarding the physical system (an 8-atom cubic cell of diamond in the example).  Most of the contents should be familiar from your experience with the automated calculations of the oxygen dimer binding curve in :ref:`dimer-automation` (if you have skipped ahead you may want to skim that section for relevant information).  The most important change is the expanded description of the physical system:
 
-::
+.. code-block:: python
 
   # details of your physical system (diamond conventional cell below)
   my_project_name = 'diamond_vmc'   # directory to perform runs
@@ -1335,7 +1335,7 @@ Basic Python data types (``int``, ``float``, ``str``, ``tuple``, ``list``, ``arr
 Intrinsic types: ``int, float, str``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-::
+.. code-block:: python
 
   #this is a comment
   i=5                     # integer
@@ -1353,7 +1353,7 @@ Intrinsic types: ``int, float, str``
 Container types: ``tuple, list, array, dict, obj``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-::
+.. code-block:: python
 
   from numpy import array  # get array from numpy module
   from developer import obj  # get obj from Nexus' developer module
@@ -1412,7 +1412,7 @@ Container types: ``tuple, list, array, dict, obj``
 
 An important feature of Python to be aware of is that assignment is most often by reference, that is, new values are not always created.  This point is illustrated with an ``obj`` instance in the following example, but it also holds for ``list``, ``array``, ``dict``, and others.
 
-::
+.. code-block:: python
 
   >>> o = obj(a=5,b=6)
   >>>
@@ -1437,7 +1437,7 @@ Here ``p`` is just another name for ``o``, while ``q`` is a fully independent co
 Conditional Statements: ``if/elif/else``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-::
+.. code-block:: python
 
   a = 5
   if a is None:
@@ -1459,7 +1459,7 @@ The "``\#end if``" is not part of Python syntax, but you will see text like this
 Iteration: ``for``
 ^^^^^^^^^^^^^^^^^^
 
-::
+.. code-block:: python
 
   from developer import obj
 
@@ -1497,7 +1497,7 @@ Iteration: ``for``
 Functions: ``def``, argument syntax
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-::
+.. code-block:: python
 
   def f(a,b,c=5):          # basic function, c has a default value
       print(a,b,c)

--- a/docs/lab_qmc_statistics.rst
+++ b/docs/lab_qmc_statistics.rst
@@ -480,7 +480,7 @@ can lead to autocorrelation since the new samples will be in the
 neighborhood of previous samples. Type ``grep timestep H.xml`` to see
 the varying time step values in this QMCPACK input file (``H.xml``):
 
-::
+.. code-block:: xml
 
   <parameter name="timestep">10</parameter>
   <parameter name="timestep">5</parameter>

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -85,7 +85,7 @@ Additional information:
 
 The particle configurations are written to a ``.config.h5`` file.
 
-.. code-block::
+.. code-block:: xml
   :caption: The following is an example of running a simulation that can be restarted.
   :name: Listing 42
 
@@ -101,7 +101,7 @@ Check that this file exists before attempting a restart.
 
 To continue a run, specify the ``mcwalkerset`` element before your VMC/DMC block:
 
-.. code-block::
+.. code-block:: xml
   :caption: Restart (read walkers from previous run).
   :name: Listing 43
 
@@ -310,7 +310,7 @@ Additional information:
 
 An example VMC section for a simple batched ``vmc`` run:
 
-::
+.. code-block:: xml
 
   <qmc method="vmc" move="pbyp">
     <estimator name="LocalEnergy" hdf5="no"/>
@@ -443,7 +443,7 @@ Additional information:
 
 An example VMC section for a simple VMC run:
 
-::
+.. code-block:: xml
 
   <qmc method="vmc" move="pbyp">
     <estimator name="LocalEnergy" hdf5="no"/>
@@ -460,7 +460,7 @@ Here we set 256 ``walkers`` per MPI, have a brief initial equilibration of 100 `
 
 The following is an example of VMC section storing configurations (walker samples) for optimization.
 
-::
+.. code-block:: xml
 
   <qmc method="vmc" move="pbyp" gpu="yes">
      <estimator name="LocalEnergy" hdf5="no"/>
@@ -496,7 +496,7 @@ can therefore make use of crowds, batching, and supports running a large number 
 
 A typical optimization block looks like the following. It starts with method="linear" and contains three blocks of parameters.
 
-::
+.. code-block:: xml
 
   <loop max="10">
    <qmc method="linear" move="pbyp" gpu="yes">
@@ -589,7 +589,7 @@ Additional information:
 
 The cost function consists of three components: energy, unreweighted variance, and reweighted variance.
 
-::
+.. code-block:: xml
 
      <cost name="energy">                   0.95 </cost>
      <cost name="unreweightedvariance">     0.00 </cost>
@@ -606,7 +606,7 @@ If variational parameters are set as not optimizable in the predominant way, the
 
 The following example shows optimizing subsets of parameters in stages in a single QMCPACK run.
 
-::
+.. code-block:: xml
 
     <qmc method="linear">
       ...
@@ -652,7 +652,7 @@ optimizers can be switched among “OneShiftOnly” (default), “adaptive,”
 “descent,” “hybrid,” "sr_cg," and “quartic” (old) using the following line in the
 optimization block:
 
-::
+.. code-block:: xml
 
 <parameter name="MinMethod"> THE METHOD YOU LIKE </parameter>
 
@@ -716,7 +716,7 @@ also use large ``minwalkers``, for example adding three-body Jastrow factor to c
 developing a reliable optimization recipe for a new system, one should check convergence of the process with significantly increased
 samples, e.g. 4x, and repeat the check each time the flexibility in the wavefunction and number of parameters is increased.
 
-::
+.. code-block:: xml
 
   <loop max="6">
    <qmc method="linear" move="pbyp" gpu="yes">
@@ -901,7 +901,7 @@ Recommendations:
     filtration is on so that accelerated descent can be used to optimize
     parameters that the LM leaves untouched. :cite:`Otis2021`
 
-::
+.. code-block:: xml
 
   <loop max="15">
    <qmc method="linear" move="pbyp">
@@ -1081,8 +1081,7 @@ Additional information and recommendations:
    it may be useful to try the hybrid optimization approach described in
    the next subsection.
 
-::
-
+.. code-block:: xml
 
   <loop max="2000">
      <qmc method="linear" move="pbyp" checkpoint="-1" gpu="no">
@@ -1148,8 +1147,7 @@ There are two additional parameters used in the hybrid optimization and it requi
   | ``Stored_Vectors``  | integer      | :math:`> 0` | 5           | Number of vectors to transfer to BLM |
   +---------------------+--------------+-------------+-------------+--------------------------------------+
 
-::
-
+.. code-block:: xml
 
   <loop max="203">
   <qmc method="linear" move="pbyp" checkpoint="-1" gpu="no">
@@ -1304,7 +1302,7 @@ Recommendations:
    3-Body J), set ``exp0`` to 0 and do a single inner iteration (max its=1) per
    sample of configurations.
 
-::
+.. code-block:: xml
 
   <!-- Specify the optimizer options -->
   <parameter name="MinMethod">quartic</parameter>
@@ -1347,15 +1345,15 @@ stored in HDF5 format. The optimization header block will have to
 specify that the new CI coefficients will be saved to HDF5 format. If
 the tag is not added coefficients will not be saved.
 
-::
+.. code-block:: xml
 
   <qmc method="linear" move="pbyp" gpu="no" hdf5="yes">
 
-  The rest of the optimization block remains the same.
+The rest of the optimization block remains the same.
 
 When running the optimization, the new coefficients will be stored in a ``*.sXXX.opt.h5`` file,  where XXX corresponds to the series number. The H5 file contains only the optimized coefficients. The corresponding ``*.sXXX.opt.xml`` will be updated for each optimization block as follows:
 
-::
+.. code-block:: xml
 
   <detlist size="1487" type="DETS" nca="0" ncb="0" nea="2" neb="2" nstates="85" cutoff="1e-2" href="../LiH.orbs.h5" opt_coeffs="LiH.s001.opt.h5"/>
 
@@ -1376,7 +1374,7 @@ The gradients of the energy with respect to the variational parameters can be ch
 The check compares the analytic derivatives with a finite difference approximation.
 These are activated by giving a ``gradient_test`` method in an ``optimize`` block, as follows:
 
-::
+.. code-block:: xml
 
      <qmc method="linear" move="pbyp">
       <optimize method="gradient_test">
@@ -1399,7 +1397,7 @@ It contains one line per loop iteration, to allow using existing tools to comput
 
 The input would look like the following:
 
-::
+.. code-block:: xml
 
     <qmc method="linear" move="pbyp" checkpoint="-1" gpu="no">
       <optimize method="gradient_test">
@@ -1563,7 +1561,7 @@ where :math:`E_\text{ref}` is the :math:`E_\text{pop\_avg}` average over all the
   'limited_history' uses weighted average of :math:`E_\text{pop\_avg}` of the latest at maximum
   min(1, int(1.0 / (feedback * tau))) steps collected post warm-up. Default 'unlimited_history'.
 
-.. code-block::
+.. code-block:: xml
   :caption: The following is an example of a minimal DMC section using the batched ``dmc`` driver
   :name: Listing 48b
 
@@ -1836,7 +1834,7 @@ where :math:`E_\text{ref}` is the :math:`E_\text{pop\_avg}` average over all the
       wavefunction quality via the term :math:`\sigma`.
       :math:`\mathrm{sigmaBound}` is default to 10.
 
-.. code-block::
+.. code-block:: xml
   :caption: The following is an example of a very simple DMC section.
   :name: Listing 44
 
@@ -1850,7 +1848,7 @@ where :math:`E_\text{ref}` is the :math:`E_\text{pop\_avg}` average over all the
 The time step should be individually adjusted for each problem.  Please refer to the theory section
 on diffusion Monte Carlo.
 
-.. code-block::
+.. code-block:: xml
   :caption: The following is an example of running a simulation that can be restarted.
   :name: Listing 45
 
@@ -1866,7 +1864,7 @@ This also works in VMC. This will output an h5 file with the name
 attempting a restart. To read in this file for a continuation run,
 specify the following:
 
-.. code-block::
+.. code-block:: xml
   :caption: Restart (read walkers from previous run).
   :name: Listing 46
 
@@ -1876,7 +1874,7 @@ BH is the project id, and s002 is the calculation number to read in the walkers 
 
 Combining VMC and DMC in a single run (wavefunction optimization can be combined in this way too) is the standard way in which QMCPACK is typically run.   There is no need to run two separate jobs since method sections can be stacked and walkers are transferred between them.
 
-.. code-block::
+.. code-block:: xml
   :caption: Combined VMC and DMC run.
   :name: Listing 47
 
@@ -1906,7 +1904,7 @@ Combining VMC and DMC in a single run (wavefunction optimization can be combined
 Reptation Monte Carlo
 ---------------------
 
-Note: repatation Monte Carlo is not currently supported as a batched driver.
+Note: reptation Monte Carlo is not currently supported as a batched driver.
 It can only be run by selecting use of legacy drivers via the driver_version project level setting, see :ref:`driver-version-parameter`.
 To aid prioritization, potential users are welcome to request porting and describe their science case.
 
@@ -2010,7 +2008,7 @@ declaration to ensure correct sampling:
 
 
 
-.. _walker_logging
+.. _walker_logging:
 
 Walker Data Logging
 ===================
@@ -2029,7 +2027,7 @@ The default walker data logging functionality is enabled by including the
 <walkerlogs/> XML element (once) just before the QMC driver sections, 
 for example:
 
-::
+.. code-block:: xml
 
   <walkerlogs/>
   <qmc method="vmc" move="pbyp">

--- a/docs/performance_portable.rst
+++ b/docs/performance_portable.rst
@@ -61,7 +61,7 @@ Use the following changes to update input files to use the batched drivers.
 1. Update the project block to include the ``driver_version`` parameter. While not required (their use is the default), specifying the ``driver_version``
    helps indicate that the input is for the modern code. For example:
 
-::
+.. code-block:: xml
 
   <project id="my_qmc_research" series="0">
      <parameter name="driver_version">batch</parameter>

--- a/docs/simulationcell.rst
+++ b/docs/simulationcell.rst
@@ -41,7 +41,7 @@ Attribute:
 
 An example of a block is given below:
 
-::
+.. code-block:: xml
 
    <simulationcell>
        <parameter name="lattice">
@@ -107,7 +107,7 @@ specified axes.
 An example of a ``simulationcell`` block using is given below. The size of the box along
 the z-axis increases from 12 to 18 by the vacuum scale of 1.5.
 
-::
+.. code-block:: xml
 
    <simulationcell>
        <parameter name="lattice">
@@ -320,7 +320,7 @@ Example use cases
 
 .. centered:: Particleset elements for ions and electrons randomizing electron start positions.
 
-::
+.. code-block:: xml
 
      <particleset name="i" size="2">
        <group name="Li">
@@ -352,7 +352,7 @@ Example use cases
 
 .. centered:: Particleset elements for ions and electrons specifying electron start positions.
 
-::
+.. code-block:: xml
 
      <particleset name="e">
        <group name="u" size="4">
@@ -397,7 +397,7 @@ Example use cases
 
 .. centered:: Particleset elements for ions specifying positions by ion type.
 
-::
+.. code-block:: xml
 
      <particleset name="ion0">
        <group name="O" size="1">

--- a/docs/spin_orbit.rst
+++ b/docs/spin_orbit.rst
@@ -51,7 +51,7 @@ Using the generated single particle spinors, we build the many-body wavefunction
 
 where we now utilize determinants of spinors, as opposed to the usual product of up and down determinants. An example xml input block for the trial wave function is show below:
 
-.. code-block::
+.. code-block:: xml
   :caption: wavefunction specification for a single determinant trial wave function
   :name: slisting1
 
@@ -92,7 +92,7 @@ The electon-electron cusp in this case should be -1/2, as discussed in :cite:`Me
 
 We also make a small modification in the particleset specification 
 
-.. code-block::
+.. code-block:: xml
   :caption: specification for the electron particle when performing spin-orbit calculations
   :name: slisting2
 
@@ -138,7 +138,7 @@ Note that this includes a contribution from the *spin drift* :math:`\mathbf{v}_{
 
 In both the VMC and DMC methods, there are no required changes to a typical input
 
-.. code-block::
+.. code-block:: xml
 
   <qmc method="vmc/dmc">
     <parameter name="steps"    >    50   </parameter>
@@ -152,7 +152,7 @@ Whether or not spin moves are used is determined internally by the ``spinor=yes`
 By default, the spin mass :math:`\mu_s` (which controls the rate of spin sampling relative to the spatial sampling) is set to 1.0. 
 This can be changed by adding an additional parameter to the QMC input
 
-.. code-block::
+.. code-block:: xml
 
  <parameter name="spinMass" > 0.25 </parameter>
 
@@ -194,7 +194,7 @@ We note the following relations between the two representations of the relativis
 
 The structure of the spin-orbit ``.xml`` is 
 
-.. code-block::
+.. code-block:: xml
 
   <?xml version="1.0" encoding="UTF-8"?>
   <pseudo>
@@ -217,7 +217,7 @@ In order to accumulate the spin-orbit energy, but exclude it from the local ener
 the ``physicalSO`` flag should be set to no in the Hamiltonian input.
 A typical application will include the SOC terms in the local energy, and an example input block is given as
 
-.. code-block::
+.. code-block:: xml
   
   <hamiltonian name="h0" type="generic" target="e">
     <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>

--- a/docs/unit_testing.rst
+++ b/docs/unit_testing.rst
@@ -48,7 +48,7 @@ Example
 
 The first example is one test from ``src/Numerics/tests/test_grid_functor.cpp``.
 
-.. code-block::
+.. code-block:: cpp
   :caption: Unit test example using Catch.
   :name: Listing 75
 
@@ -169,7 +169,7 @@ The ``Libxml2Document`` class has a ``parseFromString`` function to parse XML in
 
 The following code fragment to read the xml is common
 
-.. code-block::
+.. code-block:: cpp
 
   const char* xml_str = R"(<tmp><wavefunction></wavefunction></tmp>)";
   Libxml2Document doc;


### PR DESCRIPTION
## Proposed changes

This PR just updates the QMCPACK documentation to use the proper syntax highlighting for code blocks. In general this just involves taking double colon fences `::` and turning them into code blocks `.. code-block:: <language>`.

I tried to focus on the typical languages I was familiar with, those being Python, XML, and C++, but occasionally I added syntax for a `bash` code block.

## What type(s) of changes does this code introduce?

- Documentation or build script changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora 43 KDE Plasma
Python 3.14.4
uv 0.11.8
Sphinx 9.1.0

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'