### PR TITLE
Remove QMCCostFunctionBase::Cost function

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
@@ -56,12 +56,10 @@ void QMCCostFunction::GradCost(std::vector<Return_rt>& PGradient,
     {
       // + FiniteDiff
       opt_vars[i] = PM[i] + FiniteDiff;
-      resetPsi();
       correlatedSampling(false);
       auto CostPlus = computedCost();
       // - FiniteDiff
       opt_vars[i] = PM[i] - FiniteDiff;
-      resetPsi();
       correlatedSampling(false);
       auto CostMinus = computedCost();
       // calculate gradient
@@ -71,7 +69,6 @@ void QMCCostFunction::GradCost(std::vector<Return_rt>& PGradient,
   }
   else
   {
-    resetPsi();
     //evaluate new local energies and derivatives
     EffectiveWeight effective_weight = correlatedSampling(true);
     //Estimators::accumulate has been called by correlatedSampling
@@ -501,6 +498,8 @@ void QMCCostFunction::resetPsi(bool final_reset)
 
 QMCCostFunction::EffectiveWeight QMCCostFunction::correlatedSampling(bool needGrad)
 {
+  resetPsi();
+
   const auto num_opt_vars = opt_vars.size();
   for (int ip = 0; ip < NumThreads; ++ip)
   {
@@ -631,7 +630,6 @@ QMCCostFunction::Return_rt QMCCostFunction::fillOverlapHamiltonianMatrices(Matri
   Right = 0.0;
   Left  = 0.0;
 
-  //     resetPsi();
   curAvg_w            = SumValue[SUM_E_WGT] / SumValue[SUM_WGT];
   Return_rt curAvg2_w = SumValue[SUM_ESQ_WGT] / SumValue[SUM_WGT];
   RealType V_avg      = curAvg2_w - curAvg_w * curAvg_w;

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
@@ -165,8 +165,6 @@ void QMCCostFunction::GradCost(std::vector<Return_rt>& PGradient,
       if (std::abs(w_abs) > 1.0e-10)
         PGradient[j] += w_abs * EDtotals[j];
     }
-
-    IsValid = isEffectiveWeightValid(effective_weight);
   }
 }
 
@@ -327,7 +325,6 @@ void QMCCostFunction::checkConfigurations(EngineHandle& handle)
   app_log().flush();
   setTargetEnergy(Etarget);
   ReportCounter = 0;
-  IsValid       = true;
   //collect SumValue for computedCost
   SumValue[SUM_WGT]       = etemp[1];
   SumValue[SUM_WGTSQ]     = etemp[1];

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -39,7 +39,6 @@ QMCCostFunctionBase::QMCCostFunctionBase(ParticleSet& w, TrialWaveFunction& psi,
       H(h),
       Write2OneXml(true),
       PowerE(2),
-      NumCostCalls(0),
       NumSamples(0),
       w_en(0.9),
       w_var(0.1),
@@ -121,7 +120,6 @@ void QMCCostFunctionBase::setTargetEnergy(Return_rt et)
 
 QMCCostFunctionBase::Return_rt QMCCostFunctionBase::Cost(bool needGrad)
 {
-  NumCostCalls++;
   //reset the wave function
   resetPsi();
   //evaluate new local energies

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -120,8 +120,6 @@ void QMCCostFunctionBase::setTargetEnergy(Return_rt et)
 
 QMCCostFunctionBase::Return_rt QMCCostFunctionBase::Cost(bool needGrad)
 {
-  //reset the wave function
-  resetPsi();
   //evaluate new local energies
   EffectiveWeight effective_weight = correlatedSampling(needGrad);
   IsValid                          = isEffectiveWeightValid(effective_weight);

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -282,7 +282,6 @@ void QMCCostFunctionBase::reportParametersH5()
 }
 
 
-
 /** Parses the xml input file for parameter definitions for the wavefunction optimization.
  * @param q current xmlNode
  * @return true if successful
@@ -995,7 +994,7 @@ QMCCostFunctionBase::Return_rt QMCCostFunctionBase::LMYEngineCost(const bool nee
                                                                   cqmc::engine::LMYEngine<Return_t>& EngineObj)
 {
   // prepare local energies, weights, and possibly derivative vectors
-  auto effective_weight = correlatedSampling(needDeriv);
+  correlatedSampling(needDeriv);
   // since we are using the LMYEngine, compute and return it's cost function value
   return this->LMYEngineCost_detail(EngineObj);
 }

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -118,14 +118,6 @@ void QMCCostFunctionBase::setTargetEnergy(Return_rt et)
   //       }
 }
 
-QMCCostFunctionBase::Return_rt QMCCostFunctionBase::Cost(bool needGrad)
-{
-  //evaluate new local energies
-  EffectiveWeight effective_weight = correlatedSampling(needGrad);
-  IsValid                          = isEffectiveWeightValid(effective_weight);
-  return computedCost();
-}
-
 QMCCostFunctionBase::Return_rt QMCCostFunctionBase::fillHamVec(std::vector<Return_rt>& ham)
 { throw std::runtime_error("Need to implement fillHamVec"); }
 
@@ -1003,9 +995,9 @@ void QMCCostFunctionBase::resetOptimizableObjects(TrialWaveFunction& psi, const 
 QMCCostFunctionBase::Return_rt QMCCostFunctionBase::LMYEngineCost(const bool needDeriv,
                                                                   cqmc::engine::LMYEngine<Return_t>& EngineObj)
 {
-  // prepare local energies, weights, and possibly derivative vectors, and compute standard cost
-  const Return_rt standardCost = this->Cost(needDeriv);
-
+  // prepare local energies, weights, and possibly derivative vectors
+  auto effective_weight = correlatedSampling(needDeriv);
+  IsValid               = isEffectiveWeightValid(effective_weight);
   // since we are using the LMYEngine, compute and return it's cost function value
   return this->LMYEngineCost_detail(EngineObj);
 }

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -59,7 +59,6 @@ QMCCostFunctionBase::QMCCostFunctionBase(ParticleSet& w, TrialWaveFunction& psi,
   //default: don't check fo MinNumWalkers
   MinNumWalkers = 0.3;
   SumValue.resize(SUM_INDEX_SIZE, 0.0);
-  IsValid = true;
 #if defined(QMCCOSTFUNCTION_DEBUG)
   std::array<char, 16> fname;
   int length = std::snprintf(fname.data(), fname.size(), "optdebug.p%d", OHMMS::Controller->rank());
@@ -997,7 +996,6 @@ QMCCostFunctionBase::Return_rt QMCCostFunctionBase::LMYEngineCost(const bool nee
 {
   // prepare local energies, weights, and possibly derivative vectors
   auto effective_weight = correlatedSampling(needDeriv);
-  IsValid               = isEffectiveWeightValid(effective_weight);
   // since we are using the LMYEngine, compute and return it's cost function value
   return this->LMYEngineCost_detail(EngineObj);
 }

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -98,12 +98,6 @@ public:
   ///return optimization parameter i
   Return_t Params(int i) const { return opt_vars[i]; }
   int getType(int i) const { return opt_vars.getType(i); }
-  /**
-   * @brief the cost function value with correlated sampling.
-   * @param needGrad if true, compute the derivatives of energy with respect to parameters
-   * @return cost function value
-   */
-  Return_rt Cost(bool needGrad = true);
 
   ///return the cost value for CGMinimization
   Return_rt computedCost();
@@ -123,6 +117,14 @@ public:
   inline void setNumSamples(int newNumSamples) { NumSamples = newNumSamples; }
   ///reset the wavefunction
   virtual void resetPsi(bool final_reset = false) = 0;
+
+  /** run correlated sampling
+   * return effective walkers (\sum_i w_i)^2/(Nw * \sum_i w^2_i)
+   */
+  virtual EffectiveWeight correlatedSampling(bool needGrad = true) = 0;
+
+  /// check the validity of the effective weight calculated by correlatedSampling
+  bool isEffectiveWeightValid(EffectiveWeight effective_weight) const;
 
   inline void getParameterTypes(std::vector<int>& types) const { return opt_vars.getParameterTypeList(types); }
 
@@ -308,14 +310,6 @@ protected:
 
   /// Flag on whether the variational parameter override is output to the new wavefunction
   bool do_override_output;
-
-  /** run correlated sampling
-   * return effective walkers (\sum_i w_i)^2/(Nw * \sum_i w^2_i)
-   */
-  virtual EffectiveWeight correlatedSampling(bool needGrad = true) = 0;
-
-  /// check the validity of the effective weight calculated by correlatedSampling
-  bool isEffectiveWeightValid(EffectiveWeight effective_weight) const;
 
   /// survey all the optimizable objects
   UniqueOptObjRefs extractOptimizableObjects(TrialWaveFunction& psi) const;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -83,11 +83,6 @@ public:
   ///process xml node
   bool put(xmlNodePtr cur);
   void resetCostFunction(std::vector<xmlNodePtr>& cset);
-  /** boolean to indicate if the cost function is valid.
-   *
-   * Can be used by optimizers to stop optimization.
-   */
-  bool IsValid;
   ///Save opt parameters to HDF5
   bool reportH5;
   bool CI_Opt;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -208,8 +208,6 @@ protected:
    * default PowerE=1
    */
   int PowerE;
-  ///number of times cost function evaluated
-  int NumCostCalls;
   /// global number of samples to use in correlated sampling
   int NumSamples;
   ///counter for output

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -60,12 +60,10 @@ void QMCCostFunctionBatched::GradCost(std::vector<Return_rt>& PGradient,
     {
       // + FiniteDiff
       opt_vars[i] = PM[i] + FiniteDiff;
-      resetPsi();
       correlatedSampling(false);
       auto CostPlus = computedCost();
       // - FiniteDiff
       opt_vars[i] = PM[i] - FiniteDiff;
-      resetPsi();
       correlatedSampling(false);
       auto CostMinus = computedCost();
       // calculate gradient
@@ -75,7 +73,6 @@ void QMCCostFunctionBatched::GradCost(std::vector<Return_rt>& PGradient,
   }
   else
   {
-    resetPsi();
     //evaluate new local energies and derivatives
     EffectiveWeight effective_weight = correlatedSampling(true);
     //Estimators::accumulate has been called by correlatedSampling
@@ -638,8 +635,10 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
 {
   ScopedTimer tmp_timer(corr_sampling_timer_);
 
+  resetPsi();
+
   {
-    //    synchronize the random number generator with the node
+    // synchronize the random number generator with the node
     (*MoverRng[0]) = (*RngSaved[0]);
     H.setRandomGenerator(MoverRng[0]);
   }

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -165,8 +165,6 @@ void QMCCostFunctionBatched::GradCost(std::vector<Return_rt>& PGradient,
       if (std::abs(w_abs) > 1.0e-10)
         PGradient[j] += w_abs * EDtotals[j];
     }
-
-    IsValid = isEffectiveWeightValid(effective_weight);
   }
 }
 
@@ -415,7 +413,6 @@ void QMCCostFunctionBatched::checkConfigurations(EngineHandle& handle)
   app_log().flush();
   setTargetEnergy(Etarget);
   ReportCounter = 0;
-  IsValid       = true;
 
   //collect SumValue for computedCost
   SumValue[SUM_WGT]       = etemp[1];
@@ -610,7 +607,6 @@ void QMCCostFunctionBatched::checkConfigurationsSR(EngineHandle& handle)
   app_log().flush();
   setTargetEnergy(Etarget);
   ReportCounter = 0;
-  IsValid       = true;
 
   //collect SumValue for computedCost
   SumValue[SUM_WGT]       = etemp[1];

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -209,9 +209,9 @@ bool QMCFixedSampleLinearOptimize::run()
   {
     for (int i = 0; i < optparam.size(); i++)
       optTarget->Params(i) = optparam[i] + dl * optdir[i];
-    RealType c = optTarget->Cost(false);
-    validFuncVal = optTarget->IsValid;
-    return c;
+    auto effective_weight = optTarget->correlatedSampling(false);
+    validFuncVal = optTarget->isEffectiveWeightValid(effective_weight);;
+    return optTarget->computedCost();
   };
 
   while (Total_iterations < Max_iterations)
@@ -226,10 +226,11 @@ bool QMCFixedSampleLinearOptimize::run()
     for (int i = 0; i < numParams; i++)
       optTarget->Params(i) = currentParameters[i];
     cost_function_timer_.start();
-    RealType lastCost(optTarget->Cost(true));
+  auto effective_weight = optTarget->correlatedSampling(true);
+    RealType lastCost(optTarget->computedCost());
     cost_function_timer_.stop();
     //     if cost function is currently invalid continue
-    Valid = optTarget->IsValid;
+    Valid = optTarget->isEffectiveWeightValid(effective_weight);
     if (!ValidCostFunction(Valid))
       continue;
     RealType newCost(lastCost);
@@ -359,13 +360,14 @@ bool QMCFixedSampleLinearOptimize::run()
         // 	this may have been evaluated already
         // 	newCost=evaluated_cost;
         //get cost at new minimum
-        newCost = optTarget->Cost(false);
+        auto effective_weight = optTarget->correlatedSampling(false);
+        newCost = optTarget->computedCost();
         app_log() << " OldCost: " << lastCost << " NewCost: " << newCost << " Delta Cost:" << (newCost - lastCost)
                   << std::endl;
         optTarget->printEstimates();
         //                 quit if newcost is greater than lastcost. E(Xs) looks quadratic (between steepest descent and parabolic)
         // mmorales
-        Valid = optTarget->IsValid;
+        Valid = optTarget->isEffectiveWeightValid(effective_weight);
         //if (MinMethod!="rescale" && !ValidCostFunction(Valid))
         if (!ValidCostFunction(Valid))
         {
@@ -1338,8 +1340,8 @@ bool QMCFixedSampleLinearOptimize::one_shift_run()
             << "largest LM parameter change : " << largestChange << " at parameter " << max_element << std::endl;
 
   // compute the new cost
-  optTarget->IsValid     = true;
-  const RealType newCost = optTarget->Cost(false);
+        auto effective_weight = optTarget->correlatedSampling(false);
+  const RealType newCost = optTarget->computedCost();
 
   app_log() << std::endl
             << "******************************************************************************" << std::endl
@@ -1349,7 +1351,7 @@ bool QMCFixedSampleLinearOptimize::one_shift_run()
             << newCost - initCost << std::endl
             << "******************************************************************************" << std::endl;
 
-  if (!optTarget->IsValid || qmcplusplus::isnan(newCost))
+  if (!optTarget->isEffectiveWeightValid(effective_weight) || qmcplusplus::isnan(newCost))
   {
     app_log() << std::endl << "The new set of parameters is not valid. Revert to the old set!" << std::endl;
     for (int i = 0; i < numParams; i++)

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -205,12 +205,11 @@ bool QMCFixedSampleLinearOptimize::run()
   optdir.resize(numParams, 0);
   optparam.resize(numParams, 0);
 
-  auto costfunc_evaluator = [this](RealType dl)
-  {
+  auto costfunc_evaluator = [this](RealType dl) {
     for (int i = 0; i < optparam.size(); i++)
       optTarget->Params(i) = optparam[i] + dl * optdir[i];
     auto effective_weight = optTarget->correlatedSampling(false);
-    validFuncVal = optTarget->isEffectiveWeightValid(effective_weight);;
+    validFuncVal          = optTarget->isEffectiveWeightValid(effective_weight);
     return optTarget->computedCost();
   };
 
@@ -226,7 +225,7 @@ bool QMCFixedSampleLinearOptimize::run()
     for (int i = 0; i < numParams; i++)
       optTarget->Params(i) = currentParameters[i];
     cost_function_timer_.start();
-  auto effective_weight = optTarget->correlatedSampling(true);
+    auto effective_weight = optTarget->correlatedSampling(true);
     RealType lastCost(optTarget->computedCost());
     cost_function_timer_.stop();
     //     if cost function is currently invalid continue
@@ -360,7 +359,7 @@ bool QMCFixedSampleLinearOptimize::run()
         // 	newCost=evaluated_cost;
         //get cost at new minimum
         auto effective_weight = optTarget->correlatedSampling(false);
-        newCost = optTarget->computedCost();
+        newCost               = optTarget->computedCost();
         app_log() << " OldCost: " << lastCost << " NewCost: " << newCost << " Delta Cost:" << (newCost - lastCost)
                   << std::endl;
         optTarget->printEstimates();
@@ -1134,7 +1133,7 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
   {
     for (int i = 0; i < numParams; i++)
       optTarget->Params(i) = currParams.at(i) + (k == central_index ? 0.0 : parameterDirections.at(k).at(i + 1));
-    costValues.at(k)   = optTarget->LMYEngineCost(false, *EngineObj);
+    costValues.at(k) = optTarget->LMYEngineCost(false, *EngineObj);
     good_update.at(k) =
         (good_update.at(k) && std::abs((initCost - costValues.at(k)) / initCost) < max_relative_cost_change);
     if (!good_update.at(k))
@@ -1337,7 +1336,7 @@ bool QMCFixedSampleLinearOptimize::one_shift_run()
             << "largest LM parameter change : " << largestChange << " at parameter " << max_element << std::endl;
 
   // compute the new cost
-        auto effective_weight = optTarget->correlatedSampling(false);
+  auto effective_weight  = optTarget->correlatedSampling(false);
   const RealType newCost = optTarget->computedCost();
 
   app_log() << std::endl

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -313,7 +313,6 @@ bool QMCFixedSampleLinearOptimize::run()
         }
         for (int i = 0; i < numParams; i++)
           optTarget->Params(i) = currentParameters[i] + Lambda * currentParameterDirections[i + 1];
-        optTarget->IsValid = true;
       }
       else
       {
@@ -1115,7 +1114,6 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
   // compute cost function for the initial parameters (by subtracting the middle shift's update back off)
   for (int i = 0; i < numParams; i++)
     optTarget->Params(i) = currParams.at(i) - parameterDirections.at(central_index).at(i + 1);
-  optTarget->IsValid      = true;
   const RealType initCost = optTarget->LMYEngineCost(false, *EngineObj);
 
   // compute the update directions for the smaller and larger shifts relative to that of the middle shift
@@ -1136,7 +1134,6 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
   {
     for (int i = 0; i < numParams; i++)
       optTarget->Params(i) = currParams.at(i) + (k == central_index ? 0.0 : parameterDirections.at(k).at(i + 1));
-    optTarget->IsValid = true;
     costValues.at(k)   = optTarget->LMYEngineCost(false, *EngineObj);
     good_update.at(k) =
         (good_update.at(k) && std::abs((initCost - costValues.at(k)) / initCost) < max_relative_cost_change);

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -310,7 +310,7 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
     for (int i = 0; i < optparam.size(); i++)
       optTarget->Params(i) = optparam[i] + dl * optdir[i];
     auto effective_weight = optTarget->correlatedSampling(false);
-    nrc_opt_.validFuncVal = optTarget->isEffectiveWeightValid(effective_weight);;
+    nrc_opt_.validFuncVal = optTarget->isEffectiveWeightValid(effective_weight);
     return optTarget->computedCost();
   };
 
@@ -326,11 +326,11 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
     for (int i = 0; i < numParams; i++)
       optTarget->Params(i) = currentParameters[i];
     cost_function_timer_.start();
-      auto effective_weight = optTarget->correlatedSampling(true);
+    auto effective_weight = optTarget->correlatedSampling(true);
     RealType lastCost(optTarget->computedCost());
     cost_function_timer_.stop();
     //     if cost function is currently invalid continue
-    Valid = optTarget->isEffectiveWeightValid(effective_weight);;
+    Valid = optTarget->isEffectiveWeightValid(effective_weight);
     if (!ValidCostFunction(Valid))
       continue;
     RealType newCost(lastCost);
@@ -455,8 +455,8 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
         // 	this may have been evaluated already
         // 	newCost=evaluated_cost;
         //get cost at new minimum
-      auto effective_weight = optTarget->correlatedSampling(false);
-        newCost = optTarget->computedCost();
+        auto effective_weight = optTarget->correlatedSampling(false);
+        newCost               = optTarget->computedCost();
         app_log() << " OldCost: " << lastCost << " NewCost: " << newCost << " Delta Cost:" << (newCost - lastCost)
                   << std::endl;
         optTarget->printEstimates();
@@ -1493,9 +1493,9 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
   {
     for (int i = 0; i < numParams; i++)
       optTarget->Params(i) = currParams.at(i) + (k == central_index ? 0.0 : parameterDirections.at(k).at(i + 1));
-    costValues.at(k)   = optTarget->LMYEngineCost(false, *EngineObj);
-    good_update.at(k)  = (good_update.at(k) &&
-                          std::abs((initCost - costValues.at(k)) / initCost) < options_LMY_.max_relative_cost_change);
+    costValues.at(k)  = optTarget->LMYEngineCost(false, *EngineObj);
+    good_update.at(k) = (good_update.at(k) &&
+                         std::abs((initCost - costValues.at(k)) / initCost) < options_LMY_.max_relative_cost_change);
     if (!good_update.at(k))
       costValues.at(k) = std::abs(1.5 * initCost) + 1.0;
   }
@@ -1739,7 +1739,7 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
             << "largest LM parameter change : " << largestChange << " at parameter " << max_element << std::endl;
 
   // compute the new cost
-  auto effective_weight = optTarget->correlatedSampling(false);
+  auto effective_weight  = optTarget->correlatedSampling(false);
   const RealType newCost = optTarget->computedCost();
 
 
@@ -1880,7 +1880,7 @@ bool QMCFixedSampleLinearOptimizeBatched::stochastic_reconfiguration_conjugate_g
       for (int i = 0; i < optparam.size(); i++)
         optTarget->Params(i) = optparam[i] + dl * optdir[i];
       auto effective_weight = optTarget->correlatedSampling(false);
-      nrc_opt_.validFuncVal = optTarget->isEffectiveWeightValid(effective_weight);;
+      nrc_opt_.validFuncVal = optTarget->isEffectiveWeightValid(effective_weight);
       return optTarget->computedCost();
     };
 

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -309,9 +309,9 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
   auto costfunc_evaluator = [this](RealType dl) {
     for (int i = 0; i < optparam.size(); i++)
       optTarget->Params(i) = optparam[i] + dl * optdir[i];
-    RealType c            = optTarget->Cost(false);
-    nrc_opt_.validFuncVal = optTarget->IsValid;
-    return c;
+    auto effective_weight = optTarget->correlatedSampling(false);
+    nrc_opt_.validFuncVal = optTarget->isEffectiveWeightValid(effective_weight);;
+    return optTarget->computedCost();
   };
 
   while (Total_iterations < Max_iterations)
@@ -326,10 +326,11 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
     for (int i = 0; i < numParams; i++)
       optTarget->Params(i) = currentParameters[i];
     cost_function_timer_.start();
-    RealType lastCost(optTarget->Cost(true));
+      auto effective_weight = optTarget->correlatedSampling(true);
+    RealType lastCost(optTarget->computedCost());
     cost_function_timer_.stop();
     //     if cost function is currently invalid continue
-    Valid = optTarget->IsValid;
+    Valid = optTarget->isEffectiveWeightValid(effective_weight);;
     if (!ValidCostFunction(Valid))
       continue;
     RealType newCost(lastCost);
@@ -455,13 +456,14 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
         // 	this may have been evaluated already
         // 	newCost=evaluated_cost;
         //get cost at new minimum
-        newCost = optTarget->Cost(false);
+      auto effective_weight = optTarget->correlatedSampling(false);
+        newCost = optTarget->computedCost();
         app_log() << " OldCost: " << lastCost << " NewCost: " << newCost << " Delta Cost:" << (newCost - lastCost)
                   << std::endl;
         optTarget->printEstimates();
         //                 quit if newcost is greater than lastcost. E(Xs) looks quadratic (between steepest descent and parabolic)
         // mmorales
-        Valid = optTarget->IsValid;
+        Valid = optTarget->isEffectiveWeightValid(effective_weight);
         //if (MinMethod!="rescale" && !ValidCostFunction(Valid))
         if (!ValidCostFunction(Valid))
         {
@@ -1740,8 +1742,9 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
             << "largest LM parameter change : " << largestChange << " at parameter " << max_element << std::endl;
 
   // compute the new cost
-  optTarget->IsValid     = true;
-  const RealType newCost = optTarget->Cost(false);
+  auto effective_weight = optTarget->correlatedSampling(false);
+  const RealType newCost = optTarget->computedCost();
+
 
   app_log() << std::endl
             << "******************************************************************************" << std::endl
@@ -1751,7 +1754,7 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
             << newCost - initCost << std::endl
             << "******************************************************************************" << std::endl;
 
-  if (!optTarget->IsValid || qmcplusplus::isnan(newCost))
+  if (!optTarget->isEffectiveWeightValid(effective_weight) || qmcplusplus::isnan(newCost))
   {
     app_log() << std::endl << "The new set of parameters is not valid. Revert to the old set!" << std::endl;
     for (int i = 0; i < numParams; i++)
@@ -1879,9 +1882,9 @@ bool QMCFixedSampleLinearOptimizeBatched::stochastic_reconfiguration_conjugate_g
     auto costfunc_evaluator = [this](RealType dl) {
       for (int i = 0; i < optparam.size(); i++)
         optTarget->Params(i) = optparam[i] + dl * optdir[i];
-      RealType c            = optTarget->Cost(false);
-      nrc_opt_.validFuncVal = optTarget->IsValid;
-      return c;
+      auto effective_weight = optTarget->correlatedSampling(false);
+      nrc_opt_.validFuncVal = optTarget->isEffectiveWeightValid(effective_weight);;
+      return optTarget->computedCost();
     };
 
     //set up line search stuff

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -409,7 +409,6 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
         }
         for (int i = 0; i < numParams; i++)
           optTarget->Params(i) = currentParameters[i] + nrc_opt_.Lambda * currentParameterDirections[i + 1];
-        optTarget->IsValid = true;
       }
       else
       {
@@ -1474,7 +1473,6 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
   // compute cost function for the initial parameters (by subtracting the middle shift's update back off)
   for (int i = 0; i < numParams; i++)
     optTarget->Params(i) = currParams.at(i) - parameterDirections.at(central_index).at(i + 1);
-  optTarget->IsValid      = true;
   const RealType initCost = optTarget->LMYEngineCost(false, *EngineObj);
 
   // compute the update directions for the smaller and larger shifts relative to that of the middle shift
@@ -1495,7 +1493,6 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
   {
     for (int i = 0; i < numParams; i++)
       optTarget->Params(i) = currParams.at(i) + (k == central_index ? 0.0 : parameterDirections.at(k).at(i + 1));
-    optTarget->IsValid = true;
     costValues.at(k)   = optTarget->LMYEngineCost(false, *EngineObj);
     good_update.at(k)  = (good_update.at(k) &&
                           std::abs((initCost - costValues.at(k)) / initCost) < options_LMY_.max_relative_cost_change);


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Two major issues found in this function `QMCCostFunctionBase::Cost`
1. it glues correlated sampling and cost function computation.
2. It relies on Internal state "IsValid" to handle the second output other than the cost function value. An old day C++ limitation.

In this PR, I revisited all the use of `Cost` and found it is straightforward to replace `Cost` calls directly with its content after making a few adjustments.
1. There is always `resetPsi` before a call to `correlatedSampling`. Thus put the former into the latter.
2. By directly interacting with correlatedSampling() and computedCost(), there is no longer the issue of returning two values.

Note that:
Callers of GradCost don't consume IsValid and thus removed the touch of IsValid in GradCost.
All the change in this PR is expected to be adjustment of internals.
 
## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)\

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

laptop

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
