### PR TITLE
Update stale issue workflow (7 year stale, env variables)

### DIFF
--- a/.github/workflows/close-inactive-issues-prs.yaml
+++ b/.github/workflows/close-inactive-issues-prs.yaml
@@ -9,14 +9,17 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+    env:
+      stale-time: 2555 # 7 years
+      close-time: 28   # 4 weeks
     steps:
       - uses: actions/stale@v10
         with:
-          days-before-issue-stale: 2920
-          days-before-issue-close: 28
+          days-before-issue-stale: ${{ env.stale-time }}
+          days-before-issue-close: ${{ env.close-time }}
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 2920 days with no activity. It will be closed in 28 days if there is no fresh activity. Please comment within 28 days if this issue is still important to you and it should be kept open."
-          close-issue-message: "This issue was closed because it has been inactive for 28 days since being marked as stale."
+          stale-issue-message: "This issue is stale because it has been open for ${{ env.stale-time }} days with no activity. It will be closed in ${{ env.close-time }} days if there is no fresh activity. Please comment within 28 days if this issue is still important to you and it should be kept open."
+          close-issue-message: "This issue was closed because it has been inactive for ${{ env.close-time }} days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close-inactive-issues-prs.yaml
+++ b/.github/workflows/close-inactive-issues-prs.yaml
@@ -18,7 +18,7 @@ jobs:
           days-before-issue-stale: ${{ env.stale-time }}
           days-before-issue-close: ${{ env.close-time }}
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for ${{ env.stale-time }} days with no activity. It will be closed in ${{ env.close-time }} days if there is no fresh activity. Please comment within 28 days if this issue is still important to you and it should be kept open."
+          stale-issue-message: "This issue is stale because it has been open for ${{ env.stale-time }} days with no activity. It will be closed in ${{ env.close-time }} days if there is no fresh activity. Please comment within ${{ env.close-time }} days if this issue is still important to you and it should be kept open."
           close-issue-message: "This issue was closed because it has been inactive for ${{ env.close-time }} days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Revise the stale issues workflow, set to 7 years. Use variables in messages, settings.


## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Other (please describe):
GitHub

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

None

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
