### PR TITLE
Nexus: Add support for passing arguments from `nxs-test` to pytest

### DIFF
--- a/nexus/nexus/bin/nxs-test
+++ b/nexus/nexus/bin/nxs-test
@@ -54,7 +54,7 @@ if __name__ == "__main__":
             )
             sys.exit(1)
 
-        for idx, arg in enumerate(sys.argv[1:]):
+        for arg in sys.argv[1:]:
             pytest_args.append(arg)
 
     retcode = pytest.main([

--- a/nexus/nexus/bin/nxs-test
+++ b/nexus/nexus/bin/nxs-test
@@ -40,9 +40,27 @@ if __name__ == "__main__":
     except PermissionError:
         pass
 
+    pytest_args = []
+    if len(sys.argv) > 1:
+        if "-h" in sys.argv or "--help" in sys.argv:
+            print(
+                "Usage:\n"
+                '$ nxs-test <pytest_args>\n\n'
+                "See https://docs.pytest.org/en/stable/how-to/usage.html\n"
+                "for specification of arguments.\n\n"
+                "To select only specific tests, use `-k '<expr>'` from\n"
+                "Pytest's section on specifying which tests to run.\n"
+                "The other methods listed there are not supported by nxs-test."
+            )
+            sys.exit(1)
+
+        for idx, arg in enumerate(sys.argv[1:]):
+            pytest_args.append(arg)
+
     retcode = pytest.main([
         "--exitfirst",
         "--disable-warnings",
+       *pytest_args,
        f"{test_dir}",
     ])
 


### PR DESCRIPTION
## Proposed changes

By request of @jtkrogel, this PR adds support to `nxs-test` to be able to pass additional command line arguments to Pytest through `nxs-test`.

Additionally, it will capture `-h` and `--help` and print a usage statement with a link to Pytest's documentation.

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora 43 KDE Plasma
Python 3.14.4
uv 0.11.11
Numpy 2.4.4
Pytest 9.0.3

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'