### PR TITLE
Update Numerics/codegen to python3

### DIFF
--- a/src/Numerics/codegen/gen_cartesian_tensor.py
+++ b/src/Numerics/codegen/gen_cartesian_tensor.py
@@ -1,4 +1,4 @@
-
+#! /usr/bin/env python3
 # Generate angular tensors using symbolic expressions for the GTO's and derivatives
 
 # There are two steps to the code generation, and only the second is automated.

--- a/src/Numerics/codegen/gen_cartesian_tensor.py
+++ b/src/Numerics/codegen/gen_cartesian_tensor.py
@@ -860,7 +860,7 @@ def run_template(fname_in, fname_out, bodies):
         if key in bodies:
           line = bodies[key]
         else:
-          print 'Error, template item not found, key:',key, ' line = ',line
+          print('Error, template item not found, key:', key, ' line = ', line)
       out += line
 
   with open(fname_out, 'w') as f:
@@ -904,11 +904,11 @@ def create_soa_cartesian_tensor_h():
 
 
 if __name__ == '__main__':
-    #print gen_evaluate()
-    #print gen_evaluate_all()
-    #print gen_evaluate_with_hessian()
-    #print gen_evaluate_with_third_deriv()
-    #print gen_evaluate_third_deriv_only()
+    #print(gen_evaluate())
+    #print(gen_evaluate_all())
+    #print(gen_evaluate_with_hessian())
+    #print(gen_evaluate_with_third_deriv())
+    #print(gen_evaluate_third_deriv_only())
 
     # Create CartesianTensor.h from CartesianTensor.h.in
     create_cartesian_tensor_h()

--- a/src/Numerics/codegen/gen_cartesian_tensor.py
+++ b/src/Numerics/codegen/gen_cartesian_tensor.py
@@ -12,8 +12,7 @@
 #      C. Apply clang-format on modified source files.
 
 
-from collections import namedtuple, defaultdict
-from sympy import *
+from sympy import sympify, Symbol, symbols, diff
 
 # See the GaussianOrbitals notebook in the qmc_algorithms repo for more explanation,
 #  especially about the normalization.

--- a/src/Numerics/codegen/read_order.py
+++ b/src/Numerics/codegen/read_order.py
@@ -10,7 +10,7 @@ def count_vals(s):
     x,y,z = 0,0,0
     mult = 1
     for c,c1 in zip(s,s[1:]+' '):
-        #print 'c,c1',c,c1
+        #print('c,c1', c, c1)
         if c.isdigit():
             continue
         if c1.isdigit():
@@ -23,7 +23,7 @@ def count_vals(s):
              z += mult
         mult = 1
         if not c.isdigit() and c not in ['S','X','Y','Z']:
-             print 'Error, unknown character',c
+             print('Error, unknown character', c)
     return x,y,z
 
 # order by max number of repeats, then x,y,z
@@ -166,11 +166,11 @@ def read_order(fname):
                 already_seen[order] = 1
             #new_sum = x + y + z
             #if new_sum != current_sum:
-            #    print '  # ',shell_name[new_sum]
+            #    print('  # ', shell_name[new_sum])
             #    current_sum = new_sum
     
-            #print order,x,y,z
-            #print "  ijk.append('%s')"%to_string(x,y,z)
+            #print(order, x, y, z)
+            #print("  ijk.append('%s')"%to_string(x,y,z))
     return order_list
 
 if __name__ == "__main__":
@@ -178,13 +178,13 @@ if __name__ == "__main__":
     order_list = read_order('order.txt')
 
     # Create get_ijk for gen_cartesian_tensor.py
-    #print create_get_ijk(order_list)
+    #print(create_get_ijk(order_list))
 
     # Create getABC for CartesianTensor.h.in
-    #print create_getABC(order_list)
+    #print(create_getABC(order_list))
 
     # Create getABC for SoaCartesianTensor.h.in
-    #print create_getABC_SoA(order_list)
+    #print(create_getABC_SoA(order_list))
 
     # Create order dictionary for PyscfToQmcpack.py in QMCTools
-    print create_gms_order_for_pyscf(order_list)
+    print(create_gms_order_for_pyscf(order_list))

--- a/src/Numerics/codegen/read_order.py
+++ b/src/Numerics/codegen/read_order.py
@@ -1,4 +1,4 @@
-
+#! /usr/bin/env python3
 # Generate order of i,j,k indices from Gamess output
 
 # Also see the SETLAB routine in inputb.src for the ordering


### PR DESCRIPTION
## Proposed changes

Python3 updates motivated by #5921.

Unfortunately the cartesian tensor file has permanent edits to it for offload, but a few by eye spot checks look good. The generated read_order also matchs PyscfToQmcpack.py code by eye.


## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)
- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

dev container

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
