### PR TITLE
Nexus: Add `Path` to `str` conversion to some functions

### DIFF
--- a/nexus/nexus/fileio.py
+++ b/nexus/nexus/fileio.py
@@ -30,6 +30,7 @@ from .developer import DevBase, obj, error, to_str
 from .periodic_table import Elements
 from .unit_converter import convert
 from . import numpy_extensions as npe
+from .utilities import path_string
 
 class TextFile(DevBase):
     # interface to mmap files
@@ -39,11 +40,13 @@ class TextFile(DevBase):
         self.mm = None
         self.f  = None
         if filepath is not None:
+            filepath = path_string(filepath)
             self.open(filepath)
         #end if
     #end def __init__
 
     def open(self,filepath):
+        filepath = path_string(filepath)
         if not os.path.exists(filepath):
             self.error('cannot open non-existent file: {0}'.format(filepath))
         #end if
@@ -243,7 +246,8 @@ class StandardFile(DevBase):
     def __init__(self,filepath=None):
         if filepath is None:
             None
-        elif isinstance(filepath, (str, Path)):
+        elif isinstance(filepath, str | bytes | Path):
+            filepath = path_string(filepath)
             self.read(filepath)
         else:
             self.error('unsupported input: {0}'.format(filepath))

--- a/nexus/nexus/gamess_analyzer.py
+++ b/nexus/nexus/gamess_analyzer.py
@@ -21,6 +21,7 @@ from .developer import obj
 from .fileio import TextFile
 from .simulation import SimulationAnalyzer,Simulation
 from .gamess_input import GamessInput
+from .utilities import path_string
 
 
 def assign_value(host,dest,file,string):
@@ -68,6 +69,7 @@ class GamessAnalyzer(SimulationAnalyzer):
             infile = arg0
         #end if
         if infile is not None:
+            infile = path_string(infile)
             info = self.info
             info.path = os.path.dirname(infile)
             info.input = GamessInput(infile)

--- a/nexus/nexus/gamess_input.py
+++ b/nexus/nexus/gamess_input.py
@@ -36,6 +36,7 @@ from .periodic_table import Elements
 from .developer import DevBase, obj, error, warn
 from .nexus_base import nexus_noncore
 from .simulation import SimulationInput
+from .utilities import path_string
 
 
 class GIbase(DevBase):
@@ -801,6 +802,7 @@ class GamessInput(SimulationInput,GIbase):
 
     def __init__(self,filepath=None):
         if filepath is not None:
+            filepath = path_string(filepath)
             self.read(filepath)
         #end if
     #end def __init__

--- a/nexus/nexus/generic.py
+++ b/nexus/nexus/generic.py
@@ -38,7 +38,7 @@ from pickle import UnpicklingError
 from random import randint
 from pathlib import Path
 
-from .utilities import sorted_py2
+from .utilities import sorted_py2, path_string
 
 
 class generic_settings:
@@ -1047,7 +1047,8 @@ class obj(object_interface):
 
     def path_exists(self,path):
         o = self
-        if isinstance(path,str):
+        if isinstance(path, str | bytes | Path):
+            path = path_string(path)
             path = path.split('/')
         #end if
         for p in path:
@@ -1062,7 +1063,8 @@ class obj(object_interface):
     def set_path(self,path,value=None):
         o = self
         cls = self.__class__
-        if isinstance(path,str):
+        if isinstance(path, str | bytes | Path):
+            path = path_string(path)
             path = path.split('/')
         #end if
         for p in path[0:-1]:
@@ -1076,7 +1078,8 @@ class obj(object_interface):
 
     def get_path(self,path,value=None):
         o = self
-        if isinstance(path,str):
+        if isinstance(path, str | bytes | Path):
+            path = path_string(path)
             path = path.split('/')
         #end if
         for p in path[0:-1]:

--- a/nexus/nexus/nexus_base.py
+++ b/nexus/nexus/nexus_base.py
@@ -28,7 +28,7 @@
 import os
 import gc as garbage_collector
 from os import PathLike
-from pathlib import Path
+from .utilities import path_string
 from .nexus_version import nexus_version
 from .memory import resident
 from .developer import DevBase, obj, log
@@ -230,8 +230,7 @@ _____________________________________________________
             Optional message to pass to the output log.
         """
         NexusCore.working_directory = os.getcwd()
-        if isinstance(directory, Path):
-            directory = str(directory.resolve())
+        directory = path_string(directory)
 
         self.log('    Entering ' + directory, msg)
         if changedir:

--- a/nexus/nexus/pseudopotential.py
+++ b/nexus/nexus/pseudopotential.py
@@ -1723,7 +1723,7 @@ class GaussianPP(SemilocalPP):
 
         if not Elements.is_element(element):
             if not Elements.is_element(self.element):
-                self.error('cannot identify element for pseudopotential file '+filepath)
+                self.error('cannot identify element for pseudopotential file '+path_string(filepath))
             #end if
         else:
             self.element = element

--- a/nexus/nexus/tests/test_machines.py
+++ b/nexus/nexus/tests/test_machines.py
@@ -8,7 +8,7 @@ generic_settings.raise_error = True
 from .. import testing
 from ..testing import object_eq,object_diff,failed,FailedTest
 from ..testing import divert_nexus_log,restore_nexus_log
-
+from ..utilities import path_string
 
 all_machines = []
 machines_data = dict()
@@ -487,7 +487,7 @@ def init_job(j,
              ):
     import os
     identifier = id
-    directory  = dir
+    directory  = path_string(dir)
     j.set_id()
     j.identifier  = identifier
     j.directory   = directory


### PR DESCRIPTION
## Proposed changes

This uses `path_string` to "protect" some functions that may store filepaths and/or use them as strings.

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora Linux 43 (KDE Plasma Desktop Edition)
AMD Ryzen 7 PRO 7840U (8 cores, 16 logical processors)
```
Python        3.14.5
uv            0.11.13
cif2cell      2.1.0
h5py          3.16.0
matplotlib    3.10.9
numpy         2.4.4
pycifrw       4.4.6
pydot         4.0.1
pytest        9.0.3
pytest-order  1.4.0
scipy         1.17.1
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'