### PR TITLE
Rerun failed tests up to 4x on nitrogen2 CI

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen2.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen2.sh
@@ -75,8 +75,7 @@ case "$1" in
     echo "Running deterministic tests"
     amd-smi version
     cd ${GITHUB_WORKSPACE}/../qmcpack-build
-    ctest --output-on-failure -L deterministic -j 40 --timeout 120 --repeat after-timeout:4
-    ctest --output-on-failure -L determinsitic -j 40 --timeout 120 --rerun-failed --repeat until-pass:4
+    ctest --output-on-failure -L deterministic -j 40 --timeout 120 --repeat until-pass:4
     ;;
     
 esac

--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen2.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen2.sh
@@ -76,7 +76,7 @@ case "$1" in
     amd-smi version
     cd ${GITHUB_WORKSPACE}/../qmcpack-build
     ctest --output-on-failure -L deterministic -j 40 --timeout 120 --repeat after-timeout:4
-    ctest --output-on-failure -j 40 --timeout 120 --rerun-failed --repeat until-pass:4
+    ctest --output-on-failure -L determinsitic -j 40 --timeout 120 --rerun-failed --repeat until-pass:4
     ;;
     
 esac

--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen2.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen2.sh
@@ -75,7 +75,8 @@ case "$1" in
     echo "Running deterministic tests"
     amd-smi version
     cd ${GITHUB_WORKSPACE}/../qmcpack-build
-    ctest --output-on-failure -L deterministic -j 32 --timeout 120 --repeat after-timeout:4
+    ctest --output-on-failure -L deterministic -j 40 --timeout 120 --repeat after-timeout:4
+    ctest --output-on-failure -j 40 --timeout 120 --rerun-failed --repeat until-pass:4
     ;;
     
 esac


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Work around current unreliability problems. Rather than remove from being required to pass, retry failed tests. Rerunning current test failures takes too much of my time. Also set to allow 40 cores.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- Yes
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

None

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
