### PR TITLE
More restart miniapp fixes

### DIFF
--- a/src/Sandbox/ParticleIOUtility.cpp
+++ b/src/Sandbox/ParticleIOUtility.cpp
@@ -48,9 +48,13 @@ void expandSuperCell(const ParticleSet& in, const Tensor<int, OHMMS_DIM>& tmat, 
   const int natoms    = in.getTotalNum();
   const int numCopies = std::abs(det(tmat));
 
+  std::vector<int> group_sizes;
+  for (int is = 0; is < in.groups(); is++)
+    group_sizes.push_back(in.groupsize(is) * numCopies);
+  out.create(group_sizes);
+
   const auto& primPos(in.R);
   const auto& primTypes(in.GroupID);
-  out.create({natoms * numCopies});
   const int maxCopies = 10;
   int index           = 0;
   //set the unit to the Cartesian!

--- a/src/Sandbox/input/graphite.hpp
+++ b/src/Sandbox/input/graphite.hpp
@@ -34,14 +34,11 @@ inline auto create_prim_lattice()
 void tile_cell(ParticleSet& ions, Tensor<int, 3>& tmat)
 {
   SimulationCell sim_cell(create_prim_lattice());
-  // create Ni and O by group
-  std::vector<int> graphite_group{4};
   ParticleSet prim_ions(sim_cell);
-  // create particles by groups
-  prim_ions.create(graphite_group);
   // using lattice coordinates
   prim_ions.R.InUnit = PosUnit::Lattice;
 
+  // create particles by groups
   prim_ions.create({4});
   prim_ions.R[0] = {0.0, 0.0, 0.0};
   prim_ions.R[1] = {0.0, 2.68525, 0.0};

--- a/src/Sandbox/input/nio.hpp
+++ b/src/Sandbox/input/nio.hpp
@@ -27,15 +27,13 @@ inline auto create_prim_lattice()
 
 void tile_cell(ParticleSet& ions, const Tensor<int, 3>& tmat)
 {
-  auto prim_lat(create_prim_lattice());
-  // create Ni and O by group
-  std::vector<int> nio_group{16, 16};
-  ParticleSet prim_ions(prim_lat);
-  // create particles by groups
-  prim_ions.create(nio_group);
+  SimulationCell sim_cell(create_prim_lattice());
+  ParticleSet prim_ions(sim_cell);
   // using lattice coordinates
   prim_ions.R.InUnit = PosUnit::Lattice;
 
+  // create Ni and O by group
+  prim_ions.create({16, 16});
   // O
   prim_ions.R[0]  = {0.5, 0.0, 0.25};
   prim_ions.R[1]  = {0.0, 0.0, 0.75};

--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -115,7 +115,7 @@ int main(int argc, char** argv)
   if (!AverageWalkersPerNode)
     AverageWalkersPerNode = NumThreads;
   //set nwtot, to be random
-  nwtot = std::abs(AverageWalkersPerNode + myComm->rank() % 5 - 2);
+  nwtot = std::max(1, AverageWalkersPerNode + myComm->rank() % 5 - 2);
   FairDivideLow(nwtot, NumThreads, wPerNode);
 
   //Random.init(iseed);

--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -125,7 +125,6 @@ int main(int argc, char** argv)
   if (myComm->rank())
     outputManager.shutOff();
 
-  int nptcl = 0;
   double t0 = 0.0, t1 = 0.0;
 
   SimulationCell supercell(createSuperLattice(create_prim_lattice(), tmat));
@@ -135,36 +134,32 @@ int main(int argc, char** argv)
   auto& rnc_children = RandomNumberControl::getChildren();
   std::vector<uint_type> mt(Random.state_size(), 0);
   std::vector<std::vector<uint_type>> mt_children(NumThreads, mt);
-  std::vector<MCWalkerConfiguration> elecs(NumThreads, MCWalkerConfiguration(supercell));
+  MCWalkerConfiguration elecs_with_walkers(supercell);
+
+  const int nions = ions.getTotalNum();
+  const int nels  = count_electrons(ions);
+
+  elecs_with_walkers.create({nels / 2, nels - nels / 2});
+  elecs_with_walkers.createWalkers(nwtot);
+
+  std::vector<ParticleSet> elecs(NumThreads, elecs_with_walkers);
 
 #pragma omp parallel reduction(+ : t0)
   {
     const int ip = omp_get_thread_num();
 
-    MCWalkerConfiguration& els                = elecs[ip];
+    auto& els                                 = elecs[ip];
     RandomNumberControl::Generator& random_th = *rnc_children[ip];
 
-    const int nions = ions.getTotalNum();
-    const int nels  = count_electrons(ions);
-    const int nels3 = 3 * nels;
-
-#pragma omp master
-    nptcl = nels;
-
-    { //create up/down electrons
-      els.create({nels / 2, nels - nels / 2});
+    { //setup up/down electrons
       els.R.InUnit = PosUnit::Lattice;
-      std::generate(&els.R[0][0], &els.R[0][0] + nels3, std::ref(random_th));
+      std::generate(&els.R[0][0], &els.R[0][0] + nels * 3, std::ref(random_th));
       els.convert2Cart(els.R); // convert to Cartiesian
       els.update();
     }
 
-    if (!ip)
-      elecs[0].createWalkers(nwtot);
-#pragma omp barrier
-
-    for (MCWalkerConfiguration::iterator wi = elecs[0].begin() + wPerNode[ip];
-         wi != elecs[0].begin() + wPerNode[ip + 1]; wi++)
+    for (MCWalkerConfiguration::iterator wi = elecs_with_walkers.begin() + wPerNode[ip];
+         wi != elecs_with_walkers.begin() + wPerNode[ip + 1]; wi++)
       els.saveWalker(**wi);
 
     // save random seeds
@@ -172,7 +167,7 @@ int main(int argc, char** argv)
   } //end of omp parallel
   Random.save(mt);
 
-  setWalkerOffsets(elecs[0], myComm);
+  setWalkerOffsets(elecs_with_walkers, myComm);
 
   //storage variables for timers
   double h5write = 0.0, h5read = 0.0;         //random seed R/W speeds
@@ -231,10 +226,10 @@ int main(int argc, char** argv)
   }
 
   // dump electron coordinates.
-  HDFWalkerOutput wOut(elecs[0].getTotalNum(), directory + "restart", myComm);
+  HDFWalkerOutput wOut(elecs_with_walkers.getTotalNum(), directory + "restart", myComm);
   myComm->barrier();
   h5clock.restart(); //start timer
-  wOut.dump(elecs[0], 1);
+  wOut.dump(elecs_with_walkers, 1);
   myComm->barrier();
   walkerWrite += h5clock.elapsed(); //store timer
   if (!myComm->rank())
@@ -242,9 +237,9 @@ int main(int argc, char** argv)
 
   // save walkers before destroying them
   std::vector<Walker_t> saved_walkers;
-  for (int wi = 0; wi < elecs[0].getActiveWalkers(); wi++)
-    saved_walkers.push_back(*elecs[0][wi]);
-  elecs[0].destroyWalkers(elecs[0].begin(), elecs[0].end());
+  for (int wi = 0; wi < elecs_with_walkers.getActiveWalkers(); wi++)
+    saved_walkers.push_back(*elecs_with_walkers[wi]);
+  elecs_with_walkers.destroyWalkers(elecs_with_walkers.begin(), elecs_with_walkers.end());
 
   // load walkers
   std::string restart_input = R"(
@@ -260,21 +255,21 @@ int main(int argc, char** argv)
   xmlNodePtr restart_leaf = xmlFirstElementChild(root);
 
   HDFVersion in_version(0, 4);
-  HDFWalkerInput_0_4 wIn(elecs[0], elecs[0].getTotalNum(), myComm, in_version);
+  HDFWalkerInput_0_4 wIn(elecs_with_walkers, elecs_with_walkers.getTotalNum(), myComm, in_version);
   myComm->barrier();
   h5clock.restart(); //start timer
   wIn.put(restart_leaf);
   myComm->barrier();
   walkerRead += h5clock.elapsed(); //store time spent
 
-  if (saved_walkers.size() != elecs[0].getActiveWalkers())
+  if (saved_walkers.size() != elecs_with_walkers.getActiveWalkers())
     std::cout << "Fail: Rank " << myComm->rank() << " had " << saved_walkers.size() << "  walkers but loaded only "
-              << elecs[0].getActiveWalkers() << " walkers from file!" << std::endl;
+              << elecs_with_walkers.getActiveWalkers() << " walkers from file!" << std::endl;
 
   mismatch_count = 0;
   for (int wi = 0; wi < saved_walkers.size(); wi++)
   {
-    saved_walkers[wi].R = saved_walkers[wi].R - elecs[0][wi]->R;
+    saved_walkers[wi].R = saved_walkers[wi].R - elecs_with_walkers[wi]->R;
     if (Dot(saved_walkers[wi].R, saved_walkers[wi].R) > std::numeric_limits<RealType>::epsilon())
       mismatch_count++;
   }
@@ -311,15 +306,15 @@ int main(int argc, char** argv)
 
     if (subComm->getGroupID() == 0)
     {
-      elecs[0].destroyWalkers(elecs[0].begin(), elecs[0].end());
-      HDFWalkerInput_0_4 subwIn(elecs[0], elecs[0].getTotalNum(), subComm, in_version);
+      elecs_with_walkers.destroyWalkers(elecs_with_walkers.begin(), elecs_with_walkers.end());
+      HDFWalkerInput_0_4 subwIn(elecs_with_walkers, elecs_with_walkers.getTotalNum(), subComm, in_version);
       subwIn.put(restart_leaf);
       subComm->barrier();
       if (!subComm->rank())
         std::cout << "Walkers are loaded again by the subgroup!\n";
-      setWalkerOffsets(elecs[0], subComm);
-      HDFWalkerOutput subwOut(elecs[0].getTotalNum(), "XXXX", subComm);
-      subwOut.dump(elecs[0], 1);
+      setWalkerOffsets(elecs_with_walkers, subComm);
+      HDFWalkerOutput subwOut(elecs_with_walkers.getTotalNum(), "XXXX", subComm);
+      subwOut.dump(elecs_with_walkers, 1);
       if (!subComm->rank())
         std::cout << "Walkers are dumped again by the subgroup!\n";
     }


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

A few fixes to the restart miniapp and components in the sandbox
1. restart miniapp doesn't initialize the collection of ParticleSet properly. This is caused by using more `shared_ptr` components in ParticleSet. So I rewrote the initialization closer to a batched driver.
2. OMP_NUM_THREADS=2 now works.
3. expandSuperCell in ParticleIOUtility.cpp now properly handles >1 species.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Bugfix

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

laptop


## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
