### PR TITLE
Nexus: Ensure files are closed after opening

### DIFF
--- a/nexus/nexus/basisset.py
+++ b/nexus/nexus/basisset.py
@@ -154,6 +154,7 @@ class gaussBasisFile(BasisFile):
         #end if
         file = TextFile(filepath)
         self.read_file(file)
+        file.close()
     #end def read
 
     def read_file(self,file):
@@ -319,7 +320,8 @@ class GaussianBasisSet(DevBase):
         #end if
         #self.name = split_delims(os.path.split(filepath)[1])[0]
         self.name = os.path.split(filepath)[1].split('.')[0]
-        text = open(filepath,'r').read()
+        with open(filepath, "r") as f:
+            text = f.read()
         self.read_text(text,format)
     #end def read
 

--- a/nexus/nexus/fileio.py
+++ b/nexus/nexus/fileio.py
@@ -255,7 +255,9 @@ class StandardFile(DevBase):
         if not os.path.exists(filepath):
             self.error('read failed\nfile does not exist: {0}'.format(filepath))
         #end if
-        self.read_text(open(filepath,'r').read())
+        with open(filepath, "r") as f:
+            self.read_text(f.read())
+
         self.check_valid('read failed')
     #end def read
 
@@ -264,7 +266,8 @@ class StandardFile(DevBase):
         self.check_valid('write failed')
         text = self.write_text()
         if filepath is not None:
-            open(filepath,'w').write(text)
+            with open(filepath, "w") as f:
+                f.write(text)
         #end if
         return text
     #end def write

--- a/nexus/nexus/gamess.py
+++ b/nexus/nexus/gamess.py
@@ -225,7 +225,8 @@ class Gamess(Simulation):
 
 
     def check_sim_status(self):
-        output = open(os.path.join(self.locdir,self.outfile),'r').read()
+        with open(os.path.join(self.locdir,self.outfile), "r") as out:
+            output = out.read()
         #errors = open(os.path.join(self.locdir,self.errfile),'r').read()
         
         self.failed = 'EXECUTION OF GAMESS TERMINATED -ABNORMALLY-' in output

--- a/nexus/nexus/gamess_analyzer.py
+++ b/nexus/nexus/gamess_analyzer.py
@@ -194,6 +194,7 @@ class GamessAnalyzer(SimulationAnalyzer):
                 self.ao_populations = ao_populations
             #end if
         #end if
+        log.close()
     #end def analyze_log
 
 
@@ -484,6 +485,7 @@ class GamessAnalyzer(SimulationAnalyzer):
                     #end if
                     punch.norbitals = norbs
                 #end if
+                text.close()
             #end if
         except:
             if self.info.exit:

--- a/nexus/nexus/gamess_analyzer.py
+++ b/nexus/nexus/gamess_analyzer.py
@@ -194,7 +194,8 @@ class GamessAnalyzer(SimulationAnalyzer):
                 self.ao_populations = ao_populations
             #end if
         #end if
-        log.close()
+        if log is not None:
+            log.close()
     #end def analyze_log
 
 

--- a/nexus/nexus/pseudopotential.py
+++ b/nexus/nexus/pseudopotential.py
@@ -119,7 +119,8 @@ class gamessPPFile(PseudoFile):
     #end def __init__
 
     def read(self,filepath):
-        lines = open(filepath,'r').read().splitlines()
+        with open(filepath, "r") as f:
+            lines = f.read().splitlines()
         new_block  = True
         tokens     = []
         block      = ''
@@ -390,7 +391,8 @@ class Pseudopotential(DevBase):
             self.error('cannot read {0}, file does not exist'.format(filepath))
         #end if
         self.element = pp_elem_label(os.path.split(filepath)[1])[0]
-        text = open(filepath,'r').read()
+        with open(filepath, "r") as f:
+            text = f.read()
         self.read_text(text,format,filepath=filepath)
     #end def read
 
@@ -405,7 +407,8 @@ class Pseudopotential(DevBase):
         #end if
         text = self.write_text(format)
         if filepath is not None:
-            open(filepath,'w').write(text)
+            with open(filepath, "w") as f:
+                f.write(text)
         #end if
         return text
     #end def write
@@ -1489,7 +1492,8 @@ class SemilocalPP(Pseudopotential):
         text = header+grid+L2+semilocal+footer
 
         if filepath is not None:
-            open(filepath,'w').write(text)
+            with open (filepath, "w") as f:
+                f.write(text)
         #end if
         return text
     #end def write_qmcpack
@@ -2656,7 +2660,7 @@ class CasinoPP(SemilocalPP):
             #end for
             lpots.append(convert(v,self.unitmap[units],'Ha'))
         #end while
-
+        file.close()
         # fill in SemilocalPP class data obtained from read
         self.element = element
         self.Zval    = int(Z)

--- a/nexus/nexus/pwscf_analyzer.py
+++ b/nexus/nexus/pwscf_analyzer.py
@@ -178,7 +178,8 @@ class PwscfAnalyzer(SimulationAnalyzer):
         #end try
 
         try:
-            lines = open(outfile,'r').read().splitlines()
+            with open(outfile, "r") as f:
+                lines = f.read().splitlines()
         except:
             nx+=1
             if self.info.warn:
@@ -622,7 +623,8 @@ class PwscfAnalyzer(SimulationAnalyzer):
 
         try:
             if pw2c_outfile_name is not None:
-                lines = open(os.path.join(path,pw2c_outfile_name),'r').readlines()
+                with open(os.path.join(path,pw2c_outfile_name), "r") as out:
+                    lines = out.readlines()
                 for l in lines:
                     if l.find('Kinetic')!=-1:
                         tokens = l.split()

--- a/nexus/nexus/pwscf_data_reader.py
+++ b/nexus/nexus/pwscf_data_reader.py
@@ -124,7 +124,8 @@ def read_qexml(inp):
     if isinstance(inp,list):
         rawlines = inp
     elif isinstance(inp,str):# and os.path.exists(inp):
-        rawlines = open(inp,'r').read().splitlines()
+        with open(inp, "r") as f:
+            rawlines = f.read().splitlines()
     else:
         print('read_qexml error: input can only be filename or list of lines')
         print('  input received: ',inp)

--- a/nexus/nexus/pwscf_postprocessors.py
+++ b/nexus/nexus/pwscf_postprocessors.py
@@ -760,7 +760,8 @@ class ProjwfcAnalyzer(SimulationAnalyzer):
             #end if
         #end for
         if filepath is not None:
-            open(filepath,'w').write(text)
+            with open(filepath, "w") as f:
+                f.write(text)
         #end if
         return text
     #end def write_lowdin

--- a/nexus/nexus/qmcpack_converters.py
+++ b/nexus/nexus/qmcpack_converters.py
@@ -386,9 +386,8 @@ class Pw2qmcpack(Simulation):
 
     def check_sim_status(self):
         outfile = os.path.join(self.locdir,self.outfile)
-        fobj = open(outfile,'r')
-        output = fobj.read()
-        fobj.close()
+        with open(outfile, "r") as fobj:
+            output = fobj.read()
         inputpp = self.input.inputpp
         prefix = 'pwscf'
         outdir = './'
@@ -856,7 +855,8 @@ class Convert4qmc(Simulation):
 
 
     def check_sim_status(self):
-        output = open(os.path.join(self.locdir,self.outfile),'r').read()
+        with open(os.path.join(self.locdir,self.outfile), "r") as out:
+            output = out.read()
         #errors = open(os.path.join(self.locdir,self.errfile),'r').read()
 
         # Recent versions of convert4qmc no longer produce the orbs.h5 file.
@@ -1348,7 +1348,8 @@ class PyscfToAfqmc(Simulation):
 
 
     def check_sim_status(self):
-        output = open(os.path.join(self.locdir,self.outfile),'r').read()
+        with open(os.path.join(self.locdir,self.outfile), "r") as out:
+            output = out.read()
 
         success = '# Finished.' in output
         success &= os.path.exists(os.path.join(self.locdir,self.input.output))

--- a/nexus/nexus/qmcpack_input.py
+++ b/nexus/nexus/qmcpack_input.py
@@ -5311,7 +5311,8 @@ class QmcpackInputTemplate(SimulationInputTemplate):
                             include_file = token.replace('href','').replace('=','').replace('"','').strip()
                             include_path = os.path.join(basepath,include_file)
                             if os.path.exists(include_path):
-                                icont = open(include_path,'r').read()+'\n'
+                                with open(include_path, "r") as f:
+                                    icont = f.read() + "\n"
                                 line = ''
                                 for iline in icont.splitlines():
                                     if '<?' not in iline:

--- a/nexus/nexus/structure.py
+++ b/nexus/nexus/structure.py
@@ -4941,7 +4941,8 @@ class Structure(Sobj):
         elem = []
         pos  = []
         if os.path.exists(filepath):
-            lines = open(filepath,'r').read().strip().splitlines()
+            with open(filepath, "r") as f:
+                lines = f.read().strip().splitlines()
         else:
             lines = filepath.strip().splitlines() # "filepath" is file contents
         #end if
@@ -5022,7 +5023,8 @@ class Structure(Sobj):
 
     def read_poscar(self,filepath,elem=None):
         if os.path.exists(filepath):
-            lines = open(filepath,'r').read().splitlines()
+            with open(filepath, "r") as f:
+                lines = f.read().splitlines()
         else:
             lines = filepath.splitlines()  # "filepath" is file contents
         #end if
@@ -5142,7 +5144,8 @@ class Structure(Sobj):
     # test needed
     def read_fhi_aims(self,filepath):
         if os.path.exists(filepath):
-            lines = open(filepath,'r').read().splitlines()
+            with open(filepath, "r") as f:
+                lines = f.read().splitlines()
         else:
             lines = filepath.splitlines() # "filepath" is contents
         #end if
@@ -5300,7 +5303,8 @@ class Structure(Sobj):
         #end for
 
         if filepath is not None:
-            open(filepath,'w').write(c)
+            with open(filepath, "w") as f:
+                f.write(c)
         #end if
         return c
     #end def write_xyz
@@ -5333,7 +5337,8 @@ class Structure(Sobj):
             c += '   {0:>3} {1:12.8f}  {2:12.8f}  {3:12.8f}\n'.format(enum,r[0],r[1],r[2])
         #end for
         if filepath is not None:
-            open(filepath,'w').write(c)
+            with open(filepath, "w") as f:
+                f.write(c)
         #end if
         return c
     #end def write_xsf
@@ -5352,7 +5357,8 @@ class Structure(Sobj):
         poscar.pos        = s.pos
         c = poscar.write_text()
         if filepath is not None:
-            open(filepath,'w').write(c)
+            with open(filepath, "w") as f:
+                f.write(c)
         #end if
         return c
     #end def write_poscar
@@ -5372,7 +5378,8 @@ class Structure(Sobj):
             c += 'atom_frac   {0: 12.8f}  {1: 12.8f}  {2: 12.8f}  {3}\n'.format(p[0],p[1],p[2],e)
         #end for
         if filepath is not None:
-            open(filepath,'w').write(c)
+            with open(filepath, "w") as f:
+                f.write(c)
         #end if
         return c
     #end def write_fhi_aims

--- a/nexus/nexus/template_simulation.py
+++ b/nexus/nexus/template_simulation.py
@@ -318,8 +318,11 @@ class TemplateSimulation(Simulation):
         #  read output/error files to check whether simulation has
         #    completed successfully
         #  one could also check whether all output files exist
-        output = open(os.path.join(self.locdir,self.outfile),'r').read()
-        errors = open(os.path.join(self.locdir,self.errfile),'r').read()
+        with open(os.path.join(self.locdir,self.outfile), "r") as out:
+            output = out.read()
+
+        with open(os.path.join(self.locdir,self.errfile), "r") as err:
+            errors = err.read()
         
         success = False
         # check output and errors

--- a/nexus/nexus/vasp.py
+++ b/nexus/nexus/vasp.py
@@ -144,7 +144,8 @@ class Vasp(Simulation):
         if all_exist:
             success = True
             for outpath in outpaths:
-                outcar = open(outpath,'r').read()
+                with open(outpath, "r") as f:
+                    outcar = f.read()
                 success &= 'General timing and accounting' in outcar
             #end for
         #end if

--- a/nexus/nexus/vasp_analyzer.py
+++ b/nexus/nexus/vasp_analyzer.py
@@ -366,7 +366,8 @@ def read_vxml(filepath):
         VXML.class_error('file {0} does not exist'.format(filepath),'read_vxml')
     #end if
     #print 'read'
-    contents = open(filepath,'r').read()
+    with open(filepath, "r") as f:
+        contents = f.read()
     #print 'replace'
     contents = contents.replace('<rc>',' ').replace('</rc>',' ')
     contents = contents.replace('<r>' ,' ').replace('</r>' ,' ')

--- a/nexus/nexus/vasp_input.py
+++ b/nexus/nexus/vasp_input.py
@@ -324,7 +324,8 @@ class VFile(Vobj):
         if not os.path.exists(filepath):
             self.error('file {0} does not exist'.format(filepath))
         #end if
-        text = open(filepath,'r').read()
+        with open(filepath, "r") as f:
+            text = f.read()
         self.read_text(text,filepath)
         return text
     #end def read
@@ -333,7 +334,8 @@ class VFile(Vobj):
     def write(self,filepath=None):
         text = self.write_text(filepath)
         if filepath is not None:
-            open(filepath,'w').write(text)
+            with open(filepath, "w") as f:
+                f.write(text)
         #end if
         return text
     #end def write
@@ -1341,7 +1343,8 @@ class Potcar(VFormattedFile):
             #end for
         elif self.filepath is not None and self.files is not None:
             for file in self.files:
-                text += open(os.path.join(self.filepath,file),'r').read()
+                with open(os.path.join(self.filepath, file), "r") as f:
+                    text += f.read()
             #end for
         #end if
         return text

--- a/nexus/nexus/xmlreader.py
+++ b/nexus/nexus/xmlreader.py
@@ -306,8 +306,8 @@ class XMLreader(DevBase):
 
         #read in xml file
         if xml is None:
-            fobj = open(fpath,'r')
-            self.xml = fobj.read()
+            with open(fpath, "r") as fobj:
+                self.xml = fobj.read()
         else:
             self.xml = xml
         #end if
@@ -350,10 +350,9 @@ class XMLreader(DevBase):
             if ir != -1:
                 cont = self.xml[il:ir].strip(pair[0]).rstrip(pair[1])
                 fname = cont.split('=',1)[1].strip().strip('"')
-                fobj = open(os.path.join(self.base_path,fname),'r')
-                fcont = fobj.read()
+                with open(os.path.join(self.base_path,fname), "r") as fobj:
+                    fcont = fobj.read()
                 fcont = remove_pair_sections(fcont,qpair)
-                fobj.close()
                 self.xml = self.xml.replace(self.xml[il:ir],fcont)
             #end if
         #end while


### PR DESCRIPTION
## Proposed changes

There were several cases in Nexus where a file is opened and, in theory, not closed. In practice, it is likely that the garbage collector handled almost all of these cases, but it is best to be explicit with it.

To catch the instances where a file might not be closed after opening, I used the following command:
```shell
> PYTHONDEVMODE=1 pytest > pytest_devmode.log 2>&1
```
which enables extra Python warnings such as `ResourceWarning` which can tell you if a file is opened but not closed. As best I can tell I have fixed every case, though it is not quite possible to say with certainty because the test coverage is not 100%.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora Linux 43 (KDE Plasma Desktop Edition)
AMD Ryzen 7 PRO 7840U (8 cores, 16 logical processors)
```
Python        3.14.5
uv            0.11.13
cif2cell      2.1.0
coverage      7.13.5
h5py          3.16.0
matplotlib    3.10.9
numpy         2.4.4
pycifrw       4.4.6
pydot         4.0.1
pytest        9.0.3
pytest-cov    7.1.0
pytest-order  1.4.0
scipy         1.17.1
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'