### PR TITLE
Nexus: add qmca feature to save plots to image files (png, pdf, svg, eps)

### DIFF
--- a/docs/analyzing.rst
+++ b/docs/analyzing.rst
@@ -40,66 +40,66 @@ typing ``qmca`` at the command line with no other inputs (also try
 
     Usage: qmca [options] [file(s)]
 
-  Options:
-    --version             show program's version number and exit
-    -v, --verbose         Print detailed information (default=False).
-    -q QUANTITIES, --quantities=QUANTITIES
-                          Quantity or list of quantities to analyze.  See names
-                          and abbreviations below (default=all).
-    -u UNITS, --units=UNITS
-                          Desired energy units.  Can be Ha (Hartree), Ry
-                          (Rydberg), eV (electron volts), kJ_mol (k.
-                          joule/mole), K (Kelvin), J (Joules) (default=Ha).
-    -e EQUILIBRATION, --equilibration=EQUILIBRATION
-                          Equilibration length in blocks (default=auto).
-    -a, --average         Average over files in each series (default=False).
-    --save_average        Save averaged data into scalar.dat files.
-                          (default=False).
-    -w WEIGHTS, --weights=WEIGHTS
-                          List of weights for averaging (default=None).
-    -j JOIN, --join=JOIN  Join data for a range of series (default=None).
-    -b, --reblock         (pending) Use reblocking to calculate statistics
-                          (default=False).
-    -p, --plot            Plot quantities vs. series (default=False).
-    -t, --trace           Plot a trace of quantities (default=False).
-    -h, --histogram       (pending) Plot a histogram of quantities
-                          (default=False).
-    -o, --overlay         Overlay plots (default=False).
-    --legend=LEGEND       Placement of legend.  None for no legend, outside for
-                          outside legend (default=upper right).
-    --noautocorr          Do not calculate autocorrelation. Warning: error bars
-                          are no longer valid! (default=False).
-    --noac                Alias for --noautocorr (default=False).
-    --sac                 Show autocorrelation of sample data (default=False).
-    --sv                  Show variance of sample data (default=False).
-    --sort                Display output data sorted alphabetically by file name
-                          (default=False).
-    -i, --image           Save plot PNG files (default prefix: qmca_plot).
-    --image-prefix=BASENAME
-                          Save plot PNG files with basename prefix
-                          (default=None).
-    -r, --report          (pending) Write a report (default=False).
-    -s, --show_options    Print user provided options (default=False).
-    -x, --examples        Print examples and exit (default=False).
-    --help                Print help information and exit (default=False).
-    -d DESIRED_ERROR, --desired_error=DESIRED_ERROR
-                          Show number of samples needed for desired error bar
-                          (default=none).
-    -n PARTICLE_NUMBER, --enlarge_system=PARTICLE_NUMBER
-                          Show number of samples needed to maintain error bar on
-                          larger system: desired particle number first, current
-                          particle number second (default=none)
-    --fp=PRECISION        Sets the floating point precision of displayed
-                          statistical results.  Must be a floating point format
-                          string such as 16.8f, 8.6e, or similar (default=none).
-    --nowarn              Suppress warning messages (default=False).
-    --average_all         Average over all files, ignoring differences in path
-                          (default=False).
-    --twist_info=TWIST_INFO
-                          Use twist weights in twist_info.dat files or not.
-                          Options: "use", "ignore", "require".  "use" means use
-                          when present, "ignore" means do not use, "require"
-                          means must be used (default=use).
+    Options:
+      --version             show program's version number and exit
+      -v, --verbose         Print detailed information (default=False).
+      -q QUANTITIES, --quantities=QUANTITIES
+                            Quantity or list of quantities to analyze.  See names
+                            and abbreviations below (default=all).
+      -u UNITS, --units=UNITS
+                            Desired energy units.  Can be Ha (Hartree), Ry
+                            (Rydberg), eV (electron volts), kJ_mol (k.
+                            joule/mole), K (Kelvin), J (Joules) (default=Ha).
+      -e EQUILIBRATION, --equilibration=EQUILIBRATION
+                            Equilibration length in blocks (default=auto).
+      -a, --average         Average over files in each series (default=False).
+      --save_average        Save averaged data into scalar.dat files.
+                            (default=False).
+      -w WEIGHTS, --weights=WEIGHTS
+                            List of weights for averaging (default=None).
+      -j JOIN, --join=JOIN  Join data for a range of series (default=None).
+      -b, --reblock         (pending) Use reblocking to calculate statistics
+                            (default=False).
+      -p, --plot            Plot quantities vs. series (default=False).
+      -t, --trace           Plot a trace of quantities (default=False).
+      -h, --histogram       (pending) Plot a histogram of quantities
+                            (default=False).
+      -o, --overlay         Overlay plots (default=False).
+      --legend=LEGEND       Placement of legend.  None for no legend, outside for
+                            outside legend (default=upper right).
+      --noautocorr          Do not calculate autocorrelation. Warning: error bars
+                            are no longer valid! (default=False).
+      --noac                Alias for --noautocorr (default=False).
+      --sac                 Show autocorrelation of sample data (default=False).
+      --sv                  Show variance of sample data (default=False).
+      --sort                Display output data sorted alphabetically by file name
+                            (default=False).
+      -i, --image           Save plot PNG files (default prefix: qmca_plot).
+      --image-prefix=BASENAME
+                            Save plot PNG files with basename prefix
+                            (default=None).
+      -r, --report          (pending) Write a report (default=False).
+      -s, --show_options    Print user provided options (default=False).
+      -x, --examples        Print examples and exit (default=False).
+      --help                Print help information and exit (default=False).
+      -d DESIRED_ERROR, --desired_error=DESIRED_ERROR
+                            Show number of samples needed for desired error bar
+                            (default=none).
+      -n PARTICLE_NUMBER, --enlarge_system=PARTICLE_NUMBER
+                            Show number of samples needed to maintain error bar on
+                            larger system: desired particle number first, current
+                            particle number second (default=none)
+      --fp=PRECISION        Sets the floating point precision of displayed
+                            statistical results.  Must be a floating point format
+                            string such as 16.8f, 8.6e, or similar (default=none).
+      --nowarn              Suppress warning messages (default=False).
+      --average_all         Average over all files, ignoring differences in path
+                            (default=False).
+      --twist_info=TWIST_INFO
+                            Use twist weights in twist_info.dat files or not.
+                            Options: "use", "ignore", "require".  "use" means use
+                            when present, "ignore" means do not use, "require"
+                            means must be used (default=use).
 
 .. _qmca-mean-error:
 

--- a/docs/analyzing.rst
+++ b/docs/analyzing.rst
@@ -40,47 +40,66 @@ typing ``qmca`` at the command line with no other inputs (also try
 
     Usage: qmca [options] [file(s)]
 
-    Options:
-      --version             show program's version number and exit
-      -v, --verbose         Print detailed information (default=False).
-      -q QUANTITIES, --quantities=QUANTITIES
-                            Quantity or list of quantities to analyze.  See names
-                            and abbreviations below (default=all).
-      -u UNITS, --units=UNITS
-                            Desired energy units.  Can be Ha (Hartree), Ry
-                            (Rydberg), eV (electron volts), kJ_mol (k.
-                            joule/mole), K (Kelvin), J (Joules) (default=Ha).
-      -e EQUILIBRATION, --equilibration=EQUILIBRATION
-                            Equilibration length in blocks (default=auto).
-      -a, --average         Average over files in each series (default=False).
-      -w WEIGHTS, --weights=WEIGHTS
-                            List of weights for averaging (default=None).
-      -b, --reblock         (pending) Use reblocking to calculate statistics
-                            (default=False).
-      -p, --plot            Plot quantities vs. series (default=False).
-      -t, --trace           Plot a trace of quantities (default=False).
-      -h, --histogram       (pending) Plot a histogram of quantities
-                            (default=False).
-      -o, --overlay         Overlay plots (default=False).
-      --legend=LEGEND       Placement of legend.  None for no legend, outside for
-                            outside legend (default=upper right).
-      --noautocorr          Do not calculate autocorrelation. Warning: error bars
-                            are no longer valid! (default=False).
-      --noac                Alias for --noautocorr (default=False).
-      --sac                 Show autocorrelation of sample data (default=False).
-      --sv                  Show variance of sample data (default=False).
-      -i, --image           (pending) Save image files (default=False).
-      -r, --report          (pending) Write a report (default=False).
-      -s, --show_options    Print user provided options (default=False).
-      -x, --examples        Print examples and exit (default=False).
-      --help                Print help information and exit (default=False).
-      -d DESIRED_ERROR, --desired_error=DESIRED_ERROR
-                            Show number of samples needed for desired error bar
-                            (default=none).
-      -n PARTICLE_NUMBER, --enlarge_system=PARTICLE_NUMBER
-                            Show number of samples needed to maintain error bar on
-                            larger system: desired particle number first, current
-                            particle number second (default=none)
+  Options:
+    --version             show program's version number and exit
+    -v, --verbose         Print detailed information (default=False).
+    -q QUANTITIES, --quantities=QUANTITIES
+                          Quantity or list of quantities to analyze.  See names
+                          and abbreviations below (default=all).
+    -u UNITS, --units=UNITS
+                          Desired energy units.  Can be Ha (Hartree), Ry
+                          (Rydberg), eV (electron volts), kJ_mol (k.
+                          joule/mole), K (Kelvin), J (Joules) (default=Ha).
+    -e EQUILIBRATION, --equilibration=EQUILIBRATION
+                          Equilibration length in blocks (default=auto).
+    -a, --average         Average over files in each series (default=False).
+    --save_average        Save averaged data into scalar.dat files.
+                          (default=False).
+    -w WEIGHTS, --weights=WEIGHTS
+                          List of weights for averaging (default=None).
+    -j JOIN, --join=JOIN  Join data for a range of series (default=None).
+    -b, --reblock         (pending) Use reblocking to calculate statistics
+                          (default=False).
+    -p, --plot            Plot quantities vs. series (default=False).
+    -t, --trace           Plot a trace of quantities (default=False).
+    -h, --histogram       (pending) Plot a histogram of quantities
+                          (default=False).
+    -o, --overlay         Overlay plots (default=False).
+    --legend=LEGEND       Placement of legend.  None for no legend, outside for
+                          outside legend (default=upper right).
+    --noautocorr          Do not calculate autocorrelation. Warning: error bars
+                          are no longer valid! (default=False).
+    --noac                Alias for --noautocorr (default=False).
+    --sac                 Show autocorrelation of sample data (default=False).
+    --sv                  Show variance of sample data (default=False).
+    --sort                Display output data sorted alphabetically by file name
+                          (default=False).
+    -i, --image           Save plot PNG files (default prefix: qmca_plot).
+    --image-prefix=BASENAME
+                          Save plot PNG files with basename prefix
+                          (default=None).
+    -r, --report          (pending) Write a report (default=False).
+    -s, --show_options    Print user provided options (default=False).
+    -x, --examples        Print examples and exit (default=False).
+    --help                Print help information and exit (default=False).
+    -d DESIRED_ERROR, --desired_error=DESIRED_ERROR
+                          Show number of samples needed for desired error bar
+                          (default=none).
+    -n PARTICLE_NUMBER, --enlarge_system=PARTICLE_NUMBER
+                          Show number of samples needed to maintain error bar on
+                          larger system: desired particle number first, current
+                          particle number second (default=none)
+    --fp=PRECISION        Sets the floating point precision of displayed
+                          statistical results.  Must be a floating point format
+                          string such as 16.8f, 8.6e, or similar (default=none).
+    --nowarn              Suppress warning messages (default=False).
+    --average_all         Average over all files, ignoring differences in path
+                          (default=False).
+    --twist_info=TWIST_INFO
+                          Use twist weights in twist_info.dat files or not.
+                          Options: "use", "ignore", "require".  "use" means use
+                          when present, "ignore" means do not use, "require"
+                          means must be used (default=use).
 
 .. _qmca-mean-error:
 
@@ -566,29 +585,59 @@ command line with no other input. This following is a current list:
 ::
 
   Abbreviations and full names for quantities:
-      ar              = AcceptRatio
-      bc              = BlockCPU
-      bw              = BlockWeight
-      ce              = CorrectedEnergy
-      de              = DiffEff
-      e               = LocalEnergy
-      ee              = ElecElec
-      eff             = Efficiency
-      ii              = IonIon
-      k               = Kinetic
-      kc              = KEcorr
-      l               = LocalECP
-      le2             = LocalEnergy_sq
-      mpc             = MPC
-      n               = NonLocalECP
-      nw              = NumOfWalkers
-      p               = LocalPotential
-      sw              = AvgSentWalkers
-      te              = TrialEnergy
-      ts              = TotalSamples
-      tt              = TotalTime
-      v               = Variance
-      w               = Weight
+    ar              = AcceptRatio
+    bc              = BlockCPU
+    bw              = BlockWeight
+    ce              = CorrectedEnergy
+    de              = DiffEff
+    de_AB           = dLocEne_0_1
+    dee_AB          = dElecElec_0_1
+    dii_AB          = dIonIon_0_1
+    e               = LocalEnergy
+    e_A             = LocEne_0
+    e_B             = LocEne_1
+    ee              = ElecElec
+    ee_A            = ElecElec_0
+    ee_B            = ElecElec_1
+    ee_m            = ElecElec_m
+    ee_p            = ElecElec_p
+    eff             = Efficiency
+    ei_A            = ElecIon_0
+    ei_AB           = dElecIon_0_1
+    ei_B            = ElecIon_1
+    el              = EnergyEstim__nume_real
+    fl              = Flux
+    fl_A            = Flux_0
+    fl_AB           = dFlux_0_1
+    fl_B            = Flux_1
+    ii              = IonIon
+    ii_A            = IonIon_0
+    ii_B            = IonIon_1
+    k               = Kinetic
+    k_A             = Kinetic_0
+    k_AB            = dKinetic_0_1
+    k_B             = Kinetic_1
+    k_m             = Kinetic_m
+    k_p             = Kinetic_p
+    kc              = KEcorr
+    l               = LocalECP
+    le2             = LocalEnergy_sq
+    mpc             = MPC
+    n               = NonLocalECP
+    nw              = NumOfWalkers
+    p               = LocalPotential
+    p_A             = LocPot_0
+    p_AB            = dLocPot_0_1
+    p_B             = LocPot_1
+    p_p             = LocalPotential_pure
+    sw              = AvgSentWalkers
+    te              = TrialEnergy
+    ts              = TotalSamples
+    tt              = TotalTime
+    v               = Variance
+    w               = Weight
+    wp_A            = wpsi_0
+    wp_B            = wpsi_1
 
 See the output overview for ``scalar.dat``
 (:ref:`scalardat-file`) and ``dmc.dat``
@@ -876,6 +925,19 @@ Plotting a trace of the local energy:
 ::
 
   >qmca -t -q e *scalar*
+
+Saving a trace plot of the local energy to a PNG file (default prefix: qmca_plot):
+
+::
+
+  >qmca -t -q e --image *scalar*
+
+Saving a trace plot of the local energy to a PNG file with a custom prefix:
+
+::
+
+  >qmca -t -q e --image-prefix myrun *scalar*
+
 
 Applying an equilibration cutoff to VMC data (series 0):
 

--- a/docs/analyzing.rst
+++ b/docs/analyzing.rst
@@ -74,10 +74,12 @@ typing ``qmca`` at the command line with no other inputs (also try
       --sv                  Show variance of sample data (default=False).
       --sort                Display output data sorted alphabetically by file name
                             (default=False).
-      -i, --image           Save plot PNG files (default prefix: qmca_plot).
+      -i, --image           Save plot files (default prefix: qmca_plot).
       --image-prefix=BASENAME
-                            Save plot PNG files with basename prefix
+                            Save plot files with basename prefix
                             (default=None).
+      --image-format=FORMAT Output format for saved plots: png, pdf, svg, or eps
+                            (default=png).
       -r, --report          (pending) Write a report (default=False).
       -s, --show_options    Print user provided options (default=False).
       -x, --examples        Print examples and exit (default=False).
@@ -938,6 +940,14 @@ Saving a trace plot of the local energy to a PNG file with a custom prefix:
 
   >qmca -t -q e --image-prefix myrun *scalar*
 
+Saving a trace plot to a PDF file for publication (vector format):
+
+::
+
+  >qmca -t -q e --image-format pdf --image-prefix myrun *scalar*
+
+PDF, SVG, and EPS output are resolution-independent and better suited to journal
+submission than PNG.
 
 Applying an equilibration cutoff to VMC data (series 0):
 

--- a/nexus/nexus/bin/qmca
+++ b/nexus/nexus/bin/qmca
@@ -835,6 +835,10 @@ QMCA examples:
    qmca -pa -q e -e 10 qmc.g*.s*.scalar.dat
    qmca -ta -q e -e 10 qmc.g*.s*.scalar.dat
 
+ saving plots to PNG files (-i/--image uses prefix qmca_plot; --image-prefix sets a custom prefix)
+   qmca -t -q e -i qmc.s*.scalar.dat
+   qmca -ta -q ev --image-prefix myrun qmc.g*.s*.scalar.dat
+
  multiple quantities and prefixes can be used for plots as well
 '''
         self.log(examples)
@@ -931,9 +935,13 @@ QMCA examples:
                           action='store_true',default=False,
                           help='Display output data sorted alphabetically by file name (default=%default).'
                           )
-        parser.add_option('-i','--image',dest='image',
+        parser.add_option('-i','--image', dest='save_image',
                           action='store_true',default=False,
-                          help='(pending) Save image files (default=%default).'
+                          help='Save plot PNG files (default prefix: qmca_plot).'
+                          )
+        parser.add_option('--image-prefix',dest='image_prefix',
+                          default='None',metavar='BASENAME',
+                          help='Save plot PNG files with basename prefix (default=%default).'
                           )
         parser.add_option('-r','--report',dest='report',
                           action='store_true',default=False,
@@ -979,7 +987,7 @@ QMCA examples:
                           help='Use twist weights in twist_info.dat files or not.  Options: "use", "ignore", "require".  "use" means use when present, "ignore" means do not use, "require" means must be used (default=%default).'
                           )
 
-        unsupported = set('histogram image reblock report'.split())
+        unsupported = set('histogram reblock report'.split())
 
         units = obj(hartree='Ha',ha='Ha',ev='eV',rydberg='Ry',ry='Ry',kelvin='K',kj_mol='kJ_mol',joules='J')
 
@@ -1064,8 +1072,12 @@ QMCA examples:
             #end if
             opt.join = j
         #end if
-        if opt.image=='None':
-            opt.image=None
+        if opt.image_prefix!='None':
+            opt.image = opt.image_prefix
+        elif opt.save_image:
+            opt.image = 'qmca_plot'
+        else:
+            opt.image = None
         #end if
         twist_info_options = ('use','ignore','require')
         if opt.twist_info not in twist_info_options:
@@ -1449,7 +1461,9 @@ QMCA examples:
             tracestyle  = color+line
             histstyle   = color+line
             iplot,itrace,ihist = list(range(3))
+            mode_names = ['series','trace','histogram']
             modes = [opt.plot,opt.trace,opt.histogram]
+            save_plots = opt.image is not None
             quantities = []
             for q in opt.quantities:
                 all_present = True
@@ -1562,12 +1576,23 @@ QMCA examples:
                                         ax.legend(loc=2,bbox_to_anchor=(1.0,1.0),borderaxespad=0.)
                                     #end if
                                 #end if
+                                if save_plots:
+                                    safe_prefix = prefix.replace('/','_').replace(os.sep,'_')
+                                    fname = '{0}_{1}_{2}_{3}.png'.format(
+                                        opt.image,safe_prefix,quantity,mode_names[mode])
+                                    fig.savefig(fname,dpi=150,bbox_inches='tight')
+                                    if self.verbose:
+                                        self.log('saved plot to {0}'.format(fname),n=1)
+                                    #end if
+                                    plt.close(fig)
+                                #end if
                             #end if
                         #end for
                     #end if
                 #end for
             #end for
-            plt.show()
+            if not save_plots:
+                plt.show()
         #end if
     #end def analyze_data
 #end class QMCA

--- a/nexus/nexus/bin/qmca
+++ b/nexus/nexus/bin/qmca
@@ -835,9 +835,11 @@ QMCA examples:
    qmca -pa -q e -e 10 qmc.g*.s*.scalar.dat
    qmca -ta -q e -e 10 qmc.g*.s*.scalar.dat
 
- saving plots to PNG files (-i/--image uses prefix qmca_plot; --image-prefix sets a custom prefix)
+ saving plots to files (-i/--image uses prefix qmca_plot; --image-prefix sets a custom prefix)
    qmca -t -q e -i qmc.s*.scalar.dat
    qmca -ta -q ev --image-prefix myrun qmc.g*.s*.scalar.dat
+ saving plots to PDF files (--image-format pdf for vector output suited to publication)
+   qmca -t -q e --image-format pdf --image-prefix myrun qmc.s*.scalar.dat
 
  multiple quantities and prefixes can be used for plots as well
 '''
@@ -937,11 +939,15 @@ QMCA examples:
                           )
         parser.add_option('-i','--image', dest='save_image',
                           action='store_true',default=False,
-                          help='Save plot PNG files (default prefix: qmca_plot).'
+                          help='Save plot files (default prefix: qmca_plot).'
                           )
         parser.add_option('--image-prefix',dest='image_prefix',
                           default='None',metavar='BASENAME',
-                          help='Save plot PNG files with basename prefix (default=%default).'
+                          help='Save plot files with basename prefix (default=%default).'
+                          )
+        parser.add_option('--image-format',dest='image_format',
+                          default='png',metavar='FORMAT',
+                          help='Output format for saved plots: png, pdf, svg, or eps (default=%default).'
                           )
         parser.add_option('-r','--report',dest='report',
                           action='store_true',default=False,
@@ -1079,6 +1085,12 @@ QMCA examples:
         else:
             opt.image = None
         #end if
+        image_formats = ('png','pdf','svg','eps')
+        fmt = opt.image_format.lower().lstrip('.')
+        if fmt not in image_formats:
+            self.error('image_format option is invalid\nimage_format must be one of: {}\nyou provided: {}'.format(image_formats,opt.image_format))
+        #end if
+        opt.image_format = fmt
         twist_info_options = ('use','ignore','require')
         if opt.twist_info not in twist_info_options:
             self.error('twist_info option is invalid\ntwist_info must be one of: {}\nyou provided: {}'.format(twist_info_options,opt.twist_info))
@@ -1578,9 +1590,14 @@ QMCA examples:
                                 #end if
                                 if save_plots:
                                     safe_prefix = prefix.replace('/','_').replace(os.sep,'_')
-                                    fname = '{0}_{1}_{2}_{3}.png'.format(
-                                        opt.image,safe_prefix,quantity,mode_names[mode])
-                                    fig.savefig(fname,dpi=150,bbox_inches='tight')
+                                    fmt = opt.image_format
+                                    fname = '{0}_{1}_{2}_{3}.{4}'.format(
+                                        opt.image,safe_prefix,quantity,mode_names[mode],fmt)
+                                    save_kwargs = dict(format=fmt,bbox_inches='tight')
+                                    if fmt=='png':
+                                        save_kwargs['dpi'] = 150
+                                    #end if
+                                    fig.savefig(fname,**save_kwargs)
                                     if self.verbose:
                                         self.log('saved plot to {0}'.format(fname),n=1)
                                     #end if

--- a/nexus/nexus/tests/test_qmca.py
+++ b/nexus/nexus/tests/test_qmca.py
@@ -266,3 +266,57 @@ avg series 0 -11.44375840 +/- 0.00292164  0.44863011 +/- 0.00502859  0.0392
     os.chdir(cwd)
 #end def test_weighted_twist_average
 
+
+
+def test_save_plot_pdf():
+
+    try:
+        import matplotlib.pyplot  # noqa: F401
+    except ImportError:
+        pytest.skip('matplotlib not available')
+
+    cwd = Path.cwd()
+    os.chdir(QA_PATHS["vmc"])
+
+    prefix = 'testplot_pdf'
+    plot_file = f'{prefix}_vmc_LocalEnergy_trace.pdf'
+    if os.path.exists(plot_file):
+        os.remove(plot_file)
+
+    command = (f'{sys.executable} {QMCA_EXE} -t -q e -e 5 '
+               f'--image-prefix {prefix} --image-format pdf --nowarn *scalar*')
+    out,err,rc = execute(command)
+    assert rc==0
+    assert os.path.exists(plot_file)
+
+    os.remove(plot_file)
+    os.chdir(cwd)
+#end def test_save_plot_pdf
+
+
+
+def test_save_plot_png_default():
+
+    try:
+        import matplotlib.pyplot  # noqa: F401
+    except ImportError:
+        pytest.skip('matplotlib not available')
+
+    cwd = Path.cwd()
+    os.chdir(QA_PATHS["vmc"])
+
+    prefix = 'testplot_png'
+    plot_file = f'{prefix}_vmc_LocalEnergy_trace.png'
+    if os.path.exists(plot_file):
+        os.remove(plot_file)
+
+    command = (f'{sys.executable} {QMCA_EXE} -t -q e -e 5 '
+               f'--image-prefix {prefix} --image --nowarn *scalar*')
+    out,err,rc = execute(command)
+    assert rc==0
+    assert os.path.exists(plot_file)
+
+    os.remove(plot_file)
+    os.chdir(cwd)
+#end def test_save_plot_png_default
+

--- a/nexus/nexus/tests/test_qmca.py
+++ b/nexus/nexus/tests/test_qmca.py
@@ -270,9 +270,10 @@ avg series 0 -11.44375840 +/- 0.00292164  0.44863011 +/- 0.00502859  0.0392
 
 def test_save_plot_pdf():
 
+    os.environ['MPLBACKEND'] = 'Agg'
     try:
         import matplotlib.pyplot  # noqa: F401
-    except ImportError:
+    except (ImportError, RuntimeError):
         pytest.skip('matplotlib not available')
 
     cwd = Path.cwd()
@@ -283,7 +284,7 @@ def test_save_plot_pdf():
     if os.path.exists(plot_file):
         os.remove(plot_file)
 
-    command = (f'{sys.executable} {QMCA_EXE} -t -q e -e 5 '
+    command = (f'MPLBACKEND=Agg {sys.executable} {QMCA_EXE} -t -q e -e 5 '
                f'--image-prefix {prefix} --image-format pdf --nowarn *scalar*')
     out,err,rc = execute(command)
     assert rc==0
@@ -297,9 +298,10 @@ def test_save_plot_pdf():
 
 def test_save_plot_png_default():
 
+    os.environ['MPLBACKEND'] = 'Agg'
     try:
         import matplotlib.pyplot  # noqa: F401
-    except ImportError:
+    except (ImportError, RuntimeError):
         pytest.skip('matplotlib not available')
 
     cwd = Path.cwd()
@@ -310,7 +312,7 @@ def test_save_plot_png_default():
     if os.path.exists(plot_file):
         os.remove(plot_file)
 
-    command = (f'{sys.executable} {QMCA_EXE} -t -q e -e 5 '
+    command = (f'MPLBACKEND=Agg {sys.executable} {QMCA_EXE} -t -q e -e 5 '
                f'--image-prefix {prefix} --image --nowarn *scalar*')
     out,err,rc = execute(command)
     assert rc==0


### PR DESCRIPTION
## Proposed changes

Add optional PNG export to qmca when plotting is enabled. Without an image option, behavior is unchanged: plots are shown interactively with plt.show().

Two explicit CLI options are used:

```
-i / --image — save plot PNG files using the default basename prefix qmca_plot
--image-prefix BASENAME — save plot PNG files using a custom basename prefix
```
Saved files follow the pattern `{prefix}_{series_prefix}_{quantity}_{mode}.png` (for example, qmca_plot_s000_Energy_series.png, myrun_g000_Energy_trace.png, myrun_avg_Variance_trace.png). 

Example usage:
```
qmca -t -q e -i qmc.s*.scalar.dat
qmca -ta -q ev --image-prefix myrun qmc.g*.s*.scalar.dat
```

qmca related sections in the manual also have a limited update. 

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Python 3.12.7

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
