### PR TITLE
Nexus: Add `Path` to `string` conversion to more functions

### DIFF
--- a/nexus/nexus/__init__.py
+++ b/nexus/nexus/__init__.py
@@ -30,6 +30,7 @@ from .nexus_version import nexus_version
 from .generic       import generic_settings
 from .developer     import obj,                error,              log
 from .debug         import ci
+from .utilities     import path_string
 
 from .nexus_base      import NexusCore,              nexus_core,     nexus_noncore,          nexus_core_noncore,         restore_nexus_core_defaults,    nexus_core_defaults
 from .machines        import Job,                    job,            Machine, Supercomputer, get_machine
@@ -193,6 +194,17 @@ class Settings(NexusCore):
     # sets up Nexus core class behavior and passes information to broader class structure
     def __call__(self,**kwargs):
         kwargs = obj(**kwargs)
+        # Ensure no pathlib.Path objects are stored
+        core_path_vars = (
+            "runs",
+            "results",
+            "pseudo_dir",
+            "local_directory",
+            "remote_directory",
+        )
+        for var in core_path_vars:
+            if var in kwargs:
+                kwargs[var] = path_string(kwargs[var])
 
         # guard against invalid settings
         not_allowed = set(kwargs.keys()) - Settings.allowed_vars
@@ -599,9 +611,9 @@ class Settings(NexusCore):
         if 'file_locations' in kw:
             fl = kw.file_locations
             if isinstance(fl,str):
-                nexus_core.file_locations.extend([fl])
+                nexus_core.file_locations.extend([path_string(fl)])
             else:
-                nexus_core.file_locations.extend(list(fl))
+                nexus_core.file_locations.extend([path_string(f) for f in fl])
             #end if
         #end if
         if 'pseudo_dir' not in kw:

--- a/nexus/nexus/__init__.py
+++ b/nexus/nexus/__init__.py
@@ -201,7 +201,7 @@ class Settings(NexusCore):
             "pseudo_dir",
             "local_directory",
             "remote_directory",
-        )
+            )
         for var in core_path_vars:
             if var in kwargs:
                 kwargs[var] = path_string(kwargs[var])

--- a/nexus/nexus/basisset.py
+++ b/nexus/nexus/basisset.py
@@ -9,6 +9,7 @@ import numpy as np
 from .periodic_table import Elements
 from .developer import DevBase, obj, error, to_str, unavailable
 from .fileio import TextFile
+from .utilities import path_string
 
 try:
     import matplotlib.pyplot as plt
@@ -109,6 +110,7 @@ class BasisFile(DevBase):
         self.filename      = None
         self.location      = None
         if filepath is not None:
+            filepath = path_string(filepath)
             self.filename = os.path.basename(filepath)
             self.location = os.path.realpath(filepath)
             elem_label = self.filename.split('.')[0]
@@ -334,7 +336,8 @@ class GaussianBasisSet(DevBase):
         #end if
         text = self.write_text(format)
         if filepath is not None:
-            open(filepath,'w').write(text)
+            with open(filepath,'w') as fobj:
+                fobj.write(text)
         #end if
         return text
     #end def write

--- a/nexus/nexus/hdfreader.py
+++ b/nexus/nexus/hdfreader.py
@@ -22,6 +22,7 @@ import numpy as np
 import keyword
 from inspect import getmembers
 from .developer import DevBase, obj, unavailable, valid_variable_name
+from .utilities import path_string
 
 try:
     import h5py
@@ -263,7 +264,7 @@ class HDFgroup(DevBase):
 class HDFreader(DevBase):
     
     def __init__(self,fpath,verbose=False,view=False):
-        
+        fpath = path_string(fpath)
         HDFglobals.view = view
 
         if verbose:

--- a/nexus/nexus/machines.py
+++ b/nexus/nexus/machines.py
@@ -248,7 +248,7 @@ class Job(NexusCore):
             "outfile",
             "errfile",
             "subfile",
-        )
+            )
         for arg in path_arguments:
             if arg in kw:
                 kw[arg] = path_string(kw[arg])

--- a/nexus/nexus/machines.py
+++ b/nexus/nexus/machines.py
@@ -255,7 +255,7 @@ class Job(NexusCore):
 
         # Theoretically a bash alias can have invalid filename characters,
         # so we treat app_name with some more special logic.
-        if kw.app_name is not None:
+        if "app_name" in kw:
             if isinstance(kw.app_name, Path):
                 kw.app_name = path_string(kw.app_name)
             elif not isinstance(kw.app_name, str):

--- a/nexus/nexus/machines.py
+++ b/nexus/nexus/machines.py
@@ -51,6 +51,7 @@ import numpy as np
 from .developer import DevBase, obj
 from .nexus_base import NexusCore, nexus_core
 from .execute import execute
+from .utilities import path_string
 import importlib.util
 import importlib.machinery
 
@@ -239,6 +240,18 @@ class Job(NexusCore):
     def __init__(self,**kwargs):
         # rewrap keyword arguments
         kw = obj(**kwargs)
+        # Ensure no pathlib.Path objects are stored
+        path_arguments = (
+            "directory",
+            "subdir",
+            "app_name",
+            "outfile",
+            "errfile",
+            "subfile",
+        )
+        for arg in path_arguments:
+            if arg in kw:
+                kw[arg] = path_string(kw[arg])
 
         # save information used to initialize job object
         self.init_info = kw.copy()

--- a/nexus/nexus/machines.py
+++ b/nexus/nexus/machines.py
@@ -44,6 +44,7 @@
 
 
 import os
+from pathlib import Path
 #from multiprocessing import cpu_count
 from socket import gethostname
 from subprocess import Popen
@@ -244,7 +245,6 @@ class Job(NexusCore):
         path_arguments = (
             "directory",
             "subdir",
-            "app_name",
             "outfile",
             "errfile",
             "subfile",
@@ -252,6 +252,14 @@ class Job(NexusCore):
         for arg in path_arguments:
             if arg in kw:
                 kw[arg] = path_string(kw[arg])
+
+        # Theoretically a bash alias can have invalid filename characters,
+        # so we treat app_name with some more special logic.
+        if kw.app_name is not None:
+            if isinstance(kw.app_name, Path):
+                kw.app_name = path_string(kw.app_name)
+            elif not isinstance(kw.app_name, str):
+                self.error("app_name must be a str or Path object!")
 
         # save information used to initialize job object
         self.init_info = kw.copy()

--- a/nexus/nexus/pseudopotential.py
+++ b/nexus/nexus/pseudopotential.py
@@ -387,6 +387,7 @@ class Pseudopotential(DevBase):
 
 
     def read(self,filepath,format=None):
+        filepath = path_string(filepath)
         if self.requires_format:
             if format is None:
                 self.error('format keyword must be specified to read file {0}\nvalid options are: {1}'.format(filepath,self.formats))
@@ -2435,7 +2436,7 @@ class GaussianPP(SemilocalPP):
         keep_chans = keep.split()
         # Are the labels recognized?
         if keep_chans[0] not in chan_labels or keep_chans[1] not in chan_labels:
-            slef.error('Requested channel to keep is not recognized')
+            self.error('Requested channel to keep is not recognized')
         #end if
         # Does the original potential contain the requested channels?
         if keep_chans[0] not in comps or keep_chans[1] not in comps:
@@ -2623,6 +2624,7 @@ class CasinoPP(SemilocalPP):
     unitmap = dict(rydberg='Ry',hartree='Ha',ev='eV')
 
     def read(self,filepath,format=None):
+        filepath = path_string(filepath)
         if not os.path.exists(filepath):
             self.error('cannot read {0}, file does not exist'.format(filepath))
         #end if

--- a/nexus/nexus/pwscf_analyzer.py
+++ b/nexus/nexus/pwscf_analyzer.py
@@ -28,6 +28,7 @@ from .structure import Structure, get_kpath
 from .pwscf_input import PwscfInput
 from .pwscf_data_reader import read_qexml
 from .fileio import TextFile
+from .utilities import path_string
 from . import numpy_extensions as npe
 
 
@@ -88,7 +89,7 @@ class PwscfAnalyzer(SimulationAnalyzer):
             outfile_name= sim.outfile
             self.input_structure = sim.system.structure
         elif arg0 is not None:
-            path = arg0
+            path = path_string(arg0)
             if not os.path.exists(path):
                 self.error('path to QE data does not exist\npath provided: {}'.format(path))
             #end if

--- a/nexus/nexus/qmcpack_input.py
+++ b/nexus/nexus/qmcpack_input.py
@@ -146,6 +146,7 @@ from .structure import Structure, Jellium, get_kpath
 from .physical_system import PhysicalSystem
 from .simulation import SimulationInput, SimulationInputTemplate
 from .pwscf_input import array_to_string as pwscf_array_string
+from .utilities import path_string
 from . import numpy_extensions as npe
 
 yesno_dict     = {True:'yes' ,False:'no'}
@@ -3168,7 +3169,7 @@ class QmcpackInput(SimulationInput,Names):
         if arg0 is None and arg1 is None:
             None
         elif isinstance(arg0,(str, Path)) and arg1 is None:
-            filepath = arg0
+            filepath = path_string(arg0)
         elif isinstance(arg0,QIxml) and arg1 is None:
             element = arg0
         elif isinstance(arg0,meta) and isinstance(arg1,QIxml):

--- a/nexus/nexus/simulation.py
+++ b/nexus/nexus/simulation.py
@@ -493,7 +493,7 @@ class Simulation(NexusCore):
             self.path = p
         #end if
         if 'files' in allowed:
-            self.files = set(self.files)
+            self.files = set([path_string(f) for f in self.files])
         #end if
         if not isinstance(self.input,(self.input_type,GenericSimulationInput)):
             self.error('input must be of type {0}\nreceived {1}\nplease provide input appropriate to {2}'.format(self.input_type.__name__,self.input.__class__.__name__,self.__class__.__name__))

--- a/nexus/nexus/structure.py
+++ b/nexus/nexus/structure.py
@@ -137,6 +137,7 @@ from .numerics import nearest_neighbors, convex_hull, voronoi_neighbors
 from .periodic_table import Elements
 from .fileio import XsfFile, PoscarFile
 from .developer import DevBase, obj, unavailable, error
+from .utilities import path_string
 from . import numpy_extensions as npe
 
 try:
@@ -5023,6 +5024,7 @@ class Structure(Sobj):
 
     def read(self,filepath,format=None,elem=None,block=None,grammar='1.1',cell='prim',contents=False):
         if os.path.exists(filepath):
+            filepath = path_string(filepath)
             path,file = os.path.split(filepath)
             if format is None:
                 if '.' in file:

--- a/nexus/nexus/vasp_input.py
+++ b/nexus/nexus/vasp_input.py
@@ -45,6 +45,7 @@ from .simulation import SimulationInput
 from .structure import interpolate_structures, Structure
 from .physical_system import PhysicalSystem
 from .developer import DevBase, obj, error
+from .utilities import path_string
 from . import numpy_extensions as npe
 
 # support functions for keyword files
@@ -298,6 +299,7 @@ assign_value_functions = obj(
 
 class Vobj(DevBase):
     def get_path(self,filepath):
+        filepath = path_string(filepath)
         if os.path.exists(filepath) and os.path.isdir(filepath):
             path = filepath
         else:
@@ -315,6 +317,7 @@ class Vobj(DevBase):
 class VFile(Vobj):
     def __init__(self,filepath=None):
         if filepath is not None:
+            filepath = path_string(filepath)
             self.read(filepath)
         #end if
     #end def __init__
@@ -1452,6 +1455,7 @@ class VaspInput(SimulationInput,Vobj):
 
 
     def read(self,filepath,prefix='',postfix=''):
+        filepath = path_string(filepath)
         path = self.get_path(filepath)
         for file in os.listdir(path):
             name = str(file)

--- a/nexus/nexus/xmlreader.py
+++ b/nexus/nexus/xmlreader.py
@@ -29,6 +29,7 @@ import re
 import os
 import numpy as np
 from .developer import DevBase, obj, valid_variable_name
+from .utilities import path_string
 
 
 def parse_string(s, delim = None):
@@ -282,6 +283,7 @@ class XMLreader(DevBase):
         if element_aliases is None:
             element_aliases = {}
 
+        fpath = path_string(fpath)
         #assign values
         self.fpath=fpath
         if fpath is None:


### PR DESCRIPTION
## Proposed changes

More of what was done in #5983.

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora Linux 43 (KDE Plasma Desktop Edition)
AMD Ryzen 7 PRO 7840U (8 cores, 16 logical processors)
```
Python        3.14.5
uv            0.11.13
cif2cell      2.1.0
h5py          3.16.0
matplotlib    3.10.9
numpy         2.4.4
pycifrw       4.4.6
pydot         4.0.1
pytest        9.0.3
pytest-order  1.4.0
scipy         1.17.1
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
