### PR TITLE
ppconvert initialization fixes

### DIFF
--- a/src/QMCTools/ppconvert/src/common/DFTAtom.cc
+++ b/src/QMCTools/ppconvert/src/common/DFTAtom.cc
@@ -119,6 +119,7 @@ void DFTAtom::SetGrid(std::shared_ptr<Grid>& newgrid)
 
 void DFTAtom::SetBarePot(Potential *newPot)
 {
+  assert(newPot != nullptr);
   BarePot = newPot;
   V.BarePot = BarePot;
   for (int i=0; i<RadialWFs.size(); i++)
@@ -292,4 +293,3 @@ void DFTAtom::Read(IOSectionClass &in)
   V.Charge = charge;
   assert (in.ReadVar("NewMix", NewMix));
 }
-

--- a/src/QMCTools/ppconvert/src/common/DFTAtom.h
+++ b/src/QMCTools/ppconvert/src/common/DFTAtom.h
@@ -28,12 +28,12 @@ private:
   void UpdateHartree();
   void UpdateExCorr();
   Array<double, 1> temp, temp2;
-  Potential* BarePot;
+  Potential* BarePot{nullptr};
   Array<double, 1> OldEnergies;
 
 public:
   ScreenedPot V;
-  double NewMix;
+  double NewMix{0.0};
 
   AtomType Type() override;
   /// This function calculates the charge density, hartree and exchange

--- a/src/QMCTools/ppconvert/src/common/ScreenedPot.h
+++ b/src/QMCTools/ppconvert/src/common/ScreenedPot.h
@@ -22,9 +22,9 @@
 class ScreenedPot : public Potential
 {
 public:
-  double Charge;
+  double Charge{0.0};
   CubicSplineCommon HXC;
-  Potential* BarePot;
+  Potential* BarePot{nullptr};
 
   bool IsPH() override;
   bool NeedsRel() override;


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Several initialization fixes from 5.6 Sol for our ppconvert test to nearly pass msan. V.Charge in SetBarePot is also problematic, but I did not investigate how to (re)compute it since this would require more extensive testing to check. 

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Bugfix

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->
LLVM 21.1.8 as per #6122


## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
