### PR TITLE
Use PySCF 2.14.0 in dev image

### DIFF
--- a/tests/test_automation/containers/Dockerfile_gcc_mpi_develop_complete
+++ b/tests/test_automation/containers/Dockerfile_gcc_mpi_develop_complete
@@ -4,7 +4,7 @@ LABEL Description="Development version of QMCPACK and Nexus configured for use w
 SHELL ["/bin/bash", "-c"]
 
 ENV QE_VERSION="7.6"
-ENV PYSCF_VERSION=2.13.1
+ENV PYSCF_VERSION=2.14.0
 #ENV QMCPACK_VERSION="4.3.0"
 
 ARG USERNAME=qmcuser


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Version bump


## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->
Local docker build, arm


## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
