### PR TITLE
Remove LinearMethod as a base class

### DIFF
--- a/src/QMCDrivers/WFOpt/LinearMethod.cpp
+++ b/src/QMCDrivers/WFOpt/LinearMethod.cpp
@@ -120,7 +120,7 @@ LinearMethod::Real LinearMethod::selectEigenvalue(std::vector<Real>& eigenvals,
 }
 
 
-LinearMethod::Real LinearMethod::getLowestEigenvector(Matrix<Real>& A, std::vector<Real>& ev) const
+LinearMethod::Real LinearMethod::getLowestEigenvector(Matrix<Real>& A, std::vector<Real>& ev)
 {
   int Nl(ev.size());
   //   Getting the optimal worksize
@@ -205,7 +205,7 @@ LinearMethod::Real LinearMethod::getLowestEigenvector(Matrix<Real>& A, std::vect
   //     }
 }
 
-void LinearMethod::getNonLinearRange(int& first, int& last, const QMCCostFunctionBase& optTarget) const
+void LinearMethod::getNonLinearRange(int& first, int& last, const QMCCostFunctionBase& optTarget)
 {
   std::vector<int> types;
   optTarget.getParameterTypes(types);
@@ -239,7 +239,7 @@ void LinearMethod::getNonLinearRange(int& first, int& last, const QMCCostFunctio
 
 LinearMethod::Real LinearMethod::getNonLinearRescale(std::vector<Real>& dP,
                                                      Matrix<Real>& S,
-                                                     const QMCCostFunctionBase& optTarget) const
+                                                     const QMCCostFunctionBase& optTarget)
 {
   int first(0), last(0);
   getNonLinearRange(first, last, optTarget);

--- a/src/QMCDrivers/WFOpt/LinearMethod.h
+++ b/src/QMCDrivers/WFOpt/LinearMethod.h
@@ -33,7 +33,7 @@ class LinearMethod
   using Real = QMCTraits::RealType;
 
   // obtain the range of non-linear parameters
-  void getNonLinearRange(int& first, int& last, const QMCCostFunctionBase& optTarget) const;
+  static void getNonLinearRange(int& first, int& last, const QMCCostFunctionBase& optTarget);
 
 public:
   /** Select eigenvalue and return corresponding scaled eigenvector
@@ -69,9 +69,9 @@ public:
   static Real getLowestEigenvector_Gen(Matrix<Real>& A, Matrix<Real>& B, std::vector<Real>& ev);
 
   //asymmetric EV
-  Real getLowestEigenvector(Matrix<Real>& A, std::vector<Real>& ev) const;
+  static Real getLowestEigenvector(Matrix<Real>& A, std::vector<Real>& ev);
   // compute a rescale factor. Ye: Where is the method from?
-  Real getNonLinearRescale(std::vector<Real>& dP, Matrix<Real>& S, const QMCCostFunctionBase& optTarget) const;
+  static Real getNonLinearRescale(std::vector<Real>& dP, Matrix<Real>& S, const QMCCostFunctionBase& optTarget);
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -899,11 +899,11 @@ void QMCFixedSampleLinearOptimize::solveShiftsWithoutLMYEngine(const std::vector
     LinearMethod::getLowestEigenvector(prdMat, parameterDirections.at(shift_index));
 
     // compute the scaling constant to apply to the update
-    Lambda = LinearMethod::getNonLinearRescale(parameterDirections.at(shift_index), ovlMat, *optTarget);
+    auto lambda = LinearMethod::getNonLinearRescale(parameterDirections.at(shift_index), ovlMat, *optTarget);
 
     // scale the update by the scaling constant
     for (int i = 0; i < numParams; i++)
-      parameterDirections.at(shift_index).at(i + 1) *= Lambda;
+      parameterDirections.at(shift_index).at(i + 1) *= lambda;
   }
 }
 
@@ -1310,11 +1310,11 @@ bool QMCFixedSampleLinearOptimize::one_shift_run()
   }
 
   // compute the scaling constant to apply to the update
-  Lambda = LinearMethod::getNonLinearRescale(parameterDirections, ovlMat, *optTarget);
+  auto lambda = LinearMethod::getNonLinearRescale(parameterDirections, ovlMat, *optTarget);
 
   // scale the update by the scaling constant
   for (int i = 0; i < numParams; i++)
-    parameterDirections.at(i + 1) *= Lambda;
+    parameterDirections.at(i + 1) *= lambda;
 
   // now that we are done building the matrices, prevent further computation of derivative vectors
   optTarget->setneedGrads(false);

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -28,6 +28,7 @@
 #include "CPU/Blasf.h"
 #include "Numerics/MatrixOperators.h"
 #include "Message/UniformCommunicateError.h"
+#include "LinearMethod.h"
 #include <cassert>
 #ifdef HAVE_LMY_ENGINE
 #include "formic/utils/matrix.h"
@@ -286,8 +287,8 @@ bool QMCFixedSampleLinearOptimize::run()
 
       {
         ScopedTimer local(eigenvalue_timer_);
-        getLowestEigenvector(Right, currentParameterDirections);
-        Lambda = getNonLinearRescale(currentParameterDirections, S, *optTarget);
+        LinearMethod::getLowestEigenvector(Right, currentParameterDirections);
+        Lambda = LinearMethod::getNonLinearRescale(currentParameterDirections, S, *optTarget);
       }
       //       biggest gradient in the parameter direction vector
       RealType bigVec(0);
@@ -895,10 +896,10 @@ void QMCFixedSampleLinearOptimize::solveShiftsWithoutLMYEngine(const std::vector
         std::swap(prdMat(i, j), prdMat(j, i));
 
     // compute the lowest eigenvalue of the product matrix and the corresponding eigenvector
-    getLowestEigenvector(prdMat, parameterDirections.at(shift_index));
+    LinearMethod::getLowestEigenvector(prdMat, parameterDirections.at(shift_index));
 
     // compute the scaling constant to apply to the update
-    Lambda = getNonLinearRescale(parameterDirections.at(shift_index), ovlMat, *optTarget);
+    Lambda = LinearMethod::getNonLinearRescale(parameterDirections.at(shift_index), ovlMat, *optTarget);
 
     // scale the update by the scaling constant
     for (int i = 0; i < numParams; i++)
@@ -1305,11 +1306,11 @@ bool QMCFixedSampleLinearOptimize::one_shift_run()
   // compute the lowest eigenvalue of the product matrix and the corresponding eigenvector
   {
     ScopedTimer local(eigenvalue_timer_);
-    getLowestEigenvector(prdMat, parameterDirections);
+    LinearMethod::getLowestEigenvector(prdMat, parameterDirections);
   }
 
   // compute the scaling constant to apply to the update
-  Lambda = getNonLinearRescale(parameterDirections, ovlMat, *optTarget);
+  Lambda = LinearMethod::getNonLinearRescale(parameterDirections, ovlMat, *optTarget);
 
   // scale the update by the scaling constant
   for (int i = 0; i < numParams; i++)

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
@@ -26,11 +26,12 @@
 #include "QMCDrivers/Optimizers/DescentEngine.h"
 #include "QMCDrivers/Optimizers/HybridEngine.h"
 #include "OutputMatrix.h"
-#include "LinearMethod.h"
 
 namespace qmcplusplus
 {
 
+///forward declaration of a cost function
+class QMCCostFunctionBase;
 class GradientTest;
 class VMC;
 
@@ -41,7 +42,7 @@ class VMC;
  * generated from VMC.
  */
 
-class QMCFixedSampleLinearOptimize : public QMCDriver, public LinearMethod, private NRCOptimization<QMCTraits::RealType>
+class QMCFixedSampleLinearOptimize : public QMCDriver, private NRCOptimization<QMCTraits::RealType>
 {
 public:
   ///Constructor.

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -1060,11 +1060,11 @@ void QMCFixedSampleLinearOptimizeBatched::solveShiftsWithoutLMYEngine(
     LinearMethod::getLowestEigenvector(prdMat, parameterDirections.at(shift_index));
 
     // compute the scaling constant to apply to the update
-    objFuncWrapper_.Lambda = LinearMethod::getNonLinearRescale(parameterDirections.at(shift_index), ovlMat, *optTarget);
+    auto lambda = LinearMethod::getNonLinearRescale(parameterDirections.at(shift_index), ovlMat, *optTarget);
 
     // scale the update by the scaling constant
     for (int i = 0; i < numParams; i++)
-      parameterDirections.at(shift_index).at(i + 1) *= objFuncWrapper_.Lambda;
+      parameterDirections.at(shift_index).at(i + 1) *= lambda;
   }
 }
 
@@ -1704,19 +1704,19 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
     app_log() << "  Execution time (eigenvalue) = " << std::setprecision(4) << t_eigen.elapsed() << std::endl;
 
     // compute the scaling constant to apply to the update
-    objFuncWrapper_.Lambda = LinearMethod::getNonLinearRescale(parameterDirections, ovlMat, *optTarget);
+    auto lambda = LinearMethod::getNonLinearRescale(parameterDirections, ovlMat, *optTarget);
 
     if (do_output_matrices_hdf_)
     {
       hout.write(lowestEV, "lowest_eigenvalue");
       hout.write(parameterDirections, "scaled_eigenvector");
-      hout.write(objFuncWrapper_.Lambda, "non_linear_rescale");
+      hout.write(lambda, "non_linear_rescale");
       hout.close();
     }
 
     // scale the update by the scaling constant
     for (int i = 0; i < numParams; i++)
-      parameterDirections.at(i + 1) *= objFuncWrapper_.Lambda;
+      parameterDirections.at(i + 1) *= lambda;
   }
   myComm->bcast(parameterDirections);
 

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -31,6 +31,7 @@
 #include "Numerics/MatrixOperators.h"
 #include "EstimatorInputDelegates.h"
 #include "Message/UniformCommunicateError.h"
+#include "LinearMethod.h"
 #include <cassert>
 #ifdef HAVE_LMY_ENGINE
 #include "formic/utils/matrix.h"
@@ -384,8 +385,8 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
       app_log() << "  Using XS:" << XS << " " << failedTries << " " << stability << std::endl;
       {
         ScopedTimer local(eigenvalue_timer_);
-        getLowestEigenvector(Right, currentParameterDirections);
-        objFuncWrapper_.Lambda = getNonLinearRescale(currentParameterDirections, S, *optTarget);
+        LinearMethod::getLowestEigenvector(Right, currentParameterDirections);
+        objFuncWrapper_.Lambda = LinearMethod::getNonLinearRescale(currentParameterDirections, S, *optTarget);
       }
       //       biggest gradient in the parameter direction vector
       RealType bigVec(0);
@@ -1056,10 +1057,10 @@ void QMCFixedSampleLinearOptimizeBatched::solveShiftsWithoutLMYEngine(
         std::swap(prdMat(i, j), prdMat(j, i));
 
     // compute the lowest eigenvalue of the product matrix and the corresponding eigenvector
-    getLowestEigenvector(prdMat, parameterDirections.at(shift_index));
+    LinearMethod::getLowestEigenvector(prdMat, parameterDirections.at(shift_index));
 
     // compute the scaling constant to apply to the update
-    objFuncWrapper_.Lambda = getNonLinearRescale(parameterDirections.at(shift_index), ovlMat, *optTarget);
+    objFuncWrapper_.Lambda = LinearMethod::getNonLinearRescale(parameterDirections.at(shift_index), ovlMat, *optTarget);
 
     // scale the update by the scaling constant
     for (int i = 0; i < numParams; i++)
@@ -1683,12 +1684,12 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
     if (eigensolver_ == "general")
     {
       app_log() << "  Using generalized eigenvalue solver (ggev)" << std::endl;
-      lowestEV = getLowestEigenvector_Gen(hamMat, invMat, parameterDirections);
+      lowestEV = LinearMethod::getLowestEigenvector_Gen(hamMat, invMat, parameterDirections);
     }
     else if (eigensolver_ == "inverse")
     {
       app_log() << "  Using inverse + regular eigenvalue solver (geev)" << std::endl;
-      lowestEV = getLowestEigenvector_Inv(hamMat, invMat, parameterDirections);
+      lowestEV = LinearMethod::getLowestEigenvector_Inv(hamMat, invMat, parameterDirections);
     }
     else if (eigensolver_ == "arpack")
     {
@@ -1703,7 +1704,7 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
     app_log() << "  Execution time (eigenvalue) = " << std::setprecision(4) << t_eigen.elapsed() << std::endl;
 
     // compute the scaling constant to apply to the update
-    objFuncWrapper_.Lambda = getNonLinearRescale(parameterDirections, ovlMat, *optTarget);
+    objFuncWrapper_.Lambda = LinearMethod::getNonLinearRescale(parameterDirections, ovlMat, *optTarget);
 
     if (do_output_matrices_hdf_)
     {

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -29,7 +29,6 @@
 #include "QMCDrivers/Optimizers/DescentEngine.h"
 #include "QMCDrivers/Optimizers/HybridEngine.h"
 #include "OutputMatrix.h"
-#include "LinearMethod.h"
 
 namespace qmcplusplus
 {
@@ -47,7 +46,7 @@ class VMCBatched;
 class GradientTest;
 
 
-class QMCFixedSampleLinearOptimizeBatched : public QMCDriverNew, LinearMethod
+class QMCFixedSampleLinearOptimizeBatched : public QMCDriverNew
 {
 public:
   ///Constructor.

--- a/src/QMCDrivers/tests/test_LinearMethod.cpp
+++ b/src/QMCDrivers/tests/test_LinearMethod.cpp
@@ -22,7 +22,6 @@ using Real = QMCTraits::RealType;
 
 TEST_CASE("selectEigenvalues", "[drivers]")
 {
-  LinearMethod lm;
   const int Ne = 4; // Number of eigenvalues
   const int Nv = 4; // Size of eigenvectors
 
@@ -35,7 +34,7 @@ TEST_CASE("selectEigenvalues", "[drivers]")
   std::vector<Real> evals{-1.2, -1.5}; // size Ne
   std::vector<Real> selected_evec(Nv);
   Real zerozero      = -1.0;
-  Real selected_eval = lm.selectEigenvalue(evals, evecs, zerozero, selected_evec);
+  Real selected_eval = LinearMethod::selectEigenvalue(evals, evecs, zerozero, selected_evec);
 
   // Selects the closest to zerozero - 2.0
   CHECK(selected_eval == Approx(-1.5));


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Turn all the member functions of LinearMethod static and thus all its members can be used as free functions.
Hence, it doesn't need to be a base class.

I also changed a few locally used variables "Lambda" truly local.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

laptop

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
