### PR TITLE
Nexus: Add generic workstation 'ws' machine that automatically detects number of available cpu cores

### DIFF
--- a/nexus/docs/user-scripts.rst
+++ b/nexus/docs/user-scripts.rst
@@ -144,8 +144,15 @@ machine.
       generate_only = True,                 # only write input files, do not run
       sleep         = 3,                    # check on jobs every 3 seconds
       pseudo_dir    = './pseudopotentials', # path to PP file collection
-      machine       = 'ws8'                 # local machine is an 8 core workstation
+      machine       = 'ws'                  # automatically detect the number of cores
       )
+
+.. tip::
+
+    Specifying the number of cores in a workstation with, e.g., ``machine = "ws8"`` for
+    an 8-core workstation is still possible, however many users will likely want to
+    switch to using the new automatic core count functionality in Nexus, which only
+    requires specifying ``machine = "ws"`` (demonstrated in the above code).
 
 A few additional parameters are available in ``settings`` to control
 where runs are performed, where output data is gathered, and whether to

--- a/nexus/nexus/__init__.py
+++ b/nexus/nexus/__init__.py
@@ -33,7 +33,7 @@ from .debug         import ci
 from .utilities     import path_string
 
 from .nexus_base      import NexusCore,              nexus_core,     nexus_noncore,          nexus_core_noncore,         restore_nexus_core_defaults,    nexus_core_defaults
-from .machines        import Job,                    job,            Machine, Supercomputer, get_machine
+from .machines        import Job,                    job,            Machine, Supercomputer, get_machine, get_cpu_cores, Workstation
 from .simulation      import generate_simulation,    input_template, multi_input_template,   generate_template_input,    generate_multi_template_input,  graph_sims, DynamicProcess
 from .project_manager import ProjectManager,     DynamicWorkflowManager,     workflow_manager
 
@@ -504,6 +504,17 @@ class Settings(NexusCore):
         #end if
         if 'machine' in mset:
             machine_name = mset.machine
+            if machine_name in ("ws", "workstation"):
+                self.log("Automatically detecting physical CPU cores for workstation...", n=1)
+                n_cores = get_cpu_cores()
+                self.log(f"Using {n_cores} core workstation", n=1)
+                machine_name = f"ws{n_cores}"
+
+                if not Machine.exists(machine_name):
+                    # Register a workstation with the determined number of cores
+                    # if there is not already one that exists.
+                    Workstation(machine_name, n_cores, 'mpirun')
+
             if not Machine.exists(machine_name):
                 self.error('machine {0} is unknown'.format(machine_name))
             #end if

--- a/nexus/nexus/machines.py
+++ b/nexus/nexus/machines.py
@@ -45,11 +45,12 @@
 
 import os
 from pathlib import Path
-#from multiprocessing import cpu_count
+import platform
 from socket import gethostname
-from subprocess import Popen
+import subprocess
+from subprocess import Popen, CalledProcessError
 import numpy as np
-from .developer import DevBase, obj
+from .developer import DevBase, obj, warn
 from .nexus_base import NexusCore, nexus_core
 from .execute import execute
 from .utilities import path_string
@@ -68,31 +69,50 @@ def our_load_source(modname, filename):
     loader.exec_module(module)
     return module
 
-def cpu_count():
-    """ Number of virtual or physical CPUs on this system, i.e.
-    user/real as output by time(1) when called with an optimally scaling
-    userspace-only program"""
 
-    # Python 2.6+
+def get_cpu_cores() -> int:
+    """Get the number of physical CPU cores, defaulting to logical if not available.
+
+    This function makes calls to ``lscpu`` on Linux and ``sysctl`` on MacOS.
+    If these commands fail, it will default to :py:func:`os.cpu_count()`, which returns
+    the number of logical processors in the system. This may be up to twice as
+    much as the number of physical cores.
+    """
+    n_cores = os.cpu_count() # Set ahead of time so it is never unbound
     try:
-        import multiprocessing
-        return multiprocessing.cpu_count()
-    except (ImportError, NotImplementedError):
-        pass
-    #end try
+        sysname = platform.system()
+        match sysname:
+            case "Linux":
+                query = subprocess.run(
+                    ["lscpu", "-p=Core,Socket"],
+                    capture_output=True,
+                    check=True,
+                    )
+                output = query.stdout.decode().strip().splitlines()
+                # set will automatically remove duplicate entries.
+                # Anything that remains is the list of physical cores.
+                output = set([i for i in output if not i.startswith("#")])
+                n_cores = len(output)
+            case "Darwin":
+                query = subprocess.run(
+                    ["sysctl", "-n", "hw.physicalcpu"],
+                    capture_output=True,
+                    check=True,
+                    )
+                n_cores = int(query.stdout.decode().strip())
+            case _:
+                warn(
+                   f"Operating system '{sysname}' not recognized by Nexus.\n"
+                    "Could not get number of physical CPU cores, defaulting to logical..."
+                    )
 
-    # POSIX
-    try:
-        res = int(os.sysconf('SC_NPROCESSORS_ONLN'))
+    except CalledProcessError as err:
+        warn(
+            "Could not get number of physical CPU cores, defaulting to logical...\n"
+           f"Error is:\n{err}"
+            )
 
-        if res > 0:
-            return res
-        #end if
-    except (AttributeError, ValueError):
-        pass
-    #end try
-#end def cpu_count
-
+    return n_cores
 
 
 class Options(DevBase):
@@ -957,7 +977,7 @@ class Workstation(Machine):
         Machine.__init__(self,name)
         self.app_launcher = app_launcher
         if cores is None:
-            self.cores = cpu_count()
+            self.cores = get_cpu_cores()
         else:
             self.cores = cores
         #end if

--- a/nexus/nexus/tests/test_machines.py
+++ b/nexus/nexus/tests/test_machines.py
@@ -56,10 +56,10 @@ def get_supercomputers():
 
 
 
-def test_cpu_count():
-    from ..machines import cpu_count
-    assert(isinstance(cpu_count(),int))
-#end def test_cpu_count
+def test_get_cpu_cores():
+    from ..machines import get_cpu_cores
+    assert(isinstance(get_cpu_cores(), int))
+#end def test_get_cpu_cores
 
 
 

--- a/nexus/nexus/tests/test_machines.py
+++ b/nexus/nexus/tests/test_machines.py
@@ -5,6 +5,7 @@ pytestmark = pytest.mark.order(NexusTestOrder.MACHINES)
 from ..generic import generic_settings
 generic_settings.raise_error = True
 
+import os
 from . import isolate_nexus_core
 from .. import testing
 from ..testing import object_eq,object_diff,failed,FailedTest
@@ -59,6 +60,8 @@ def get_supercomputers():
 def test_get_cpu_cores():
     from ..machines import get_cpu_cores
     assert(isinstance(get_cpu_cores(), int))
+    assert(get_cpu_cores() >= 0)
+    assert(get_cpu_cores() <= os.cpu_count())
 #end def test_get_cpu_cores
 
 


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

By request from @prckent, this adds in the ability for Nexus to automatically get the number of physical CPU cores and choose the correct workstation for the machine.

Users can now use
```python
from nexus import settings
settings(
    machine="ws"
)
```
or
```python
from nexus import settings
settings(
    machine="workstation"
)
```
to have Nexus automatically pick the workstation with the same CPU count as the system they're on.

I added in a fallback that defaults to `os.cpu_count()` should the executed system commands fail, which returns the number of logical processors. I decided against dividing that value in half since not all CPUs have hyperthreading on all cores (e.g. Intel's performance cores versus efficiency cores).

Additionally, I added some code that will create a workstation with the detected number of cores if it does not already exist. This means that, for folks with the monstrously large 192-core AMD EPYC 9965 CPUs, there should be no problems using Nexus.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- New feature
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation or build script changes

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->

- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

Laptop, Fedora Linux 43 (KDE Plasma Desktop Edition)
AMD Ryzen 7 PRO 7840U (8 cores, 16 logical processors)
```
Python        3.14.5
uv            0.11.21
cif2cell      2.1.0
coverage      7.13.5
h5py          3.16.0
matplotlib    3.10.9
numpy         2.4.4
pycifrw       4.4.6
pydot         4.0.1
pytest        9.0.3
pytest-cov    7.1.0
pytest-order  1.4.0
scipy         1.17.1
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
