### PR TITLE
Nexus: Add tests and docstrings for some `Structure` functions.

### DIFF
--- a/nexus/nexus/structure.py
+++ b/nexus/nexus/structure.py
@@ -131,6 +131,7 @@ from numpy import (
     sqrt,
 )
 from numpy.linalg import inv, det, norm
+import numpy.typing as npt
 from .unit_converter import convert
 from .numerics import nearest_neighbors, convex_hull, voronoi_neighbors
 from .periodic_table import Elements
@@ -1143,8 +1144,33 @@ class Structure(Sobj):
     #end def has_folded_structure
 
             
-    # test needed
-    def group_atoms(self,folded=True):
+    def group_atoms(self, folded=True) -> None:
+        """Group the atoms by their element type, sorting in alphabetical order.
+
+        Parameters
+        ----------
+        folded : bool, default=True
+            Optionally sort the folded structure, if it exists.
+
+        Examples
+        --------
+        >>> structure = Structure(
+        ...     elem = ["Be", "N", "C", "Be", "C", "O"],
+        ...     pos = np.array([
+        ...         [0, 0, 0],
+        ...         [0, 0, 0],
+        ...         [0, 0, 0],
+        ...         [0, 0, 0],
+        ...         [0, 0, 0],
+        ...         [0, 0, 0],
+        ...     ], dtype=np.float64),
+        ... )
+        >>> print(structure.elem)
+        ['Be' 'N' 'C' 'Be' 'C' 'O']
+        >>> structure.group_atoms()
+        >>> print(structure.elem)
+        ['Be' 'Be' 'C' 'C' 'N' 'O']
+        """
         if len(self.elem)>0:
             order = self.elem.argsort()
             if (self.elem!=self.elem[order]).any():
@@ -1158,8 +1184,35 @@ class Structure(Sobj):
     #end def group_atoms
 
 
-    # test needed
-    def rename(self,folded=True,**name_pairs):
+    def rename(self, folded=True, **name_pairs) -> None:
+        """Rename element names in a structure.
+
+        Parameters
+        ----------
+        folded : bool, default=True
+            Rename elements in folded structure as well as tiled structure
+            (if there is no folded structure then this does nothing)
+        **name_pairs : dict[str]
+            A dictionary containing key:value pairs where the key is the old
+            element name and the value is the new element name.
+
+        Examples
+        --------
+        >>> structure = Structure(
+        ...     elem = ["N", "C", "O", "H"],
+        ...     pos = np.array([
+        ...         [0, 0, 0],
+        ...         [0, 0, 0],
+        ...         [0, 0, 0],
+        ...         [0, 0, 0],
+        ...     ], dtype=np.float64),
+        ... )
+        >>> print(structure.elem)
+        ['N' 'C' 'O' 'H']
+        >>> structure.rename(N="Dy", C="Er")
+        >>> print(structure.elem)
+        ['Dy' 'Er' 'O' 'H']
+        """
         elem = self.elem
         for old,new in name_pairs.items():
             for i in range(len(self.elem)):
@@ -1174,8 +1227,77 @@ class Structure(Sobj):
     #end def rename
 
 
-    # test needed
-    def reset_axes(self,axes=None):
+    def reset_axes(self, axes: npt.ArrayLike | None = None) -> None:
+        """Reset the structure's axes, k-space axes, and center.
+
+        Notes
+        -----
+        If ``axes`` is given, this function will remove the previous folded
+        structure (as new axes could invalidate the tiling) and then set
+        ``self.axes`` to the new axes, update the k-space axes, and set the
+        center of the cell to be the (0.5, 0.5, 0.5) point.
+
+        If ``axes`` are not given (e.g. ``axes=None``, the default), then this
+        function will reuse the same axes as the current structure, reset the
+        k-space axes, and set the cell center at the (0.5, 0.5, 0.5) point.
+
+        Examples
+        --------
+        Providing axes will also make sure ``kaxes`` and ``center`` are consistent.
+
+        >>> structure = Structure(
+        ...     axes = np.array([
+        ...         [6.0, 0.0, 0.0],
+        ...         [0.0, 6.0, 0.0],
+        ...         [0.0, 0.0, 6.0],
+        ...     ]),
+        ... )
+        >>> print(structure.axes)
+        [[6. 0. 0.]
+        [0. 6. 0.]
+        [0. 0. 6.]]
+        >>> print(structure.kaxes)
+        [[1.04719755 0.         0.        ]
+        [0.         1.04719755 0.        ]
+        [0.         0.         1.04719755]]
+        >>> print(structure.center)
+        [3. 3. 3.]
+
+        >>> structure.reset_axes(np.array([
+        ...     [12.0,  0.0,  0.0],
+        ...     [ 0.0, 12.0,  0.0],
+        ...     [ 0.0,  0.0, 12.0],
+        ... ]))
+        >>> print(structure.axes)
+        [[12.  0.  0.]
+        [ 0. 12.  0.]
+        [ 0.  0. 12.]]
+        >>> print(structure.kaxes)
+        [[0.52359878 0.         0.        ]
+        [0.         0.52359878 0.        ]
+        [0.         0.         0.52359878]]
+        >>> print(structure.center)
+        [6. 6. 6.]
+
+        Alternatively, if you don't provide ``axes`` you can ensure that the
+        ``kaxes`` and ``center`` of the structure are correct. Here we set
+        ``center`` to be at the origin, then use ``reset_axes`` to correct it.
+
+        >>> structure = Structure(
+        ...     axes = np.array([
+        ...         [6.0, 0.0, 0.0],
+        ...         [0.0, 6.0, 0.0],
+        ...         [0.0, 0.0, 6.0],
+        ...     ]),
+        ...     center = np.array([0.0, 0.0, 0.0]),
+        ... )
+        >>> print(structure.center)
+        [0. 0. 0.]
+
+        >>> structure.reset_axes()
+        >>> print(structure.center)
+        [3. 3. 3.]
+        """
         if axes is None:
             axes = self.axes
         else:
@@ -1217,7 +1339,11 @@ class Structure(Sobj):
     #end def reshape_axes
 
 
-    def write_axes(self):
+    def write_axes(self) -> str:
+        """Write the unit cell axes as a string.
+
+        Only implemented for ``self.dim=3``.
+        """
         c = ''
         for a in self.axes:
             c+='{0:12.8f} {1:12.8f} {2:12.8f}\n'.format(a[0],a[1],a[2])
@@ -1225,8 +1351,12 @@ class Structure(Sobj):
         return c
     #end def write_axes
 
-    
-    def corners(self):
+
+    def corners(self) -> npt.NDArray[np.float64]:
+        """Calculate vectors corresponding to the 8 corners of the unit cell.
+
+        Only implemented for ``self.dim=3``.
+        """
         a = self.axes
         c = np.array([(0,0,0),
                    a[0],

--- a/nexus/nexus/tests/test_structure.py
+++ b/nexus/nexus/tests/test_structure.py
@@ -11,6 +11,7 @@ from .. import testing
 from ..testing import value_eq as value_eq_orig
 from ..testing import object_eq as object_eq_orig
 from ..testing import object_diff as object_diff_orig
+from ..testing import text_eq
 
 
 struct_atol = 1e-10
@@ -1779,9 +1780,9 @@ def test_reset_axes():
 
     structure.reset_axes(new_axes)
 
-    np.testing.assert_allclose(structure.axes, new_axes, rtol=1e-7)
-    np.testing.assert_allclose(structure.kaxes, new_kaxes, rtol=1e-7)
-    np.testing.assert_allclose(structure.center, new_center, rtol=1e-7)
+    np.testing.assert_allclose(structure.axes, new_axes)
+    np.testing.assert_allclose(structure.kaxes, new_kaxes)
+    np.testing.assert_allclose(structure.center, new_center)
 
 
 def test_reset_axes_none():
@@ -1836,9 +1837,9 @@ def test_reset_axes_none():
 
     structure.reset_axes(axes = None)
 
-    np.testing.assert_allclose(structure.axes, original_axes, rtol=1e-7)
-    np.testing.assert_allclose(structure.kaxes, ref_kaxes, rtol=1e-7)
-    np.testing.assert_allclose(structure.center, ref_center, rtol=1e-7)
+    np.testing.assert_allclose(structure.axes, original_axes)
+    np.testing.assert_allclose(structure.kaxes, ref_kaxes)
+    np.testing.assert_allclose(structure.center, ref_center)
 
 def test_write_axes():
     from nexus.structure import Structure
@@ -1870,7 +1871,8 @@ def test_write_axes():
         "  0.00000000  12.00000000   0.00000000\n"
         "  0.00000000   0.00000000 300.00000000\n"
     )
-    assert(structure.write_axes() == ref_write_axes)
+    calc_write_axes = structure.write_axes()
+    assert(text_eq(calc_write_axes, ref_write_axes))
 
 
 def test_corners():
@@ -1909,4 +1911,4 @@ def test_corners():
         [7.0, 14.0, 35.0],
     ]
 
-    np.testing.assert_allclose(structure.corners(), ref_corners, rtol=1e-7)
+    np.testing.assert_allclose(structure.corners(), ref_corners)

--- a/nexus/nexus/tests/test_structure.py
+++ b/nexus/nexus/tests/test_structure.py
@@ -1647,3 +1647,266 @@ def test_rmg_transform():
 
     assert(testing.check_object_eq(res,ref,atol=1e-12))
 #end def test_rmg_transform
+
+
+def test_group_atoms():
+    from nexus.structure import Structure
+
+    unordered_elem = ["H", "N", "C", "H", "C", "O", "H", "H", "O", "H"]
+    ordered_elem = ["C", "C", "H", "H", "H", "H", "H", "N", "O", "O"]
+
+    structure = Structure(
+        axes = np.array([
+            [6.00000, 0.00000, 0.00000],
+            [0.00000, 6.00000, 0.00000],
+            [0.00000, 0.00000, 6.00000],
+        ], dtype=np.float64),
+        elem = unordered_elem,
+        pos = np.array([
+            [ 0.711045, 1.361274, 3.966292],
+            [ 1.848745, 2.865874, 3.041292],
+            [ 0.679145, 1.977474, 3.067692],
+            [ 1.827545, 3.514674, 3.813792],
+            [-0.580355, 2.805074, 3.070592],
+            [-0.510755, 4.011174, 3.052592],
+            [ 2.706445, 2.334474, 3.038892],
+            [ 0.690245, 1.335874, 2.186592],
+            [-1.779455, 2.202274, 3.093292],
+            [-2.558655, 2.774774, 3.094192],
+        ], dtype=np.float64),
+        units="A",
+    )
+
+    np.testing.assert_array_equal(structure.elem, unordered_elem)
+
+    structure.group_atoms()
+    np.testing.assert_array_equal(structure.elem, ordered_elem)
+
+
+def test_rename():
+    from nexus.structure import Structure
+
+    original_elem = ["N", "C", "C", "O", "O", "H", "H", "H", "H", "H"]
+
+    structure = Structure(
+        axes = np.array([
+            [6.00000, 0.00000, 0.00000],
+            [0.00000, 6.00000, 0.00000],
+            [0.00000, 0.00000, 6.00000],
+        ], dtype=np.float64),
+        elem = original_elem,
+        pos = np.array([
+            [ 1.848745, 2.865874, 3.041292],
+            [ 0.679145, 1.977474, 3.067692],
+            [-0.580355, 2.805074, 3.070592],
+            [-0.510755, 4.011174, 3.052592],
+            [-1.779455, 2.202274, 3.093292],
+            [ 1.827545, 3.514674, 3.813792],
+            [ 2.706445, 2.334474, 3.038892],
+            [ 0.690245, 1.335874, 2.186592],
+            [ 0.711045, 1.361274, 3.966292],
+            [-2.558655, 2.774774, 3.094192],
+        ], dtype=np.float64),
+        units="A",
+    )
+
+    np.testing.assert_array_equal(structure.elem, original_elem)
+
+    new_elem = ["La", "Np", "Np", "Te", "Te", "Ag", "Ag", "Ag", "Ag", "Ag"]
+    structure.rename(
+        folded=True,
+        N = "La",
+        C = "Np",
+        O = "Te",
+        H = "Ag",
+    )
+
+    np.testing.assert_array_equal(structure.elem, new_elem)
+
+
+def test_reset_axes():
+    from nexus.structure import Structure
+
+    original_axes = np.array([
+        [6.00000, 0.00000, 0.00000],
+        [0.00000, 6.00000, 0.00000],
+        [0.00000, 0.00000, 6.00000],
+    ], dtype=np.float64)
+
+    original_kaxes = np.array([
+        [1.0471975511965976, 0.0, 0.0],
+        [0.0, 1.0471975511965976, 0.0],
+        [0.0, 0.0, 1.0471975511965976],
+    ], dtype=np.float64)
+
+    original_center = np.array([3.0, 3.0, 3.0], dtype=np.float64)
+
+    structure = Structure(
+        axes = original_axes,
+        elem = ["N", "C", "C", "O", "O", "H", "H", "H", "H", "H"],
+        pos = np.array([
+            [ 1.848745, 2.865874, 3.041292],
+            [ 0.679145, 1.977474, 3.067692],
+            [-0.580355, 2.805074, 3.070592],
+            [-0.510755, 4.011174, 3.052592],
+            [-1.779455, 2.202274, 3.093292],
+            [ 1.827545, 3.514674, 3.813792],
+            [ 2.706445, 2.334474, 3.038892],
+            [ 0.690245, 1.335874, 2.186592],
+            [ 0.711045, 1.361274, 3.966292],
+            [-2.558655, 2.774774, 3.094192],
+        ], dtype=np.float64),
+        units="A",
+    )
+
+    np.testing.assert_array_equal(structure.axes, original_axes)
+    np.testing.assert_array_equal(structure.kaxes, original_kaxes)
+    np.testing.assert_array_equal(structure.center, original_center)
+
+    new_axes = np.array([
+        [12.00000,  0.00000,  0.00000],
+        [ 0.00000, 12.00000,  0.00000],
+        [ 0.00000,  0.00000, 12.00000],
+    ], dtype=np.float64)
+
+    new_kaxes = np.array([
+        [0.5235987755982988, 0.0, 0.0],
+        [0.0, 0.5235987755982988, 0.0],
+        [0.0, 0.0, 0.5235987755982988],
+    ], dtype=np.float64)
+
+    new_center = np.array([6.0, 6.0, 6.0], dtype=np.float64)
+
+    structure.reset_axes(new_axes)
+
+    np.testing.assert_allclose(structure.axes, new_axes, rtol=1e-7)
+    np.testing.assert_allclose(structure.kaxes, new_kaxes, rtol=1e-7)
+    np.testing.assert_allclose(structure.center, new_center, rtol=1e-7)
+
+
+def test_reset_axes_none():
+    from nexus.structure import Structure
+
+    original_axes = np.array([
+        [6.00000, 0.00000, 0.00000],
+        [0.00000, 6.00000, 0.00000],
+        [0.00000, 0.00000, 6.00000],
+    ], dtype=np.float64)
+
+    original_kaxes = np.array([
+        [7.0, 0.0, 0.0],
+        [0.0, 7.0, 0.0],
+        [0.0, 0.0, 7.0],
+    ], dtype=np.float64)
+
+    original_center = np.array([400.0, 400.0, 400.0], dtype=np.float64)
+
+    structure = Structure(
+        axes = original_axes,
+        elem = ["N", "C", "C", "O", "O", "H", "H", "H", "H", "H"],
+        pos = np.array([
+            [ 1.848745, 2.865874, 3.041292],
+            [ 0.679145, 1.977474, 3.067692],
+            [-0.580355, 2.805074, 3.070592],
+            [-0.510755, 4.011174, 3.052592],
+            [-1.779455, 2.202274, 3.093292],
+            [ 1.827545, 3.514674, 3.813792],
+            [ 2.706445, 2.334474, 3.038892],
+            [ 0.690245, 1.335874, 2.186592],
+            [ 0.711045, 1.361274, 3.966292],
+            [-2.558655, 2.774774, 3.094192],
+        ], dtype=np.float64),
+        units="A",
+        center = original_center,
+    )
+
+    structure.kaxes = original_kaxes
+
+    np.testing.assert_array_equal(structure.axes, original_axes)
+    np.testing.assert_array_equal(structure.kaxes, original_kaxes)
+    np.testing.assert_array_equal(structure.center, original_center)
+
+    ref_kaxes = np.array([
+        [1.0471975511965976, 0.0, 0.0],
+        [0.0, 1.0471975511965976, 0.0],
+        [0.0, 0.0, 1.0471975511965976],
+    ], dtype=np.float64)
+
+    ref_center = np.array([3.0, 3.0, 3.0], dtype=np.float64)
+
+    structure.reset_axes(axes = None)
+
+    np.testing.assert_allclose(structure.axes, original_axes, rtol=1e-7)
+    np.testing.assert_allclose(structure.kaxes, ref_kaxes, rtol=1e-7)
+    np.testing.assert_allclose(structure.center, ref_center, rtol=1e-7)
+
+def test_write_axes():
+    from nexus.structure import Structure
+
+    structure = Structure(
+        axes = np.array([
+            [6.00000,  0.00000,   0.00000],
+            [0.00000, 12.00000,   0.00000],
+            [0.00000,  0.00000, 300.00000],
+        ], dtype=np.float64),
+        elem = ["N", "C", "C", "O", "O", "H", "H", "H", "H", "H"],
+        pos = np.array([
+            [ 1.848745, 2.865874, 3.041292],
+            [ 0.679145, 1.977474, 3.067692],
+            [-0.580355, 2.805074, 3.070592],
+            [-0.510755, 4.011174, 3.052592],
+            [-1.779455, 2.202274, 3.093292],
+            [ 1.827545, 3.514674, 3.813792],
+            [ 2.706445, 2.334474, 3.038892],
+            [ 0.690245, 1.335874, 2.186592],
+            [ 0.711045, 1.361274, 3.966292],
+            [-2.558655, 2.774774, 3.094192],
+        ], dtype=np.float64),
+        units="A",
+    )
+
+    ref_write_axes = (
+        "  6.00000000   0.00000000   0.00000000\n"
+        "  0.00000000  12.00000000   0.00000000\n"
+        "  0.00000000   0.00000000 300.00000000\n"
+    )
+    assert(structure.write_axes() == ref_write_axes)
+
+
+def test_corners():
+    from nexus.structure import Structure
+
+    structure = Structure(
+        axes = np.array([
+            [7.00000,  0.00000,  0.00000],
+            [0.00000, 14.00000,  0.00000],
+            [0.00000,  0.00000, 35.00000],
+        ], dtype=np.float64),
+        elem = ["N", "C", "C", "O", "O", "H", "H", "H", "H", "H"],
+        pos = np.array([
+            [ 1.848745, 2.865874, 3.041292],
+            [ 0.679145, 1.977474, 3.067692],
+            [-0.580355, 2.805074, 3.070592],
+            [-0.510755, 4.011174, 3.052592],
+            [-1.779455, 2.202274, 3.093292],
+            [ 1.827545, 3.514674, 3.813792],
+            [ 2.706445, 2.334474, 3.038892],
+            [ 0.690245, 1.335874, 2.186592],
+            [ 0.711045, 1.361274, 3.966292],
+            [-2.558655, 2.774774, 3.094192],
+        ], dtype=np.float64),
+        units="A",
+    )
+
+    ref_corners = [
+        [0.0,  0.0,  0.0],
+        [7.0,  0.0,  0.0],
+        [0.0, 14.0,  0.0],
+        [0.0,  0.0, 35.0],
+        [7.0, 14.0,  0.0],
+        [0.0, 14.0, 35.0],
+        [7.0,  0.0, 35.0],
+        [7.0, 14.0, 35.0],
+    ]
+
+    np.testing.assert_allclose(structure.corners(), ref_corners, rtol=1e-7)


### PR DESCRIPTION
## Proposed changes

Adds tests for `Structure.group_atoms()`, `Structure.rename()`, `Structure.reset_axes()`, `Structure.write_axes()`, and `Structure.corners()`.

Additionally, docstrings have been added for each function.

## What type(s) of changes does this code introduce?

- Testing changes
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora Linux 43 (KDE Plasma Desktop Edition)
AMD Ryzen 7 PRO 7840U (8 cores, 16 logical processors)
```
Python        3.14.5
uv            0.11.13
cif2cell      2.1.0
coverage      7.13.5
h5py          3.16.0
matplotlib    3.10.9
numpy         2.4.4
pycifrw       4.4.6
pydot         4.0.1
pytest        9.0.3
pytest-cov    7.1.0
pytest-order  1.4.0
scipy         1.17.1
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
