### PR TITLE
Nexus: Explicitly use `sys.exit` in `pwscf_input.py`

### DIFF
--- a/nexus/nexus/pwscf_input.py
+++ b/nexus/nexus/pwscf_input.py
@@ -905,7 +905,6 @@ for sec in section_classes:
 #end for
 
 
-exit_ = sys.exit
 def check_new_variables(exit=True):
     sections = section_classes
     msg = ''
@@ -926,7 +925,7 @@ def check_new_variables(exit=True):
         log('section checks of new variables passed')
     #end if
     if exit:
-        exit_()
+        sys.exit()
     #end if
 #end def check_new_variables
 #check_new_variables()
@@ -971,7 +970,7 @@ def check_section_classes(exit=True):
         log('pwscf input checks passed')
     #end if
     if exit:
-        exit_()
+        sys.exit()
     #end if
 #end def check_section_classes
 #check_section_classes()

--- a/nexus/nexus/pwscf_input.py
+++ b/nexus/nexus/pwscf_input.py
@@ -45,6 +45,7 @@
 
 
 import os
+import sys
 import inspect
 from copy import deepcopy
 import numpy as np
@@ -904,7 +905,7 @@ for sec in section_classes:
 #end for
 
 
-exit_ = exit
+exit_ = sys.exit
 def check_new_variables(exit=True):
     sections = section_classes
     msg = ''


### PR DESCRIPTION
## Proposed changes

For some reason there's a call to a bare `exit` in `pwscf_input.py`, which appears to be some strange builtin thing that behaves how `sys.exit` behaves. This becomes a problem when trying to use Nexus in a Jupyter notebook, as there is some level of weird initialization order of operations that means that `exit` does not get created properly in the notebook. The fix I think is easiest is to just replace it with `sys.exit`, which mimics the behavior exactly.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora 43 KDE Plasma
Python 3.14.5
uv 0.11.13
Numpy 2.4.4
Pytest 9.0.3

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'