### PR TITLE
remove last runtime strides

### DIFF
--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
@@ -529,12 +529,12 @@ public:
       if (getKr)
       {
         assert(get<0>(KEright->sizes()) == nwalk && get<1>(KEright->sizes()) == local_nCV);
-        assert(KEright->stride(0) == get<1>(KEright->sizes()));
+        assert(KEright->stride() == get<1>(KEright->sizes()));
       }
       if (getKl)
       {
         assert(get<0>(KEleft->sizes()) == nwalk && get<1>(KEleft->sizes()) == local_nCV);
-        assert(KEleft->stride(0) == get<1>(KEleft->sizes()));
+        assert(KEleft->stride() == get<1>(KEleft->sizes()));
       }
     }
     else if (getKr or getKl)
@@ -845,7 +845,7 @@ public:
 #if defined(MIXED_PRECISION)
         if(getKr) {
           assert(KEright->size(0) == nwalk && KEright->size(1) == local_nCV);
-          assert(KEright->stride(0) == KEright->size(1));
+          assert(KEright->stride() == KEright->size(1));
         }
 #else
         if(getKr) {
@@ -861,12 +861,12 @@ public:
 #if defined(MIXED_PRECISION)
         if(getKl) {
           assert(KEleft->size(0) == nwalk && KEleft->size(1) == local_nCV);
-          assert(KEleft->stride(0) == KEleft->size(1));
+          assert(KEleft->stride() == KEleft->size(1));
         }
 #else
         if(getKl) {
           assert(KEleft->size(0) == nwalk && KEleft->size(1) == local_nCV);
-          assert(KEleft->stride(0) == KEleft->size(1));
+          assert(KEleft->stride() == KEleft->size(1));
           Klptr = make_device_ptr(KEleft->origin());
         } else 
 #endif

--- a/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
@@ -363,7 +363,7 @@ public:
       if (getKr)
       {
         assert(KEright->size(0) == nwalk && KEright->size(1) == nGu);
-        assert(KEright->stride(0) == KEright->size(1));
+        assert(KEright->stride() == KEright->size(1));
         Krptr = to_address(KEright->origin());
       }
       else
@@ -374,7 +374,7 @@ public:
       if (getKl)
       {
         assert(KEleft->size(0) == nwalk && KEleft->size(1) == nGu);
-        assert(KEleft->stride(0) == KEleft->size(1));
+        assert(KEleft->stride() == KEleft->size(1));
         Klptr = to_address(KEleft->origin());
       }
       else

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
@@ -255,19 +255,19 @@ public:
       if (getKr)
       {
         assert(get<0>(KEright->sizes()) == nwalk && get<1>(KEright->sizes()) == local_nCV);
-        assert(KEright->stride(0) == get<1>(KEright->sizes()));
+        assert(KEright->stride() == get<1>(KEright->sizes()));
       }
 #if defined(MIXED_PRECISION)
       if (getKl)
       {
         assert(get<0>(KEleft->sizes()) == nwalk && get<1>(KEleft->sizes()) == local_nCV);
-        assert(KEleft->stride(0) == get<1>(KEleft->sizes()));
+        assert(KEleft->stride() == get<1>(KEleft->sizes()));
       }
 #else
       if (getKl)
       {
         assert(get<0>(KEleft->sizes()) == nwalk && get<1>(KEleft->sizes()) == local_nCV);
-        assert(KEleft->stride(0) == get<1>(KEleft->sizes()));
+        assert(KEleft->stride() == get<1>(KEleft->sizes()));
         Klptr = to_address(KEleft->origin());
       }
       else

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched.hpp
@@ -244,19 +244,19 @@ public:
       if (getKr)
       {
         assert(KEright->size(0) == nwalk && KEright->size(1) == local_nCV);
-        assert(KEright->stride(0) == KEright->size(1));
+        assert(KEright->stride() == KEright->size(1));
       }
 #if defined(MIXED_PRECISION)
       if (getKl)
       {
         assert(KEleft->size(0) == nwalk && KEleft->size(1) == local_nCV);
-        assert(KEleft->stride(0) == KEleft->size(1));
+        assert(KEleft->stride() == KEleft->size(1));
       }
 #else
       if (getKl)
       {
         assert(KEleft->size(0) == nwalk && KEleft->size(1) == local_nCV);
-        assert(KEleft->stride(0) == KEleft->size(1));
+        assert(KEleft->stride() == KEleft->size(1));
         Klptr = make_device_ptr(KEleft->origin());
       }
       else

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
@@ -259,12 +259,12 @@ public:
       if (getKr)
       {
         assert(get<0>(KEright->sizes()) == nwalk && get<1>(KEright->sizes()) == local_nCV);
-        assert(KEright->stride(0) == get<1>(KEright->sizes()));
+        assert(KEright->stride() == get<1>(KEright->sizes()));
       }
       if (getKl)
       {
         assert(get<0>(KEleft->sizes()) == nwalk && get<1>(KEleft->sizes()) == local_nCV);
-        assert(KEleft->stride(0) == get<1>(KEleft->sizes()));
+        assert(KEleft->stride() == get<1>(KEleft->sizes()));
       }
     }
     else if (getKr or getKl)


### PR DESCRIPTION
## Proposed changes

.stride(d) is deprecated in Multi.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 26.04


## Checklist

* * [x ] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [  ] Code added or changed in the PR has been clang-formatted
* * [  ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [  ] Documentation has been added (if appropriate)
