### PR TITLE
Use centos10-openmpi image in ci

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -212,19 +212,19 @@ jobs:
         include:
           - jobname: GCC14-NoMPI-Debug-Real
             container:
-              image: ghcr.io/qmcpack/centos10:latest
+              image: ghcr.io/qmcpack/centos10-openmpi:latest
               options: -u 1001
           - jobname: GCC14-NoMPI-NoOMP-Real
             container:
-              image: ghcr.io/qmcpack/centos10:latest
+              image: ghcr.io/qmcpack/centos10-openmpi:latest
               options: -u 1001
           - jobname: GCC14-NoMPI-NoOMP-Complex
             container:
-              image: ghcr.io/qmcpack/centos10:latest
+              image: ghcr.io/qmcpack/centos10-openmpi:latest
               options: -u 1001
           - jobname: GCC14-NoMPI-Sandbox-Real
             container:
-              image: ghcr.io/qmcpack/centos10:latest
+              image: ghcr.io/qmcpack/centos10-openmpi:latest
               options: -u 1001
 
     steps:

--- a/CMake/CheckSIMDAlignment.cmake
+++ b/CMake/CheckSIMDAlignment.cmake
@@ -2,7 +2,7 @@
 # Since cross-compiling is not unusual on HPC systems (Cray),
 # try_compile is robust against
 try_compile(CXX_COMPILER_HAVE_AVX512_MACRO ${CMAKE_BINARY_DIR} ${PROJECT_CMAKE}/try_compile_sources/check_AVX512.cpp
-            CMAKE_FLAGS "${CMAKE_CXX_FLAGS}")
+            CMAKE_FLAGS "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
 if(CXX_COMPILER_HAVE_AVX512_MACRO)
   set(default_alignment 64)

--- a/CMake/GNUCompilers.cmake
+++ b/CMake/GNUCompilers.cmake
@@ -143,7 +143,7 @@ file(
   "#include <iostream>\n#if __GLIBC__ == 2 && ( __GLIBC_MINOR__ == 22 || __GLIBC_MINOR__ == 23 )\n#error buggy glibc version\n#endif\n int main() { return 0; }\n"
 )
 try_compile(PASS_GLIBC ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src_glibc.cxx
-            CMAKE_FLAGS "${CMAKE_CXX_FLAGS}" OUTPUT_VARIABLE COMPILE_OUTPUT)
+            CMAKE_FLAGS "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}" OUTPUT_VARIABLE COMPILE_OUTPUT)
 if(NOT PASS_GLIBC)
   message(FATAL_ERROR "Test glibc compilation failed. Output:\n${COMPILE_OUTPUT}")
 endif()

--- a/src/Platforms/OMPTarget/CMakeLists.txt
+++ b/src/Platforms/OMPTarget/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
   # Test if C++ compiler supports OpenMP user defined reduction on complex type
   try_compile(
     OMP_UDR_COMPLEX_OKAY ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/test_user_defined_reduction_complex.cpp
-    CMAKE_FLAGS "${CMAKE_CXX_FLAGS}"
+    CMAKE_FLAGS "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
     OUTPUT_VARIABLE COMPILE_OUTPUT)
 
   if(NOT OMP_UDR_COMPLEX_OKAY)
@@ -50,7 +50,7 @@ else()
     try_compile(
       OMP_IMPLICIT_REDUCTION_COMPLEX_OKAY ${CMAKE_CURRENT_BINARY_DIR}
       ${CMAKE_CURRENT_SOURCE_DIR}/test_user_defined_reduction_complex.cpp
-      CMAKE_FLAGS "${CMAKE_CXX_FLAGS}"
+      CMAKE_FLAGS "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
       COMPILE_DEFINITIONS "-DOPENMP_NO_UDR"
       OUTPUT_VARIABLE COMPILE_OUTPUT)
 

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -16,6 +16,8 @@ case "$1" in
       # e.g. ctest
       echo "PATH=$PATH" >> $GITHUB_ENV
     fi
+
+    cmake --version
     
     if [ -d ${GITHUB_WORKSPACE}/../qmcpack-build ]
     then


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Following #6055 , update the workflow to use the newly named image


## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->
None.


## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
