### PR TITLE
Correct test_OneDimCubicSplineLinearGrid.cpp

### DIFF
--- a/src/Numerics/tests/test_OneDimCubicSplineLinearGrid.cpp
+++ b/src/Numerics/tests/test_OneDimCubicSplineLinearGrid.cpp
@@ -42,10 +42,8 @@ TEST_CASE("test oneDimCubicSplineLinearGrid", "[numerics]")
   for (int i = 0; i < check_xvals.size(); i++)
   {
     double r   = check_xvals[i];
-    double val = cubic_spline.splint(r);
+    double val = linear_grid_cubic_spline.splint(r);
     check_yvals.push_back(val);
-
-    //std::cout << i << " r = " << r << " val = " << val << " " << check_yvals[i] << std::endl;
   }
 
   CHECK(check_yvals[0] == Approx(0.5));


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

This unit test wasn't making the intended call.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Bugfix

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->
laptop


## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
