### PR TITLE
Nexus: Update last few bits of `array.shape = shape` in testing suite

### DIFF
--- a/nexus/nexus/bin/qmc-fit
+++ b/nexus/nexus/bin/qmc-fit
@@ -358,7 +358,7 @@ def process_scalar_files(scalar_files,equils=None,reblock_factors=None,series_st
         nbe = len(E)%bt
         E = E[nbe:]
         reblock = len(E)//bt
-        E.shape = (bt,reblock)
+        npe.reshape_inplace(E, (bt,reblock))
         if reblock>1:
             E = E.sum(1)/reblock
         #end if

--- a/nexus/nexus/tests/test_fileio.py
+++ b/nexus/nexus/tests/test_fileio.py
@@ -145,7 +145,7 @@ def test_xsffile_density(tmp_path):
 
     grid = 3,5,7
     dens = 0.01*np.arange(np.prod(grid),dtype=float)
-    dens.shape=grid
+    dens = dens.reshape(grid, copy=False)
 
     ref.add_density(ref.primvec,dens,add_ghost=True)
     assert(ref.is_valid())

--- a/nexus/nexus/tests/test_fileio.py
+++ b/nexus/nexus/tests/test_fileio.py
@@ -7,6 +7,7 @@ generic_settings.raise_error = True
 
 from . import TEST_DIR
 from ..testing import value_eq, object_eq
+from .. import numpy_extensions as npe
 
 
 TEST_FILES = {
@@ -145,7 +146,7 @@ def test_xsffile_density(tmp_path):
 
     grid = 3,5,7
     dens = 0.01*np.arange(np.prod(grid),dtype=float)
-    dens = dens.reshape(grid, copy=False)
+    npe.reshape_inplace(dens, grid)
 
     ref.add_density(ref.primvec,dens,add_ghost=True)
     assert(ref.is_valid())

--- a/nexus/nexus/tests/test_structure.py
+++ b/nexus/nexus/tests/test_structure.py
@@ -12,6 +12,7 @@ from ..testing import value_eq as value_eq_orig
 from ..testing import object_eq as object_eq_orig
 from ..testing import object_diff as object_diff_orig
 from ..testing import text_eq
+from .. import numpy_extensions as npe
 
 
 struct_atol = 1e-10
@@ -484,7 +485,7 @@ def test_matrix_tiling():
         npass = 0
         for tmat in matrix_tilings:
             tmat = np.array(tmat,dtype=int)
-            tmat = tmat.reshape((3, 3), copy=False)
+            npe.reshape_inplace(tmat, (3, 3))
             st = s.tile(tmat)
             st.check_tiling()
         #end for

--- a/nexus/nexus/tests/test_structure.py
+++ b/nexus/nexus/tests/test_structure.py
@@ -484,7 +484,7 @@ def test_matrix_tiling():
         npass = 0
         for tmat in matrix_tilings:
             tmat = np.array(tmat,dtype=int)
-            tmat.shape = 3,3
+            tmat = tmat.reshape((3, 3), copy=False)
             st = s.tile(tmat)
             st.check_tiling()
         #end for


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

With the release of Numpy 2.5, the last bits of setting array shape with `array.shape = new_shape` now emit `DeprecationWarning`, which I can capture through `pytest`. As such, I've updated the 2 spots I seem to have missed in my initial replacing in PR #5757.

I opted for using `array = array.reshape(new_shape, copy=False)` in the two spots I've changed since the arrays are created locally and there are no additional objects that point to them, so a reshape is a safe operation. 

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Bugfix

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->

- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

Laptop, Fedora Linux 43 (KDE Plasma Desktop Edition)
AMD Ryzen 7 PRO 7840U (8 cores, 16 logical processors)
```
Python        3.14.5
uv            0.11.21
cif2cell      2.1.0
coverage      7.13.5
h5py          3.16.0
matplotlib    3.10.9
numpy         2.5.0
pycifrw       4.4.6
pydot         4.0.1
pytest        9.0.3
pytest-cov    7.1.0
pytest-order  1.4.0
scipy         1.17.1
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
