### PR TITLE
Fix offload to host MPI case

### DIFF
--- a/src/Estimators/tests/CMakeLists.txt
+++ b/src/Estimators/tests/CMakeLists.txt
@@ -116,6 +116,8 @@ if(HAVE_MPI)
       qmcwfs
       qmcparticle
       qmcwfs_omptarget
+      spline2
+      spline2_omptarget
       qmcparticle_omptarget
       qmcutil
       platform_omptarget_LA

--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -122,6 +122,8 @@ if(HAVE_MPI)
       qmcwfs
       qmcparticle
       qmcwfs_omptarget
+      spline2
+      spline2_omptarget
       qmcparticle_omptarget
       qmcutil
       platform_omptarget_LA)


### PR DESCRIPTION
## Proposed changes

The host offload build in our CI doesn't enable MPI and leave this bug undetected.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
