### PR TITLE
Potential fix for GCC16 SFINAE warnings

### DIFF
--- a/src/QMCDrivers/tests/WalkerConsumer.h
+++ b/src/QMCDrivers/tests/WalkerConsumer.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "Particle/Walker.h"
+#include "QMCHamiltonians/QMCHamiltonian.h"
 
 namespace qmcplusplus
 {

--- a/src/type_traits/OptionalRef.hpp
+++ b/src/type_traits/OptionalRef.hpp
@@ -13,18 +13,90 @@
 #ifndef QMCPLUSPLUS_OPTIONALREF_HPP
 #define QMCPLUSPLUS_OPTIONALREF_HPP
 
-#include <functional>
 #include <optional>
 
 namespace qmcplusplus
 {
+/** An optional, non-owning reference.
+ *
+ * This class intentionally stores a pointer instead of using
+ * std::optional<std::reference_wrapper<T>>.  In C++17, reference_wrapper
+ * examines whether T has legacy callable typedefs.  Doing so for a
+ * forward-declared T causes GCC 16's -Wsfinae-incomplete warning when T is
+ * later defined.
+ */
 template<typename T>
-using OptionalRef = std::optional<std::reference_wrapper<T>>;
+class OptionalRef
+{
+public:
+  class Reference
+  {
+  public:
+    constexpr Reference() noexcept = default;
+    constexpr Reference(T& object) noexcept : object_(&object) {}
+
+    constexpr Reference& operator=(T& object) noexcept
+    {
+      object_ = &object;
+      return *this;
+    }
+
+    constexpr T& get() const noexcept { return *object_; }
+    constexpr operator T&() const noexcept { return get(); }
+
+  private:
+    T* object_ = nullptr;
+  };
+
+  constexpr OptionalRef() noexcept = default;
+  constexpr OptionalRef(std::nullopt_t) noexcept {}
+  constexpr OptionalRef(T& object) noexcept : reference_(object), has_value_(true) {}
+
+  constexpr OptionalRef& operator=(std::nullopt_t) noexcept
+  {
+    reset();
+    return *this;
+  }
+
+  constexpr bool has_value() const noexcept { return has_value_; }
+  constexpr explicit operator bool() const noexcept { return has_value(); }
+
+  constexpr Reference& value()
+  {
+    if (!has_value_)
+      throw std::bad_optional_access();
+    return reference_;
+  }
+
+  constexpr const Reference& value() const
+  {
+    if (!has_value_)
+      throw std::bad_optional_access();
+    return reference_;
+  }
+
+  constexpr Reference& operator*() { return value(); }
+  constexpr const Reference& operator*() const { return value(); }
+  constexpr Reference* operator->() { return &value(); }
+  constexpr const Reference* operator->() const { return &value(); }
+
+  constexpr void emplace(T& object) noexcept
+  {
+    reference_ = object;
+    has_value_ = true;
+  }
+
+  constexpr void reset() noexcept { has_value_ = false; }
+
+private:
+  Reference reference_;
+  bool has_value_ = false;
+};
 
 template<typename T>
 constexpr auto makeOptionalRef(T& obj)
 {
-  return std::make_optional<std::reference_wrapper<T>>(obj);
+  return OptionalRef<T>(obj);
 }
 } // namespace qmcplusplus
 #endif


### PR DESCRIPTION
## Proposed changes

A codex proposed solution to the many SFINAE warnings put out by GCC16.

There is likely a more concise way of doing this, but essentially it built out a new OptionalRef class that avoids the problem caused by the reference_wrapper.

@ye-luo I assume you would prefer to build out an alternative solution; I'll close this PR after we have an alternative solution worked out.

Only tested for `cmake -GNinja -DCMAKE_C_COMPILER=gcc-16 -DCMAKE_CXX_COMPILER=g++-16 -DQMC_MPI=0 -DCMAKE_BUILD_TYPE=Debug ..`

After this fix is handled the only new warnings are to do with OpenMP master/masked which needs OpenMP 5.1 support to implement universally.

## What type(s) of changes does this code introduce?

- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu26 dev container using Ubuntu repo provided gcc16

## Checklist

_Update the following with an [x] where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
