### PR TITLE
Remove the unncessary include <memory>

### DIFF
--- a/src/Platforms/CUDA/MemManageCUDA.hpp
+++ b/src/Platforms/CUDA/MemManageCUDA.hpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2025 QMCPACK developers.
+// Copyright (c) 2026 QMCPACK developers.
 //
 // File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //
@@ -19,7 +19,6 @@
 #ifndef QMCPLUSPLUS_MEMMANAGE_CUDA_H
 #define QMCPLUSPLUS_MEMMANAGE_CUDA_H
 
-#include <memory>
 #include <cstdlib>
 #include <stdexcept>
 #include <atomic>

--- a/src/Platforms/SYCL/MemManageSYCL.hpp
+++ b/src/Platforms/SYCL/MemManageSYCL.hpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2022 QMCPACK developers.
+// Copyright (c) 2026 QMCPACK developers.
 //
 // File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //
@@ -19,7 +19,6 @@
 #ifndef QMCPLUSPLUS_MEMMANAGE_SYCL_H
 #define QMCPLUSPLUS_MEMMANAGE_SYCL_H
 
-#include <memory>
 #include <cstdlib>
 #include <stdexcept>
 #include <atomic>


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixing a compilation issue with upstream llvm and cuda 12.9.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

JLSE, Aurora

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
