### PR TITLE
CI: keep Gcov jobs green when the codecov upload is rejected

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -72,7 +72,8 @@ jobs:
           files: ../qmcpack-build/coverage.xml,../qmcpack-build/python_coverage.xml
           flags: tests-deterministic # optional
           name: codecov-QMCPACK # optional
-          fail_ci_if_error: true # optional (default = false)
+          disable_search: true # only upload the files listed above
+          fail_ci_if_error: false # codecov service errors must not fail CI
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -129,7 +130,8 @@ jobs:
           files: ../qmcpack-build/coverage.xml,../qmcpack-build/python_coverage.xml
           flags: tests-deterministic # optional
           name: codecov-QMCPACK # optional
-          fail_ci_if_error: true # optional (default = false)
+          disable_search: true # only upload the files listed above
+          fail_ci_if_error: false # codecov service errors must not fail CI
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Every Gcov job on recent develop push runs fails in the Upload Coverage step, not in the tests:
`Upload queued for processing failed: {"message":"Repository not found"}` (runs 31212046886, 31181287791, 31173136765).
A token is present in those runs, so the stored CODECOV_TOKEN no longer matches the repository on codecov's side and needs re-issuing by an admin; fork PR uploads go through the tokenless app path, which is why PR runs still upload fine.
With fail_ci_if_error the rejection turns the whole job red, so drop it back to non-blocking.
Also disable the uploader's file auto-search, which uploads tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_coverage.in.xml (a QMC input deck matched by the *coverage* glob) as a coverage report.