### PR TITLE
Nexus: Fix improperly formatted docstrings, and/or adapt them to `numpydoc`

### DIFF
--- a/nexus/nexus/machines.py
+++ b/nexus/nexus/machines.py
@@ -1943,31 +1943,37 @@ class Supercomputer(Machine):
     #end def seconds_to_walltime
 
     def validate_queue_config(self, job):
-        """
-        Validate job against queue configuration constraints
-        Returns True if valid, raises an error with detailed message if invalid
+        """Validate job against queue configuration constraints
+        
+        Returns
+        -------
+        bool
+            ``True`` if valid, raises an error with detailed message if invalid
 
-        Queue config format:
-        queue_configs = {
-            'default': 'queue_name',
-            'queue_name': {
-                'min_nodes'     : minimum number of nodes,
-                'max_nodes'     : maximum number of nodes,
-                'max_walltime'      : maximum walltime in hours,
-                'cores_per_node': cores per node,
-                'ram_per_node'  : RAM per node in GB,
-                'constraints'   : {
-                    'knl': {
-                        'max_nodes': knl specific max nodes,
-                        'max_time': knl specific max time,
-                        ...
-                    },
-                    'haswell': {...},
-                    'gpu': {...},
-                    'cpu': {...}
-                }
-            }
-        }
+        Examples
+        --------
+        Queue config format
+
+        >>> queue_configs = {
+        ...     'default': 'queue_name',
+        ...     'queue_name': {
+        ...         'min_nodes'     : minimum number of nodes,
+        ...         'max_nodes'     : maximum number of nodes,
+        ...         'max_walltime'      : maximum walltime in hours,
+        ...         'cores_per_node': cores per node,
+        ...         'ram_per_node'  : RAM per node in GB,
+        ...         'constraints'   : {
+        ...             'knl': {
+        ...                 'max_nodes': knl specific max nodes,
+        ...                 'max_time': knl specific max time,
+        ...                 ...
+        ...             },
+        ...             'haswell': {...},
+        ...             'gpu': {...},
+        ...             'cpu': {...}
+        ...         }
+        ...     }
+        ... }
         """
         if self.queue_configs is None:
             return True

--- a/nexus/nexus/nexus_base.py
+++ b/nexus/nexus/nexus_base.py
@@ -172,10 +172,16 @@ _____________________________________________________
 
     def log(self,*texts,**kwargs):
         """Write output to log file.
-           Keyword arguments
-            n - spaces to indent
-            progress - if True and output is to a terminal, overwrite and
-                       update the last line, rather than scrolling.
+
+        Parameters
+        ----------
+        *texts
+            Strings that will be joined by newlines
+        n : int, kwargs
+            Spaces to indent
+        progress : bool, kwargs
+            If ``True`` and output is to a terminal, overwrite and update the
+            last line, rather than scrolling.
         """
         if nexus_core.verbose:
             if len(kwargs)>0:

--- a/nexus/nexus/numerics.py
+++ b/nexus/nexus/numerics.py
@@ -803,25 +803,31 @@ def check_jackknife_inputs(args,kwargs,position):
 #"""
 
 def ndgrid(*args, **kwargs):
-    """
-    n-dimensional gridding like Matlab's NDGRID
-    
-    The input *args are an arbitrary number of numerical sequences, 
-    e.g. lists, arrays, or tuples.
-    The i-th dimension of the i-th output argument 
-    has copies of the i-th input argument.
-    
-    Optional keyword argument:
-    same_dtype : If False (default), the result is an ndarray.
-                 If True, the result is a lists of ndarrays, possibly with 
-                 different dtype. This can save space if some *args 
-                 have a smaller dtype than others.
+    """n-dimensional gridding like Matlab's NDGRID
 
-    Typical usage:
+    Parameters
+    ----------
+    *args
+        An arbitrary number of numerical sequences, e.g. lists, arrays, or tuples.
+
+        The i-th dimension of the i-th output argument has copies of the i-th
+        input argument.
+    same_dtype : bool, default False, kwargs
+        If False (default), the result is an ``ndarray``.
+
+        If True, the result is a lists of ``ndarrays``, possibly with
+        different dtype. This can save space if some ``*args`` have a
+        smaller dtype than others.
+
+    Examples
+    --------
+    Typical usage
+
     >>> x, y, z = [0, 1], [2, 3, 4], [5, 6, 7, 8]
     >>> X, Y, Z = ndgrid(x, y, z) # unpacking the returned ndarray into X, Y, Z
 
     Each of X, Y, Z has shape [len(v) for v in x, y, z].
+
     >>> X.shape == Y.shape == Z.shape == (2, 3, 4)
     True
     >>> X
@@ -847,6 +853,7 @@ def ndgrid(*args, **kwargs):
             [5, 6, 7, 8]]])
     
     With an unpacked argument list:
+
     >>> V = [[0, 1], [2, 3, 4]]
     >>> ndgrid(*V) # an array of two arrays with shape (2, 3)
     array([[[0, 0, 0],
@@ -856,11 +863,13 @@ def ndgrid(*args, **kwargs):
     
     For input vectors of different data types, same_dtype=False makes ndgrid()
     return a list of arrays with the respective dtype.
+
     >>> ndgrid([0, 1], [1.0, 1.1, 1.2], same_dtype=False)
     [array([[0, 0, 0], [1, 1, 1]]), 
      array([[ 1. ,  1.1,  1.2], [ 1. ,  1.1,  1.2]])]
     
     Default is to return a single array.
+
     >>> ndgrid([0, 1], [1.0, 1.1, 1.2])
     array([[[ 0. ,  0. ,  0. ], [ 1. ,  1. ,  1. ]],
            [[ 1. ,  1.1,  1.2], [ 1. ,  1.1,  1.2]]])

--- a/nexus/nexus/pseudopotential.py
+++ b/nexus/nexus/pseudopotential.py
@@ -2028,8 +2028,10 @@ class GaussianPP(SemilocalPP):
 
     # test needed
     def simplify(self):
-        '''
-        This function simplifies the Guassian ECP. The simplificactions are as follows:
+        '''This function simplifies the Gaussian ECP.
+        
+        The simplificactions are as follows:
+
         1. Remove all terms with coefficients that are equal to zero -- unless only one term exists.
         2. Within each component, look for terms that have matching exponents and r-powers, if any are
            present, then sum their coefficicents to make a single term. If the coefficients sum to


### PR DESCRIPTION
## Proposed changes

The docstrings for the following functions were updated to be compliant with (play nice with) `numpydoc`:

- `nexus_base.NexusCore.log()`
- `numerics.ndgrid()`
- `machines.Supercomputer.validate_queue_config()`
- `pseudopotential.GaussianPP.simplify()`

## What type(s) of changes does this code introduce?

- Documentation or build script changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop, Fedora Linux 43 (KDE Plasma Desktop Edition)
AMD Ryzen 7 PRO 7840U (8 cores, 16 logical processors)
```
Python        3.14.5
uv            0.11.19
cif2cell      2.1.0
coverage      7.13.5
h5py          3.16.0
matplotlib    3.10.9
numpy         2.4.4
pycifrw       4.4.6
pydot         4.0.1
pytest        9.0.3
pytest-cov    7.1.0
pytest-order  1.4.0
scipy         1.17.1
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Documentation has been added (if appropriate)
