### PR TITLE
Update gcovr command to ignore source not found errors

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -398,7 +398,7 @@ EOF
     # see https://gcovr.com/en/stable/faq.html#why-does-c-code-have-so-many-uncovered-branches
     # set suspicious hits threshold=2^40
     # see https://gcovr.com/en/stable/manpage.html#gcov-options
-    gcovr --exclude-unreachable-branches --exclude-throw-branches --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --gcov-suspicious-hits-threshold=1099511627776 --root=${GITHUB_WORKSPACE}/.. --xml-pretty -o coverage.xml
+    gcovr --exclude-unreachable-branches --exclude-throw-branches --gcov-ignore-errors=source_not_found --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --gcov-suspicious-hits-threshold=1099511627776 --root=${GITHUB_WORKSPACE}/.. --xml-pretty -o coverage.xml
     du -hs coverage.xml
     #cat coverage.xml
     python3-coverage combine nexus/nexus/tests/.coverage*


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Attempt to fix the missing C++ coverage.

https://github.com/QMCPACK/qmcpack/actions/runs/31017352593/job/92344792521?pr=6087#step:7:17 indicates that Catch2 related source is not being found (?). gcovr currently exits with an error. This results in no coverage.xml and hence no C++ coverage. Try to simply ignore the errors.

EDIT: C++ coverage restored by this PR

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Bugfix
- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->
None. Speculative. CI coverage output should be checked.


## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
