### PR TITLE
Enable CTest distributing testing jobs to GPUs by setting QMC_CTEST_NUM_GPUS

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -16,6 +16,17 @@
 
 include(test_labels)
 
+# Reserve one GPU for a test. CTest obtains the available GPU IDs from the
+# resource specification generated in the top-level CMakeLists.txt.
+function(SET_TEST_GPU_RESOURCES TESTNAME)
+  if(ENABLE_CUDA
+     OR ENABLE_ROCM
+     OR ENABLE_SYCL
+     OR ENABLE_OFFLOAD)
+    set_tests_properties(${TESTNAME} PROPERTIES RESOURCE_GROUPS "gpus:1")
+  endif()
+endfunction()
+
 # Function to copy a directory
 function(COPY_DIRECTORY SRC_DIR DST_DIR)
   execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory "${SRC_DIR}" "${DST_DIR}")
@@ -142,8 +153,8 @@ function(
     if(${TOT_PROCS} GREATER ${TEST_MAX_PROCS})
       message(VERBOSE "Disabling test ${TESTNAME} (exceeds maximum number of processors ${TEST_MAX_PROCS})")
     else()
-      add_test(NAME ${TESTNAME} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${PROCS} ${MPIEXEC_PREFLAGS}
-                                        ${QMC_APP} ${ARGN})
+      add_test(NAME ${TESTNAME} COMMAND ${QMC_GPU_TEST_LAUNCHER} ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${PROCS}
+                                        ${MPIEXEC_PREFLAGS} ${QMC_APP} ${ARGN})
       set_tests_properties(
         ${TESTNAME}
         PROPERTIES FAIL_REGULAR_EXPRESSION
@@ -168,7 +179,7 @@ function(
     endif()
   else()
     if((${PROCS} STREQUAL "1"))
-      add_test(NAME ${TESTNAME} COMMAND ${QMC_APP} ${ARGN})
+      add_test(NAME ${TESTNAME} COMMAND ${QMC_GPU_TEST_LAUNCHER} ${QMC_APP} ${ARGN})
       set_tests_properties(
         ${TESTNAME}
         PROPERTIES FAIL_REGULAR_EXPRESSION
@@ -198,12 +209,7 @@ function(
       APPEND
       PROPERTY LABELS "QMCPACK")
 
-    if(ENABLE_CUDA
-       OR ENABLE_ROCM
-       OR ENABLE_SYCL
-       OR ENABLE_OFFLOAD)
-      set_tests_properties(${TESTNAME} PROPERTIES RESOURCE_LOCK exclusively_owned_gpus)
-    endif()
+    set_test_gpu_resources(${TESTNAME})
 
     if(ENABLE_OFFLOAD)
       set_property(TEST ${TESTNAME} APPEND PROPERTY ENVIRONMENT "OMP_TARGET_OFFLOAD=mandatory")

--- a/CMake/unit_test.cmake
+++ b/CMake/unit_test.cmake
@@ -5,12 +5,12 @@ function(ADD_UNIT_TEST TESTNAME PROCS THREADS TEST_BINARY)
   message(VERBOSE "Adding test ${TESTNAME}")
   math(EXPR TOT_PROCS "${PROCS} * ${THREADS}")
   if(HAVE_MPI)
-    add_test(NAME ${TESTNAME} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${PROCS} ${MPIEXEC_PREFLAGS}
-                                      ${TEST_BINARY} ${ARGN})
+    add_test(NAME ${TESTNAME} COMMAND ${QMC_GPU_TEST_LAUNCHER} ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${PROCS}
+                                      ${MPIEXEC_PREFLAGS} ${TEST_BINARY} ${ARGN})
     set(TEST_ADDED TRUE)
   else()
     if((${PROCS} STREQUAL "1"))
-      add_test(NAME ${TESTNAME} COMMAND ${TEST_BINARY} ${ARGN})
+      add_test(NAME ${TESTNAME} COMMAND ${QMC_GPU_TEST_LAUNCHER} ${TEST_BINARY} ${ARGN})
       set(TEST_ADDED TRUE)
     else()
       message(VERBOSE "Disabling test ${TESTNAME} (building without MPI)")
@@ -27,12 +27,7 @@ function(ADD_UNIT_TEST TESTNAME PROCS THREADS TEST_BINARY)
         PROPERTY ENVIRONMENT LSAN_OPTIONS=${LSAN_OPTIONS})
     endif()
 
-    if(ENABLE_CUDA
-       OR ENABLE_ROCM
-       OR ENABLE_SYCL
-       OR ENABLE_OFFLOAD)
-      set_tests_properties(${TESTNAME} PROPERTIES RESOURCE_LOCK exclusively_owned_gpus)
-    endif()
+    set_test_gpu_resources(${TESTNAME})
 
     if(ENABLE_OFFLOAD)
       set_property(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,12 @@ if(DEFINED ENABLE_CUDA OR DEFINED ENABLE_ROCM OR DEFINED QMC_CUDA2HIP OR DEFINED
 endif()
 
 include(DetermineGPUFeatures)
+set(QMC_CTEST_NUM_GPUS
+    1
+    CACHE STRING "Number of GPUs available to CTest on the local node")
+if(NOT QMC_CTEST_NUM_GPUS MATCHES "^[1-9][0-9]*$")
+  message(FATAL_ERROR "QMC_CTEST_NUM_GPUS must be a positive integer, but is \"${QMC_CTEST_NUM_GPUS}\"")
+endif()
 # Use CMake object library targets to workaround clang linker not being able to handle fat
 # binary archives which contain both host and device codes, for example OpenMP offload regions.
 # CMake does not propagate indirect object files by design.
@@ -963,6 +969,16 @@ if(QMC_DATA)
 endif()
 
 #-------------------------------------------------------------------
+# Verify Python3 available
+#-------------------------------------------------------------------
+find_package(Python3)
+if(NOT Python3_FOUND)
+  message(FATAL_ERROR "Could not find required python3")
+endif(NOT Python3_FOUND)
+
+include(python)
+
+#-------------------------------------------------------------------
 # CTest
 #-------------------------------------------------------------------
 set(DROP_METHOD "http")
@@ -975,16 +991,40 @@ set(DART_TESTING_TIMEOUT
     3600
     CACHE STRING "Maximum time for one test")
 enable_testing()
+if(QMC_GPU)
+  math(EXPR QMC_LAST_GPU_ID "${QMC_CTEST_NUM_GPUS} - 1")
+  set(QMC_CTEST_GPU_RESOURCES "")
+  foreach(QMC_GPU_ID RANGE 0 ${QMC_LAST_GPU_ID})
+    if(QMC_CTEST_GPU_RESOURCES)
+      string(APPEND QMC_CTEST_GPU_RESOURCES ",\n")
+    endif()
+    string(APPEND QMC_CTEST_GPU_RESOURCES "        { \"id\": \"${QMC_GPU_ID}\", \"slots\": 1 }")
+  endforeach()
+
+  set(CTEST_RESOURCE_SPEC_FILE "${qmcpack_BINARY_DIR}/CTestGPUResourceSpec.json")
+  file(
+    GENERATE
+    OUTPUT "${CTEST_RESOURCE_SPEC_FILE}"
+    CONTENT
+      "{\n  \"version\": { \"major\": 1, \"minor\": 0 },\n  \"local\": [\n    {\n      \"gpus\": [\n${QMC_CTEST_GPU_RESOURCES}\n      ]\n    }\n  ]\n}\n"
+  )
+  message(STATUS "CTest GPU resources: ${QMC_CTEST_NUM_GPUS}")
+endif()
 include(CTest)
 
-#-------------------------------------------------------------------
-# Verify Python3 available
-#-------------------------------------------------------------------
-find_package(Python3)
-if(NOT Python3_FOUND)
-  message(FATAL_ERROR "Could not find required python3")
-endif(NOT Python3_FOUND)
-include(python)
+# Determine environment variable to set GPU visibility based on the GPU architecture
+if(QMC_GPU)
+  if(QMC_CUDA2HIP OR QMC_GPU_ARCHS MATCHES "(^|;)gfx")
+    set(QMC_GPU_VISIBILITY_VARIABLE ROCR_VISIBLE_DEVICES)
+  elseif(ENABLE_SYCL OR QMC_GPU_ARCHS MATCHES "(^|;)intel_gpu_")
+    set(QMC_GPU_VISIBILITY_VARIABLE ZE_AFFINITY_MASK)
+  else()
+    set(QMC_GPU_VISIBILITY_VARIABLE CUDA_VISIBLE_DEVICES)
+  endif()
+  set(QMC_GPU_TEST_LAUNCHER ${Python3_EXECUTABLE} ${qmcpack_SOURCE_DIR}/tests/scripts/gpu_test_resource_launcher.py
+                            ${QMC_GPU_VISIBILITY_VARIABLE})
+endif()
+
 
 #-------------------------------------------------------------------
 # Check if PySCF is available

--- a/tests/performance/C-graphite/CMakeLists.txt
+++ b/tests/performance/C-graphite/CMakeLists.txt
@@ -36,19 +36,17 @@ function(
   set(TEST_NAME ${TEST_NAME}-r${PROCS}-t${THREADS})
   math(EXPR TOT_PROCS "${PROCS} * ${THREADS}")
   if(HAVE_MPI)
-    add_test(NAME ${TEST_NAME} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${PROCS} ${MPIEXEC_PREFLAGS}
-                                       ${QMC_APP} ${PERF_ARGS} ${INPUT_FILE})
+    add_test(NAME ${TEST_NAME} COMMAND ${QMC_GPU_TEST_LAUNCHER} ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${PROCS}
+                                       ${MPIEXEC_PREFLAGS} ${QMC_APP} ${PERF_ARGS} ${INPUT_FILE})
   else()
-    add_test(NAME ${TEST_NAME} COMMAND ${QMC_APP} ${PERF_ARGS} ${INPUT_FILE})
+    add_test(NAME ${TEST_NAME} COMMAND ${QMC_GPU_TEST_LAUNCHER} ${QMC_APP} ${PERF_ARGS} ${INPUT_FILE})
   endif()
 
   set_tests_properties(${TEST_NAME} PROPERTIES LABELS "performance")
   set_tests_properties(${TEST_NAME} PROPERTIES WORKING_DIRECTORY "${WDIR}")
   set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=${THREADS})
   set_tests_properties(${TEST_NAME} PROPERTIES PROCESSORS ${TOT_PROCS} PROCESSOR_AFFINITY TRUE)
-  if(ENABLE_CUDA OR ENABLE_SYCL OR ENABLE_OFFLOAD)
-    set_tests_properties(${TEST_NAME} PROPERTIES RESOURCE_LOCK exclusively_owned_gpus)
-  endif()
+  set_test_gpu_resources(${TEST_NAME})
 
   if(ENABLE_TIMERS)
     add_test(NAME "${TEST_NAME}-time" COMMAND ${Python3_EXECUTABLE} ../process_perf.py ${INPUT_FILE})

--- a/tests/performance/C-molecule/CMakeLists.txt
+++ b/tests/performance/C-molecule/CMakeLists.txt
@@ -43,19 +43,17 @@ if(NOT QMC_COMPLEX)
     set(TEST_NAME ${TEST_NAME}-r${PROCS}-t${THREADS})
     math(EXPR TOT_PROCS "${PROCS} * ${THREADS}")
     if(HAVE_MPI)
-      add_test(NAME ${TEST_NAME} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${PROCS} ${MPIEXEC_PREFLAGS}
-                                         ${QMC_APP} ${PERF_ARGS} ${INPUT_FILE})
+      add_test(NAME ${TEST_NAME} COMMAND ${QMC_GPU_TEST_LAUNCHER} ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${PROCS}
+                                         ${MPIEXEC_PREFLAGS} ${QMC_APP} ${PERF_ARGS} ${INPUT_FILE})
     else()
-      add_test(NAME ${TEST_NAME} COMMAND ${QMC_APP} ${PERF_ARGS} ${INPUT_FILE})
+      add_test(NAME ${TEST_NAME} COMMAND ${QMC_GPU_TEST_LAUNCHER} ${QMC_APP} ${PERF_ARGS} ${INPUT_FILE})
     endif()
 
     set_tests_properties(${TEST_NAME} PROPERTIES LABELS "performance")
     set_tests_properties(${TEST_NAME} PROPERTIES WORKING_DIRECTORY "${WDIR}")
     set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=${THREADS})
     set_tests_properties(${TEST_NAME} PROPERTIES PROCESSORS ${TOT_PROCS} PROCESSOR_AFFINITY TRUE)
-    if(ENABLE_CUDA OR ENABLE_SYCL OR ENABLE_OFFLOAD)
-      set_tests_properties(${TEST_NAME} PROPERTIES RESOURCE_LOCK exclusively_owned_gpus)
-    endif()
+    set_test_gpu_resources(${TEST_NAME})
 
     if(ENABLE_TIMERS)
       add_test(NAME "${TEST_NAME}-time" COMMAND ${Python3_EXECUTABLE} ../process_perf.py ${INPUT_FILE})

--- a/tests/performance/NiO/CMakeLists.txt
+++ b/tests/performance/NiO/CMakeLists.txt
@@ -41,19 +41,17 @@ function(
   set(TEST_NAME ${TEST_NAME}-r${PROCS}-t${THREADS})
   math(EXPR TOT_PROCS "${PROCS} * ${THREADS}")
   if(HAVE_MPI)
-    add_test(NAME ${TEST_NAME} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${PROCS} ${MPIEXEC_PREFLAGS}
-                                       ${QMC_APP} ${PERF_ARGS} ${INPUT_FILE})
+    add_test(NAME ${TEST_NAME} COMMAND ${QMC_GPU_TEST_LAUNCHER} ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${PROCS}
+                                       ${MPIEXEC_PREFLAGS} ${QMC_APP} ${PERF_ARGS} ${INPUT_FILE})
   else()
-    add_test(NAME ${TEST_NAME} COMMAND ${QMC_APP} ${PERF_ARGS} ${INPUT_FILE})
+    add_test(NAME ${TEST_NAME} COMMAND ${QMC_GPU_TEST_LAUNCHER} ${QMC_APP} ${PERF_ARGS} ${INPUT_FILE})
   endif()
 
   set_tests_properties(${TEST_NAME} PROPERTIES LABELS "performance")
   set_tests_properties(${TEST_NAME} PROPERTIES WORKING_DIRECTORY "${WDIR}")
   set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=${THREADS})
   set_tests_properties(${TEST_NAME} PROPERTIES PROCESSORS ${TOT_PROCS} PROCESSOR_AFFINITY TRUE)
-  if(ENABLE_CUDA OR ENABLE_SYCL OR ENABLE_OFFLOAD)
-    set_tests_properties(${TEST_NAME} PROPERTIES RESOURCE_LOCK exclusively_owned_gpus)
-  endif()
+  set_test_gpu_resources(${TEST_NAME})
 
   if(ENABLE_TIMERS)
     add_test(NAME "${TEST_NAME}-time" COMMAND ${Python3_EXECUTABLE} ../process_perf.py ${INPUT_FILE})

--- a/tests/scripts/gpu_test_resource_launcher.py
+++ b/tests/scripts/gpu_test_resource_launcher.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+"""Helper to launch a CTest GPU test on the GPU assigned by CTest's resource scheduler.
+
+The first argument names the backend-specific device visibility variable, such
+as ROCR_VISIBLE_DEVICES or CUDA_VISIBLE_DEVICES. The launcher reads CTest's GPU
+resource assignment, maps its logical device ID through any visibility mask
+provided by a job scheduler, restricts the child process to that device, and
+then replaces itself with the requested test command.
+"""
+
+import os
+import re
+import sys
+
+
+def get_gpu_id():
+    """Return the GPU ID assigned to resource group zero by CTest."""
+    assignment = os.environ.get("CTEST_RESOURCE_GROUP_0_GPUS")
+    if assignment is None:
+        sys.stderr.write(
+            "GPU test has no CTest resource assignment. "
+            "Configure with QMC_CTEST_NUM_GPUS and run the test through ctest.\n"
+        )
+        sys.exit(1)
+
+    match = re.search(r"(?:^|;)id:([^,;]+),slots:[0-9]+(?:;|$)", assignment)
+    if match is None:
+        sys.stderr.write(f"Invalid CTest GPU resource assignment: {assignment!r}\n")
+        sys.exit(1)
+    return match.group(1)
+
+
+def map_visible_gpu(gpu_id, visibility_variable):
+    """Map a CTest logical ID through a visibility mask from a job launcher."""
+    gpu_index = int(gpu_id)
+    visible_devices = os.environ.get(visibility_variable)
+    if visible_devices:
+        device_ids = [device.strip() for device in visible_devices.split(",")]
+        if gpu_index >= len(device_ids):
+            sys.stderr.write(
+                f"CTest assigned GPU {gpu_id}, but {visibility_variable} only exposes "
+                f"{len(device_ids)} device(s).\n"
+            )
+            sys.exit(1)
+        return device_ids[gpu_index]
+    return gpu_id
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.stderr.write("GPU test resource launcher requires a visibility variable and command to run.\n")
+        return 1
+
+    visibility_variable = sys.argv[1]
+    gpu_id = map_visible_gpu(get_gpu_id(), visibility_variable)
+    os.environ[visibility_variable] = gpu_id
+
+    os.execvpe(sys.argv[2], sys.argv[2:], os.environ)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen2.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen2.sh
@@ -58,6 +58,7 @@ case "$1" in
           -DCMAKE_CXX_COMPILER=amdclang++ \
           -DQMC_MPI=0 \
           -DQMC_GPU_ARCHS=gfx90a \
+          -DQMC_CTEST_NUM_GPUS=2 \
           -DQMC_COMPLEX=$IS_COMPLEX \
           -DQMC_MIXED_PRECISION=$IS_MIXED_PRECISION \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen2.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen2.sh
@@ -76,7 +76,7 @@ case "$1" in
     echo "Running deterministic tests"
     amd-smi version
     cd ${GITHUB_WORKSPACE}/../qmcpack-build
-    ctest --output-on-failure -L deterministic -j 32 --timeout 120 --repeat after-timeout:4
+    ctest --output-on-failure -L deterministic -j 40 --timeout 120 --repeat after-timeout:4
     ;;
     
 esac


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Optionally enable multi-GPU test execution via new variable QMC_CTEST_NUM_GPUS. 

Replace prior exclusively_owned_gpus RESOURCE_LOCK with numbered gpu RESOURCE_GROUP.

GPU tests request 1 GPU resource. This hardwiring could be expanded in future for tests genuinely requiring multiple GPUs (shared splines etc.)

GPU architecture specific environmental variables control visibility (ROCR_VISIBLE_DEVICES, ZE_AFFINITY_MASK, CUDA_VISIBLE_DEVICES). A helper python script modifies this variable ahead of the MPI launcher. 

Only tested on nitrogen2 (2xAMD MI210). This update should improve the CI performance, roughly halving the required GPU wall clock time per CI run. 

Once appropriately reviewed, refined, and merged I will add docs in a subsequent PR. Build recipes for HPC nodes will also be updated.

Test scheduling verified (two NiO a512 batched performance tests):
<img width="685" height="821" alt="Screenshot 2026-08-12 at 7 39 15 PM" src="https://github.com/user-attachments/assets/0639e7b7-07e6-4241-8d9b-4477bf7a88e4" />


Nearly entirely done with Codex/GPT 5.6 Sol

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- New feature
- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->
nitrogen2, ROCm 7.14


## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
