### PR TITLE
Nexus: Update Nexus workflow and upgrade `uv.lock` file

### DIFF
--- a/.github/workflows/ci-github-actions-nexus.yaml
+++ b/.github/workflows/ci-github-actions-nexus.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Install uv and Setup Python ${{ matrix.python-version }}
       uses: astral-sh/setup-uv@v7
       with:
-        version: "0.11.6"
+        version: "0.11.11"
         python-version: ${{ matrix.python-version }}
 
     - name: Install Project and All Dependencies
@@ -42,7 +42,9 @@ jobs:
       working-directory: ./nexus
 
     - name: Run Nexus Tests
-      run: uv run pytest nexus/tests/
+      run: |
+        source .venv/bin/activate
+        pytest nexus/tests/
       working-directory: ./nexus
 
   macos:
@@ -62,7 +64,7 @@ jobs:
     - name: Install uv and Setup Python ${{ matrix.python-version }}
       uses: astral-sh/setup-uv@v7
       with:
-        version: "0.11.6"
+        version: "0.11.11"
         python-version: ${{ matrix.python-version }}
 
     - name: Install Project and All Dependencies
@@ -75,5 +77,7 @@ jobs:
       working-directory: ./nexus
 
     - name: Run Nexus Tests
-      run: uv run pytest nexus/tests/
+      run: |
+        source .venv/bin/activate
+        pytest nexus/tests/
       working-directory: ./nexus

--- a/.github/workflows/ci-github-actions-nexus.yaml
+++ b/.github/workflows/ci-github-actions-nexus.yaml
@@ -36,9 +36,9 @@ jobs:
       run: uv sync --locked --all-extras --dev
       working-directory: ./nexus
 
-    - name: Use Numpy 1.22.0 (Python 3.10 only)
+    - name: Downgrade to Minimum Versions (Python 3.10 only)
       if: contains(matrix.python-version, '3.10')
-      run: uv pip install numpy==1.22.0
+      run: uv pip install numpy==1.22.0 scipy==1.8.0 h5py==3.6.0 matplotlib==3.3.0 spglib==1.16.0 cif2cell==2.1.0 pydot==2.0.0 seekpath==2.0.0
       working-directory: ./nexus
 
     - name: Run Nexus Tests

--- a/.github/workflows/ci-github-actions-nexus.yaml
+++ b/.github/workflows/ci-github-actions-nexus.yaml
@@ -71,9 +71,9 @@ jobs:
       run: uv sync --locked --all-extras --dev
       working-directory: ./nexus
 
-    - name: Use Numpy 1.22.0 (Python 3.10 only)
+    - name: Downgrade to Minimum Versions (Python 3.10 only)
       if: contains(matrix.python-version, '3.10')
-      run: uv pip install numpy==1.22.0
+      run: uv pip install numpy==1.22.0 scipy==1.8.0 h5py==3.6.0 matplotlib==3.3.0 spglib==1.16.0 cif2cell==2.1.0 pydot==2.0.0 seekpath==2.0.0
       working-directory: ./nexus
 
     - name: Run Nexus Tests

--- a/.github/workflows/ci-github-actions-nexus.yaml
+++ b/.github/workflows/ci-github-actions-nexus.yaml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Downgrade to Minimum Versions (Python 3.10 only)
       if: contains(matrix.python-version, '3.10')
-      run: uv pip install numpy==1.22.0 scipy==1.8.0 h5py==3.6.0 matplotlib==3.3.0 spglib==1.16.0 cif2cell==2.1.0 pydot==2.0.0 seekpath==2.0.0
+      run: uv pip install numpy==1.22.0 scipy==1.8.0 matplotlib==3.3.0 spglib==1.16.0 cif2cell==2.1.0 pydot==2.0.0 seekpath==2.0.0
       working-directory: ./nexus
 
     - name: Run Nexus Tests

--- a/.github/workflows/ci-github-actions-nexus.yaml
+++ b/.github/workflows/ci-github-actions-nexus.yaml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Downgrade to Minimum Versions (Python 3.10 only)
       if: contains(matrix.python-version, '3.10')
-      run: uv pip install numpy==1.22.0 scipy==1.8.0 matplotlib==3.3.0 spglib==1.16.0 cif2cell==2.1.0 pydot==2.0.0 seekpath==2.0.0
+      run: uv pip install numpy==1.22.0 scipy==1.8.0 spglib==1.16.0 cif2cell==2.1.0 pydot==2.0.0 seekpath==2.0.0
       working-directory: ./nexus
 
     - name: Run Nexus Tests

--- a/nexus/uv.lock
+++ b/nexus/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.12' and python_full_version < '3.14'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -235,7 +236,8 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.12' and python_full_version < '3.14'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -460,7 +462,8 @@ name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.12' and python_full_version < '3.14'",
     "python_full_version == '3.11.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
@@ -1062,7 +1065,8 @@ name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.12' and python_full_version < '3.14'",
     "python_full_version == '3.11.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
@@ -1142,11 +1146,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -1370,14 +1374,14 @@ wheels = [
 
 [[package]]
 name = "pytest-order"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/66/02ae17461b14a52ce5a29ae2900156b9110d1de34721ccc16ccd79419876/pytest_order-1.3.0.tar.gz", hash = "sha256:51608fec3d3ee9c0adaea94daa124a5c4c1d2bb99b00269f098f414307f23dde", size = 47544, upload-time = "2024-08-22T12:29:54.512Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/76/c7b4a2ad3758a3c2757f532c6e931aa5e387781512a71b67b6ddc19d9ef8/pytest_order-1.4.0.tar.gz", hash = "sha256:327fb6eee1ae771051da13d2a0d9306d947e87f9ab8f4d6302e5d122c7472691", size = 49891, upload-time = "2026-04-26T12:37:43.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/73/59b038d1aafca89f8e9936eaa8ffa6bb6138d00459d13a32ce070be4f280/pytest_order-1.3.0-py3-none-any.whl", hash = "sha256:2cd562a21380345dd8d5774aa5fd38b7849b6ee7397ca5f6999bbe6e89f07f6e", size = 14609, upload-time = "2024-08-22T12:29:53.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d0/c62c07141151f259faddff6bd591f28235c37dd0c486160d0d2a0d4e6e5a/pytest_order-1.4.0-py3-none-any.whl", hash = "sha256:05b1710cf16bb2123294eec5bdfaee513322ff1926c0dfa86eb8be632eb264a1", size = 14918, upload-time = "2026-04-26T12:37:41.123Z" },
 ]
 
 [[package]]
@@ -1544,7 +1548,8 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.12' and python_full_version < '3.14'",
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
@@ -1754,7 +1759,8 @@ name = "sphinx"
 version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.12' and python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "alabaster", marker = "python_full_version >= '3.12'" },
@@ -1808,7 +1814,7 @@ wheels = [
 
 [[package]]
 name = "sphinxcontrib-bibtex"
-version = "2.6.5"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1819,9 +1825,9 @@ dependencies = [
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/83/1488c9879f2fa3c2cbd6f666c7a3a42a1fa9e08462bec73281fa6c092cba/sphinxcontrib_bibtex-2.6.5.tar.gz", hash = "sha256:9b3224dd6fece9268ebd8c905dc0a83ff2f6c54148a9235fe70e9d1e9ff149c0", size = 118462, upload-time = "2025-06-27T10:40:14.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/6a/8e0b2c2420286389e7fed78ff361ec30e2f1d58c8560af8d64df5e7b61e0/sphinxcontrib_bibtex-2.7.0.tar.gz", hash = "sha256:fee700f7aae29bb8f654c62913f00d34ac44fc0b8ca0fa67ac922ff4453addee", size = 120669, upload-time = "2026-05-06T09:29:24.935Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/a0/3a612da94f828f26cabb247817393e79472c32b12c49222bf85fb6d7b6c8/sphinxcontrib_bibtex-2.6.5-py3-none-any.whl", hash = "sha256:455ea4509642ea0b28ede3721550273626f85af65af01f161bfd8e19dc1edd7d", size = 40410, upload-time = "2025-06-27T10:40:12.274Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c0/d28e62407f4733bbe0169287bc012f0ac3b4a2021066b285570654119c8b/sphinxcontrib_bibtex-2.7.0-py3-none-any.whl", hash = "sha256:28cf0ec7a957d1c7548d5749317ed472ce877e1b629f430f88e3789aa51f87b1", size = 40287, upload-time = "2026-05-06T09:29:23.253Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Proposed changes

This PR updates the Nexus workflow to fix a problem with using the command `uv run pytest nexus/tests` since that command automatically updated the version of NumPy used in the tests, thus the Python 3.10 tests were not actually using Numpy 1.22.0.

Additionally, I've bumped the version of `uv` to 0.11.11, and upgraded the `uv.lock` file to keep the dependencies up to date.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Workflow update, needs actions

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'