### PR TITLE
Nexus: Add friendlier exit message for users with outdated Python trying to use executables

### DIFF
--- a/nexus/nexus/bin/eshdf
+++ b/nexus/nexus/bin/eshdf
@@ -6,6 +6,16 @@ import sys
 from pathlib import Path
 from optparse import OptionParser
 
+if sys.version_info[0:3] < (3, 10, 0):
+    v = sys.version_info[0:3]
+    print(
+       f"Your version of Python ({v[0]}.{v[1]}.{v[2]}) is less than the minimum required for Nexus!\n"
+        "To use Nexus, please install at least Python 3.10.0 or higher!\n\n"
+        "If you already have a higher version installed, ensure that your Python\n"
+        "environment is properly activated and your $PATH is set correctly."
+    )
+    sys.exit(1)
+
 # Non-standard Python library imports
 import numpy as np
 

--- a/nexus/nexus/bin/nxs-redo
+++ b/nexus/nexus/bin/nxs-redo
@@ -1,8 +1,19 @@
 #! /usr/bin/env python3
 
 import os
+import sys
 from pathlib import Path
 from optparse import OptionParser
+
+if sys.version_info[0:3] < (3, 10, 0):
+    v = sys.version_info[0:3]
+    print(
+       f"Your version of Python ({v[0]}.{v[1]}.{v[2]}) is less than the minimum required for Nexus!\n"
+        "To use Nexus, please install at least Python 3.10.0 or higher!\n\n"
+        "If you already have a higher version installed, ensure that your Python\n"
+        "environment is properly activated and your $PATH is set correctly."
+    )
+    sys.exit(1)
 
 # Copied from qmca. Modification must done on qmca first
 # Locate and import the closely coupled Nexus module

--- a/nexus/nexus/bin/nxs-sim
+++ b/nexus/nexus/bin/nxs-sim
@@ -1,8 +1,19 @@
 #! /usr/bin/env python3
 
 import os
+import sys
 from pathlib import Path
 from optparse import OptionParser
+
+if sys.version_info[0:3] < (3, 10, 0):
+    v = sys.version_info[0:3]
+    print(
+       f"Your version of Python ({v[0]}.{v[1]}.{v[2]}) is less than the minimum required for Nexus!\n"
+        "To use Nexus, please install at least Python 3.10.0 or higher!\n\n"
+        "If you already have a higher version installed, ensure that your Python\n"
+        "environment is properly activated and your $PATH is set correctly."
+    )
+    sys.exit(1)
 
 # Copied from qmca. Modification must done on qmca first
 # Locate and import the closely coupled Nexus module

--- a/nexus/nexus/bin/nxs-test
+++ b/nexus/nexus/bin/nxs-test
@@ -12,6 +12,16 @@ for development.
 
 import sys
 
+if sys.version_info[0:3] < (3, 10, 0):
+    v = sys.version_info[0:3]
+    print(
+       f"Your version of Python ({v[0]}.{v[1]}.{v[2]}) is less than the minimum required for Nexus!\n"
+        "To use Nexus, please install at least Python 3.10.0 or higher!\n\n"
+        "If you already have a higher version installed, ensure that your Python\n"
+        "environment is properly activated and your $PATH is set correctly."
+    )
+    sys.exit(1)
+
 try:
     import pytest
 except ImportError:

--- a/nexus/nexus/bin/qdens
+++ b/nexus/nexus/bin/qdens
@@ -2,8 +2,19 @@
 
 import gc
 import os
+import sys
 from pathlib import Path
 from optparse import OptionParser
+
+if sys.version_info[0:3] < (3, 10, 0):
+    v = sys.version_info[0:3]
+    print(
+       f"Your version of Python ({v[0]}.{v[1]}.{v[2]}) is less than the minimum required for Nexus!\n"
+        "To use Nexus, please install at least Python 3.10.0 or higher!\n\n"
+        "If you already have a higher version installed, ensure that your Python\n"
+        "environment is properly activated and your $PATH is set correctly."
+    )
+    sys.exit(1)
 
 # Copied from qmca. Modification must done on qmca first
 # Locate and import the closely coupled Nexus module

--- a/nexus/nexus/bin/qdens-radial
+++ b/nexus/nexus/bin/qdens-radial
@@ -2,6 +2,17 @@
 
 from pathlib import Path
 from optparse import OptionParser
+import sys
+
+if sys.version_info[0:3] < (3, 10, 0):
+    v = sys.version_info[0:3]
+    print(
+       f"Your version of Python ({v[0]}.{v[1]}.{v[2]}) is less than the minimum required for Nexus!\n"
+        "To use Nexus, please install at least Python 3.10.0 or higher!\n\n"
+        "If you already have a higher version installed, ensure that your Python\n"
+        "environment is properly activated and your $PATH is set correctly."
+    )
+    sys.exit(1)
 
 # Copied from qmca. Modification must done on qmca first
 # Locate and import the closely coupled Nexus module

--- a/nexus/nexus/bin/qmc-fit
+++ b/nexus/nexus/bin/qmc-fit
@@ -5,6 +5,16 @@ import sys
 import argparse
 from pathlib import Path
 
+if sys.version_info[0:3] < (3, 10, 0):
+    v = sys.version_info[0:3]
+    print(
+       f"Your version of Python ({v[0]}.{v[1]}.{v[2]}) is less than the minimum required for Nexus!\n"
+        "To use Nexus, please install at least Python 3.10.0 or higher!\n\n"
+        "If you already have a higher version installed, ensure that your Python\n"
+        "environment is properly activated and your $PATH is set correctly."
+    )
+    sys.exit(1)
+
 try:
     import numpy as np
 except:

--- a/nexus/nexus/bin/qmca
+++ b/nexus/nexus/bin/qmca
@@ -5,6 +5,15 @@ from pathlib import Path
 import sys
 from optparse import OptionParser
 
+if sys.version_info[0:3] < (3, 10, 0):
+    v = sys.version_info[0:3]
+    print(
+       f"Your version of Python ({v[0]}.{v[1]}.{v[2]}) is less than the minimum required for Nexus!\n"
+        "To use Nexus, please install at least Python 3.10.0 or higher!\n\n"
+        "If you already have a higher version installed, ensure that your Python\n"
+        "environment is properly activated and your $PATH is set correctly."
+    )
+    sys.exit(1)
 
 # Gold implementation. All the Nexus scripts need to be updated once modified.
 # Locate and import the closely coupled Nexus module


### PR DESCRIPTION
## Proposed changes

Closes #5980.

The error message that this prints is
```
Your version of Python (3.9.25) is less than the minimum required for Nexus!
To use Nexus, please install at least Python 3.10.0 or higher!

If you already have a higher version installed, ensure that your Python
environment is properly activated and your $PATH is set correctly.
```

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Desktop Fedora Linux 43 (KDE Plasma Desktop Edition)
AMD Ryzen 9 7900X (12 cores, 24 logical processors)
```
Python        3.9.25
uv            0.11.15
cif2cell      2.1.0
coverage      7.13.5
h5py          3.14.0
matplotlib    3.9.4
numpy         2.0.2
pycifrw       4.4.6
scipy         1.13.1
seekpath      2.2.1
spglib        2.7.0
```

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'