### PR TITLE
Remove unused return value of MPI calls.

### DIFF
--- a/src/Message/CommOperatorsMPI.h
+++ b/src/Message/CommOperatorsMPI.h
@@ -786,7 +786,7 @@ inline void Communicate::gatherv(std::vector<char>& l,
                                  std::vector<int>& displ,
                                  int dest)
 {
-  int ierr = MPI_Gatherv(l.data(), l.size(), MPI_CHAR, g.data(), counts.data(), displ.data(), MPI_CHAR, dest, myMPI);
+  MPI_Gatherv(l.data(), l.size(), MPI_CHAR, g.data(), counts.data(), displ.data(), MPI_CHAR, dest, myMPI);
 }
 
 
@@ -797,8 +797,7 @@ inline void Communicate::gatherv(std::vector<double>& l,
                                  std::vector<int>& displ,
                                  int dest)
 {
-  int ierr =
-      MPI_Gatherv(l.data(), l.size(), MPI_DOUBLE, g.data(), counts.data(), displ.data(), MPI_DOUBLE, dest, myMPI);
+  MPI_Gatherv(l.data(), l.size(), MPI_DOUBLE, g.data(), counts.data(), displ.data(), MPI_DOUBLE, dest, myMPI);
 }
 
 template<>
@@ -808,7 +807,7 @@ inline void Communicate::gatherv(std::vector<float>& l,
                                  std::vector<int>& displ,
                                  int dest)
 {
-  int ierr = MPI_Gatherv(l.data(), l.size(), MPI_FLOAT, g.data(), counts.data(), displ.data(), MPI_FLOAT, dest, myMPI);
+  MPI_Gatherv(l.data(), l.size(), MPI_FLOAT, g.data(), counts.data(), displ.data(), MPI_FLOAT, dest, myMPI);
 }
 
 template<>
@@ -818,7 +817,7 @@ inline void Communicate::gatherv(std::vector<int>& l,
                                  std::vector<int>& displ,
                                  int dest)
 {
-  int ierr = MPI_Gatherv(l.data(), l.size(), MPI_INT, g.data(), counts.data(), displ.data(), MPI_INT, dest, myMPI);
+  MPI_Gatherv(l.data(), l.size(), MPI_INT, g.data(), counts.data(), displ.data(), MPI_INT, dest, myMPI);
 }
 
 template<>
@@ -840,7 +839,7 @@ inline void Communicate::allgatherv(std::vector<int>& l,
                                     std::vector<int>& counts,
                                     std::vector<int>& displ)
 {
-  int ierr = MPI_Allgatherv(l.data(), l.size(), MPI_INT, g.data(), counts.data(), displ.data(), MPI_INT, myMPI);
+  MPI_Allgatherv(l.data(), l.size(), MPI_INT, g.data(), counts.data(), displ.data(), MPI_INT, myMPI);
 }
 
 template<>
@@ -850,25 +849,25 @@ inline void Communicate::gatherv(std::vector<long>& l,
                                  std::vector<int>& displ,
                                  int dest)
 {
-  int ierr = MPI_Gatherv(l.data(), l.size(), MPI_LONG, g.data(), counts.data(), displ.data(), MPI_LONG, dest, myMPI);
+  MPI_Gatherv(l.data(), l.size(), MPI_LONG, g.data(), counts.data(), displ.data(), MPI_LONG, dest, myMPI);
 }
 
 template<>
 inline void Communicate::gather(std::vector<double>& l, std::vector<double>& g, int dest)
 {
-  int ierr = MPI_Gather(l.data(), l.size(), MPI_DOUBLE, g.data(), l.size(), MPI_DOUBLE, dest, myMPI);
+  MPI_Gather(l.data(), l.size(), MPI_DOUBLE, g.data(), l.size(), MPI_DOUBLE, dest, myMPI);
 }
 
 template<>
 inline void Communicate::gather(std::vector<char>& l, std::vector<char>& g, int dest)
 {
-  int ierr = MPI_Gather(l.data(), l.size(), MPI_CHAR, g.data(), l.size(), MPI_CHAR, dest, myMPI);
+  MPI_Gather(l.data(), l.size(), MPI_CHAR, g.data(), l.size(), MPI_CHAR, dest, myMPI);
 }
 
 template<>
 inline void Communicate::gather(std::vector<int>& l, std::vector<int>& g, int dest)
 {
-  int ierr = MPI_Gather(l.data(), l.size(), MPI_INT, g.data(), l.size(), MPI_INT, dest, myMPI);
+  MPI_Gather(l.data(), l.size(), MPI_INT, g.data(), l.size(), MPI_INT, dest, myMPI);
 }
 
 template<>
@@ -878,14 +877,13 @@ inline void Communicate::gatherv(PooledData<double>& l,
                                  std::vector<int>& displ,
                                  int dest)
 {
-  int ierr =
-      MPI_Gatherv(l.data(), l.size(), MPI_DOUBLE, g.data(), counts.data(), displ.data(), MPI_DOUBLE, dest, myMPI);
+  MPI_Gatherv(l.data(), l.size(), MPI_DOUBLE, g.data(), counts.data(), displ.data(), MPI_DOUBLE, dest, myMPI);
 }
 
 template<>
 inline void Communicate::gather(PooledData<double>& l, PooledData<double>& g, int dest)
 {
-  int ierr = MPI_Gather(l.data(), l.size(), MPI_DOUBLE, g.data(), l.size(), MPI_DOUBLE, dest, myMPI);
+  MPI_Gather(l.data(), l.size(), MPI_DOUBLE, g.data(), l.size(), MPI_DOUBLE, dest, myMPI);
 }
 
 template<>
@@ -923,7 +921,7 @@ inline void Communicate::gsum(std::vector<std::complex<double>>& g)
 template<>
 inline void Communicate::gatherv(char* l, char* g, int n, std::vector<int>& counts, std::vector<int>& displ, int dest)
 {
-  int ierr = MPI_Gatherv(l, n, MPI_CHAR, g, counts.data(), displ.data(), MPI_CHAR, dest, myMPI);
+  MPI_Gatherv(l, n, MPI_CHAR, g, counts.data(), displ.data(), MPI_CHAR, dest, myMPI);
 }
 
 template<>
@@ -939,8 +937,7 @@ inline void Communicate::scatterv(std::vector<char>& sb,
                                   std::vector<int>& displ,
                                   int source)
 {
-  int ierr =
-      MPI_Scatterv(sb.data(), counts.data(), displ.data(), MPI_CHAR, rb.data(), rb.size(), MPI_CHAR, source, myMPI);
+  MPI_Scatterv(sb.data(), counts.data(), displ.data(), MPI_CHAR, rb.data(), rb.size(), MPI_CHAR, source, myMPI);
 }
 
 template<typename T, typename TMPI, typename IT>


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Consistently not checking the return value of MPI calls. This safe to do in MPI since we don't customize error handler and every failure is immediate abort. This reduces compiler warning about unused `ierr`.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->
Laptop


## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [ ] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
