### PR TITLE
Disable unused formic::RowVec to prevent standard library related errors

### DIFF
--- a/src/formic/utils/matrix.cpp
+++ b/src/formic/utils/matrix.cpp
@@ -441,6 +441,8 @@ template formic::ColVec<int> formic::ConstMatrix<int>::col_as_vec(const size_t j
 template formic::ColVec<double> formic::ConstMatrix<double>::col_as_vec(const size_t j) const;
 template formic::ColVec<std::complex<double> > formic::ConstMatrix<std::complex<double> >::col_as_vec(const size_t j) const;
 
+/*
+// formic::RowVec disabled because it is not used and it triggers STL-related errors in debug
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// \brief  returns a new row vector whose elements are copied from the specified row
 ///         of this matrix
@@ -459,7 +461,7 @@ template<class S> formic::RowVec<S> formic::ConstMatrix<S>::row_as_vec(const siz
 template formic::RowVec<int> formic::ConstMatrix<int>::row_as_vec(const size_t i) const;
 template formic::RowVec<double> formic::ConstMatrix<double>::row_as_vec(const size_t i) const;
 template formic::RowVec<std::complex<double> > formic::ConstMatrix<std::complex<double> >::row_as_vec(const size_t i) const;
-
+*/
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// \brief  places the elements of the supplied vector in the specified column
 ///


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
As found by #6036  , the RowVec functionality of formic's ConstMatrix class has problems (variable signs, perhaps also constness). Since this functionality is completely unused, simply disable the functionality and add a comment.

After merge, please review #6036 

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Bugfix

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->
Ubuntu 24 desktop X86. gcc 13.3.0. 


## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
