### PR TITLE
Fewer type aliases and more verbose function names

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
@@ -36,10 +36,10 @@ template<typename ST>
 class AtomicOrbitals
 {
 public:
-  static const int D           = 3;
-  using AtomicBCType           = typename bspline_traits<ST, 1>::BCType;
-  using PointType              = TinyVector<ST, D>;
-  using value_type             = ST;
+  static const int D = 3;
+  using AtomicBCType = typename bspline_traits<ST, 1>::BCType;
+  using PointType    = TinyVector<ST, D>;
+  using value_type   = ST;
 
   using vContainer_type = aligned_vector<ST>;
 

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
@@ -37,9 +37,7 @@ class AtomicOrbitals
 {
 public:
   static const int D           = 3;
-  using AtomicSplineType       = typename bspline_traits<ST, 1>::SplineType;
   using AtomicBCType           = typename bspline_traits<ST, 1>::BCType;
-  using AtomicSingleSplineType = UBspline_1d_d;
   using PointType              = TinyVector<ST, D>;
   using value_type             = ST;
 
@@ -136,7 +134,7 @@ public:
 
   inline void flush_zero() { SplineInst->flush_zero(); }
 
-  inline void set_spline(AtomicSingleSplineType* spline, int lm, int ispline)
+  inline void set_spline(UBspline_1d_d* spline, int lm, int ispline)
   { SplineInst->copy_spline(spline, lm * Npad + ispline, 0, BaseN); }
 
   bool read_splines(hdf_archive& h5f);

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.cpp
@@ -682,8 +682,8 @@ void HybridRepSetReader<ST>::create_atomic_centers_Gspace(const Vector<std::comp
         UBspline_1d_d* atomic_spline_r = nullptr;
         for (size_t ip = 0; ip < spline_npoints; ip++)
           splineData_r[ip] = all_vals[idx][ip][lm];
-        atomic_spline_r = einspline::create(atomic_spline_r, 0.0, spline_radius, spline_npoints, splineData_r.data(),
-                                            ((lm == 0) || (lm > 3)));
+        atomic_spline_r = einspline::create_UBspline_1d_d(0.0, spline_radius, spline_npoints, splineData_r.data(),
+                                                          ((lm == 0) || (lm > 3)));
         if (!use_duplex_splines_)
         {
           mycenter.set_spline(atomic_spline_r, lm, iorb);
@@ -695,8 +695,8 @@ void HybridRepSetReader<ST>::create_atomic_centers_Gspace(const Vector<std::comp
           UBspline_1d_d* atomic_spline_i = nullptr;
           for (size_t ip = 0; ip < spline_npoints; ip++)
             splineData_i[ip] = all_vals[idx][ip][lm + lm_tot];
-          atomic_spline_i = einspline::create(atomic_spline_i, 0.0, spline_radius, spline_npoints, splineData_i.data(),
-                                              ((lm == 0) || (lm > 3)));
+          atomic_spline_i = einspline::create_UBspline_1d_d(0.0, spline_radius, spline_npoints, splineData_i.data(),
+                                                            ((lm == 0) || (lm > 3)));
           mycenter.set_spline(atomic_spline_r, lm, iorb * 2);
           mycenter.set_spline(atomic_spline_i, lm, iorb * 2 + 1);
           einspline::destroy(atomic_spline_r);

--- a/src/QMCWaveFunctions/BsplineFactory/OneSplineOrbData.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/OneSplineOrbData.cpp
@@ -35,9 +35,9 @@ void OneSplineOrbData::create(const TinyVector<int, 3>& halfG)
 
   TinyVector<double, 3> start(0.0);
   TinyVector<double, 3> end(1.0);
-  spline_r = einspline::create(spline_r, start, end, mesh_size_, halfG);
+  spline_r = einspline::create_UBspline_3d_d(start, end, mesh_size_, halfG);
   if (isComplex_)
-    spline_i = einspline::create(spline_i, start, end, mesh_size_, halfG);
+    spline_i = einspline::create_UBspline_3d_d(start, end, mesh_size_, halfG);
 }
 
 OneSplineOrbData::OneSplineOrbData(const TinyVector<int, 3>& mesh_size,

--- a/src/spline2/MultiBsplineAllocator.hpp
+++ b/src/spline2/MultiBsplineAllocator.hpp
@@ -24,7 +24,6 @@ template<typename T, typename ALLOC = aligned_allocator<T>>
 class MultiBsplineAllocator
 {
   using SplineType       = typename bspline_traits<T, 3>::SplineType;
-  using SingleSplineType = typename bspline_traits<T, 3>::SingleSplineType;
   using BCType           = typename bspline_traits<T, 3>::BCType;
   using real_type        = typename bspline_traits<T, 3>::real_type;
 

--- a/src/spline2/MultiBsplineBase.hpp
+++ b/src/spline2/MultiBsplineBase.hpp
@@ -178,7 +178,7 @@ public:
    * @param single UBspline_3d_d
    * @param int index of single in multi
    */
-  void set_spline(const typename bspline_traits<double, 3>::SingleSplineType& single, int i)
+  void set_spline(const UBspline_3d_d& single, int i)
   {
     size_t iblock = 0;
     while (iblock < spline_blocks.size() && i >= offsets_[iblock + 1])

--- a/src/spline2/bspline_traits.hpp
+++ b/src/spline2/bspline_traits.hpp
@@ -33,7 +33,6 @@ template<>
 struct bspline_traits<float, 3>
 {
   using SplineType                       = multi_UBspline_3d_s;
-  using SingleSplineType                 = UBspline_3d_s;
   using BCType                           = BCtype_s;
   using real_type                        = float;
   using value_type                       = float;
@@ -46,7 +45,6 @@ template<>
 struct bspline_traits<double, 3>
 {
   using SplineType                       = multi_UBspline_3d_d;
-  using SingleSplineType                 = UBspline_3d_d;
   using BCType                           = BCtype_d;
   using real_type                        = double;
   using value_type                       = double;
@@ -60,7 +58,6 @@ template<>
 struct bspline_traits<float, 1>
 {
   using SplineType       = multi_UBspline_1d_s;
-  using SingleSplineType = UBspline_1d_s;
   using BCType           = BCtype_s;
   using DataType         = float;
   using real_type        = float;
@@ -72,42 +69,11 @@ template<>
 struct bspline_traits<double, 1>
 {
   using SplineType       = multi_UBspline_1d_d;
-  using SingleSplineType = UBspline_1d_d;
   using BCType           = BCtype_d;
   using DataType         = double;
   using real_type        = double;
   using value_type       = double;
 };
 
-
-/** helper class to determine the value_type of einspline objects
-   */
-template<typename ST>
-struct bspline_type
-{};
-
-template<>
-struct bspline_type<multi_UBspline_3d_s>
-{
-  using value_type = float;
-};
-
-template<>
-struct bspline_type<multi_UBspline_3d_d>
-{
-  using value_type = double;
-};
-
-template<>
-struct bspline_type<UBspline_3d_s>
-{
-  using value_type = float;
-};
-
-template<>
-struct bspline_type<UBspline_3d_d>
-{
-  using value_type = double;
-};
 } // namespace qmcplusplus
 #endif

--- a/src/spline2/einspline_impl.hpp
+++ b/src/spline2/einspline_impl.hpp
@@ -48,7 +48,7 @@ namespace einspline
 
 
 template<typename VT, typename IT>
-UBspline_3d_d* create(UBspline_3d_d* s, VT& start, VT& end, IT& ng, IT& halfg, int n = 1)
+UBspline_3d_d* create_UBspline_3d_d(VT& start, VT& end, IT& ng, IT& halfg)
 {
   Ugrid x_grid, y_grid, z_grid;
   BCtype_d xBC, yBC, zBC;
@@ -73,13 +73,12 @@ inline void recompute(UBspline_3d_d* s, double* restrict data) { recompute_UBspl
 
 // 1D spline
 /** create a single spline for double */
-template<typename VT>
-UBspline_1d_d* create(UBspline_1d_d* s,
-                      const VT& start,
-                      const VT& end,
-                      const int spline_npoints,
-                      double* indata,
-                      bool lFlat)
+template<typename T>
+UBspline_1d_d* create_UBspline_1d_d(const T start,
+                                    const T end,
+                                    const int spline_npoints,
+                                    double* indata,
+                                    bool lFlat)
 {
   BCtype_d bc;
   if (lFlat)


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->



## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

laptop

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
