### PR TITLE
Relocate ValueApprox away from Configuration.h

### DIFF
--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 
 #include "OhmmsData/Libxml2Doc.h"
 #include "ProjectData.h"

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -17,13 +17,6 @@
 #include "Utilities/TimerManager.h"
 #include "hdf/hdf_archive.h"
 
-#undef APP_ABORT
-#define APP_ABORT(x)             \
-  {                              \
-    std::cout << x << std::endl; \
-    throw;                       \
-  }
-
 #include <stdio.h>
 #include <string>
 

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -9,6 +9,7 @@
 // File created by: Fionn Malone, malone14@llnl.gov, Lawrence Livermore National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 

--- a/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
+++ b/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
@@ -11,6 +11,7 @@
 
 //#undef NDEBUG
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 

--- a/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
+++ b/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
@@ -13,7 +13,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 
 #include "OhmmsData/Libxml2Doc.h"
 #include "ProjectData.h"

--- a/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
+++ b/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
@@ -19,13 +19,6 @@
 #include "hdf/hdf_archive.h"
 #include "hdf/hdf_multi.h"
 
-#undef APP_ABORT
-#define APP_ABORT(x)             \
-  {                              \
-    std::cout << x << std::endl; \
-    throw;                       \
-  }
-
 #include <string>
 #include <vector>
 #include <complex>

--- a/src/AFQMC/Hamiltonians/tests/test_hamiltonian_factory.cpp
+++ b/src/AFQMC/Hamiltonians/tests/test_hamiltonian_factory.cpp
@@ -12,7 +12,6 @@
 //#undef NDEBUG
 #include <catch2/catch_test_macros.hpp>
 
-#include "Configuration.h"
 
 #include "OhmmsData/Libxml2Doc.h"
 #include "ProjectData.h"

--- a/src/AFQMC/Hamiltonians/tests/test_hamiltonian_factory.cpp
+++ b/src/AFQMC/Hamiltonians/tests/test_hamiltonian_factory.cpp
@@ -17,13 +17,6 @@
 #include "ProjectData.h"
 #include "hdf/hdf_archive.h"
 
-#undef APP_ABORT
-#define APP_ABORT(x)             \
-  {                              \
-    std::cout << x << std::endl; \
-    throw;                       \
-  }
-
 #include <string>
 #include <vector>
 #include <complex>

--- a/src/AFQMC/Matrix/tests/matrix_helpers.h
+++ b/src/AFQMC/Matrix/tests/matrix_helpers.h
@@ -18,6 +18,7 @@
 #include <type_traits>
 
 #include "multi/array.hpp"
+#include "Utilities/for_testing/Catch2Approx.h"
 
 using std::complex;
 using std::string;

--- a/src/AFQMC/Memory/raw_pointers.hpp
+++ b/src/AFQMC/Memory/raw_pointers.hpp
@@ -17,6 +17,7 @@
 
 #include <type_traits>
 #include <complex>
+#include <iostream>
 #include "AFQMC/Utilities/type_conversion.hpp"
 
 namespace qmcplusplus

--- a/src/AFQMC/Numerics/performance/performance.cpp
+++ b/src/AFQMC/Numerics/performance/performance.cpp
@@ -22,7 +22,6 @@
 #include "AFQMC/Numerics/ma_blas.hpp"
 #include "AFQMC/Numerics/batched_operations.hpp"
 #include "AFQMC/Numerics/ma_operations.hpp"
-#include "AFQMC/Matrix/tests/matrix_helpers.h"
 #include "AFQMC/Memory/buffer_managers.h"
 #include "AFQMC/Memory/arch.hpp"
 

--- a/src/AFQMC/Numerics/shm_tests/test_shm_gemm.cpp
+++ b/src/AFQMC/Numerics/shm_tests/test_shm_gemm.cpp
@@ -13,8 +13,7 @@
 
 #undef NDEBUG
 
-//#include "catch.hpp"
-#include "Configuration.h"
+
 
 #include <vector>
 #include <iostream>

--- a/src/AFQMC/Numerics/tests/test_batched_operations.cpp
+++ b/src/AFQMC/Numerics/tests/test_batched_operations.cpp
@@ -11,6 +11,7 @@
 //    Lawrence Livermore National Laboratory
 ////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 #include "Configuration.h"
 
 #undef APP_ABORT

--- a/src/AFQMC/Numerics/tests/test_batched_operations.cpp
+++ b/src/AFQMC/Numerics/tests/test_batched_operations.cpp
@@ -13,13 +13,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#undef APP_ABORT
-#define APP_ABORT(x) \
-  {                  \
-    std::cout << x;  \
-    exit(0);         \
-  }
-
 #include <vector>
 
 

--- a/src/AFQMC/Numerics/tests/test_batched_operations.cpp
+++ b/src/AFQMC/Numerics/tests/test_batched_operations.cpp
@@ -12,7 +12,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
-#include "Configuration.h"
 
 #undef APP_ABORT
 #define APP_ABORT(x) \

--- a/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
@@ -27,14 +27,6 @@
 #define MKL_Complex8 std::complex<float>
 #define MKL_Complex16 std::complex<double>
 
-// Avoid the need to link with other libraries just to get APP_ABORT
-#undef APP_ABORT
-#define APP_ABORT(x) \
-  {                  \
-    std::cout << x;  \
-    throw;           \
-  }
-
 #include <stdio.h>
 #include <string>
 #include <complex>

--- a/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
@@ -18,9 +18,8 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-//#include "catch.hpp"
+
 #include <catch2/catch_test_macros.hpp>
-#include "Configuration.h"
 
 // Always test the fallback code, regardless of MKL definition
 //#undef HAVE_MKL

--- a/src/AFQMC/Numerics/tests/test_determinant.cpp
+++ b/src/AFQMC/Numerics/tests/test_determinant.cpp
@@ -11,6 +11,7 @@
 //    Lawrence Livermore National Laboratory
 ////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 #include "Configuration.h"
 
 #undef APP_ABORT

--- a/src/AFQMC/Numerics/tests/test_determinant.cpp
+++ b/src/AFQMC/Numerics/tests/test_determinant.cpp
@@ -13,13 +13,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#undef APP_ABORT
-#define APP_ABORT(x) \
-  {                  \
-    std::cout << x;  \
-    exit(0);         \
-  }
-
 #include <vector>
 
 

--- a/src/AFQMC/Numerics/tests/test_determinant.cpp
+++ b/src/AFQMC/Numerics/tests/test_determinant.cpp
@@ -12,7 +12,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
-#include "Configuration.h"
 
 #undef APP_ABORT
 #define APP_ABORT(x) \

--- a/src/AFQMC/Numerics/tests/test_ma_blas.cpp
+++ b/src/AFQMC/Numerics/tests/test_ma_blas.cpp
@@ -16,13 +16,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
 
-#undef APP_ABORT
-#define APP_ABORT(x) \
-  {                  \
-    std::cout << x;  \
-    throw;           \
-  }
-
 #include <vector>
 #include <iostream>
 

--- a/src/AFQMC/Numerics/tests/test_ma_blas.cpp
+++ b/src/AFQMC/Numerics/tests/test_ma_blas.cpp
@@ -15,7 +15,6 @@
 //    Lawrence Livermore National Laboratory
 ////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
-#include "Configuration.h"
 
 #undef APP_ABORT
 #define APP_ABORT(x) \

--- a/src/AFQMC/Numerics/tests/test_ma_blas_extensions.cpp
+++ b/src/AFQMC/Numerics/tests/test_ma_blas_extensions.cpp
@@ -11,6 +11,7 @@
 //    Lawrence Livermore National Laboratory
 ////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 #include "Configuration.h"
 
 #undef APP_ABORT

--- a/src/AFQMC/Numerics/tests/test_ma_blas_extensions.cpp
+++ b/src/AFQMC/Numerics/tests/test_ma_blas_extensions.cpp
@@ -12,7 +12,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
-#include "Configuration.h"
 
 #undef APP_ABORT
 #define APP_ABORT(x) \

--- a/src/AFQMC/Numerics/tests/test_ma_blas_extensions.cpp
+++ b/src/AFQMC/Numerics/tests/test_ma_blas_extensions.cpp
@@ -10,15 +10,9 @@
 // Fionn D. Malone, malone14@llnl.gov
 //    Lawrence Livermore National Laboratory
 ////////////////////////////////////////////////////////////////////////////////
+
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
-
-#undef APP_ABORT
-#define APP_ABORT(x) \
-  {                  \
-    std::cout << x;  \
-    exit(0);         \
-  }
 
 #include <vector>
 

--- a/src/AFQMC/Numerics/tests/test_misc_kernels.cpp
+++ b/src/AFQMC/Numerics/tests/test_misc_kernels.cpp
@@ -12,13 +12,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
 
-#undef APP_ABORT
-#define APP_ABORT(x) \
-  {                  \
-    std::cout << x;  \
-    exit(0);         \
-  }
-
 #include <vector>
 
 
@@ -37,7 +30,6 @@
 
 #include "multi/array.hpp"
 #include "multi/array_ref.hpp"
-
 
 using boost::multi::array;
 using boost::multi::array_ref;

--- a/src/AFQMC/Numerics/tests/test_misc_kernels.cpp
+++ b/src/AFQMC/Numerics/tests/test_misc_kernels.cpp
@@ -11,7 +11,6 @@
 //    Lawrence Livermore National Laboratory
 ////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
-#include "Configuration.h"
 
 #undef APP_ABORT
 #define APP_ABORT(x) \

--- a/src/AFQMC/Numerics/tests/test_sparse_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_sparse_numerics.cpp
@@ -17,7 +17,6 @@
 //    Lawrence Livermore National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
-#include "Configuration.h"
 
 // Always test the fallback code, regardless of MKL definition
 #define MKL_INT int

--- a/src/AFQMC/Numerics/tests/test_sparse_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_sparse_numerics.cpp
@@ -23,13 +23,6 @@
 #define MKL_Complex8 std::complex<float>
 #define MKL_Complex16 std::complex<double>
 
-#undef APP_ABORT
-#define APP_ABORT(x) \
-  {                  \
-    std::cout << x;  \
-    throw;           \
-  }
-
 #include <iostream>
 #include <vector>
 

--- a/src/AFQMC/Numerics/tests/test_sparse_numerics_native.cpp
+++ b/src/AFQMC/Numerics/tests/test_sparse_numerics_native.cpp
@@ -17,7 +17,6 @@
 //    Lawrence Livermore National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
-#include "Configuration.h"
 
 // Always test the fallback code, regardless of MKL definition
 #undef HAVE_MKL

--- a/src/AFQMC/Numerics/tests/test_sparse_numerics_native.cpp
+++ b/src/AFQMC/Numerics/tests/test_sparse_numerics_native.cpp
@@ -24,13 +24,6 @@
 #define MKL_Complex8 std::complex<float>
 #define MKL_Complex16 std::complex<double>
 
-#undef APP_ABORT
-#define APP_ABORT(x) \
-  {                  \
-    std::cout << x;  \
-    throw;           \
-  }
-
 #include <iostream>
 #include <vector>
 

--- a/src/AFQMC/Numerics/tests/test_tensor_contraction.cpp
+++ b/src/AFQMC/Numerics/tests/test_tensor_contraction.cpp
@@ -10,14 +10,8 @@
 // Miguel A. Morales, moralessilva2@llnl.gov
 //    Lawrence Livermore National Laboratory
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch_test_macros.hpp>
 
-#undef APP_ABORT
-#define APP_ABORT(x) \
-  {                  \
-    std::cout << x;  \
-    throw;           \
-  }
+#include <catch2/catch_test_macros.hpp>
 
 #include <vector>
 #include <iostream>

--- a/src/AFQMC/Numerics/tests/test_tensor_contraction.cpp
+++ b/src/AFQMC/Numerics/tests/test_tensor_contraction.cpp
@@ -11,7 +11,6 @@
 //    Lawrence Livermore National Laboratory
 ////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
-#include "Configuration.h"
 
 #undef APP_ABORT
 #define APP_ABORT(x) \

--- a/src/AFQMC/Numerics/tests/test_tensor_operations.cpp
+++ b/src/AFQMC/Numerics/tests/test_tensor_operations.cpp
@@ -13,15 +13,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#undef APP_ABORT
-#define APP_ABORT(x) \
-  {                  \
-    std::cout << x;  \
-    exit(0);         \
-  }
-
 #include <vector>
-
 
 #include "AFQMC/config.h"
 #include "AFQMC/config.0.h"

--- a/src/AFQMC/Numerics/tests/test_tensor_operations.cpp
+++ b/src/AFQMC/Numerics/tests/test_tensor_operations.cpp
@@ -11,6 +11,7 @@
 //    Lawrence Livermore National Laboratory
 ////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 #include "Configuration.h"
 
 #undef APP_ABORT

--- a/src/AFQMC/Numerics/tests/test_tensor_operations.cpp
+++ b/src/AFQMC/Numerics/tests/test_tensor_operations.cpp
@@ -12,7 +12,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
-#include "Configuration.h"
 
 #undef APP_ABORT
 #define APP_ABORT(x) \

--- a/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
+++ b/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
@@ -19,13 +19,6 @@
 #include "Utilities/RandomGenerator.h"
 #include "Utilities/TimerManager.h"
 
-#undef APP_ABORT
-#define APP_ABORT(x)             \
-  {                              \
-    std::cout << x << std::endl; \
-    throw;                       \
-  }
-
 #include <string>
 #include <vector>
 #include <complex>

--- a/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
+++ b/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
@@ -12,7 +12,6 @@
 #undef NDEBUG
 #include <catch2/catch_test_macros.hpp>
 
-#include "Configuration.h"
 
 #include "OhmmsData/Libxml2Doc.h"
 #include "ProjectData.h"

--- a/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
+++ b/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
@@ -13,8 +13,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-//#include "catch.hpp"
-#include "Configuration.h"
+
 
 #include "ProjectData.h"
 

--- a/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
+++ b/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
@@ -17,14 +17,6 @@
 
 #include "ProjectData.h"
 
-// Avoid the need to link with other libraries just to get APP_ABORT
-#undef APP_ABORT
-#define APP_ABORT(x)             \
-  {                              \
-    std::cout << x << std::endl; \
-    throw;                       \
-  }
-
 #include <stdio.h>
 #include <string>
 #include <vector>

--- a/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
+++ b/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
@@ -11,6 +11,7 @@
 
 #undef NDEBUG
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 //#include "catch.hpp"
 #include "Configuration.h"

--- a/src/AFQMC/Walkers/tests/test_sharedwset.cpp
+++ b/src/AFQMC/Walkers/tests/test_sharedwset.cpp
@@ -14,7 +14,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 
 // Avoid the need to link with other libraries just to get APP_ABORT
 #undef APP_ABORT

--- a/src/AFQMC/Walkers/tests/test_sharedwset.cpp
+++ b/src/AFQMC/Walkers/tests/test_sharedwset.cpp
@@ -15,14 +15,6 @@
 #include "Utilities/for_testing/Catch2Approx.h"
 
 
-// Avoid the need to link with other libraries just to get APP_ABORT
-#undef APP_ABORT
-#define APP_ABORT(x)             \
-  {                              \
-    std::cout << x << std::endl; \
-    throw;                       \
-  }
-
 #include "OhmmsData/Libxml2Doc.h"
 #include "Utilities/RandomGenerator.h"
 #include "ProjectData.h"

--- a/src/AFQMC/Walkers/tests/test_sharedwset.cpp
+++ b/src/AFQMC/Walkers/tests/test_sharedwset.cpp
@@ -12,6 +12,7 @@
 
 #undef NDEBUG
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -11,6 +11,7 @@
 
 //#undef NDEBUG
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -13,7 +13,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 
 #include "OhmmsData/Libxml2Doc.h"
 #include "ProjectData.h"

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -21,13 +21,6 @@
 #include "Utilities/Timer.h"
 #include "Platforms/Host/OutputManager.h"
 
-#undef APP_ABORT
-#define APP_ABORT(x)             \
-  {                              \
-    std::cout << x << std::endl; \
-    throw;                       \
-  }
-
 #include <string>
 #include <vector>
 #include <complex>

--- a/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
@@ -11,6 +11,7 @@
 
 //#undef NDEBUG
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 

--- a/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
@@ -13,7 +13,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 
 #include "OhmmsData/Libxml2Doc.h"
 #include "ProjectData.h"

--- a/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
@@ -21,13 +21,6 @@
 #include "Utilities/Timer.h"
 #include "Platforms/Host/OutputManager.h"
 
-#undef APP_ABORT
-#define APP_ABORT(x)             \
-  {                              \
-    std::cout << x << std::endl; \
-    throw;                       \
-  }
-
 #include <string>
 #include <vector>
 #include <complex>

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -27,10 +27,6 @@
 #include "Platforms/Host/OutputManager.h"
 #include "Message/Communicate.h"
 
-#ifdef TEST_CASE
-#include "Utilities/for_testing/Catch2Approx.h"
-#endif
-
 //define empty DEBUG_MEMORY
 #define DEBUG_MEMORY(msg)
 //uncomment this out to trace the call tree of destructors
@@ -100,16 +96,6 @@ struct PtclOnLatticeTraits
   using ParticleLaplacian   = Vector<QTFull::ValueType>;
   using SingleParticleValue = QTFull::ValueType;
 };
-
-// For unit tests
-//  Check if we are compiling with Catch defined.  Could use other symbols if needed.
-#ifdef TEST_CASE
-#ifdef QMC_COMPLEX
-using ValueApprox = ::ComplexApprox;
-#else
-using ValueApprox = ::Approx;
-#endif
-#endif
 
 } // namespace qmcplusplus
 

--- a/src/Estimators/tests/test_MagnetizationDensity.cpp
+++ b/src/Estimators/tests/test_MagnetizationDensity.cpp
@@ -10,6 +10,7 @@
 // File created by: Raymond Clay, rclay@sandia.gov, Sandia National Laboratories
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 #include "Estimators/MagnetizationDensityInput.h"
 #include "ValidMagnetizationDensityInput.h"
 #include "Configuration.h"

--- a/src/Estimators/tests/test_MagnetizationDensity.cpp
+++ b/src/Estimators/tests/test_MagnetizationDensity.cpp
@@ -13,7 +13,6 @@
 #include "Utilities/for_testing/Catch2Approx.h"
 #include "Estimators/MagnetizationDensityInput.h"
 #include "ValidMagnetizationDensityInput.h"
-#include "Configuration.h"
 //#include "QMCHamiltonians/MagDensityEstimator.h"
 //for wavefunction
 #include "OhmmsData/Libxml2Doc.h"

--- a/src/Particle/Lattice/LRBreakupParameters.h
+++ b/src/Particle/Lattice/LRBreakupParameters.h
@@ -16,6 +16,7 @@
 #include <iostream>
 #include "config.h"
 #include "OhmmsPETE/TinyVector.h"
+#include "OhmmsPETE/Tensor.h"
 
 namespace qmcplusplus
 {

--- a/src/Particle/Lattice/tests/test_CrystalLattice.cpp
+++ b/src/Particle/Lattice/tests/test_CrystalLattice.cpp
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <string>
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "OhmmsPETE/TinyVector.h"

--- a/src/Particle/Lattice/tests/test_CrystalLattice.cpp
+++ b/src/Particle/Lattice/tests/test_CrystalLattice.cpp
@@ -15,7 +15,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "OhmmsPETE/TinyVector.h"
 #include "Lattice/CrystalLattice.h"
 

--- a/src/Particle/Lattice/tests/test_LRBreakupParameters.cpp
+++ b/src/Particle/Lattice/tests/test_LRBreakupParameters.cpp
@@ -15,7 +15,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "OhmmsPETE/TinyVector.h"
 #include "Lattice/LRBreakupParameters.h"
 

--- a/src/Particle/Lattice/tests/test_LRBreakupParameters.cpp
+++ b/src/Particle/Lattice/tests/test_LRBreakupParameters.cpp
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <string>
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "OhmmsPETE/TinyVector.h"

--- a/src/Particle/Lattice/tests/test_ParticleBConds.cpp
+++ b/src/Particle/Lattice/tests/test_ParticleBConds.cpp
@@ -9,6 +9,7 @@
 // File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include <stdio.h>
 #include <string>

--- a/src/Particle/LongRange/tests/test_StructFact.cpp
+++ b/src/Particle/LongRange/tests/test_StructFact.cpp
@@ -13,7 +13,6 @@
 
 #include <vector>
 #include <complex>
-#include "Configuration.h"
 #include "ParticleSet.h"
 #include "LongRange/StructFact.h"
 

--- a/src/Particle/LongRange/tests/test_StructFact.cpp
+++ b/src/Particle/LongRange/tests/test_StructFact.cpp
@@ -9,6 +9,7 @@
 // File created by: Yubo "Paul" Yang, yubo.paul.yang@gmail.com, University of Illinois Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include <vector>
 #include <complex>

--- a/src/Particle/LongRange/tests/test_ewald3d.cpp
+++ b/src/Particle/LongRange/tests/test_ewald3d.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "Lattice/CrystalLattice.h"
 #include "Particle/ParticleSet.h"
 #include "LongRange/EwaldHandler3D.h"

--- a/src/Particle/LongRange/tests/test_ewald3d.cpp
+++ b/src/Particle/LongRange/tests/test_ewald3d.cpp
@@ -9,6 +9,7 @@
 // File created by: Yubo "Paul" Yang, yubo.paul.yang@gmail.com, University of Illinois Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Lattice/CrystalLattice.h"

--- a/src/Particle/LongRange/tests/test_lrhandler.cpp
+++ b/src/Particle/LongRange/tests/test_lrhandler.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "Lattice/CrystalLattice.h"
 #include "Particle/ParticleSet.h"
 #include "LongRange/LRHandlerBase.h"

--- a/src/Particle/LongRange/tests/test_lrhandler.cpp
+++ b/src/Particle/LongRange/tests/test_lrhandler.cpp
@@ -9,6 +9,7 @@
 // File created by: Yubo "Paul" Yang, yubo.paul.yang@gmail.com, University of Illinois Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Lattice/CrystalLattice.h"

--- a/src/Particle/LongRange/tests/test_srcoul.cpp
+++ b/src/Particle/LongRange/tests/test_srcoul.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "Lattice/CrystalLattice.h"
 #include "Particle/ParticleSet.h"
 #include "LongRange/LRHandlerSRCoulomb.h"

--- a/src/Particle/LongRange/tests/test_srcoul.cpp
+++ b/src/Particle/LongRange/tests/test_srcoul.cpp
@@ -9,6 +9,7 @@
 // File created by: Yubo "Paul" Yang, yubo.paul.yang@gmail.com, University of Illinois Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Lattice/CrystalLattice.h"

--- a/src/Particle/LongRange/tests/test_temp.cpp
+++ b/src/Particle/LongRange/tests/test_temp.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "Lattice/CrystalLattice.h"
 #include "Particle/ParticleSet.h"
 #include "LongRange/LRHandlerTemp.h"

--- a/src/Particle/LongRange/tests/test_temp.cpp
+++ b/src/Particle/LongRange/tests/test_temp.cpp
@@ -9,6 +9,7 @@
 // File created by: Yubo "Paul" Yang, yubo.paul.yang@gmail.com, University of Illinois Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Lattice/CrystalLattice.h"

--- a/src/Particle/tests/test_walker.cpp
+++ b/src/Particle/tests/test_walker.cpp
@@ -10,6 +10,7 @@
 // File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include <cstring>
 #include "QMCDrivers/WalkerProperties.h"

--- a/src/Particle/tests/test_walker.cpp
+++ b/src/Particle/tests/test_walker.cpp
@@ -14,7 +14,6 @@
 
 #include <cstring>
 #include "QMCDrivers/WalkerProperties.h"
-#include "Configuration.h"
 #include "Particle/WalkerConfigurations.h"
 #include "Particle/HDFWalkerOutput.h"
 #include "Particle/HDFWalkerInput_0_4.h"

--- a/src/Platforms/CPU/VectorOps.h
+++ b/src/Platforms/CPU/VectorOps.h
@@ -34,6 +34,9 @@
 #ifndef OHMMS_PARTICLEATTRIB_OPS_H
 #define OHMMS_PARTICLEATTRIB_OPS_H
 
+#include "OhmmsPETE/TinyVector.h"
+#include "OhmmsPETE/OhmmsVector.h"
+
 namespace qmcplusplus
 {
 template<class T1, class T2, unsigned D>

--- a/src/QMCDrivers/tests/test_Crowd.cpp
+++ b/src/QMCDrivers/tests/test_Crowd.cpp
@@ -10,7 +10,6 @@
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 #include "QMCDrivers/Crowd.h"
 #include "type_traits/template_types.hpp"

--- a/src/QMCDrivers/tests/test_DescentEngine.cpp
+++ b/src/QMCDrivers/tests/test_DescentEngine.cpp
@@ -10,6 +10,7 @@
 // File created by: Leon Otis, leon_otis@berkeley.edu University, University of California Berkeley
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCDrivers/Optimizers/DescentEngine.h"

--- a/src/QMCDrivers/tests/test_DescentEngine.cpp
+++ b/src/QMCDrivers/tests/test_DescentEngine.cpp
@@ -15,7 +15,6 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCDrivers/Optimizers/DescentEngine.h"
 #include "VariableSet.h"
-#include "Configuration.h"
 #include "Message/Communicate.h"
 
 namespace qmcplusplus

--- a/src/QMCDrivers/tests/test_EngineHandle.cpp
+++ b/src/QMCDrivers/tests/test_EngineHandle.cpp
@@ -13,7 +13,6 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCDrivers/Optimizers/DescentEngine.h"
 #include "QMCDrivers/WFOpt/EngineHandle.h"
-#include "Configuration.h"
 #include "Message/Communicate.h"
 
 namespace qmcplusplus

--- a/src/QMCDrivers/tests/test_MCPopulation.cpp
+++ b/src/QMCDrivers/tests/test_MCPopulation.cpp
@@ -12,7 +12,6 @@
 #include <vector>
 #include <algorithm>
 
-#include "Configuration.h"
 #include "OhmmsPETE/TinyVector.h"
 #include "QMCDrivers/MCPopulation.h"
 #include "QMCDrivers/tests/WalkerConsumer.h"

--- a/src/QMCDrivers/tests/test_clone_manager.cpp
+++ b/src/QMCDrivers/tests/test_clone_manager.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 #include "Utilities/RandomGenerator.h"
 #include "Utilities/RuntimeOptions.h"

--- a/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
@@ -9,6 +9,7 @@
 // File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Numerics/Quadrature.h"

--- a/src/QMCHamiltonians/tests/test_SOECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_SOECPotential.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "QMCHamiltonians/SOECPotential.h"
 #include "QMCWaveFunctions/ElectronGas/FreeOrbital.h"
 #include "QMCWaveFunctions/SpinorSet.h"

--- a/src/QMCHamiltonians/tests/test_SOECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_SOECPotential.cpp
@@ -9,6 +9,7 @@
 // File created by: Cody A. Melton, cmelton@sandia.gov, Sandia Nationaln Laboratories
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "QMCHamiltonians/SOECPotential.h"

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -19,7 +19,6 @@
 #include <string>
 
 #include <checkMatrix.hpp>
-#include "Configuration.h"
 #include <Listener.hpp>
 #include <OhmmsData/Libxml2Doc.h>
 #include <OhmmsPETE/OhmmsMatrix.h>

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -10,6 +10,7 @@
 // File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include <CoulombPBCAA.h>
 

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -10,6 +10,7 @@
 // File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Numerics/Quadrature.h"

--- a/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
@@ -10,7 +10,6 @@
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"

--- a/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCHamiltonians/HamiltonianPool.h"

--- a/src/QMCTools/tests/test_qmcfstool.cpp
+++ b/src/QMCTools/tests/test_qmcfstool.cpp
@@ -9,6 +9,7 @@
 // File created by: Cody A. Melton, cmelton@sandia.gov, Sandia National Laboratories
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 #include <iostream>
 #include <vector>
 

--- a/src/QMCTools/tests/test_qmcfstool.cpp
+++ b/src/QMCTools/tests/test_qmcfstool.cpp
@@ -13,7 +13,6 @@
 #include <iostream>
 #include <vector>
 
-#include "Configuration.h"
 #include "QMCTools/QMCFiniteSize/SkParserBase.h"
 #include "QMCTools/QMCFiniteSize/SkParserASCII.h"
 #include "QMCTools/QMCFiniteSize/QMCFiniteSize.h"

--- a/src/QMCWaveFunctions/WaveFunctionTypes.hpp
+++ b/src/QMCWaveFunctions/WaveFunctionTypes.hpp
@@ -12,8 +12,10 @@
 #ifndef QMCPLUSPLUS_QMC_WAVEFUNCTION_TYPES_HPP
 #define QMCPLUSPLUS_QMC_WAVEFUNCTION_TYPES_HPP
 
+#include "config.h"
 #include "type_traits/complex_help.hpp"
-#include "OhmmsPETE/OhmmsMatrix.h"
+#include "OhmmsPETE/TinyVector.h"
+#include "OhmmsPETE/Tensor.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/tests/test_ConstantSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/test_ConstantSPOSet.cpp
@@ -9,7 +9,6 @@
 // File created by: Raymond Clay, rclay@sandia.gov, Sandia National Laboratories
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
-#include "Configuration.h"
 #include "QMCWaveFunctions/WaveFunctionTypes.hpp"
 #include "QMCWaveFunctions/tests/ConstantSPOSet.h"
 #include "Utilities/for_testing/checkMatrix.hpp"

--- a/src/QMCWaveFunctions/tests/test_DiracMatrixInverterOMPTarget.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracMatrixInverterOMPTarget.cpp
@@ -9,6 +9,7 @@
 // File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 #include <algorithm>
 #include "Configuration.h"
 #include "OhmmsData/Libxml2Doc.h"

--- a/src/QMCWaveFunctions/tests/test_DiracMatrixInverterOMPTarget.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracMatrixInverterOMPTarget.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 #include <algorithm>
-#include "Configuration.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "OhmmsPETE/OhmmsVector.h"

--- a/src/QMCWaveFunctions/tests/test_LCAO_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_LCAO_diamondC_2x1x1.cpp
@@ -908,10 +908,11 @@ void test_LCAO_DiamondC_2x1x1_cplx(const bool useOffload)
 }
 
 TEST_CASE("LCAOrbitalSet batched PBC DiamondC",
-          "[wavefunction]"){SECTION("2x1x1 real"){test_LCAO_DiamondC_2x1x1_real(false);
-} // namespace qmcplusplus
+          "[wavefunction]")
+{
+  SECTION("2x1x1 real") { test_LCAO_DiamondC_2x1x1_real(false); }
 #ifdef QMC_COMPLEX
-SECTION("2x1x1 cplx") { test_LCAO_DiamondC_2x1x1_cplx(false); }
+  SECTION("2x1x1 cplx") { test_LCAO_DiamondC_2x1x1_cplx(false); }
 #endif
 }
 

--- a/src/QMCWaveFunctions/tests/test_LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/tests/test_LCAOrbitalBuilder.cpp
@@ -10,7 +10,6 @@
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 
 #include "LCAO/LCAOrbitalBuilder.h"

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 #include "Numerics/OneDimGridBase.h"
 #include "ParticleIO/XMLParticleIO.h"

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -9,6 +9,7 @@
 // File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Message/Communicate.h"

--- a/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/ParticleSetPool.h"

--- a/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
@@ -9,6 +9,7 @@
 // File created by: Cody A. Melton, cmelton@sandia.gov, Sandia National Laboratories
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Message/Communicate.h"

--- a/src/QMCWaveFunctions/tests/test_SolverInverters.cpp
+++ b/src/QMCWaveFunctions/tests/test_SolverInverters.cpp
@@ -9,6 +9,7 @@
 // File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_template_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Common/Queue.hpp"

--- a/src/QMCWaveFunctions/tests/test_SolverInverters.cpp
+++ b/src/QMCWaveFunctions/tests/test_SolverInverters.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "Common/Queue.hpp"
 #include "QMCWaveFunctions/Fermion/DiracMatrix.h"
 #include "QMCWaveFunctions/Fermion/InverterAccel.hpp"

--- a/src/QMCWaveFunctions/tests/test_cartesian_ao.cpp
+++ b/src/QMCWaveFunctions/tests/test_cartesian_ao.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 #include "Numerics/OneDimGridBase.h"
 #include "ParticleIO/XMLParticleIO.h"

--- a/src/QMCWaveFunctions/tests/test_cartesian_ao.cpp
+++ b/src/QMCWaveFunctions/tests/test_cartesian_ao.cpp
@@ -9,6 +9,7 @@
 // File created by: Cody A. Melton, cmelton@sandia.gov, Sandia National Laboratories
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Message/Communicate.h"

--- a/src/QMCWaveFunctions/tests/test_counting_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_counting_jastrow.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "Particle/ParticleSet.h"
 #include "VariableSet.h"

--- a/src/QMCWaveFunctions/tests/test_counting_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_counting_jastrow.cpp
@@ -9,6 +9,7 @@
 // File created by: Brett Van Der Goetz, bvdg@berkeley.edu, University of California at Berkeley
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "OhmmsData/Libxml2Doc.h"

--- a/src/QMCWaveFunctions/tests/test_example_he.cpp
+++ b/src/QMCWaveFunctions/tests/test_example_he.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 #include "CPU/VectorOps.h"
 #include "OhmmsData/Libxml2Doc.h"

--- a/src/QMCWaveFunctions/tests/test_example_he.cpp
+++ b/src/QMCWaveFunctions/tests/test_example_he.cpp
@@ -9,6 +9,7 @@
 // File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Message/Communicate.h"

--- a/src/QMCWaveFunctions/tests/test_multiquintic_spline.cpp
+++ b/src/QMCWaveFunctions/tests/test_multiquintic_spline.cpp
@@ -12,7 +12,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 
 #include "Message/Communicate.h"
 #include "OhmmsPETE/OhmmsMatrix.h"

--- a/src/QMCWaveFunctions/tests/test_multiquintic_spline.cpp
+++ b/src/QMCWaveFunctions/tests/test_multiquintic_spline.cpp
@@ -10,6 +10,7 @@
 // File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 

--- a/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
@@ -17,6 +17,7 @@
  *  the reference values obtained from PySCF. The reference values were generated from Carbon1x1x1-tw1_gen_mos.py.   
 */
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Message/Communicate.h"

--- a/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
@@ -19,7 +19,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 #include "Numerics/OneDimGridBase.h"
 #include "ParticleIO/XMLParticleIO.h"

--- a/src/QMCWaveFunctions/tests/test_short_range_cusp_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_short_range_cusp_jastrow.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCWaveFunctions/Jastrow/ShortRangeCuspFunctor.h"

--- a/src/QMCWaveFunctions/tests/test_short_range_cusp_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_short_range_cusp_jastrow.cpp
@@ -9,6 +9,7 @@
 // File created by: Eric Neuscamman, eneuscamman@berkeley.edu, University of California, Berkeley
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Message/Communicate.h"

--- a/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
+++ b/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
@@ -10,6 +10,7 @@
 // File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Message/Communicate.h"

--- a/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
+++ b/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
@@ -12,7 +12,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 #include "Numerics/OneDimGridBase.h"
 #include "ParticleIO/XMLParticleIO.h"

--- a/src/QMCWaveFunctions/tests/test_user_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_user_jastrow.cpp
@@ -9,6 +9,7 @@
 // File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Utilities/for_testing/Catch2Approx.h"
 
 #include "Configuration.h"
 #include "Message/Communicate.h"

--- a/src/QMCWaveFunctions/tests/test_user_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_user_jastrow.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCWaveFunctions/Jastrow/UserFunctor.h"

--- a/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
+++ b/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
@@ -10,7 +10,6 @@
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
 
-#include "Configuration.h"
 #include "Message/Communicate.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"

--- a/src/Utilities/for_testing/Catch2Approx.h
+++ b/src/Utilities/for_testing/Catch2Approx.h
@@ -15,6 +15,8 @@
 #include <limits>
 #include <ostream>
 
+#include <config.h>
+
 class Approx : public Catch::Approx
 {
 public:
@@ -111,5 +113,11 @@ private:
   std::complex<double> value_;
   double epsilon_ = std::numeric_limits<float>::epsilon() * 100;
 };
+
+#ifdef QMC_COMPLEX
+using ValueApprox = ::ComplexApprox;
+#else
+using ValueApprox = ::Approx;
+#endif
 
 #endif


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Addressing https://github.com/QMCPACK/qmcpack/pull/6053#discussion_r3677295221
ValueApprox naturally belongs to newly added Catch2Approx.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

laptop

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
