### PR TITLE
Nexus: Replace old warning system with Python's `warnings` library

### DIFF
--- a/nexus/nexus/developer.py
+++ b/nexus/nexus/developer.py
@@ -32,7 +32,8 @@
 
 
 from .utilities import to_str
-from .generic import obj, object_interface, hidden, NexusError, log, error, warn, message
+from .generic import obj, object_interface, hidden, NexusError
+from .generic import log, error, warn, message, nxs_deprecate
 from .debug import ci, interact
 
 

--- a/nexus/nexus/generic.py
+++ b/nexus/nexus/generic.py
@@ -30,6 +30,7 @@
 #====================================================================#
 
 
+import os
 import sys
 import traceback
 from typing import TextIO
@@ -38,9 +39,13 @@ import pickle
 from pickle import UnpicklingError
 from random import randint
 from pathlib import Path
+import warnings
+from typing import TypeAlias
+import functools
 
 from .utilities import sorted_py2, path_string
 
+VersionStr: TypeAlias = str
 
 class generic_settings:
     devlog         = sys.stdout
@@ -51,6 +56,42 @@ class generic_settings:
 class NexusError(Exception):
     None
 #end class NexusError
+
+
+class NexusDevWarning(Warning):
+    def __init__(self, msg: str, indent: str = "    ", cls: str | None = None):
+        self.message = msg
+        self.indent  = indent
+        self.cls     = cls
+#end class NexusDevWarning
+
+
+class NexusUserWarning(NexusDevWarning):
+    None
+#end class NexusUserWarning
+
+
+# Hook for replacing `warnings.showwarning`
+def __nexus_showwarning(message, category, filename, lineno, file=None, line=None):
+    if file is None:
+        file = generic_settings.devlog
+
+    if isinstance(message, DeprecationWarning):
+        indent, msg = str(message).split(";", maxsplit=1)
+        cls = ""
+    elif isinstance(message, NexusDevWarning | NexusUserWarning):
+        msg    = message.message
+        indent = message.indent
+        cls    = f"{message.cls}:" if message.cls is not None else ""
+
+    if os.path.exists(filename):
+        # Printing the whole file path can be very confusing, so we just
+        # print the file name and its parent directory.
+        filename = os.path.relpath(filename, os.path.dirname(filename+"/../../"))
+
+    file.write(f"{indent}{filename}:{lineno}:{cls} {category.__name__}: {msg}\n")
+
+warnings.showwarning = __nexus_showwarning
 
 
 exit_call = sys.exit
@@ -128,13 +169,100 @@ def message(msg,header=None,post_header=' message:',indent='    ',logfile=None):
 #end def message
 
 
-def warn(msg,header=None,indent='    ',logfile=None):
-    if logfile is None:
-        logfile = generic_settings.devlog
-    #end if
-    post_header=' warning:'
-    message(msg,header,post_header,indent,logfile)
+def warn(
+    msg      : str,
+    indent   : str        = "    ",
+    warn_type: str        = "user",
+    cls      : str | None = None,
+    ) -> None:
+    """Report a warning.
+
+    Parameters
+    ----------
+    msg : str
+        The message for the warning.
+    indent : str. default="    "
+        The indentation for the warning message.
+    warn_type : {"user", "dev", "deprecate", "class"}
+        See the notes for a description of when you should use each
+        warning type.
+    cls : str, optional
+        Meant to be passed through ``self.warn()`` in a class that
+        derives from ``object_interface``.
+
+    Notes
+    -----
+    If you are a developer who wants to use this function but are unsure
+    of what kind of warning type to use, here are some basic guidelines
+    for choosing:
+
+    - If the function you're putting a warning in will be directly
+      called by a user, you should use ``"user"``, as this will show
+      them where in their own script they've called the function.
+    - If the function you're putting a warning in will be indirectly
+      called by a function that a user has called, **and** if the
+      problem is due to something the user has done you should use the
+      class's ``self.warn()`` functionality if it inherits from
+      ``DevBase``, otherwise use the warning type ``"class"`` and pass
+      in the name of the class and/or function you're calling from.
+    - If the function is called indirectly by a user and it is not
+      necessarily their fault that something has gone awry, you should
+      use ``"dev"``. This should likely only be used in places where
+      you are *mostly* sure there won't be any problems but the code
+      has not been thoroughly tested.
+    - If you are deprecating a function, use the ``@nxs_deprecate``
+      decorator and supply the version and the replacement that a user
+      should use instead of the soon-to-be-removed function.
+    """
+    match warn_type:
+        case "dev":
+            msg = NexusDevWarning(msg, indent, cls)
+            warnings.warn(msg, stacklevel=2)
+        case "user":
+            msg = NexusUserWarning(msg, indent, cls)
+            # len(traceback.format_stack()) brings you all the way back
+            # to the user file no matter where the warning was raised.
+            warnings.warn(msg, stacklevel=len(traceback.format_stack()))
+        case "deprecate":
+            msg = DeprecationWarning(f"{indent};{msg}")
+            warnings.warn(msg, stacklevel=3)
+        case "class":
+            msg = NexusUserWarning(msg, indent, cls)
+            warnings.warn(msg, stacklevel=3)
 #end def warn
+
+
+def nxs_deprecate(
+    since: VersionStr,
+    replacement: str,
+    indent: str = "    "
+    ):
+    """Decorator for signaling the deprecation of a Nexus function.
+
+    This should itself be deprecated when the minimum Python version is
+    3.13, when the official ``warnings.deprecated()`` decorator is added.
+
+    Parameters
+    ----------
+    since : Version
+        The version of Nexus when the function was deprecated.
+    replacement : str
+        The replacement function for the function being deprecated.
+    indent : str, default = "    "
+        Indentation to go before the warning.
+    """
+    def inner(f):
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            warn_msg = f"{f.__qualname__} is deprecated as of Nexus version {since}, and will be removed in a future update."
+            if replacement is not None:
+                warn_msg += f" Please use {replacement} instead."
+
+            warn(msg=warn_msg, indent=indent, warn_type="deprecate")
+            return f(*args, **kwargs)
+        return wrapper
+    return inner
+#end def nxs_deprecate
 
 
 def error(
@@ -561,11 +689,12 @@ class object_interface(object):
         log(*items,**kwargs)
     #end def log
 
-    def warn(self,message,header=None):
-        if header is None:
-            header=self.__class__.__name__
-        #end if
-        warn(message,header,logfile=self._logfile)
+    def warn(self, msg: str, indent: str = "    "):
+        """Warning from inside a Nexus class.
+
+        See ``generic.warn()`` for description.
+        """
+        warn(msg, indent, warn_type="class", cls=type(self).__qualname__)
     #end def warn
 
     def error(self,message,header=None,exit=True,trace=-2):

--- a/nexus/nexus/generic.py
+++ b/nexus/nexus/generic.py
@@ -80,8 +80,14 @@ def __nexus_showwarning(message, category, filename, lineno, file=None, line=Non
     cls    = ""
     if isinstance(message, DeprecationWarning):
         message = str(message)
-        if ";" in message:
-            indent, msg = message.split(";", maxsplit=1)
+        # To pass indentation through `DeprecationWarning` we prepend it
+        # to the message along with a pipe character "|".
+        # Here we strip the whitespace indentation, then make sure the
+        # message starts with the pipe character before splitting it to
+        # retrieve the indentation.
+        # This reduces the chance of an accidental split.
+        if message.lstrip().startswith("|"):
+            indent, msg = message.split("|", maxsplit=1)
         else:
             msg = message
     elif isinstance(message, NexusDevWarning | NexusUserWarning):
@@ -92,11 +98,14 @@ def __nexus_showwarning(message, category, filename, lineno, file=None, line=Non
         msg = message
 
     if os.path.exists(filename):
-        # Printing the whole file path can be very confusing, so we just
-        # print the file name and its parent directory.
-        filename = os.path.relpath(filename, os.path.dirname(filename+"/../../"))
+        filename = os.path.realpath(filename)
 
-    file.write(f"{indent}{filename}:{lineno}:{cls} {category.__name__}: {msg}\n")
+    msg = (indent*2)+msg.strip().replace("\n", "\n"+(indent*2))
+
+    file.write(
+        f"{indent}{filename}:{lineno}:{cls} {category.__name__}:\n"
+        f"{msg}\n"
+        )
 
 warnings.showwarning = __nexus_showwarning
 
@@ -231,7 +240,7 @@ def warn(
             # to the user file no matter where the warning was raised.
             warnings.warn(msg, stacklevel=len(traceback.format_stack()))
         case "deprecate":
-            msg = DeprecationWarning(f"{indent};{msg}")
+            msg = DeprecationWarning(f"{indent}|{msg}")
             warnings.warn(msg, stacklevel=3)
         case "class":
             msg = NexusUserWarning(msg, indent, cls)
@@ -263,7 +272,7 @@ def nxs_deprecate(
         def wrapper(*args, **kwargs):
             warn_msg = f"{f.__qualname__} is deprecated as of Nexus version {since}, and will be removed in a future update."
             if replacement is not None:
-                warn_msg += f" Please use {replacement} instead."
+                warn_msg += f"\nPlease use {replacement} instead."
 
             warn(msg=warn_msg, indent=indent, warn_type="deprecate")
             return f(*args, **kwargs)

--- a/nexus/nexus/generic.py
+++ b/nexus/nexus/generic.py
@@ -76,9 +76,14 @@ def __nexus_showwarning(message, category, filename, lineno, file=None, line=Non
     if file is None:
         file = generic_settings.devlog
 
+    indent = ""
+    cls    = ""
     if isinstance(message, DeprecationWarning):
-        indent, msg = str(message).split(";", maxsplit=1)
-        cls = ""
+        message = str(message)
+        if ";" in message:
+            indent, msg = message.split(";", maxsplit=1)
+        else:
+            msg = message
     elif isinstance(message, NexusDevWarning | NexusUserWarning):
         msg    = message.message
         indent = message.indent

--- a/nexus/nexus/generic.py
+++ b/nexus/nexus/generic.py
@@ -88,6 +88,8 @@ def __nexus_showwarning(message, category, filename, lineno, file=None, line=Non
         msg    = message.message
         indent = message.indent
         cls    = f"{message.cls}:" if message.cls is not None else ""
+    else:
+        msg = message
 
     if os.path.exists(filename):
         # Printing the whole file path can be very confusing, so we just

--- a/nexus/nexus/tests/test_generic.py
+++ b/nexus/nexus/tests/test_generic.py
@@ -21,7 +21,7 @@ TEST_FILES = {
 
 @isolate_nexus_core
 def test_logging():
-    from ..generic import log,warn,error
+    from ..generic import log,error
     from ..generic import generic_settings,NexusError
 
     logfile = generic_settings.devlog
@@ -64,25 +64,7 @@ def test_logging():
     log(s2,logfile=logfile2)
     assert(logfile.s=='')
     assert(logfile2.s==s2+'\n')
-    
 
-    # test warn
-    logfile.reset()
-    s = 'this is a warning'
-    warn(s)
-    so = '''
-  warning:
-    this is a warning
-'''
-    assert(logfile.s==so)
-    logfile.reset()
-    s = 'this is a warning'
-    warn(s,header='Special')
-    so = '''
-  Special warning:
-    this is a warning
-'''
-    assert(logfile.s==so)
 
     # test error
     #   in testing environment, should raise an error

--- a/nexus/nexus/tests/test_generic.py
+++ b/nexus/nexus/tests/test_generic.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from . import isolate_nexus_core, FakeLog
 from ..testing import failed,FailedTest
 from ..testing import object_eq,object_neq
+from ..generic import obj
+from ..generic import warn, NexusDevWarning, NexusUserWarning, nxs_deprecate
 
 TEST_FILES = {
     "old_nxs_pwscf_input.p": Path(__file__+"/../test_generic_files/old_nxs_pwscf_input.p").resolve(),
@@ -403,25 +405,6 @@ def test_intrinsics(tmp_path):
     o.log(s2,logfile=logfile2)
     assert(logfile.s=='')
     assert(logfile2.s==s2+'\n')
-    
-
-    # test warn
-    logfile.reset()
-    s = 'this is a warning'
-    o.warn(s)
-    so = '''
-  DerivedObj warning:
-    this is a warning
-'''
-    assert(logfile.s==so)
-    logfile.reset()
-    s = 'this is a warning'
-    o.warn(s,header='Special')
-    so = '''
-  Special warning:
-    this is a warning
-'''
-    assert(logfile.s==so)
 
     # test error
     #   in testing environment, should raise an error
@@ -463,14 +446,12 @@ def test_intrinsics(tmp_path):
     except Exception as e:
         failed(str(e))
     #end try
-
 #end def test_intrinsics
-
 
 
 def test_extensions():
     # test obj functions
-    from ..generic import obj,NexusError
+    from ..generic import NexusError
 
     # make a simple object
     o = obj(
@@ -1123,12 +1104,11 @@ def test_extensions():
     #end for
     o2 = o.serial()
     assert(object_eq(o2,oref))
-
 #end def test_extensions
+
 
 def test_old_nexus_unpickle():
     import numpy as np
-    from ..generic import obj
 
     sim_obj = obj()
     if np.lib.NumpyVersion(np.__version__) >= '2.0.0b1':
@@ -1253,3 +1233,30 @@ def test_old_nexus_unpickle():
     assert(inp_obj.system.smearing    == "fermi-dirac")
     assert(inp_obj.system.tot_charge  == 0)
 #end def test_old_nexus_unpickle
+
+
+@isolate_nexus_core
+def test_warn():
+    with pytest.warns(NexusUserWarning, match="This is a test warning"):
+        warn("This is a test warning", warn_type="user")
+
+    with pytest.warns(NexusDevWarning, match="This is a developer warning"):
+        warn("This is a developer warning", warn_type="dev")
+    
+    with pytest.warns(NexusUserWarning, match="This is a warning from inside obj"):
+        obj().warn("This is a warning from inside obj")
+#end def test_warn
+
+
+@isolate_nexus_core
+def test_nxs_deprecate():
+
+    @nxs_deprecate(since="2.3.9", replacement="Some other function")
+    def deprecated_function():
+        pass
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="deprecated_function is deprecated as of Nexus version 2.3.9, and will be removed in a future update."
+        ):
+        deprecated_function()


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

This PR switches over Nexus's warning system from regular `stdout` printing to Python's `warnings` library. It also introduces the `@nxs_deprecate` decorator, which can be used to mark a function as deprecated.

The benefits of the `warnings` library are that Python's default warnings filter will generally protect most users from unnecessarily repeated warnings, or warnings that likely shouldn't be shown to a user. In addition, the `@nxs_deprecate` decorator, which emits `DeprecationWarning`, will only emit the warning if the function is directly called by a user, meaning internal Nexus functions can be marked and only a developer will see the warning.

There are 4 kinds of warnings that are supported by `nexus.generic.warn()`:

- `"dev"`
  - Emits `NexusDevWarning` pointing to the module and line number the warning came from.
  - Examples
    - `nexus/__init__.py:87: NexusDevWarning: Dev warning inside run_project()`
    - `nexus/project_manager.py:44: NexusDevWarning: Dev Warning from inside ProjectManager.__init__()`
- `"user"`
  - Emits `NexusUserWarning` pointing to the line number in the user's script where they called the function that raised the warning.
  - Examples
    - `ignored_files/test.py:7: NexusUserWarning: User warning inside run_project()`
    - `ignored_files/test.py:7: NexusUserWarning: User Warning from inside ProjectManager.__init__()`
- `"deprecate"`
  - Emits `DeprecationWarning`, pointing to where the deprecated function was called from.
  - Only visible to users if they are the ones directly calling the deprecated function.
  - Example
    - `ignored_files/test.py:9: DeprecationWarning: trivial is deprecated as of Nexus version 2.3.9, and will be removed in a future update. Please use Nothing instead.`
- `"class"`
  - Emits `NexusUserWarning`, pointing to the module and line number the warning came from.
  - This is supposed to come from `self.warn()` inside a class that inherits from `object_interface`.
  - Example
    - `nexus/project_manager.py:46:ProjectManager: NexusUserWarning: Self Warning from inside ProjectManager.__init__()`

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- New feature
- Testing changes
- Documentation or build script changes

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->

- Maybe?

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

Desktop, Fedora Linux 43 (KDE Plasma Desktop Edition)
AMD Ryzen 9 7900X (12 cores, 24 logical processors)
```
Python        3.14.5
uv            0.11.16
cif2cell      2.1.0
coverage      7.13.5
h5py          3.16.0
matplotlib    3.10.9
numpy         2.4.6
pycifrw       5.0.1
pydot         4.0.1
pytest        9.0.3
pytest-cov    7.1.0
pytest-order  1.4.0
scipy         1.17.1
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
