### PR TITLE
replace stride(n) by get<n>(strides())

### DIFF
--- a/src/AFQMC/HamiltonianOperations/THCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOps.hpp
@@ -1153,10 +1153,10 @@ protected:
       // dispatch these through ma_blas_extensions!!!
       // Gwv = sum_a Twav Pva
       if (nu0 > 0) // calculate Guu from u={0,nu0}
-        Aijk_Bkj_Cik(nw, nelec[ispin], nu0, make_device_ptr(Tav.origin()), Tav.stride(1), Tav.stride(),
+        Aijk_Bkj_Cik(nw, nelec[ispin], nu0, make_device_ptr(Tav.origin()), get<1>(Tav.strides()), Tav.stride(),
                      make_device_ptr(rotcPua[k].origin()), rotcPua[k].stride(), make_device_ptr(Guu.origin()), nv);
       if (nu0 + nu < nv) // calculate Guu from u={nu0+nu,nv}
-        Aijk_Bkj_Cik(nw, nelec[ispin], nv - nu0 - nu, make_device_ptr(Tav.origin()) + nu0 + nu, Tav.stride(1),
+        Aijk_Bkj_Cik(nw, nelec[ispin], nv - nu0 - nu, make_device_ptr(Tav.origin()) + nu0 + nu, get<1>(Tav.strides()),
                      Tav.stride(), make_device_ptr(rotcPua[k][nu0 + nu].origin()), rotcPua[k].stride(),
                      make_device_ptr(Guu.origin()) + nu0 + nu, nv);
     }

--- a/src/AFQMC/Numerics/ma_lapack.hpp
+++ b/src/AFQMC/Numerics/ma_lapack.hpp
@@ -25,13 +25,13 @@
 
 namespace ma
 {
+  using std::get;
 template<class MultiArray2D>
 int getrf_optimal_workspace_size(MultiArray2D&& A)
 {
   assert(A.stride() > 0);
-  assert(A.stride(1) == 1);
+  assert(get<1>(A.strides()) == 1);
 
-  using std::get;
   int res;
   getrf_bufferSize(get<1>(A.sizes()), get<0>(A.sizes()), pointer_dispatch(A.origin()), A.stride(), res);
   return res;
@@ -42,7 +42,7 @@ MultiArray2D&& getrf(MultiArray2D&& m, Array1D& pivot, Buffer&& WORK)
 {
   using std::get;
   assert(m.stride() >= std::max(std::size_t(1), std::size_t(get<1>(m.sizes()))));
-  assert(m.stride(1) == 1);
+  assert(get<1>(m.strides()) == 1);
   assert(pivot.size() >= std::min(get<1>(m.sizes()), get<0>(m.sizes()) + 1));
 
   int status = -1;
@@ -55,9 +55,9 @@ MultiArray2D&& getrf(MultiArray2D&& m, Array1D& pivot, Buffer&& WORK)
 template<class MultiArray2D>
 int getri_optimal_workspace_size(MultiArray2D&& A)
 {
-  assert(A.stride(1) == 1);
-
   using std::get;
+  assert(get<1>(A.strides()) == 1);
+
   assert(get<0>(A.sizes()) == get<1>(A.sizes()));
   int lwork = -1;
   getri_bufferSize(A.size(), pointer_dispatch(A.origin()), A.stride(), lwork);
@@ -67,8 +67,9 @@ int getri_optimal_workspace_size(MultiArray2D&& A)
 template<class MultiArray2D, class MultiArray1D, class Buffer>
 MultiArray2D&& getri(MultiArray2D&& A, MultiArray1D const& IPIV, Buffer&& WORK)
 {
+  using std::get;
   //  assert(A.stride() > std::max(std::size_t(1), A.size(1)));
-  assert(A.stride(1) == 1);
+  assert(get<1>(A.strides()) == 1);
   assert(IPIV.size() >= size_t(A.size()));
   assert(WORK.size() >= std::max(std::size_t(1), size_t(A.size())));
 
@@ -82,10 +83,10 @@ MultiArray2D&& getri(MultiArray2D&& A, MultiArray1D const& IPIV, Buffer&& WORK)
 template<class MultiArray2D>
 int geqrf_optimal_workspace_size(MultiArray2D&& A)
 {
-  assert(A.stride() > 0);
-  assert(A.stride(1) == 1);
-
   using std::get;
+  assert(A.stride() > 0);
+  assert(get<1>(A.strides()) == 1);
+
   int res;
   geqrf_bufferSize(get<1>(A.sizes()), get<0>(A.sizes()), pointer_dispatch(A.origin()), A.stride(), res);
   return res;
@@ -97,7 +98,7 @@ MultiArray2D&& geqrf(MultiArray2D&& A, Array1D&& TAU, Buffer&& WORK)
   using std::get;
   // why was this here???
   //assert(A.stride() > std::max(std::size_t(1), A.size(0)));
-  assert(A.stride(1) == 1);
+  assert(get<1>(A.strides()) == 1);
   assert(TAU.stride() == 1);
   assert(TAU.size() >= std::max(std::size_t(1), size_t(std::min(get<0>(A.sizes()), get<1>(A.sizes())))));
   assert(WORK.size() >= std::max(std::size_t(1), size_t(A.size())));
@@ -112,10 +113,10 @@ MultiArray2D&& geqrf(MultiArray2D&& A, Array1D&& TAU, Buffer&& WORK)
 template<class MultiArray2D>
 int gelqf_optimal_workspace_size(MultiArray2D&& A)
 {
-  assert(A.stride() > 0);
-  assert(A.stride(1) == 1);
-
   using std::get;
+  assert(A.stride() > 0);
+  assert(get<1>(A.strides()) == 1);
+
   int res;
   gelqf_bufferSize(get<1>(A.sizes()), get<0>(A.sizes()), pointer_dispatch(A.origin()), A.stride(), res);
   return res;
@@ -125,8 +126,8 @@ template<class MultiArray2D, class Array1D, class Buffer>
 MultiArray2D&& gelqf(MultiArray2D&& A, Array1D&& TAU, Buffer&& WORK)
 {
   using std::get;
-  assert(A.stride(1) > 0);
-  assert(A.stride(1) == 1);
+  assert(get<1>(A.strides()) > 0);
+  assert(get<1>(A.strides()) == 1);
   assert(TAU.stride() == 1);
   assert(TAU.size() >= std::max(std::size_t(1), size_t(std::min(get<0>(A.sizes()), get<1>(A.sizes())))));
   assert(WORK.size() >= std::max(std::size_t(1), size_t(get<1>(A.sizes()))));
@@ -143,10 +144,10 @@ MultiArray2D&& gelqf(MultiArray2D&& A, Array1D&& TAU, Buffer&& WORK)
 template<class MultiArray2D>
 int gqr_optimal_workspace_size(MultiArray2D&& A)
 {
-  assert(A.stride() > 0);
-  assert(A.stride(1) == 1);
-
   using std::get;
+  assert(A.stride() > 0);
+  assert(get<1>(A.strides()) == 1);
+
   int res;
   gqr_bufferSize(get<1>(A.sizes()), get<0>(A.sizes()), std::max(std::size_t(1), size_t(std::min(get<0>(A.sizes()), get<1>(A.sizes())))),
                  pointer_dispatch(A.origin()), A.stride(), res);
@@ -157,7 +158,7 @@ template<class MultiArray2D, class Array1D, class Buffer>
 MultiArray2D&& gqr(MultiArray2D&& A, Array1D&& TAU, Buffer&& WORK)
 {
   using std::get;
-  assert(A.stride(1) == 1);
+  assert(get<1>(A.strides()) == 1);
   assert(TAU.stride() == 1);
   assert(TAU.size() >= std::max(std::size_t(1), size_t(std::min(get<0>(A.sizes()), get<1>(A.sizes())))));
   assert(WORK.size() >= std::max(std::size_t(1), size_t(A.size())));
@@ -173,10 +174,10 @@ MultiArray2D&& gqr(MultiArray2D&& A, Array1D&& TAU, Buffer&& WORK)
 template<class MultiArray2D>
 int glq_optimal_workspace_size(MultiArray2D&& A)
 {
-  assert(A.stride() > 0);
-  assert(A.stride(1) == 1);
-
   using std::get;
+  assert(A.stride() > 0);
+  assert(get<1>(A.strides()) == 1);
+
   int res;
   glq_bufferSize(get<1>(A.sizes()), get<0>(A.sizes()), std::max(std::size_t(1), size_t(std::min(get<0>(A.sizes()), get<1>(A.sizes())))),
                  pointer_dispatch(A.origin()), A.stride(), res);
@@ -188,7 +189,7 @@ MultiArray2D&& glq(MultiArray2D&& A, Array1D&& TAU, Buffer&& WORK)
 {
   using std::get;
 
-  assert(A.stride(1) == 1);
+  assert(get<1>(A.strides()) == 1);
   assert(TAU.stride() == 1);
   assert(TAU.size() >= std::max(std::size_t(1), size_t(std::min(get<0>(A.sizes()), get<1>(A.sizes())))));
   assert(WORK.size() >= std::max(std::size_t(1), size_t(get<1>(A.sizes()))));
@@ -214,10 +215,10 @@ MultiArray2D&& potrf(MultiArray2D&& A)
 template<class MultiArray2D>
 int gesvd_optimal_workspace_size(MultiArray2D&& A)
 {
-  assert(A.stride() > 0);
-  assert(A.stride(1) == 1);
-
   using std::get;
+  assert(A.stride() > 0);
+  assert(get<1>(A.strides()) == 1);
+
   int res;
   gesvd_bufferSize(get<1>(A.sizes()), get<0>(A.sizes()), pointer_dispatch(A.origin()), res);
   return res;
@@ -233,10 +234,10 @@ MultiArray2D&& gesvd(char jobU,
                      Buffer&& WORK,
                      RBuffer&& RWORK)
 {
-  assert(A.stride(1) > 0);
-  assert(A.stride(1) == 1);
-
   using std::get;
+  assert(get<1>(A.strides()) > 0);
+  assert(get<1>(A.strides()) == 1);
+
 
   // in C: A = U * S * VT
   // in F: At = (U * S * VT)t = VTt * S * Ut
@@ -263,7 +264,7 @@ std::pair<MultiArray1D, MultiArray2D> symEig(MultiArray2D const& A)
 
   using std::get;
   assert(A.size() == get<1>(A.sizes()));
-  assert(A.stride(1) == 1);
+  assert(get<1>(A.strides()) == 1);
   assert(A.size() > 0);
   int N   = A.size();
   int LDA = A.stride();
@@ -338,7 +339,7 @@ std::pair<MultiArray1D, MultiArray2D> symEigSelect(MultiArray2DA& A, int neig)
 
   using std::get;
   assert(get<0>(A.sizes()) == get<1>(A.sizes()));
-  assert(A.stride(1) == 1);
+  assert(get<1>(A.strides()) == 1);
   assert(get<0>(A.sizes()) > 0);
   int N   = get<0>(A.sizes());
   int LDA = A.stride();
@@ -420,9 +421,9 @@ std::pair<MultiArray1D, MultiArray2D> genEigSelect(MultiArray2DA& A, MultiArray2
   assert(get<0>(A.sizes()) == get<1>(A.sizes()));
   assert(get<0>(A.sizes()) == get<0>(S.sizes()));
   assert(get<0>(S.sizes()) == get<1>(S.sizes()));
-  assert(A.stride(1) == 1);
+  assert(get<1>(A.strides()) == 1);
   assert(get<0>(A.sizes()) > 0);
-  assert(S.stride(1) == 1);
+  assert(get<1>(S.strides()) == 1);
   assert(get<0>(S.sizes()) > 0);
   int N   = get<0>(A.sizes());
   int LDA = A.stride();

--- a/src/AFQMC/Numerics/ma_operations.hpp
+++ b/src/AFQMC/Numerics/ma_operations.hpp
@@ -247,6 +247,7 @@ template<
     >
 MultiArray2DC&& product(T alpha, SparseMatrixA const& A, MultiArray2DB const& B, T beta, MultiArray2DC&& C)
 {
+  using std::get;
   using elementA = std::remove_cv_t<typename SparseMatrixA::element>;
   using elementB = std::remove_cv_t<typename MultiArray2DB::element>;
   using elementC = typename std::decay<MultiArray2DC>::type::element;
@@ -256,10 +257,9 @@ MultiArray2DC&& product(T alpha, SparseMatrixA const& A, MultiArray2DB const& B,
   assert(op_tag<SparseMatrixA>::value == 'N' || op_tag<SparseMatrixA>::value == 'T' ||
          op_tag<SparseMatrixA>::value == 'C' || op_tag<SparseMatrixA>::value == 'H');
   assert(op_tag<MultiArray2DB>::value == 'N');
-  assert(arg(B).stride(1) == 1);
-  assert(std::forward<MultiArray2DC>(C).stride(1) == 1);
+  assert(get<1>(arg(B).strides()) == 1);
+  assert(get<1>(std::forward<MultiArray2DC>(C).strides()) == 1);
 
-  using std::get;
   if (op_tag<SparseMatrixA>::value == 'N')
   {
     assert(arg(A).size() == std::forward<MultiArray2DC>(C).size());

--- a/src/AFQMC/Propagators/generate1BodyPropagator.hpp
+++ b/src/AFQMC/Propagators/generate1BodyPropagator.hpp
@@ -48,7 +48,7 @@ P_Type generate1BodyPropagator(TaskGroup_& TG,
   using std::get;
   assert(H1.dimensionality == 2);
   assert(get<0>(H1.sizes()) == get<1>(H1.sizes()));
-  assert(H1.stride(1) == 1);
+  assert(get<1>(H1.strides()) == 1);
   int NMO = H1.size();
   if (TG.TG_local().root())
   {
@@ -87,10 +87,10 @@ P_Type generate1BodyPropagator(TaskGroup_& TG,
   using std::get;
   assert(H1.dimensionality == 2);
   assert(get<0>(H1.sizes()) == get<1>(H1.sizes()));
-  assert(H1.stride(1) == 1);
+  assert(get<1>(H1.strides()) == 1);
   assert(H1ext.dimensionality == 2);
   assert(get<0>(H1ext.sizes()) == get<1>(H1ext.sizes()));
-  assert(H1ext.stride(1) == 1);
+  assert(get<1>(H1ext.strides()) == 1);
   assert(get<0>(H1.sizes()) == get<1>(H1ext.sizes()));
   int NMO = H1.size();
   if (TG.TG_local().root())

--- a/src/AFQMC/SlaterDeterminantOperations/apply_expM.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/apply_expM.hpp
@@ -156,12 +156,12 @@ inline void apply_expM(const MatA& V, MatB&& S, MatC& T1, MatC& T2, int order = 
   assert(S.stride() == get<1>(S.sizes()) * get<2>(S.sizes()));
   assert(T1.stride() == get<1>(T1.sizes()) * get<2>(T1.sizes()));
   assert(T2.stride() == get<1>(T2.sizes()) * get<2>(T2.sizes()));
-  assert(S.stride(1) == get<2>(S.sizes()));
-  assert(T1.stride(1) == get<2>(T1.sizes()));
-  assert(T2.stride(1) == get<2>(T2.sizes()));
-  assert(S.stride(2) == 1);
-  assert(T1.stride(2) == 1);
-  assert(T2.stride(2) == 1);
+  assert(get<1>(S.strides()) == get<2>(S.sizes()));
+  assert(get<1>(T1.strides()) == get<2>(T1.sizes()));
+  assert(get<1>(T2.strides()) == get<2>(T2.sizes()));
+  assert(get<2>(S.strides()) == 1);
+  assert(get<2>(T1.strides()) == 1);
+  assert(get<2>(T2.strides()) == 1);
 
   using ComplexType = typename std::decay<MatB>::type::element;
   ComplexType zero(0.);
@@ -216,12 +216,12 @@ inline void apply_expM_noncollinear(const MatA& V, MatB&& S, MatC& T1, MatC& T2,
   assert(S.stride() == get<1>(S.sizes()) * get<2>(S.sizes()));
   assert(T1.stride() == get<1>(T1.sizes()) * get<2>(T1.sizes()));
   assert(T2.stride() == get<1>(T2.sizes()) * get<2>(T2.sizes()));
-  assert(S.stride(1) == get<2>(S.sizes()));
-  assert(T1.stride(1) == get<2>(T1.sizes()));
-  assert(T2.stride(1) == get<2>(T2.sizes()));
-  assert(S.stride(2) == 1);
-  assert(T1.stride(2) == 1);
-  assert(T2.stride(2) == 1);
+  assert(get<1>(S.strides()) == get<2>(S.sizes()));
+  assert(get<1>(T1.strides()) == get<2>(T1.sizes()));
+  assert(get<1>(T2.strides()) == get<2>(T2.sizes()));
+  assert(get<2>(S.strides()) == 1);
+  assert(get<2>(T1.strides()) == 1);
+  assert(get<2>(T2.strides()) == 1);
 
   using ComplexType = typename std::decay<MatB>::type::element;
   ComplexType zero(0.);
@@ -235,7 +235,7 @@ inline void apply_expM_noncollinear(const MatA& V, MatB&& S, MatC& T1, MatC& T2,
   using pointerC = typename std::decay<MatC>::type::element_ptr;
 
   int nbatch = S.size();
-  int ldv    = V.stride(1);
+  int ldv    = get<1>(V.strides());
   int M      = get<2>(T2.sizes());
   int N      = get<1>(T2.sizes());
   int K      = get<1>(T1.sizes());
@@ -268,8 +268,8 @@ inline void apply_expM_noncollinear(const MatA& V, MatB&& S, MatC& T1, MatC& T2,
     ComplexType fact = im * static_cast<ComplexType>(1.0 / static_cast<double>(n));
     using ma::gemmBatched;
     // careful with fortran ordering
-    gemmBatched('N', TA, M, N, K, fact, pT1i->data(), (*pT1).stride(1), Vi.data(), ldv, zero, pT2i->data(),
-                (*pT2).stride(1), nbatch);
+    gemmBatched('N', TA, M, N, K, fact, pT1i->data(), get<1>((*pT1).strides()), Vi.data(), ldv, zero, pT2i->data(),
+                get<1>((*pT2).strides()), nbatch);
     using ma::axpy;
     axpy(S.num_elements(), ComplexType(1.0), (*pT2).origin(), 1, S.origin(), 1);
     std::swap(pT1, pT2);

--- a/src/AFQMC/SlaterDeterminantOperations/mixed_density_matrix.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/mixed_density_matrix.hpp
@@ -1036,14 +1036,14 @@ void MixedDensityMatrix(std::vector<MatA>& hermA,
     assert(get<2>(TNM3D.sizes()) == NMO);
   }
   assert(IWORK.num_elements() >= nbatch * (NEL + 1));
-  assert(TNN3D.stride(1) == NEL); // needed by getriBatched
+  assert(get<1>(TNN3D.strides()) == NEL); // needed by getriBatched
 
   using element = typename std::decay<MatC>::type::element;
   using pointer = typename std::decay<MatC>::type::element_ptr;
 
   int ldw = (*Bi[0]).stride();
-  int ldN = TNN3D.stride(1);
-  int ldC = C.stride(1);
+  int ldN = get<1>(TNN3D.strides());
+  int ldC = get<1>(C.strides());
   std::vector<pointer> Carray;
   std::vector<pointer> Warray;
   std::vector<pointer> NNarray;
@@ -1097,7 +1097,7 @@ void MixedDensityMatrix(std::vector<MatA>& hermA,
   {
     if (herm)
     {
-      int ldM = TNM3D.stride(1);
+      int ldM = get<1>(TNM3D.strides());
       std::vector<pointer> NMarray;
       std::vector<decltype(&TNM3D[0])> TNMi;
       NMarray.reserve(nbatch);
@@ -1128,7 +1128,7 @@ void MixedDensityMatrix(std::vector<MatA>& hermA,
       for (int b = 0; b < nbatch; ++b)
         ma::product(TNN3D[b], H(*hermA[b]), TNM3D[b]);
 
-      int ldM = TNM3D.stride(1);
+      int ldM = get<1>(TNM3D.strides());
       std::vector<pointer> NMarray;
       NMarray.reserve(nbatch);
       for (int i = 0; i < nbatch; i++)
@@ -1198,7 +1198,7 @@ void DensityMatrices(std::vector<MatA> const& Left,
 
   int ldR = (*Right[0]).stride();
   int ldL = (*Left[0]).stride();
-  int ldN = TNN3D.stride(1);
+  int ldN = get<1>(TNN3D.strides());
   int ldG = (*G[0]).stride();
   std::vector<pointer> Garray;
   std::vector<pointer> Rarray;
@@ -1246,7 +1246,7 @@ void DensityMatrices(std::vector<MatA> const& Left,
   }
   else
   {
-    int ldM = TNM3D.stride(1);
+    int ldM = get<1>(TNM3D.strides());
     std::vector<pointer> NMarray;
     NMarray.reserve(nbatch);
     for (int i = 0; i < nbatch; i++)
@@ -1313,7 +1313,7 @@ void Overlap(std::vector<MatA>& hermA,
   using pointer = typename std::decay<Mat>::type::element_ptr;
 
   int ldw = (*Bi[0]).stride();
-  int ldN = TNN3D.stride(1);
+  int ldN = get<1>(TNN3D.strides());
   std::vector<pointer> Warray;
   std::vector<pointer> NNarray;
   std::vector<decltype(&TNN3D[0])> Ci;

--- a/src/AFQMC/Utilities/type_conversion.hpp
+++ b/src/AFQMC/Utilities/type_conversion.hpp
@@ -171,7 +171,7 @@ template<class VType, class MType,
 void emplace_back_array_ref(VType& V, MType&& M, bool device=true) {
   // noly makes sense for continguous arrays
   assert(M.stride() == M.size(1));
-  assert(M.stride(1) == 1);
+  assert(get<1>(M.strides()) == 1);
   if(device) {  
     V.emplace_back(make_device_ptr(M.origin()),iextensions<2u>{M.size(0),M.size(1)});
   } else {

--- a/src/AFQMC/Walkers/WalkerControl.hpp
+++ b/src/AFQMC/Walkers/WalkerControl.hpp
@@ -54,7 +54,7 @@ inline int swapWalkersSimple(WlkBucket& wset,
   static_assert(std::decay<Mat>::type::dimensionality == 2, "Wrong dimensionality");
   if (wlk_size != get<1>(Wexcess.sizes()))
     throw std::runtime_error("Array dimension error in swapWalkersSimple().");
-  if (1 != Wexcess.stride(1))
+  if (1 != get<1>(Wexcess.strides()))
     throw std::runtime_error("Array shape error in swapWalkersSimple().");
   if (CurrNumPerNode.size() < NumContexts || NewNumPerNode.size() < NumContexts)
     throw std::runtime_error("Array dimension error in swapWalkersSimple().");
@@ -123,7 +123,7 @@ inline int swapWalkersAsync(WlkBucket& wset,
   static_assert(std::decay<Mat>::type::dimensionality == 2, "Wrong dimensionality");
   if (wlk_size != get<1>(Wexcess.sizes()))
     throw std::runtime_error("Array dimension error in swapWalkersAsync().");
-  if (1 != Wexcess.stride(1) || (get<0>(Wexcess.sizes()) > 0 && get<1>(Wexcess.sizes()) != Wexcess.stride()))
+  if (1 != get<1>(Wexcess.strides()) || (get<0>(Wexcess.sizes()) > 0 && get<1>(Wexcess.sizes()) != Wexcess.stride()))
     throw std::runtime_error("Array shape error in swapWalkersAsync().");
   if (CurrNumPerNode.size() < NumContexts || NewNumPerNode.size() < NumContexts)
     throw std::runtime_error("Array dimension error in swapWalkersAsync().");

--- a/src/AFQMC/Walkers/WalkerSetBase.h
+++ b/src/AFQMC/Walkers/WalkerSetBase.h
@@ -31,6 +31,7 @@
 
 namespace qmcplusplus
 {
+  using std::get;
 namespace afqmc
 {
 /*
@@ -167,7 +168,6 @@ public:
    */
   iterator begin()
   {
-    using std::get;
     assert(get<1>(walker_buffer.sizes()) == walker_size);
     return iterator(0, boost::multi::static_array_cast<element, pointer>(walker_buffer), data_displ, wlk_desc);
   }
@@ -177,7 +177,6 @@ public:
    */
   const_iterator begin() const
   {
-    using std::get;
     assert(get<1>(walker_buffer.sizes()) == walker_size);
     return const_iterator(0, boost::multi::static_array_cast<element, pointer>(walker_buffer), data_displ, wlk_desc);
   }
@@ -187,7 +186,6 @@ public:
    */
   iterator end()
   {
-    using std::get;
     assert(get<1>(walker_buffer.sizes()) == walker_size);
     return iterator(tot_num_walkers, boost::multi::static_array_cast<element, pointer>(walker_buffer), data_displ,
                     wlk_desc);
@@ -198,7 +196,6 @@ public:
    */
   reference operator[](int i)
   {
-    using std::get;
     if (i < 0 || i > tot_num_walkers)
       APP_ABORT("error: index out of bounds.\n");
     assert(get<1>(walker_buffer.sizes()) == walker_size);
@@ -212,7 +209,6 @@ public:
   {
     if (i < 0 || i > tot_num_walkers)
       APP_ABORT("error: index out of bounds.\n");
-    using std::get;
     assert(get<1>(walker_buffer.sizes()) == walker_size);
     return const_reference(boost::multi::static_array_cast<element, pointer>(walker_buffer.const_array_cast())[i], data_displ, wlk_desc);
   }
@@ -248,7 +244,6 @@ public:
   template<class MatA, class MatB>
   void resize(int n, MatA&& A, MatB&& B)
   {
-    using std::get;
     assert(get<0>(A.sizes()) == wlk_desc[0]);
     assert(get<1>(A.sizes()) == wlk_desc[1]);
     if (walkerType == COLLINEAR)
@@ -302,7 +297,6 @@ public:
 
   void resize_bp(int nbp, int nCV, int nref)
   {
-    using std::get;
 
     assert(get<1>(walker_buffer.sizes()) == walker_size);
     assert(bp_buffer.size() == bp_walker_size);
@@ -355,7 +349,6 @@ public:
       data_displ[SM_AUX] = walker_size;
       walker_size += nrow * ncol;
       CMatrix wb({get<0>(walker_buffer.sizes()), walker_size}, walker_buffer.get_allocator());
-      using std::get;
       ma::copy(walker_buffer, wb(get<0>(wb.extensions()), {0, sz}));
       walker_buffer = std::move(wb);
     }
@@ -371,7 +364,6 @@ public:
 
   int GlobalPopulation() const
   {
-    using std::get;
 
     int res = 0;
     assert(get<1>(walker_buffer.sizes()) == walker_size);
@@ -382,7 +374,6 @@ public:
 
   RealType GlobalWeight() const
   {
-    using std::get;
 
     RealType res = 0;
     assert(get<1>(walker_buffer.sizes()) == walker_size);
@@ -402,14 +393,13 @@ public:
   template<class Mat>
   void push_walkers(Mat&& M)
   {
-    using std::get;
 
     static_assert(std::decay<Mat>::type::dimensionality == 2, "Wrong dimensionality");
     if (tot_num_walkers + M.size() > capacity())
       APP_ABORT("Insufficient capacity");
     if (single_walker_size() + single_walker_bp_size() != get<1>(M.sizes()))
       APP_ABORT("Incorrect dimensions.");
-    if (M.stride(1) != 1)
+    if (get<1>(M.strides()) != 1)
       APP_ABORT("Incorrect strides.");
     if (!TG.TG_local().root())
     {
@@ -421,7 +411,6 @@ public:
     for (int i = 0; i < M.size(); i++)
     {
       W[tot_num_walkers] = M[i].sliced(0, walker_size);
-      using std::get;
       if (wlk_desc[3] > 0)
         BPW(get<0>(BPW.extensions()), tot_num_walkers) = M[i].sliced(walker_size, walker_size + bp_walker_size);
       tot_num_walkers++;
@@ -431,7 +420,6 @@ public:
   template<class Mat>
   void pop_walkers(Mat&& M)
   {
-    using std::get;
     static_assert(std::decay<Mat>::type::dimensionality == 2, "Wrong dimensionality");
     if (tot_num_walkers < int(M.size()))
       APP_ABORT("Insufficient walkers");
@@ -445,7 +433,7 @@ public:
       if (walker_size != int(get<1>(M.sizes())))
         APP_ABORT("Incorrect dimensions.");
     }
-    if (M.stride(1) != 1)
+    if (get<1>(M.strides()) != 1)
       APP_ABORT("Incorrect strides.");
 
     if (!TG.TG_local().root())
@@ -470,7 +458,6 @@ public:
               std::vector<std::pair<double, int>>::iterator itend,
               Mat& M)
   {
-    using std::get;
 
     if (std::distance(itbegin, itend) != tot_num_walkers)
       APP_ABORT("Error in WalkerSetBase::branch(): ptr_range != # walkers. \n");
@@ -523,7 +510,6 @@ public:
         // 3. swap
         std::swap(*kill, *keep);
         W[std::distance(itbegin, kill)] = W[tot_num_walkers - 1];
-        using std::get;
         if (wlk_desc[3] > 0)
           BPW(get<0>(BPW.extensions()), std::distance(itbegin, kill)) = BPW(get<0>(BPW.extensions()), tot_num_walkers - 1);
         --tot_num_walkers;
@@ -574,7 +560,6 @@ public:
         fill_n(W[pos].origin() + data_displ[WEIGHT], 1, ComplexType(itbegin->first, 0.0));
         if (wlk_desc[6] > 0 && his_pos >= 0 && his_pos < wlk_desc[6])
           fill_n(BPW[data_displ[WEIGHT_HISTORY] + his_pos].origin() + pos, 1, ComplexType(itbegin->first, 0.0));
-        using std::get;
         for (int i = 0; i < n; i++)
         {
           W[tot_num_walkers] = W[pos];
@@ -595,7 +580,6 @@ public:
   template<class T>
   void scaleWeight(const T& w0, bool scale_last_history = false)
   {
-    using std::get;
 
     if (!TG.TG_local().root())
       return;
@@ -653,7 +637,6 @@ public:
   template<class Vec>
   void copyToIO(Vec&& x, int n)
   {
-    using std::get;
 
     assert(n < tot_num_walkers);
     assert(x.size() >= walkerSizeIO());
@@ -666,7 +649,6 @@ public:
   template<class Vec>
   void copyFromIO(Vec&& x, int n)
   {
-    using std::get;
 
     assert(n < tot_num_walkers);
     assert(x.size() >= walkerSizeIO());
@@ -713,14 +695,12 @@ public:
     if (ip < 0 || ip > wlk_desc[3])
       APP_ABORT(" Error: index out of bounds in getFields. \n");
 
-    using std::get;
     int skip = (data_displ[FIELDS] + ip * wlk_desc[4]) * get<1>(bp_buffer.sizes());
     return stdCMatrix_ptr(to_address(bp_buffer.origin()) + skip, {wlk_desc[4], get<1>(bp_buffer.sizes())});
   }
 
   stdCTensor_ptr getFields()
   {
-    using std::get;
     return stdCTensor_ptr(to_address(bp_buffer.origin()) + data_displ[FIELDS] * get<1>(bp_buffer.sizes()),
                           {wlk_desc[3], wlk_desc[4], get<1>(bp_buffer.sizes())});
   }
@@ -728,7 +708,6 @@ public:
   template<class Mat>
   void storeFields(int ip, Mat&& V)
   {
-    using std::get;
     static_assert(std::decay<Mat>::type::dimensionality == 2, "Wrong dimensionality");
     auto&& F(*getFields(ip));
     if (V.stride() == get<1>(V.sizes()))
@@ -742,14 +721,12 @@ public:
 
   stdCMatrix_ptr getWeightFactors()
   {
-    using std::get;
     return stdCMatrix_ptr(to_address(bp_buffer.origin()) + data_displ[WEIGHT_FAC] * get<1>(bp_buffer.sizes()),
                           {wlk_desc[6], get<1>(bp_buffer.sizes())});
   }
 
   stdCMatrix_ptr getWeightHistory()
   {
-    using std::get;
     return stdCMatrix_ptr(to_address(bp_buffer.origin()) + data_displ[WEIGHT_HISTORY] * get<1>(bp_buffer.sizes()),
                           {wlk_desc[6], get<1>(bp_buffer.sizes())});
   }
@@ -762,7 +739,6 @@ public:
   // LogOverlapFactor_new = LogOverlapFactor + f/nx
   void adjustLogOverlapFactor(const double f)
   {
-    using std::get;
     assert(get<1>(walker_buffer.sizes()) == walker_size);
     double nx = (walkerType == NONCOLLINEAR ? 1.0 : 2.0);
     if (TG.TG_local().root())

--- a/src/AFQMC/Wavefunctions/PHMSD.icc
+++ b/src/AFQMC/Wavefunctions/PHMSD.icc
@@ -421,12 +421,12 @@ void PHMSD::Energy_distributed(const WlkSet& wset, Mat&& E, TVec&& Ov)
 template<class WlkSet, class MatG, class TVec>
 void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool compact, bool transpose)
 {
+  using std::get;
   // if not compact, calculate compact on temporary storage and multiply by OrbMat[] on the left at the end.
   using ma::T;
-  assert(G.stride(1) == 1);
+  assert(get<1>(G.strides()) == 1);
   assert(Ov.stride() == 1);
 
-  using std::get;
   if (transpose)
     assert(get<0>(G.sizes()) == wset.size() && get<1>(G.sizes()) == size_t(dm_size(not compact)));
   else
@@ -573,7 +573,6 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
         if (compact)
         {
           ma::product(T(Rb), GB2D0_, GB2D_);
-          using std::get;
           //G({GAdims.first*GAdims.second,get<0>(G.sizes())},iw) = GB1D_;
           ma::copy(GB1D_, G({GAdims.first * GAdims.second, get<0>(G.sizes())}, iw));
         }
@@ -688,7 +687,6 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
             boost::multi::array_ref<ComplexType, 3> Gw(to_address(G.origin()),
                                                        {GAdims.first, GAdims.second, long(get<1>(G.sizes()))});
             // copying by hand for now, implement strided copy in ma_blas
-            using std::get;
             for (size_t k = 0; k < get<0>(GA2D_.sizes()); ++k)
               for (size_t m = M0; m < Mn; ++m)
                 Gw[k][m][iw] = GA2D_[k][m];
@@ -699,7 +697,6 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
                         GA2D_(GA2D_.extension(0), {M0, Mn})); // can be local
             ma::product(T(OrbMats[0]), GA2D_(GA2D_.extension(0), {M0, Mn}),
                         Gfulla(Gfulla.extension(0), {M0, Mn})); // can be local
-            using std::get;
             boost::multi::array_ref<ComplexType, 3> Gw(to_address(G.origin()),
                                                        {long(get<0>(Gfulla.sizes())), long(get<1>(Gfulla.sizes())), long(get<1>(G.sizes()))});
             // copying by hand for now, implement strided copy in ma_blas
@@ -738,11 +735,9 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
           {
             ma::product(T(Rb), GB2D0_shm(GB2D0_shm.extension(0), {M0, Mn}),
                         GB2D_(GB2D_.extension(0), {M0, Mn})); // can be local
-            using std::get;
             boost::multi::array_ref<ComplexType, 3> Gw(to_address(G[GAdims.first * GAdims.second].origin()),
                                                        {GBdims.first, GBdims.second, long(get<1>(G.sizes()))});
             // copying by hand for now, implement strided copy in ma_blas
-            using std::get;
             for (size_t k = 0; k < get<0>(GB2D_.sizes()); ++k)
               for (size_t m = M0; m < Mn; ++m)
                 Gw[k][m][iw] = GB2D_[k][m];
@@ -753,7 +748,6 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
                         GB2D_(GB2D_.extension(0), {M0, Mn})); // can be local
             ma::product(T(OrbMats[0]), GB2D_(GB2D_.extension(0), {M0, Mn}),
                         Gfullb(Gfullb.extension(0), {M0, Mn})); // can be local
-            using std::get;
             boost::multi::array_ref<ComplexType, 3> Gw(to_address(G[Gfulla.num_elements()].origin()),
                                                        {long(get<0>(Gfullb.sizes())), long(get<1>(Gfullb.sizes())), long(get<1>(G.sizes()))});
             // copying by hand for now, implement strided copy in ma_blas
@@ -806,7 +800,8 @@ void PHMSD::DensityMatrix_shared(const WlkSet& wset,
                                  bool compact,
                                  bool transposed)
 {
-  assert(G.stride(1) == 1);
+  using std::get;
+  assert(get<1>(G.strides()) == 1);
   assert(Ov.stride() == 1);
   if (transposed)
     assert(G.size(0) == wset.size() && G.size(1) == size_t(dm_size(not compact)));
@@ -824,7 +819,6 @@ void PHMSD::DensityMatrix_shared(const WlkSet& wset,
   if (localGbuff.size() < Gsize)
     localGbuff.reextent(iextensions<1u>{Gsize});
 
-  using std::get;
   if (walker_type != COLLINEAR)
   {
     if (herm)


### PR DESCRIPTION
## Proposed changes

.stride(d) is deprecated in Multi.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 26.04


## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [  ] Code added or changed in the PR has been clang-formatted
* * [  ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [  ] Documentation has been added (if appropriate)
