### PR TITLE
Add parallel offset book keeping test

### DIFF
--- a/src/QMCDrivers/tests/test_WalkerControl.cpp
+++ b/src/QMCDrivers/tests/test_WalkerControl.cpp
@@ -20,6 +20,7 @@
 #include "WaveFunctionPool.h"
 #include "HamiltonianPool.h"
 #include "QMCDrivers/MCPopulation.h"
+#include "QMCDrivers/QMCDriverNew.h"
 #include "Utilities/MPIExceptionWrapper.hpp"
 #include "Utilities/for_testing/NativeInitializerPrint.hpp"
 #include "Platforms/Host/OutputManager.h"
@@ -300,6 +301,46 @@ TEST_CASE("MPI WalkerControl population swap walkers", "[drivers][walker_control
       }
     }
   };
+  MPIExceptionWrapper mew;
+  mew(test_func);
+}
+
+// Verify that the global walker start/end offsets are computed consistently across MPI ranks,
+// even when each rank owns a different number of walkers. This guards the driver bookkeeping
+// used to map local walker indices to the global population layout.
+TEST_CASE("QMCDriverNew MPI offset bookkeeping", "[drivers][walker_control]")
+{
+  auto test_func = []() {
+    Communicate* comm = OHMMS::Controller;
+    // Each rank has a different number of walkers: rank r has r+1 walkers
+    int local_walker_count = comm->rank() + 1;
+
+    WalkerConfigurations walker_configs;
+    walker_configs.createWalkers(local_walker_count, 1);
+    QMCDriverNew::setWalkerOffsets(walker_configs, comm);
+
+    // Gather the actual walker counts from all ranks to compute expected offsets
+    std::vector<int> all_walker_counts(comm->size(), 0);
+    all_walker_counts[comm->rank()] = local_walker_count;
+    comm->allreduce(all_walker_counts);
+
+    // Compute expected cumulative offsets
+    std::vector<int> expected_offsets(comm->size() + 1, 0);
+    std::partial_sum(all_walker_counts.begin(), all_walker_counts.end(), expected_offsets.begin() + 1);
+
+    // Verify the walker offset structure
+    REQUIRE(walker_configs.getWalkerOffsets().size() == static_cast<size_t>(comm->size() + 1));
+    CHECK(walker_configs.getGlobalNumWalkers() == std::accumulate(all_walker_counts.begin(), all_walker_counts.end(), 0));
+    
+    // Check all offsets match expected cumulative sums
+    for (int ir = 0; ir < comm->size() + 1; ++ir)
+      CHECK(walker_configs.getWalkerOffsets()[ir] == expected_offsets[ir]);
+
+    // Verify rank-specific offsets
+    CHECK(walker_configs.getWalkerOffsets()[comm->rank()] == expected_offsets[comm->rank()]);
+    CHECK(walker_configs.getWalkerOffsets()[comm->rank() + 1] == expected_offsets[comm->rank() + 1]);
+  };
+
   MPIExceptionWrapper mew;
   mew(test_func);
 }


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Test the offset book keeping

Commentary: currently reviewing the walker load balancing logic and state. It is not clear to me what advantage we get from all these state variables and separate functions vs having a single longer function handle what is needed for the load balancing.

(Added while experimenting with Copilot)

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->
gcc13, openmpi, ubuntu24


## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [X] I have read the pull request guidance and develop docs
* * [X] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
