### PR TITLE
Disable implict conversion from Lattice to SimulationCell

### DIFF
--- a/src/Particle/ParticleSetPool.cpp
+++ b/src/Particle/ParticleSetPool.cpp
@@ -101,6 +101,11 @@ bool ParticleSetPool::readSimulationCellXML(xmlNodePtr cur)
   return lattice_defined;
 }
 
+void ParticleSetPool::createSimulationCellByLattice(const Lattice& lattice)
+{
+  simulation_cell_ = std::make_unique<SimulationCell>(lattice);
+}
+
 /** process an xml element
  * @param cur current xmlNodePtr
  * @return true, if successful.

--- a/src/Particle/ParticleSetPool.h
+++ b/src/Particle/ParticleSetPool.h
@@ -53,6 +53,9 @@ public:
 
   void output_particleset_info(Libxml2Document& doc, xmlNodePtr root);
 
+  ///return true, if the pool is empty
+  inline bool empty() const { return myPool.empty(); }
+
   /** initialize the supercell shared by all the particle sets
    *
    *  return value is never checked anywhere
@@ -62,8 +65,8 @@ public:
    */
   bool readSimulationCellXML(xmlNodePtr cur);
 
-  ///return true, if the pool is empty
-  inline bool empty() const { return myPool.empty(); }
+  /// create simulation cell by a lattice. Used for unit tests.
+  void createSimulationCellByLattice(const Lattice& lattice);
 
   /** add a ParticleSet* to the pool with its ownership transferred
    * ParticleSet built outside the ParticleSetPool must be constructed with
@@ -94,9 +97,6 @@ public:
   /// get simulation cell
   const auto& getSimulationCell() const { return *simulation_cell_; }
 
-  /// set simulation cell
-  void setSimulationCell(const SimulationCell& simulation_cell) { *simulation_cell_ = simulation_cell; }
-
   /** randomize a particleset particleset/@random='yes' && particleset@random_source exists
    */
   void randomize();
@@ -106,7 +106,7 @@ private:
    *
    * updated by
    * - readSimulationCellXML() parsing <simulationcell> element
-   * - setSimulationCell()
+   * - createSimulationCellByLattice()
    */
   std::unique_ptr<SimulationCell> simulation_cell_;
   /** List of ParticleSet owned

--- a/src/Particle/SimulationCell.h
+++ b/src/Particle/SimulationCell.h
@@ -26,7 +26,7 @@ class SimulationCell
 public:
   using FullPrecReal = QMCTraits::FullPrecRealType;
   SimulationCell();
-  SimulationCell(const Lattice& lattice);
+  explicit SimulationCell(const Lattice& lattice);
 
   const Lattice& getLattice() const { return lattice_; }
   const Lattice& getPrimLattice() const { return primitive_lattice_; }

--- a/src/QMCHamiltonians/tests/test_RotatedSPOs_NLPP.cpp
+++ b/src/QMCHamiltonians/tests/test_RotatedSPOs_NLPP.cpp
@@ -59,8 +59,7 @@ void test_hcpBe_rotation(bool use_single_det, bool use_nlpp_batched)
   lattice.R(2, 2) = 6.78114995;
 
 
-  const SimulationCell simulation_cell(lattice);
-  pp.setSimulationCell(simulation_cell);
+  pp.createSimulationCellByLattice(lattice);
   auto elec_ptr = std::make_unique<ParticleSet>(pp.getSimulationCell());
   auto& elec(*elec_ptr);
   auto ions_uptr = std::make_unique<ParticleSet>(pp.getSimulationCell());

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -54,7 +54,7 @@ TEST_CASE("RotatedSPOs via SplineR2R", "[wavefunction]")
   lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   // LAttice seems fine after this point...
 
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
@@ -573,7 +573,7 @@ TEST_CASE("RotatedSPOs hcpBe", "[wavefunction]")
                0.00000000, 0.00000000, 0.00000000, 6.78114995};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions(*ions_uptr);
@@ -741,7 +741,7 @@ const std::vector<QMCTraits::ValueType>& getMyVarsFull(RotatedSPOs& rot) { retur
 TEST_CASE("RotatedSPOs read and write parameters", "[wavefunction]")
 {
   // only run with comm size 1.
-  if(OHMMS::Controller->size() > 1)
+  if (OHMMS::Controller->size() > 1)
     return;
 
   //There is an issue with the real<->complex parameter parsing to h5 in QMC_COMPLEX.

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -61,7 +61,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   lattice.reset();
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell(), kind_selected);
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell(), kind_selected);
   ParticleSet& ions_(*ions_uptr);

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -69,7 +69,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
   lattice.reset();
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell(), kind_selected);
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell(), kind_selected);
   ParticleSet& ions_(*ions_uptr);

--- a/src/QMCWaveFunctions/tests/test_einset_LiH.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_LiH.cpp
@@ -43,7 +43,7 @@ void test_einset_LiH_x(bool use_offload)
   lattice.R = {-3.55, 0.0, 3.55, 0.0, 3.55, 3.55, -3.55, 3.55, 0.0};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);

--- a/src/QMCWaveFunctions/tests/test_einset_NiO_a16.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_NiO_a16.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Einspline SPO from HDF NiO a16 97 electrons", "[wavefunction]")
   lattice.R = {3.94055, 3.94055, 7.8811, 3.94055, 3.94055, -7.8811, -7.8811, 7.8811, 0};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);

--- a/src/QMCWaveFunctions/tests/test_einset_diamondC.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_diamondC.cpp
@@ -42,7 +42,7 @@ void test_einset_diamond_1x1x1(bool use_offload, int distributed_ranks = 1, int 
   lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);
@@ -331,7 +331,7 @@ TEST_CASE("Einspline SPO from HDF diamond_2x1x1 5 electrons", "[wavefunction]")
   lattice.R = {6.7463223, 6.7463223, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -54,7 +54,7 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
                0.00000000, -6.49690625, 0.00000000, 7.08268015};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);
@@ -675,8 +675,8 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
   inv_row = {0.1, 0.2, 0.3};
   inv_row.updateTo();
   std::vector<const SPOSet::ValueType*> inv_row_ptr(2, spo->isOMPoffload() ? inv_row.device_data() : inv_row.data());
-  const auto& ei_table1    = elec_.getDistTableAB(elec_.addTable(ions_));
-  const auto& ei_table2     = elec_2.getDistTableAB(elec_2.addTable(ions_));
+  const auto& ei_table1 = elec_.getDistTableAB(elec_.addTable(ions_));
+  const auto& ei_table2 = elec_2.getDistTableAB(elec_2.addTable(ions_));
   ParticleSet::mw_update(p_list);
   for (int iat = 0; iat < 3; iat++)
   {

--- a/src/QMCWaveFunctions/tests/test_hybridrep.cpp
+++ b/src/QMCWaveFunctions/tests/test_hybridrep.cpp
@@ -40,7 +40,7 @@ TEST_CASE("Hybridrep SPO from HDF diamond_1x1x1", "[wavefunction]")
   lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);
@@ -199,7 +199,7 @@ TEST_CASE("Hybridrep SPO from HDF diamond_2x1x1", "[wavefunction]")
   lattice.R = {6.7463223, 6.7463223, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);

--- a/src/QMCWaveFunctions/tests/test_pw.cpp
+++ b/src/QMCWaveFunctions/tests/test_pw.cpp
@@ -36,7 +36,7 @@ TEST_CASE("PlaneWave SPO from HDF for BCC H", "[wavefunction]")
   lattice.reset();
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions(*ions_uptr);
@@ -137,7 +137,7 @@ TEST_CASE("PlaneWave SPO from HDF for LiH arb", "[wavefunction]")
   lattice.reset();
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions(*ions_uptr);

--- a/src/QMCWaveFunctions/tests/test_spline_applyrotation.cpp
+++ b/src/QMCWaveFunctions/tests/test_spline_applyrotation.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Spline applyRotation zero rotation", "[wavefunction]")
   lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);
@@ -176,7 +176,7 @@ TEST_CASE("Spline applyRotation one rotation", "[wavefunction]")
   lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);
@@ -386,7 +386,7 @@ TEST_CASE("Spline applyRotation two rotations", "[wavefunction]")
   lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);
@@ -691,7 +691,7 @@ TEST_CASE("Spline applyRotation complex rotation", "[wavefunction]")
   lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
@@ -36,7 +36,7 @@ void test_diamond_2x1x1_xml_input(const std::string& spo_xml_string)
   lattice.R = {6.7463223, 6.7463223, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.setSimulationCell(lattice);
+  ptcl.createSimulationCellByLattice(lattice);
   auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);

--- a/src/Sandbox/diff_distancetables.cpp
+++ b/src/Sandbox/diff_distancetables.cpp
@@ -88,7 +88,8 @@ int main(int argc, char** argv)
 
   auto super_lattice(createSuperLattice(create_prim_lattice(), tmat));
   super_lattice.LR_rc = 5;
-  ParticleSet ions(super_lattice), els(super_lattice);
+  SimulationCell supercell(super_lattice);
+  ParticleSet ions(supercell), els(supercell);
 
   ions.setName("ion0");
   els.setName("e");

--- a/src/Sandbox/einspline_spo.cpp
+++ b/src/Sandbox/einspline_spo.cpp
@@ -112,9 +112,9 @@ int main(int argc, char** argv)
   spo_type spo_main;
   int nTiles = 1;
 
-  auto super_lattice(createSuperLattice(create_prim_lattice(), tmat));
+  SimulationCell supercell(createSuperLattice(create_prim_lattice(), tmat));
   {
-    ParticleSet ions(super_lattice);
+    ParticleSet ions(supercell);
     tile_cell(ions, tmat);
     const int nions = ions.getTotalNum();
     const int nels  = count_electrons(ions) / 2;
@@ -124,7 +124,7 @@ int main(int argc, char** argv)
       cout << "\nNumber of orbitals/splines = " << nels << " and Tile size = " << tileSize
            << " and Number of tiles = " << nTiles << " and Iterations = " << nsteps << endl;
     spo_main.set(nx, ny, nz, nels, nTiles);
-    spo_main.Lattice.set(super_lattice.R);
+    spo_main.Lattice.set(supercell.getLattice().R);
   }
 
   double tInit = 0.0;
@@ -156,7 +156,7 @@ int main(int argc, char** argv)
     //create generator within the thread
     RandomGenerator random_th(MakeSeed(teamID, np));
 
-    ParticleSet ions(super_lattice), els(super_lattice);
+    ParticleSet ions(supercell), els(supercell);
     tile_cell(ions, tmat);
 
     const int nions = ions.getTotalNum();

--- a/src/Sandbox/einspline_spo_nested.cpp
+++ b/src/Sandbox/einspline_spo_nested.cpp
@@ -102,9 +102,9 @@ int main(int argc, char** argv)
   spo_type spo_main;
   int nTiles = 1;
 
-  auto super_lattice(createSuperLattice(create_prim_lattice(), tmat));
+  SimulationCell supercell(createSuperLattice(create_prim_lattice(), tmat));
   {
-    ParticleSet ions(super_lattice);
+    ParticleSet ions(supercell);
     tile_cell(ions, tmat);
     const int nions = ions.getTotalNum();
     const int nels  = count_electrons(ions) / 2;
@@ -114,7 +114,7 @@ int main(int argc, char** argv)
       cout << "\nNumber of orbitals/splines = " << nels << " and Tile size = " << tileSize
            << " and Number of tiles = " << nTiles << " and Iterations = " << nsteps << endl;
     spo_main.set(nx, ny, nz, nels, nTiles);
-    spo_main.Lattice.set(super_lattice.R);
+    spo_main.Lattice.set(supercell.getLattice().R);
   }
 
   double tInit = 0.0;
@@ -134,7 +134,7 @@ int main(int argc, char** argv)
     //create generator within the thread
     RandomGenerator random_th(MakeSeed(ip, np));
 
-    ParticleSet ions(super_lattice), els(super_lattice);
+    ParticleSet ions(supercell), els(supercell);
     tile_cell(ions, tmat);
 
     const int nions = ions.getTotalNum();

--- a/src/Sandbox/input/graphite.hpp
+++ b/src/Sandbox/input/graphite.hpp
@@ -33,10 +33,10 @@ inline auto create_prim_lattice()
    */
 void tile_cell(ParticleSet& ions, Tensor<int, 3>& tmat)
 {
-  auto prim_lat(create_prim_lattice());
+  SimulationCell sim_cell(create_prim_lattice());
   // create Ni and O by group
   std::vector<int> graphite_group{4};
-  ParticleSet prim_ions(prim_lat);
+  ParticleSet prim_ions(sim_cell);
   // create particles by groups
   prim_ions.create(graphite_group);
   // using lattice coordinates

--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -128,14 +128,14 @@ int main(int argc, char** argv)
   int nptcl = 0;
   double t0 = 0.0, t1 = 0.0;
 
-  auto super_lattice(createSuperLattice(create_prim_lattice(), tmat));
-  ParticleSet ions(super_lattice);
+  SimulationCell supercell(createSuperLattice(create_prim_lattice(), tmat));
+  ParticleSet ions(supercell);
   tile_cell(ions, tmat);
 
   auto& rnc_children = RandomNumberControl::getChildren();
   std::vector<uint_type> mt(Random.state_size(), 0);
   std::vector<std::vector<uint_type>> mt_children(NumThreads, mt);
-  std::vector<MCWalkerConfiguration> elecs(NumThreads, MCWalkerConfiguration(super_lattice));
+  std::vector<MCWalkerConfiguration> elecs(NumThreads, MCWalkerConfiguration(supercell));
 
 #pragma omp parallel reduction(+ : t0)
   {


### PR DESCRIPTION
## Proposed changes
Address sanitizer reports a bug in Sandbox codes that was caused by implicit conversion. An intermediate object of  SimulationCell gets destroyed but its reference got stored in ParticleSet causing segfault. For this reason, I made the following changes:
1. The SimulationCell constructor is marked explicit.
2. ParticleSetPool:setSimulationCell is renamed to createSimulationCellByLattice and taking explicitly Lattice type as its argument, no more implicit conversion.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Laptop

## Checklist
* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
