### PR TITLE
Nexus: Fix linter errors in `test_machines.py`, and make parallel-safe

### DIFF
--- a/nexus/nexus/tests/test_machines.py
+++ b/nexus/nexus/tests/test_machines.py
@@ -2,7 +2,7 @@ import pytest
 from . import NexusTestOrder
 pytestmark = pytest.mark.order(NexusTestOrder.MACHINES)
 
-from ..generic import generic_settings
+from ..generic import generic_settings, NexusError
 generic_settings.raise_error = True
 
 import os
@@ -10,7 +10,7 @@ from random import randint
 from copy import deepcopy
 from . import isolate_nexus_core
 from .. import testing
-from ..testing import object_eq,object_diff,failed,FailedTest
+from ..testing import object_eq,object_diff
 from ..utilities import path_string
 
 all_machines = []
@@ -29,7 +29,8 @@ def get_machine_data():
             elif isinstance(machine,Supercomputer):
                 supercomputers[machine.name] = machine
             else:
-                failed()
+                msg = "Machine detected that is not a Workstation or Supercomputer!"
+                pytest.fail(msg)
             #end if
         #end for
         machines_data['ws'] = workstations
@@ -53,7 +54,7 @@ def get_all_machines():
 
 
 def get_supercomputers():
-    ws,sc = get_machine_data()
+    _ws,sc = get_machine_data()
     return sc
 #end def get_supercomputers
 
@@ -124,14 +125,11 @@ def test_job_init():
     assert(id(job)==id(Job))
 
     # empty init should fail w/o implicit or explicit machine
-    try:
+    with pytest.raises(
+        NexusError,
+        match="machine name must be a string, you provided",
+        ):
         job()
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
 
     # empty init should succeed if machine is bypassed
     j = job(skip_machine=True)
@@ -297,54 +295,36 @@ def test_machine_virtuals():
     from ..machines import Machine
     arg0 = None
     arg1 = None
-    try:
+    with pytest.raises(
+        NotImplementedError
+        ):
         Machine.query_queue(arg0)
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
-    try:
+
+    with pytest.raises(
+        NotImplementedError
+        ):
         Machine.submit_jobs(arg0)
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
-    try:
+
+    with pytest.raises(
+        NotImplementedError
+        ):
         Machine.process_job(arg0,arg1)
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
-    try:
+
+    with pytest.raises(
+        NotImplementedError
+        ):
         Machine.process_job_options(arg0,arg1)
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
-    try:
+
+    with pytest.raises(
+        NotImplementedError
+        ):
         Machine.write_job(arg0,arg1,file=False)
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
-    try:
+
+    with pytest.raises(
+        NotImplementedError
+        ):
         Machine.submit_job(arg0,arg1)
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
+
 #end def test_machine_virtuals
 
 
@@ -368,22 +348,17 @@ def test_machine_add():
     from ..machines import Machine
     mtest = first(Machine.machines)
     assert(isinstance(mtest,Machine))
-    try:
+    with pytest.raises(
+        NexusError,
+        match="attempted to create machine"
+        ):
         Machine.add(mtest)
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
-    try:
+
+    with pytest.raises(
+        NexusError,
+        match="attempted to add non-machine instance"
+        ):
         Machine.add('my_machine')
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
 #end def test_machine_add
 
 
@@ -396,22 +371,17 @@ def test_machine_get():
     m = Machine.get(mtest.name)
     assert(isinstance(m,Machine))
     assert(id(m)==id(mtest))
-    try:
+    with pytest.raises(
+        NexusError,
+        match="machine name must be a string, you provided a ",
+        ):
         Machine.get(m)
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
-    try:
+
+    with pytest.raises(
+        NexusError,
+        match="attempted to get machine some_nonexistant_machine, but it is unknown",
+        ):
         Machine.get('some_nonexistant_machine')
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
 #end def test_machine_get
 
 
@@ -419,22 +389,18 @@ def test_machine_get():
 def test_machine_instantiation():
     from ..machines import Machine
     # test guards against empty/invalid instantiation
-    try:
+    with pytest.raises(
+        TypeError,
+        match="missing 1 required positional argument: 'name'",
+        ):
         Machine()
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
-    try:
+
+    with pytest.raises(
+        NexusError,
+        match="machine name must be a string",
+        ):
         Machine(123)
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
+
     # test creation of a new machine
     test_name = 'test_machine'
     assert(not Machine.exists(test_name))
@@ -445,14 +411,11 @@ def test_machine_instantiation():
     m.validate()
 
     # test guards against multiple instantiation
-    try:
+    with pytest.raises(
+        NexusError,
+        match="attempted to create machine test_machine, but it already exists",
+        ):
         Machine(name=test_name)
-        raise FailedTest
-    except FailedTest:
-        failed()
-    except:
-        None
-    #end try
 
     # remove test machine
     del Machine.machines.test_machine
@@ -493,12 +456,12 @@ def test_workstation_init():
 
 # imitate Job.initialize w/o involving simulation object
 def init_job(j,
-             id  = 'job_ident',
-             dir = './',
+             identifier = 'job_ident',
+             directory  = './',
              ):
     import os
-    identifier = id
-    directory  = path_string(dir)
+    identifier = identifier
+    directory  = path_string(directory)
     j.set_id()
     j.identifier  = identifier
     j.directory   = directory
@@ -532,7 +495,7 @@ def test_workstation_scheduling(tmp_path):
     assert(j.processes==2)
     assert(j.run_options.np=='-np 2')
     assert(j.batch_mode==False)
-    init_job(j,dir=tmp_path) # imitate interaction w/ simulation object
+    init_job(j,directory=tmp_path) # imitate interaction w/ simulation object
     assert(ws.write_job(j)=='export OMP_NUM_THREADS=2\nmpirun -np 2 echo run')
 
     j = job(machine=ws.name,serial=True)
@@ -543,7 +506,7 @@ def test_workstation_scheduling(tmp_path):
     assert(j.processes==1)
     assert(j.run_options.np=='-np 1')
     assert(j.batch_mode==False)
-    init_job(j,dir=tmp_path) # imitate interaction w/ simulation object
+    init_job(j,directory=tmp_path) # imitate interaction w/ simulation object
     assert(ws.write_job(j)=='export OMP_NUM_THREADS=1\necho run')
 
 
@@ -599,7 +562,7 @@ def test_workstation_scheduling(tmp_path):
 
 def test_supercomputer_init():
     from ..developer import obj, to_obj
-    from ..machines import Theta
+    from ..machines import Theta, Machine
 
     class ThetaInit(Theta):
         name = 'theta_init'
@@ -637,6 +600,9 @@ def test_supercomputer_init():
 
     assert(object_eq(to_obj(sc),refsc))
 
+    # remove test machine
+    del Machine.machines["theta_init"]
+    assert(not Machine.exists("theta_init"))
 #end def test_supercomputer_init
 
 
@@ -645,7 +611,7 @@ def test_supercomputer_scheduling(tmp_path):
     import os
     import time
     from ..developer import obj, to_obj
-    from ..machines import Theta
+    from ..machines import Theta, Machine
     from ..machines import job,Job
 
     # create supercomputer for testing
@@ -680,7 +646,7 @@ def test_supercomputer_scheduling(tmp_path):
 
 
     # test write_job()
-    init_job(j,id='123',dir=tmp_path) # imitate interaction w/ simulation object
+    init_job(j,identifier='123',directory=tmp_path) # imitate interaction w/ simulation object
     ref_wj = '''#!/bin/bash
 #COBALT -q default
 #COBALT -A ABC123
@@ -722,7 +688,9 @@ aprun -e OMP_NUM_THREADS=8 -d 8 -cc depth -j 1 -n 16 -N 8 echo run'''
 
     subfile_path = os.path.join(tmp_path,j.subfile)
     assert(os.path.exists(subfile_path))
-    wj = open(subfile_path,'r').read().strip()
+    with open(subfile_path, "r") as f:
+        wj = f.read().strip()
+
     assert('aprun ' in wj)
     assert(' echo run' in wj)
     def scomp(s):
@@ -764,6 +732,9 @@ aprun -e OMP_NUM_THREADS=8 -d 8 -cc depth -j 1 -n 16 -N 8 echo run'''
     assert(sc.finished==set([j.internal_id]))
     assert(set(sc.jobs.keys())==set([j.internal_id]))
 
+    # remove test machine
+    del Machine.machines["theta_sched"]
+    assert(not Machine.exists("theta_sched"))
 #end def test_supercomputer_scheduling
 
 
@@ -777,7 +748,6 @@ def test_process_job():
     nw  = 5
     nwj = 5
     nsj = 5
-    nij = 5
 
     workstations,supercomputers = get_machine_data()
 
@@ -807,12 +777,12 @@ def test_process_job():
         threads_max   = machine.cores
         job_inputs = []
         job_inputs_base = []
-        for nj in range(njobs): # vary cores
+        for _nj in range(njobs): # vary cores
             cores   = randint(cores_min,cores_max)
             threads = randint(threads_min,threads_max)
             job_inputs_base.append(obj(cores=cores,threads=threads))
         #end for
-        for nj in range(njobs): # vary processes
+        for _nj in range(njobs): # vary processes
             processes   = randint(processes_min,processes_max)
             threads = randint(threads_min,threads_max)
             job_inputs_base.append(obj(processes=processes,threads=threads))
@@ -851,19 +821,19 @@ def test_process_job():
         # sample small number of nodes more heavily
         nodes_max   = min(small_node_ceiling,machine.nodes)
         cores_max   = min(small_node_ceiling*machine.cores_per_node,machine.cores)
-        for nj in range(njobs): # nodes alone
+        for _nj in range(njobs): # nodes alone
             nodes   = randint(nodes_min,nodes_max)
             threads = randint(threads_min,threads_max)
             job_input = obj(nodes=nodes,threads=threads,**shared_job_inputs)
             job_inputs_base.append(job_input)
         #end for
-        for nj in range(njobs): # cores alone
+        for _nj in range(njobs): # cores alone
             cores   = randint(cores_min,cores_max)
             threads = randint(threads_min,threads_max)
             job_input = obj(cores=cores,threads=threads,**shared_job_inputs)
             job_inputs_base.append(job_input)
         #end for
-        for nj in range(njobs): # nodes and cores
+        for _nj in range(njobs): # nodes and cores
             nodes   = randint(nodes_min,nodes_max)
             cores   = randint(cores_min,cores_max)
             threads = randint(threads_min,threads_max)
@@ -873,19 +843,19 @@ def test_process_job():
         # sample full node set
         nodes_max = machine.nodes
         cores_max = machine.cores
-        for nj in range(njobs): # nodes alone
+        for _nj in range(njobs): # nodes alone
             nodes   = randint(nodes_min,nodes_max)
             threads = randint(threads_min,threads_max)
             job_input = obj(nodes=nodes,threads=threads,**shared_job_inputs)
             job_inputs_base.append(job_input)
         #end for
-        for nj in range(njobs): # cores alone
+        for _nj in range(njobs): # cores alone
             cores   = randint(cores_min,cores_max)
             threads = randint(threads_min,threads_max)
             job_input = obj(cores=cores,threads=threads,**shared_job_inputs)
             job_inputs_base.append(job_input)
         #end for
-        for nj in range(njobs): # nodes and cores
+        for _nj in range(njobs): # nodes and cores
             nodes   = randint(nodes_min,nodes_max)
             cores   = randint(cores_min,cores_max)
             threads = randint(threads_min,threads_max)
@@ -938,10 +908,10 @@ def test_process_job():
             machine.process_job(job2)
             job_idempotent = object_eq(job,job2)
             if not job_idempotent:
-                d,d1,d2 = object_diff(job,job2,full=True)
+                _d,d1,d2 = object_diff(job,job2,full=True)
                 change = obj(job_before=obj(d1),job_after=obj(d2))
                 msg = machine.name+'\n'+str(change)
-                failed(msg)
+                pytest.fail(msg)
             #end if
             machine_idempotent &= job_idempotent
         #end for
@@ -956,7 +926,7 @@ def test_process_job():
             mlist+= '\n  '+name
         #end for
         msg='\n\nsome machines failed process_job idempotency test:{0}'.format(mlist)
-        failed(msg)
+        pytest.fail(msg)
     #end if
     Machine.allow_warnings = allow_warn
 
@@ -968,7 +938,7 @@ def test_job_run_command():
     from ..developer import obj
     from ..machines import Machine,Job
 
-    workstations,supercomputers = get_machine_data()
+    _workstations,supercomputers = get_machine_data()
 
     allow_warn = Machine.allow_warnings
     Machine.allow_warnings = False
@@ -998,13 +968,12 @@ def test_job_run_command():
                 args.append(t)
             #end if
         #end for
-        jc = obj(
+        return obj(
             launcher   = launcher,
             executable = exe,
             args       = args,
             options    = options,
             )
-        return jc
     #end def parse_job_command
 
     def job_commands_equal(c1,c2):
@@ -1325,6 +1294,10 @@ def test_job_run_command():
         n2_t2_e   = obj(nodes=2,threads=2,env=obj(ENV_VAR=1)),
         )
     for name in sorted(supercomputers.keys()):
+        # Protect from parallel runs that may run at the same time as
+        # test_supercomputer_init and test_supercomputer_scheduling
+        if name in {"theta_init" "theta_sched"}:
+            continue
         m = supercomputers[name]
         if m.requires_account:
             acc = 'ABC123'
@@ -1362,7 +1335,16 @@ def test_job_run_command():
             #end if
             ref_command = job_run_ref[name,jtype]
             if not job_commands_equal(command,ref_command):
-                failed('Job.run_command for machine "{0}" does not match the reference\njob inputs:\n{1}\nreference command: {2}\nincorrect command: {3}'.format(name,job_inputs[jtype],ref_command,command))
+                msg = (
+                    'Job.run_command for machine "{0}" does not match the reference\n'
+                    'job inputs:\n'
+                    '{1}\n'
+                    'reference command: {2}\n'
+                    'incorrect command: {3}'.format(
+                        name,job_inputs[jtype],ref_command,command
+                        )
+                    )
+                pytest.fail(msg)
             #end for
         #end for
     #end for
@@ -2228,17 +2210,17 @@ srun -N 2 -n 64 test.x
             #end if
         #end for
         tokens.extend(lines.pop().split())
-        jo = obj(
+        return obj(
             lines  = lines,
             tokens = set(tokens),
             )
-        return jo
     #end def process_job_file
 
     def job_files_same(jf1,jf2):
         jf1 = process_job_file(jf1)
         jf2 = process_job_file(jf2)
-        if not object_eq(jf1,jf2): print(f"compare --------------------\n * wj *\n{jf1}\n * ref_wj *\n{jf2}\n")
+        if not object_eq(jf1,jf2):
+            print(f"compare --------------------\n * wj *\n{jf1}\n * ref_wj *\n{jf2}\n")
         return object_eq(jf1,jf2)
     #end def job_files_same
 

--- a/nexus/nexus/tests/test_machines.py
+++ b/nexus/nexus/tests/test_machines.py
@@ -777,12 +777,12 @@ def test_process_job():
         threads_max   = machine.cores
         job_inputs = []
         job_inputs_base = []
-        for _nj in range(njobs): # vary cores
+        for nj in range(njobs): # vary cores
             cores   = randint(cores_min,cores_max)
             threads = randint(threads_min,threads_max)
             job_inputs_base.append(obj(cores=cores,threads=threads))
         #end for
-        for _nj in range(njobs): # vary processes
+        for nj in range(njobs): # vary processes
             processes   = randint(processes_min,processes_max)
             threads = randint(threads_min,threads_max)
             job_inputs_base.append(obj(processes=processes,threads=threads))
@@ -821,19 +821,19 @@ def test_process_job():
         # sample small number of nodes more heavily
         nodes_max   = min(small_node_ceiling,machine.nodes)
         cores_max   = min(small_node_ceiling*machine.cores_per_node,machine.cores)
-        for _nj in range(njobs): # nodes alone
+        for nj in range(njobs): # nodes alone
             nodes   = randint(nodes_min,nodes_max)
             threads = randint(threads_min,threads_max)
             job_input = obj(nodes=nodes,threads=threads,**shared_job_inputs)
             job_inputs_base.append(job_input)
         #end for
-        for _nj in range(njobs): # cores alone
+        for nj in range(njobs): # cores alone
             cores   = randint(cores_min,cores_max)
             threads = randint(threads_min,threads_max)
             job_input = obj(cores=cores,threads=threads,**shared_job_inputs)
             job_inputs_base.append(job_input)
         #end for
-        for _nj in range(njobs): # nodes and cores
+        for nj in range(njobs): # nodes and cores
             nodes   = randint(nodes_min,nodes_max)
             cores   = randint(cores_min,cores_max)
             threads = randint(threads_min,threads_max)
@@ -843,19 +843,19 @@ def test_process_job():
         # sample full node set
         nodes_max = machine.nodes
         cores_max = machine.cores
-        for _nj in range(njobs): # nodes alone
+        for nj in range(njobs): # nodes alone
             nodes   = randint(nodes_min,nodes_max)
             threads = randint(threads_min,threads_max)
             job_input = obj(nodes=nodes,threads=threads,**shared_job_inputs)
             job_inputs_base.append(job_input)
         #end for
-        for _nj in range(njobs): # cores alone
+        for nj in range(njobs): # cores alone
             cores   = randint(cores_min,cores_max)
             threads = randint(threads_min,threads_max)
             job_input = obj(cores=cores,threads=threads,**shared_job_inputs)
             job_inputs_base.append(job_input)
         #end for
-        for _nj in range(njobs): # nodes and cores
+        for nj in range(njobs): # nodes and cores
             nodes   = randint(nodes_min,nodes_max)
             cores   = randint(cores_min,cores_max)
             threads = randint(threads_min,threads_max)


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

This PR fixes several linter errors in `test_machines.py`, such as positional boolean arguments (boolean trap), function argument names shadowing builtins (`id` and `dir` in `init_job()`), opening and not closing a file, and having unused variables (either removed or prefixed with an underscore).

Additionally, tests with expected fails were migrated to use the `pytest.raises()` context manager, and any calls to `testing.failed()` were replaced with `pytest.fail()`.

Another big improvement is a fix for parallel Pytest runs with the `pytest-xdist` plugin (not required, just used privately for convenience), which would often fail due to the concurrent running of `test_job_run_command` alongside `test_supercomputer_init` and `test_supercomputer_scheduling`. This means users with that plugin can run Nexus's entire testing suite in parallel using `pytest -n <n_cores>`.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Bugfix
- New feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->

- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

Laptop, Fedora Linux 43 (KDE Plasma Desktop Edition)
AMD Ryzen 7 PRO 7840U (8 cores, 16 logical processors)
```
Python        3.14.6
uv            0.11.26
cif2cell      2.1.0
coverage      7.15.0
h5py          3.16.0
matplotlib    3.11.0
numpy         2.5.1
pycifrw       4.4.6
pydot         4.0.1
pytest        9.1.1
pytest-cov    7.1.0
pytest-order  1.5.0
scipy         1.18.0
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
