### PR TITLE
Nexus: Fix incorrect citation in `periodic_table.py`

### DIFF
--- a/nexus/nexus/periodic_table.py
+++ b/nexus/nexus/periodic_table.py
@@ -32,7 +32,7 @@ class ElementData:
     def principle_isotope(self) -> tuple[int, float]:
         """Get the mass number and relative atomic weight of the most common isotope.
 
-        Isotopic abundances defined by IUPAC [1]_.
+        Isotopic abundances defined by NIST [1]_.
 
         Returns
         -------
@@ -43,7 +43,7 @@ class ElementData:
 
         References
         ----------
-        .. [1] https://www.ciaaw.org/isotopic-abundances.htm
+        .. [1] https://www.nist.gov/pml/atomic-weights-and-isotopic-compositions-relative-atomic-masses
         """
         mass_number = list(self.isotopes.keys())[0]
         return mass_number, self.isotopes[mass_number]
@@ -53,7 +53,7 @@ class ElementData:
         return self.atomic_number
 
     def neutrons(self, mass_number: int | None = None) -> int:
-        """Get the number of neutrons for the isotope with the given mass number.
+        """Get the number of neutrons for the isotope with the givenmass number.
 
         If no mass number is provided, this defaults to the most common isotope.
 
@@ -94,14 +94,15 @@ class Elements(ElementData, Enum):
         This can be accessed as ``Element.Name.isotopes[mass_number]``,
         which yields the relative atomic mass.
 
-        These dictionaries are sorted in order of decreasing isotopic abundance,
-        as defined by IUPAC [3]_.
+        These dictionaries are sorted in order of decreasing isotopic
+        abundance, as defined by NIST [2]_. The code to generate the
+        isotope dictionaries can be found at
+        https://github.com/QMCPACK/qmcpack/pull/6006.
 
     References
     ----------
     .. [1] https://iupac.qmul.ac.uk/AtWt/
     .. [2] https://www.nist.gov/pml/atomic-weights-and-isotopic-compositions-relative-atomic-masses
-    .. [3] https://www.ciaaw.org/isotopic-abundances.htm
 
     Examples
     --------

--- a/nexus/nexus/periodic_table.py
+++ b/nexus/nexus/periodic_table.py
@@ -53,7 +53,7 @@ class ElementData:
         return self.atomic_number
 
     def neutrons(self, mass_number: int | None = None) -> int:
-        """Get the number of neutrons for the isotope with the givenmass number.
+        """Get the number of neutrons for the isotope with the given mass number.
 
         If no mass number is provided, this defaults to the most common isotope.
 


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

A mistake on my part led to me incorrectly citing IUPAC for isotopic abundances instead of NIST. I've corrected that, and included a link to this PR, which includes the code required to automatically download, parse, and write the isotope dictionaries that are in `periodic_table.py`.

[write_nexus_isotopes.py](https://github.com/user-attachments/files/29303331/write_nexus_isotopes.py)

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Documentation or build script changes

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->

- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

Laptop, Fedora Linux 43 (KDE Plasma Desktop Edition)
AMD Ryzen 7 PRO 7840U (8 cores, 16 logical processors)
```
Python        3.14.5
uv            0.11.21
cif2cell      2.1.0
coverage      7.13.5
h5py          3.16.0
matplotlib    3.10.9
numpy         2.4.4
pycifrw       4.4.6
pydot         4.0.1
pytest        9.0.3
pytest-cov    7.1.0
pytest-order  1.4.0
scipy         1.17.1
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Documentation has been added (if appropriate)
