### PR TITLE
Nexus: Update `Structure.rotate()` docstring to work with `numpydoc`

### DIFF
--- a/nexus/nexus/structure.py
+++ b/nexus/nexus/structure.py
@@ -1752,45 +1752,45 @@ class Structure(Sobj):
 
     # test needed
     def rotate(self,r,rp=None,passive=False,units="radians",check=True):
-        """
-        Arbitrary rotation of the structure.
+        """Arbitrary rotation of the structure.
+
         Parameters
         ----------
-        r  : `array_like, float, shape (3,3)` or `array_like, float, shape (3,)` or `str`
-            If a 3x3 matrix, then code executes rotation consistent with this matrix -- 
-            it is assumed that the matrix acts on a column-major vector (eg, v'=Rv)
-            If a three-dimensional array, then the operation of the function depends
-            on the input type of rp in the following ways:
-                1. If rp is a scalar, then rp is assumed to be an angle and a rotation 
-                   of rp is made about the axis defined by r
-                2. If rp is a vector, then rp is assumed to be an axis and a rotation is made 
-                   such that r aligns with rp
-                3. If rp is a str, then the rotation is such that r aligns with the
-                   axis given by the str ('x', 'y', 'z', 'a0', 'a1', or 'a2')
-            If a str then the axis, r, is defined by the input label (e.g. 'x', 'y', 'z', 'a1', 'a2', or 'a3')
-            and the operation of the function depends on the input type of rp in the following
-            ways (same as above):
-                1. If rp is a scalar, then rp is assumed to be an angle and a rotation 
-                   of rp is made about the axis defined by r
-                2. If rp is a vector, then rp is assumed to be an axis and a rotation is made 
-                   such that r aligns with rp
-                3. If rp is a str, then the rotation is such that r aligns with the
-                   axis given by the str ('x', 'y', 'z', 'a0', 'a1', or 'a2')
-        rp : `array_like, float, shape (3), optional` or `str, optional`
-            If a 3-dimensional vector is given, then rp is assumed to be an axis and a rotation is made
-            such that the axis r is aligned with rp.
-            If a str, then rp is assumed to be an angle and a rotation about the axis defined by r 
-            is made by an angle rp
-            If a str is given, then rp is assumed to be an axis defined by the given label
-            (e.g. 'x', 'y', 'z', 'a1', 'a2', or 'a3') and a rotation is made such that the axis r 
-            is aligned with rp.
-        passive : `bool, optional, default False`
-            If `True`, perform a passive rotation
-            If `False`, perform an active rotation
-        units : `str, optional, default "radians"`
-            Units of rp, if rp is given as an angle (scalar)
-        check : `bool, optional, default True`
-            Perform a check to verify rotation matrix is orthogonal
+        r : array_like of float with shape (3,3) or array_like of float shape (3,) or str
+            If a 3x3 matrix, then code executes rotation consistent with this
+            matrix -- it is assumed that the matrix acts on a column-major
+            vector (eg, v'=Rv). If a three-dimensional array, then the operation
+            of the function depends on the input type of ``rp`` in the
+            following ways:
+
+            1. If ``rp`` is a scalar, then ``rp`` is assumed to be an angle and
+               a rotation of ``rp`` is made about the axis defined by ``r``.
+            2. If ``rp`` is a vector, then ``rp`` is assumed to be an axis and a 
+               rotation is made such that ``r`` aligns with ``rp``.
+            3. If ``rp`` is a ``str``, then the rotation is such that ``r``
+               aligns with the axis given by the str
+               ``('x', 'y', 'z', 'a0', 'a1', or 'a2')``.
+
+            If a ``str`` then the axis, ``r``, is defined by the input label
+            (e.g. 'x', 'y', 'z', 'a1', 'a2', or 'a3') and the operation of the
+            function depends on the input type of ``rp`` in the same ways as
+            above.
+        rp : array_like of float with shape (3) or str, optional
+            If a 3-dimensional vector is given, then ``rp`` is assumed to be an
+            axis and a rotation is made such that the axis ``r`` is aligned with
+            ``rp``.
+            If a str, then ``rp`` is assumed to be an angle and a
+            rotation about the axis defined by ``r`` is made by an angle ``rp``.
+            If a str is given, then ``rp`` is assumed to be an axis defined by
+            the given label (e.g. 'x', 'y', 'z', 'a1', 'a2', or 'a3') and a
+            rotation is made such that the axis ``r`` is aligned with ``rp``.
+        passive : bool, default=False
+            If ``True``, perform a passive rotation.
+            If ``False``, perform an active rotation.
+        units : {"radians", "rad", "degrees", "deg"}, default="radians"
+            Units of ``rp``, if ``rp`` is given as an angle (scalar).
+        check : bool, default=True
+            Perform a check to verify rotation matrix is orthogonal.
         """
         if rp is not None:
             dirmap = dict(x=[1,0,0],y=[0,1,0],z=[0,0,1])


### PR DESCRIPTION
## Proposed changes

I didn't check the original for accuracy, and since I didn't make any real changes other than formatting/whitespace, this could technically be inaccurate if the original was too.

## What type(s) of changes does this code introduce?

- Documentation

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Desktop Fedora Linux 43 (KDE Plasma Desktop Edition)
AMD Ryzen 9 7900X (12 cores, 24 logical processors)
```
Python        3.14.4
uv            0.11.3
cif2cell      2.1.0
coverage      7.13.5
h5py          3.16.0
matplotlib    3.10.9
numpy         2.4.4
pycifrw       4.4.6
pydot         4.0.1
pytest        9.0.3
pytest-cov    7.1.0
pytest-order  1.4.0
scipy         1.17.1
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'