### PR TITLE
Initialization fixes

### DIFF
--- a/src/Estimators/EnergyDensityEstimator.cpp
+++ b/src/Estimators/EnergyDensityEstimator.cpp
@@ -426,6 +426,7 @@ void NEEnergyDensityEstimator::zero()
   for (auto& spacegrid : spacegrids_)
     spacegrid->zero();
   walkers_weight_ = 0;
+  nsamples_       = 0;
 }
 
 std::unique_ptr<OperatorEstBase> NEEnergyDensityEstimator::spawnCrowdClone() const

--- a/src/Estimators/EnergyDensityEstimator.h
+++ b/src/Estimators/EnergyDensityEstimator.h
@@ -191,7 +191,7 @@ private:
   /// @}
 
   //number of samples accumulated
-  int nsamples_;
+  int nsamples_{0};
 
   DataLocality data_locality_{DataLocality::crowd};
 

--- a/src/Estimators/tests/test_EnergyDensityEstimator.cpp
+++ b/src/Estimators/tests/test_EnergyDensityEstimator.cpp
@@ -54,6 +54,10 @@ TEST_CASE("NEEnergyDensityEstimator::Constructor", "[estimators]")
   EnergyDensityInput edein{node};
   {
     NEEnergyDensityEstimator e_den_est(edein, particle_pool.getPool());
+    PooledData<QMCTraits::RealType> buffer;
+    e_den_est.packData(buffer);
+    REQUIRE(buffer.size() == e_den_est.getFullDataSize());
+    CHECK(buffer[buffer.size() - 1] == Approx(0.0));
   }
 }
 
@@ -84,7 +88,13 @@ TEST_CASE("NEEnergyDensityEstimator::spawnCrowdClone", "[estimators]")
     auto clone = original_e_den_est.spawnCrowdClone();
     REQUIRE(clone != nullptr);
     REQUIRE(clone.get() != &original_e_den_est);
-    REQUIRE(dynamic_cast<decltype(&original_e_den_est)>(clone.get()) != nullptr);
+    auto* clone_e_den_est = dynamic_cast<decltype(&original_e_den_est)>(clone.get());
+    REQUIRE(clone_e_den_est != nullptr);
+
+    PooledData<QMCTraits::RealType> buffer;
+    clone_e_den_est->packData(buffer);
+    REQUIRE(buffer.size() == clone_e_den_est->getFullDataSize());
+    CHECK(buffer[buffer.size() - 1] == Approx(0.0));
   }
 }
 
@@ -149,6 +159,16 @@ TEST_CASE("NEEnergyDensityEstimator::AccumulateIntegration", "[estimators]")
   CHECK(summed_grid == Approx(expected_sum));
 
   e_den_est.write(hd);
+
+  PooledData<QMCTraits::RealType> buffer;
+  e_den_est.packData(buffer);
+  REQUIRE(buffer.size() == e_den_est.getFullDataSize());
+  CHECK(buffer[buffer.size() - 1] == Approx(4.0));
+
+  e_den_est.zero();
+  buffer.clear();
+  e_den_est.packData(buffer);
+  CHECK(buffer[buffer.size() - 1] == Approx(0.0));
   std::cout << "wrote success\n";
 }
 

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -69,6 +69,7 @@ ParticleSet::ParticleSet(const SimulationCell& simulation_cell, const DynamicCoo
 
 ParticleSet::ParticleSet(const ParticleSet& p)
     : Properties(p.Properties),
+      current_step(p.current_step),
       simulation_cell_(p.simulation_cell_),
       same_mass_(true),
       is_spinor_(false),

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -126,7 +126,7 @@ public:
   ///@}
 
   ///current MC step
-  int current_step;
+  int current_step{0};
 
   ///default constructor
   ParticleSet(const SimulationCell& simulation_cell, const DynamicCoordinateKind kind = DynamicCoordinateKind::DC_POS);

--- a/src/Particle/WalkerConfigurations.h
+++ b/src/Particle/WalkerConfigurations.h
@@ -40,15 +40,15 @@ namespace qmcplusplus
 template<typename T>
 struct MCDataType
 {
-  T NumSamples;
-  T RNSamples;
-  T Weight;
-  T Energy;
-  T AlternateEnergy;
-  T Variance;
-  T R2Accepted;
-  T R2Proposed;
-  T LivingFraction;
+  T NumSamples{};
+  T RNSamples{};
+  T Weight{};
+  T Energy{};
+  T AlternateEnergy{};
+  T Variance{};
+  T R2Accepted{};
+  T R2Proposed{};
+  T LivingFraction{};
 };
 
 /** A set of light weight walkers that are carried between driver sections and restart

--- a/src/Particle/tests/test_ParticleSet.cpp
+++ b/src/Particle/tests/test_ParticleSet.cpp
@@ -27,6 +27,9 @@ TEST_CASE("ParticleSet distance table management", "[particle]")
   ParticleSet ions(simulation_cell);
   ParticleSet elecs(simulation_cell);
 
+  CHECK(ions.current_step == 0);
+  ions.current_step = 13;
+
   ions.setName("ions");
   elecs.setName("electrons");
 
@@ -59,6 +62,9 @@ TEST_CASE("ParticleSet distance table management", "[particle]")
   ParticleSet elecs_copy(elecs);
   REQUIRE(elecs_copy.getDistTable(ei_table_id2).get_origin().getName() == "ions");
   REQUIRE(elecs_copy.getDistTable(ee_table_id2).get_origin().getName() == "electrons");
+
+  ParticleSet ions_copy(ions);
+  CHECK(ions_copy.current_step == 13);
 }
 
 TEST_CASE("symmetric_distance_table OpenBC", "[particle]")

--- a/src/Particle/tests/test_walker.cpp
+++ b/src/Particle/tests/test_walker.cpp
@@ -50,6 +50,20 @@ TEST_CASE("walker assumptions", "[particle]")
   REQUIRE(w1.Properties.cols() == WP::NUMPROPERTIES);
 }
 
+TEST_CASE("MCDataType default initialization", "[particle]")
+{
+  MCDataType<double> data;
+  CHECK(data.NumSamples == 0.0);
+  CHECK(data.RNSamples == 0.0);
+  CHECK(data.Weight == 0.0);
+  CHECK(data.Energy == 0.0);
+  CHECK(data.AlternateEnergy == 0.0);
+  CHECK(data.Variance == 0.0);
+  CHECK(data.R2Accepted == 0.0);
+  CHECK(data.R2Proposed == 0.0);
+  CHECK(data.LivingFraction == 0.0);
+}
+
 TEST_CASE("walker HDF read and write", "[particle]")
 {
   Communicate* c = OHMMS::Controller;

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -372,8 +372,14 @@ void QMCDriver::setWalkerOffsets()
     W[iw]->setWalkerID(id);
     W[iw]->setParentID(id);
   }
-  app_log() << "  Total number of walkers: " << W.EnsembleProperty.NumSamples << std::endl;
-  app_log() << "  Total weight: " << W.EnsembleProperty.Weight << std::endl;
+  // Compute total walker weights and counts. W.EnsembleProperty.NumSamples and W.EnsembleProperty.Weight are only set during branching / measureProperties.
+  QMCTraits::FullPrecRealType total_weight = 0;
+  for (int iw = 0; iw < nw[myComm->rank()]; ++iw)
+    total_weight += W[iw]->Weight;
+  myComm->allreduce(total_weight);
+
+  app_log() << "  Total number of walkers: " << nwoff.back() << std::endl;
+  app_log() << "  Total weight: " << total_weight << std::endl;
 }
 
 

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -94,7 +94,7 @@ public:
   /// whether to allow traces
   bool allow_traces;
   /// traces xml
-  xmlNodePtr traces_xml;
+  xmlNodePtr traces_xml{nullptr};
 
   /// whether to allow traces
   bool allow_walker_logs;

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -104,7 +104,7 @@ public:
   std::bitset<QMC_MODE_MAX> qmc_driver_mode_;
 
   /// whether to allow walker logs
-  bool allow_walker_logs;
+  bool allow_walker_logs{false};
   /// walker logs input
   WalkerLogInput walker_logs_input;
   //xmlNodePtr walker_logs_xml;

--- a/src/QMCDrivers/tests/test_QMCDriverNew.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverNew.cpp
@@ -51,6 +51,12 @@ TEST_CASE("QMCDriverNew tiny case", "[drivers]")
                                                  hamiltonian_pool.getHamiltonian().value()),
                                     rng_pool.getRngRefs(), comm);
 
+  CHECK_FALSE(qmcdriver.allow_walker_logs);
+  qmcdriver.requestWalkerLogs(true);
+  CHECK(qmcdriver.allow_walker_logs);
+  qmcdriver.requestWalkerLogs(false);
+  CHECK_FALSE(qmcdriver.allow_walker_logs);
+
   // setStatus must be called before process
   std::string root_name{"Test"};
   //For later sections this appears to contain important state.


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
A scattering of initialization fixes from 5.6 Sol to pass msan with LLVM 21.1.8 QMC_OMP=0 QMC_MPI=0 builds. Most of the changes are added tests.

The fix in QMCDriver.cpp:375 should be reviewed carefully since it adds an allreduce. Please revert changes or push additional during review to expedite merging.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Bugfix

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->
X86, msan build with instrumented libc++, FFTW, HDF5, libxml2, boost, openblas, zlib.


## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
