### PR TITLE
Remove dead function and variables in WFOpt/QMCCostFunction* and change QMCDriverInterface::run() return type to void.

### DIFF
--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
@@ -145,7 +145,7 @@ bool CSVMC::put(xmlNodePtr q)
  *
  * Similar to VMC::run
  */
-bool CSVMC::run()
+void CSVMC::run()
 {
   resetRun();
   //start the main estimator
@@ -209,7 +209,7 @@ bool CSVMC::run()
       app_log() << "  samples are written to the config.h5" << std::endl;
   }
   //finalize a qmc section
-  return finalize(nBlocks, !wrotesamples);
+  finalize(nBlocks, !wrotesamples);
 }
 
 void CSVMC::resetRun()

--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.h
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.h
@@ -41,7 +41,7 @@ public:
         std::vector<QMCHamiltonian*>&& multi_ham,
         Communicate* comm);
 
-  bool run() override;
+  void run() override;
   bool put(xmlNodePtr cur) override;
   QMCRunType getRunType() override { return QMCRunType::CSVMC; }
 

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -226,7 +226,7 @@ void DMC::resetUpdateEngines()
   app_log() << "  DMC Engine Initialization = " << init_timer.elapsed() << " secs" << std::endl;
 }
 
-bool DMC::run()
+void DMC::run()
 {
   LoopTimer<> dmc_loop;
 
@@ -317,7 +317,7 @@ bool DMC::run()
   Traces->stopRun();
 #endif
   wlog_manager_->stopRun();
-  return finalize(nBlocks);
+  finalize(nBlocks);
 }
 
 

--- a/src/QMCDrivers/DMC/DMC.h
+++ b/src/QMCDrivers/DMC/DMC.h
@@ -39,7 +39,7 @@ public:
       Communicate* comm,
       bool enable_profiling);
 
-  bool run() override;
+  void run() override;
   bool put(xmlNodePtr cur) override;
   void setTau(RealType i);
   QMCRunType getRunType() override { return QMCRunType::DMC; }

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -437,7 +437,7 @@ void DMCBatched::process(xmlNodePtr node)
     measureImbalance("Startup");
 }
 
-bool DMCBatched::run()
+void DMCBatched::run()
 {
   IndexType num_blocks = qmcdriver_input_.get_max_blocks();
 
@@ -547,7 +547,7 @@ bool DMCBatched::run()
   wlog_manager.stopRun();
   estimator_manager_->stopDriverRun();
 
-  return finalize(num_blocks, true);
+  finalize(num_blocks, true);
 }
 
 RefVector<QMCDriverNew::ContextForSteps> DMCBatched::getContextForStepsRefs() const

--- a/src/QMCDrivers/DMC/DMCBatched.h
+++ b/src/QMCDrivers/DMC/DMCBatched.h
@@ -117,7 +117,7 @@ public:
    */
   void process(xmlNodePtr cur) override;
 
-  bool run() override;
+  void run() override;
 
   QMCRunType getRunType() override { return QMCRunType::DMC_BATCH; }
 

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -306,7 +306,7 @@ void QMCDriver::recordBlock(int block)
   }
 }
 
-bool QMCDriver::finalize(int block, bool dumpwalkers)
+void QMCDriver::finalize(int block, bool dumpwalkers)
 {
   if (DumpConfig && dumpwalkers)
     wOut->dump(W, block);
@@ -319,8 +319,6 @@ bool QMCDriver::finalize(int block, bool dumpwalkers)
 
   if (DumpConfig)
     RandomNumberControl::write(RootName, myComm);
-
-  return true;
 }
 
 /** Add walkers to the end of the ensemble of walkers.

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -337,7 +337,7 @@ protected:
    * Accumulate energy and weight is written to a hdf5 file.
    * Finialize the estimators
    */
-  bool finalize(int block, bool dumpwalkers = true);
+  void finalize(int block, bool dumpwalkers = true);
 
   int rotation;
   std::string getRotationName(std::string RootName);

--- a/src/QMCDrivers/QMCDriverInterface.h
+++ b/src/QMCDrivers/QMCDriverInterface.h
@@ -35,7 +35,7 @@ class QMCDriverInterface
 public:
   using BranchEngineType              = SimpleFixedNodeBranch;
   using FullPrecRealType              = QMCTraits::FullPrecRealType;
-  virtual bool run()                  = 0;
+  virtual void run()                  = 0;
   virtual bool put(xmlNodePtr cur)    = 0;
   virtual void recordBlock(int block) = 0;
 

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -214,7 +214,7 @@ void QMCDriverNew::recordBlock(int block)
   }
 }
 
-bool QMCDriverNew::finalize(int block, bool dumpwalkers)
+void QMCDriverNew::finalize(int block, bool dumpwalkers)
 {
   population_.saveWalkerConfigurations(walker_configs_ref_);
   setWalkerOffsets(walker_configs_ref_, myComm);
@@ -230,8 +230,6 @@ bool QMCDriverNew::finalize(int block, bool dumpwalkers)
 
   if (DumpConfig)
     RandomNumberControl::write(rngs_, get_root_name(), myComm);
-
-  return true;
 }
 
 void QMCDriverNew::makeLocalWalkers(IndexType nwalkers, RealType reserve)

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -199,7 +199,7 @@ public:
    * Accumulate energy and weight is written to a hdf5 file.
    * Finialize the estimators
    */
-  bool finalize(int block, bool dumpwalkers = true);
+  void finalize(int block, bool dumpwalkers = true);
 
   ///return current step
   inline IndexType current() const { return current_step_; }

--- a/src/QMCDrivers/RMC/RMC.cpp
+++ b/src/QMCDrivers/RMC/RMC.cpp
@@ -65,7 +65,7 @@ RMC::RMC(const ProjectData& project_data,
   TransProb[1] = w.addProperty("TransProbForward");
 }
 
-bool RMC::run()
+void RMC::run()
 {
   resetRun();
   //start the main estimator
@@ -137,7 +137,7 @@ bool RMC::run()
     RandomNumberControl::Children[ip] = Rng[ip]->makeClone();
   //return nbeads and stuff to its original unset state;
   resetVars();
-  return finalize(nBlocks);
+  finalize(nBlocks);
 }
 
 void RMC::resetRun()

--- a/src/QMCDrivers/RMC/RMC.h
+++ b/src/QMCDrivers/RMC/RMC.h
@@ -34,7 +34,7 @@ public:
       TrialWaveFunction& psi,
       QMCHamiltonian& h,
       Communicate* comm);
-  bool run() override;
+  void run() override;
   bool put(xmlNodePtr cur) override;
   QMCRunType getRunType() override { return QMCRunType::RMC; }
 

--- a/src/QMCDrivers/VMC/VMC.cpp
+++ b/src/QMCDrivers/VMC/VMC.cpp
@@ -57,7 +57,7 @@ VMC::VMC(const ProjectData& project_data,
   prevStepsBetweenSamples = nStepsBetweenSamples;
 }
 
-bool VMC::run()
+void VMC::run()
 {
   resetRun();
   //start the main estimator
@@ -142,7 +142,7 @@ bool VMC::run()
       app_log() << "  samples are written to the config.h5" << std::endl;
   }
   //finalize a qmc section
-  return finalize(nBlocks, !wrotesamples);
+  finalize(nBlocks, !wrotesamples);
 }
 
 void VMC::resetRun()

--- a/src/QMCDrivers/VMC/VMC.h
+++ b/src/QMCDrivers/VMC/VMC.h
@@ -33,7 +33,7 @@ public:
       const UPtrVector<RandomBase<QMCTraits::FullPrecRealType>>& rngs,
       Communicate* comm,
       bool enable_profiling);
-  bool run() override;
+  void run() override;
   bool put(xmlNodePtr cur) override;
   QMCRunType getRunType() override { return QMCRunType::VMC; }
 

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -314,7 +314,7 @@ size_t VMCBatched::compute_samples_per_rank(const size_t num_blocks,
  *  If does consider giving more to the thread by value that should
  *  end up thread local. (I think)
  */
-bool VMCBatched::run()
+void VMCBatched::run()
 {
   IndexType num_blocks = qmcdriver_input_.get_max_blocks();
   //start the main estimator
@@ -469,7 +469,7 @@ bool VMCBatched::run()
   wlog_manager.stopRun();
   estimator_manager_->stopDriverRun();
 
-  return finalize(num_blocks, true);
+  finalize(num_blocks, true);
 }
 
 RefVector<QMCDriverNew::ContextForSteps> VMCBatched::getContextForStepsRefs() const

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -89,7 +89,7 @@ public:
 
   void process(xmlNodePtr node) override;
 
-  bool run() override;
+  void run() override;
 
   /** transitional interface on the way to better walker count adjustment handling.
    *  returns a closure taking walkers per rank and accomplishing what calc_default_local_walkers does.

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
@@ -324,7 +324,7 @@ void QMCCostFunction::checkConfigurations(EngineHandle& handle)
   app_log() << "  Total weights = " << etemp[1] << std::endl;
   app_log().flush();
   setTargetEnergy(Etarget);
-  ReportCounter = 0;
+
   //collect SumValue for computedCost
   SumValue[SUM_WGT]       = etemp[1];
   SumValue[SUM_WGTSQ]     = etemp[1];
@@ -481,7 +481,7 @@ void QMCCostFunction::engine_checkConfigurations(cqmc::engine::LMYEngine<Return_
   app_log().flush();
 
   setTargetEnergy(Etarget);
-  ReportCounter = 0;
+
 }
 #endif
 

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
@@ -29,7 +29,7 @@ QMCCostFunction::QMCCostFunction(MCWalkerConfiguration& w, TrialWaveFunction& ps
     : QMCCostFunctionBase(w, psi, h, comm),
       fill_timer_(createGlobalTimer("QMCCostFunction::fillOverlapHamiltonianMatrices", timer_level_medium))
 {
-  CSWeight = 1.0;
+
   app_log() << " Using QMCCostFunction::QMCCostFunction" << std::endl;
 }
 
@@ -591,7 +591,7 @@ QMCCostFunction::EffectiveWeight QMCCostFunction::correlatedSampling(bool needGr
   //    app_log()<<"After Purge"<<wgt_tot<<" "<< std::endl;
   for (int i = 0; i < SumValue.size(); i++)
     SumValue[i] = 0.0;
-  CSWeight = wgt_tot = (wgt_tot == 0) ? 1 : 1.0 / wgt_tot;
+  wgt_tot = (wgt_tot == 0) ? 1 : 1.0 / wgt_tot;
   for (int ip = 0; ip < NumThreads; ip++)
   {
     int nw = wClones[ip]->numSamples();

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.h
@@ -57,7 +57,6 @@ protected:
   */
   std::vector<Matrix<Return_t>*> DerivRecords;
   std::vector<Matrix<Return_rt>*> HDerivRecords;
-  Return_rt CSWeight;
 
   EffectiveWeight correlatedSampling(bool needGrad = true) override;
 

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -37,7 +37,6 @@ QMCCostFunctionBase::QMCCostFunctionBase(ParticleSet& w, TrialWaveFunction& psi,
       W(w),
       Psi(psi),
       H(h),
-      Write2OneXml(true),
       PowerE(2),
       NumSamples(0),
       w_en(0.9),
@@ -59,15 +58,6 @@ QMCCostFunctionBase::QMCCostFunctionBase(ParticleSet& w, TrialWaveFunction& psi,
   //default: don't check fo MinNumWalkers
   MinNumWalkers = 0.3;
   SumValue.resize(SUM_INDEX_SIZE, 0.0);
-#if defined(QMCCOSTFUNCTION_DEBUG)
-  std::array<char, 16> fname;
-  int length = std::snprintf(fname.data(), fname.size(), "optdebug.p%d", OHMMS::Controller->rank());
-  if (length < 0)
-    throw std::runtime_error("Error generating filename");
-  debug_stream = std::make_unique<std::ofstream>(fname.data());
-  debug_stream->setf(std::ios::scientific, std::ios::floatfield);
-  debug_stream->precision(8);
-#endif
 }
 
 /** Clean up the vector */
@@ -77,7 +67,6 @@ QMCCostFunctionBase::~QMCCostFunctionBase()
   delete_iter(d2LogPsi.begin(), d2LogPsi.end());
   if (m_doc_out != nullptr)
     xmlFreeDoc(m_doc_out);
-  debug_stream.reset();
 }
 
 void QMCCostFunctionBase::setRng(RefVector<RandomBase<FullPrecRealType>> r)
@@ -163,46 +152,6 @@ QMCCostFunctionBase::Return_rt QMCCostFunctionBase::computedCost()
   if (std::abs(w_w) > small)
     CostValue += w_w * curVar;
   return CostValue;
-}
-
-
-void QMCCostFunctionBase::Report()
-{
-  //reset the wavefunction for with the new variables
-  resetPsi();
-  if (!myComm->rank())
-  {
-    updateXmlNodes();
-    std::array<char, 128> newxml;
-    int length{0};
-    if (Write2OneXml)
-      length = std::snprintf(newxml.data(), newxml.size(), "%s.opt.xml", RootName.c_str());
-    else
-      length = std::snprintf(newxml.data(), newxml.size(), "%s.opt.%d.xml", RootName.c_str(), ReportCounter);
-    if (length < 0)
-      throw std::runtime_error("Error generating fileroot");
-    xmlSaveFormatFile(newxml.data(), m_doc_out, 1);
-    if (msg_stream)
-    {
-      msg_stream->precision(8);
-      *msg_stream << " curCost " << std::setw(5) << ReportCounter << std::setw(16) << CostValue << std::setw(16)
-                  << curAvg_w << std::setw(16) << curAvg << std::setw(16) << curVar_w << std::setw(16) << curVar
-                  << std::setw(16) << curVar_abs << std::endl;
-      *msg_stream << " curVars " << std::setw(5) << ReportCounter;
-      for (int i = 0; i < opt_vars.size(); i++)
-        *msg_stream << std::setw(16) << opt_vars[i];
-      *msg_stream << std::endl;
-    }
-    //report the data
-    //Psi.reportStatus(*mgs_stream);
-  }
-#if defined(QMCCOSTFUNCTION_DEBUG)
-  *debug_stream << ReportCounter;
-  opt_vars.print(*debug_stream);
-  *debug_stream << std::endl;
-#endif
-  ReportCounter++;
-  //myComm->barrier();
 }
 
 void QMCCostFunctionBase::reportParameters()
@@ -301,12 +250,10 @@ void QMCCostFunctionBase::reportParametersH5()
 bool QMCCostFunctionBase::put(xmlNodePtr q)
 {
   std::string includeNonlocalH;
-  std::string writeXmlPerStep("no");
   std::string computeNLPPderiv;
   std::string GEVType;
   astring variational_subset_str;
   ParameterSet m_param;
-  m_param.add(writeXmlPerStep, "dumpXML");
   m_param.add(MinNumWalkers, "minwalkers");
   m_param.add(MaxWeight, "maxWeight");
   m_param.add(includeNonlocalH, "nonlocalpp", {}, TagStatus::DEPRECATED);
@@ -334,7 +281,6 @@ bool QMCCostFunctionBase::put(xmlNodePtr q)
 
   // app_log() << "  QMCCostFunctionBase::put " << std::endl;
   // m_param.get(app_log());
-  Write2OneXml = (writeXmlPerStep == "no");
 
   // parse "cost"
   std::vector<xmlNodePtr> cset;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -123,8 +123,7 @@ public:
 
   inline void getParameterTypes(std::vector<int>& types) const { return opt_vars.getParameterTypeList(types); }
 
-  ///dump the current parameters and other report
-  void Report();
+
   ///report  parameters at the end
   void reportParameters();
 
@@ -198,8 +197,6 @@ protected:
   ///Hamiltonian
   QMCHamiltonian& H;
 
-  ///if true, do not write the *.opt.#.xml
-  bool Write2OneXml;
   /** |E-E_T|^PowerE is used for the cost function
    *
    * default PowerE=1
@@ -297,8 +294,6 @@ protected:
   std::vector<ParticleGradient*> dLogPsi;
   ///** Fixed  Laplacian , \f$\nabla^2\ln\Psi\f$, components */
   std::vector<ParticleLaplacian*> d2LogPsi;
-  ///stream for debug
-  std::unique_ptr<std::ostream> debug_stream;
 
 
   void updateXmlNodes();

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -129,8 +129,6 @@ public:
 
   ///report  parameters in HDF5 at the end
   void reportParametersH5();
-  ///return the counter which keeps track of optimization steps
-
 
   void setWaveFunctionNode(xmlNodePtr cur) { m_wfPtr = cur; }
 
@@ -204,8 +202,6 @@ protected:
   int PowerE;
   /// global number of samples to use in correlated sampling
   int NumSamples;
-  ///counter for output
-
   ///weights for energy and variance in the cost function
   Return_rt w_en, w_var, w_abs, w_w;
   ///value of the cost function

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -243,13 +243,7 @@ protected:
   OptVariables opt_vars;
   // unchanged initial checked-in variables
   OptVariables InitVariables;
-  /** index mapping for <negate> constraints
-   *
-   * - negateVarMap[i][0] : index in opt_vars
-   * - negateVarMap[i][1] : index in opt_vars
-   */
-  ///index mapping for <negative> constraints
-  std::vector<TinyVector<int, 2>> negateVarMap;
+
   ///stream to which progress is sent
   std::ostream* msg_stream;
   ///xml node to be dumped

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -130,7 +130,7 @@ public:
   ///report  parameters in HDF5 at the end
   void reportParametersH5();
   ///return the counter which keeps track of optimization steps
-  inline int getReportCounter() const { return ReportCounter; }
+
 
   void setWaveFunctionNode(xmlNodePtr cur) { m_wfPtr = cur; }
 
@@ -205,7 +205,7 @@ protected:
   /// global number of samples to use in correlated sampling
   int NumSamples;
   ///counter for output
-  int ReportCounter;
+
   ///weights for energy and variance in the cost function
   Return_rt w_en, w_var, w_abs, w_w;
   ///value of the cost function

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -412,7 +412,7 @@ void QMCCostFunctionBatched::checkConfigurations(EngineHandle& handle)
 
   app_log().flush();
   setTargetEnergy(Etarget);
-  ReportCounter = 0;
+
 
   //collect SumValue for computedCost
   SumValue[SUM_WGT]       = etemp[1];
@@ -606,7 +606,7 @@ void QMCCostFunctionBatched::checkConfigurationsSR(EngineHandle& handle)
 
   app_log().flush();
   setTargetEnergy(Etarget);
-  ReportCounter = 0;
+
 
   //collect SumValue for computedCost
   SumValue[SUM_WGT]       = etemp[1];

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
@@ -66,8 +66,7 @@ public:
   void calcOvlParmVec(const std::vector<Return_rt>& param, std::vector<Return_rt>& ovlParmVec) override;
 
 protected:
-  /// H components used in correlated sampling. It can be KE or KE+NLPP
-  std::vector<std::string> H_KE_node_names_;
+
 
   Matrix<Return_rt> RecordsOnNode_;
 

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -139,11 +139,10 @@ bool QMCFixedSampleLinearOptimize::test_run()
   testEngineObj->run(*optTarget, get_root_name());
 
   finish();
-
   return true;
 }
 
-bool QMCFixedSampleLinearOptimize::run()
+void QMCFixedSampleLinearOptimize::run()
 {
   if (do_output_matrices_ && !output_matrices_initialized_)
   {
@@ -157,7 +156,8 @@ bool QMCFixedSampleLinearOptimize::run()
   if (doGradientTest)
   {
     app_log() << "Doing gradient test run" << std::endl;
-    return test_run();
+    test_run();
+    return;
   }
 
 #ifdef HAVE_LMY_ENGINE
@@ -165,7 +165,8 @@ bool QMCFixedSampleLinearOptimize::run()
   {
 #if !defined(QMC_COMPLEX)
     app_log() << "Doing hybrid run" << std::endl;
-    return hybrid_run();
+    hybrid_run();
+    return;
 #else
     myComm->barrier_and_abort(" Error: Hybrid method does not work with QMC_COMPLEX=1. \n");
 #endif
@@ -173,7 +174,10 @@ bool QMCFixedSampleLinearOptimize::run()
 
   if (current_optimizer_type_ == OptimizerType::DESCENT)
 #if !defined(QMC_COMPLEX)
-    return descent_run();
+  {
+    descent_run();
+    return;
+  }
 #else
     myComm->barrier_and_abort(" Error: Descent method does not work with QMC_COMPLEX=1. \n");
 #endif
@@ -181,13 +185,19 @@ bool QMCFixedSampleLinearOptimize::run()
 
   // if requested, perform the update via the adaptive three-shift or single-shift method
   if (current_optimizer_type_ == OptimizerType::ADAPTIVE)
-    return adaptive_three_shift_run();
+  {
+    adaptive_three_shift_run();
+    return;
+  }
 
 
 #endif
 
   if (current_optimizer_type_ == OptimizerType::ONESHIFTONLY)
-    return one_shift_run();
+  {
+    one_shift_run();
+    return;
+  }
 
   start();
   bool Valid(true);
@@ -420,7 +430,7 @@ bool QMCFixedSampleLinearOptimize::run()
   }
 
   finish();
-  return (optTarget->getReportCounter() > 0);
+  optTarget->getReportCounter();
 }
 
 /** Parses the xml input file for parameter definitions for the wavefunction

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -429,7 +429,7 @@ void QMCFixedSampleLinearOptimize::run()
   }
 
   finish();
-  optTarget->getReportCounter();
+
 }
 
 /** Parses the xml input file for parameter definitions for the wavefunction
@@ -1223,8 +1223,7 @@ void QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
   nTargetSamples = init_num_samp;
 
   //app_log() << "block first second third end " << block_first << block_second << block_third << endl;
-  // return whether the cost function's report counter is positive
-  optTarget->getReportCounter();
+
 }
 #endif
 
@@ -1389,8 +1388,7 @@ void QMCFixedSampleLinearOptimize::one_shift_run()
   // perform some finishing touches for this linear method iteration
   finish();
 
-  // return whether the cost function's report counter is positive
-  optTarget->getReportCounter();
+
 }
 
 #ifdef HAVE_LMY_ENGINE
@@ -1438,7 +1436,7 @@ void QMCFixedSampleLinearOptimize::descent_run()
 
 
   finish();
-  optTarget->getReportCounter();
+
 }
 #endif
 
@@ -1478,7 +1476,7 @@ void QMCFixedSampleLinearOptimize::hybrid_run()
     descent_run();
 
   app_log() << "Finished a hybrid step" << std::endl;
-  optTarget->getReportCounter();
+
 }
 #endif
 

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -131,7 +131,7 @@ QMCFixedSampleLinearOptimize::QMCFixedSampleLinearOptimize(const ProjectData& pr
 
 QMCFixedSampleLinearOptimize::~QMCFixedSampleLinearOptimize() = default;
 
-bool QMCFixedSampleLinearOptimize::test_run()
+void QMCFixedSampleLinearOptimize::test_run()
 {
   // generate samples and compute weights, local energies, and derivative vectors
   start();
@@ -139,7 +139,6 @@ bool QMCFixedSampleLinearOptimize::test_run()
   testEngineObj->run(*optTarget, get_root_name());
 
   finish();
-  return true;
 }
 
 void QMCFixedSampleLinearOptimize::run()
@@ -929,7 +928,7 @@ void QMCFixedSampleLinearOptimize::solveShiftsWithoutLMYEngine(const std::vector
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #ifdef HAVE_LMY_ENGINE
-bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
+void QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
 {
   // remember what the cost function grads flag was
   const bool saved_grads_flag = optTarget->getneedGrads();
@@ -1225,11 +1224,11 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
 
   //app_log() << "block first second third end " << block_first << block_second << block_third << endl;
   // return whether the cost function's report counter is positive
-  return (optTarget->getReportCounter() > 0);
+  optTarget->getReportCounter();
 }
 #endif
 
-bool QMCFixedSampleLinearOptimize::one_shift_run()
+void QMCFixedSampleLinearOptimize::one_shift_run()
 {
   // ensure the cost function is set to compute derivative vectors
   optTarget->setneedGrads(true);
@@ -1391,12 +1390,12 @@ bool QMCFixedSampleLinearOptimize::one_shift_run()
   finish();
 
   // return whether the cost function's report counter is positive
-  return (optTarget->getReportCounter() > 0);
+  optTarget->getReportCounter();
 }
 
 #ifdef HAVE_LMY_ENGINE
 //Function for optimizing using gradient descent
-bool QMCFixedSampleLinearOptimize::descent_run()
+void QMCFixedSampleLinearOptimize::descent_run()
 {
   const bool saved_grads_flag = optTarget->getneedGrads();
 
@@ -1439,14 +1438,14 @@ bool QMCFixedSampleLinearOptimize::descent_run()
 
 
   finish();
-  return (optTarget->getReportCounter() > 0);
+  optTarget->getReportCounter();
 }
 #endif
 
 
 //Function for controlling the alternation between sections of descent optimization and Blocked LM optimization.
 #ifdef HAVE_LMY_ENGINE
-bool QMCFixedSampleLinearOptimize::hybrid_run()
+void QMCFixedSampleLinearOptimize::hybrid_run()
 {
   app_log() << "This method name is: " << MinMethod << std::endl;
 
@@ -1479,7 +1478,7 @@ bool QMCFixedSampleLinearOptimize::hybrid_run()
     descent_run();
 
   app_log() << "Finished a hybrid step" << std::endl;
-  return (optTarget->getReportCounter() > 0);
+  optTarget->getReportCounter();
 }
 #endif
 

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
@@ -56,7 +56,7 @@ public:
   ~QMCFixedSampleLinearOptimize() override;
 
   ///Run the Optimization algorithm.
-  bool run() override;
+  void run() override;
   ///preprocess xml node
   bool put(xmlNodePtr cur) override;
   ///process xml node value (parameters for both VMC and OPT) for the actual optimization

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
@@ -83,21 +83,21 @@ private:
                     const RealType ic) const;
 
   // perform the adaptive three-shift update
-  bool adaptive_three_shift_run();
+  void adaptive_three_shift_run();
 
   // perform the single-shift update, no sample regeneration
-  bool one_shift_run();
+  void one_shift_run();
 
   // perform optimization using a gradient descent algorithm
-  bool descent_run();
+  void descent_run();
 
 #ifdef HAVE_LMY_ENGINE
   // use hybrid approach of descent and blocked linear method for optimization
-  bool hybrid_run();
+  void hybrid_run();
 #endif
 
   // Perform test of parameter gradients
-  bool test_run();
+  void test_run();
 
   std::unique_ptr<GradientTest> testEngineObj;
 

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -250,43 +250,24 @@ void QMCFixedSampleLinearOptimizeBatched::run()
   {
     app_log() << "Doing gradient test run" << std::endl;
     test_run();
-    return;
   }
 #ifdef HAVE_LMY_ENGINE
-  if (options_LMY_.doHybrid)
+  else if (options_LMY_.doHybrid)
   {
     app_log() << "Doing hybrid run" << std::endl;
     hybrid_run();
-    return;
   }
-  // if requested, perform the update via the adaptive three-shift or single-shift method
-  if (options_LMY_.current_optimizer_type == OptimizerType::ADAPTIVE)
-  {
+  else if (options_LMY_.current_optimizer_type == OptimizerType::ADAPTIVE)
     adaptive_three_shift_run();
-    return;
-  }
-
-  if (options_LMY_.current_optimizer_type == OptimizerType::DESCENT)
-  {
+  else if (options_LMY_.current_optimizer_type == OptimizerType::DESCENT)
     descent_run();
-    return;
-  }
-
 #endif
-
-  if (options_LMY_.current_optimizer_type == OptimizerType::ONESHIFTONLY)
-  {
+  else if (options_LMY_.current_optimizer_type == OptimizerType::ONESHIFTONLY)
     one_shift_run();
-    return;
-  }
-
-  if (options_LMY_.current_optimizer_type == OptimizerType::STOCHASTIC_RECONFIGURATION_CG)
-  {
+  else if (options_LMY_.current_optimizer_type == OptimizerType::STOCHASTIC_RECONFIGURATION_CG)
     stochastic_reconfiguration_conjugate_gradient();
-    return;
-  }
-
-  previous_linear_methods_run();
+  else
+    previous_linear_methods_run();
 }
 
 bool QMCFixedSampleLinearOptimizeBatched::test_run()

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -509,7 +509,7 @@ void QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
   }
 
   finish();
-  optTarget->getReportCounter();
+
 }
 
 /** Parses the xml input file for parameter definitions for the wavefunction
@@ -1566,8 +1566,7 @@ void QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
   optTarget->setNumSamples(init_num_samp);
 
   //app_log() << "block first second third end " << options_LMY_.block_first << options_LMY_.block_second << options_LMY_.block_third << endl;
-  // return whether the cost function's report counter is positive
-  optTarget->getReportCounter();
+
 }
 #endif
 
@@ -1776,11 +1775,10 @@ void QMCFixedSampleLinearOptimizeBatched::one_shift_run()
   // perform some finishing touches for this linear method iteration
   finish();
 
-  // return whether the cost function's report counter is positive
-  optTarget->getReportCounter();
+
 }
 
-bool QMCFixedSampleLinearOptimizeBatched::stochastic_reconfiguration_conjugate_gradient()
+void QMCFixedSampleLinearOptimizeBatched::stochastic_reconfiguration_conjugate_gradient()
 {
   app_log() << std::endl
             << "*****************************************************************************" << std::endl
@@ -1930,7 +1928,7 @@ bool QMCFixedSampleLinearOptimizeBatched::stochastic_reconfiguration_conjugate_g
   finish();
 
   // return whether the cost function's report counter is positive
-  return (optTarget->getReportCounter() > 0);
+
 }
 
 #ifdef HAVE_LMY_ENGINE
@@ -1971,7 +1969,7 @@ void QMCFixedSampleLinearOptimizeBatched::descent_run()
   }
 
   finish();
-  optTarget->getReportCounter();
+
 }
 #endif
 
@@ -2007,7 +2005,7 @@ void QMCFixedSampleLinearOptimizeBatched::hybrid_run()
     descent_run();
 
   app_log() << "Finished a hybrid step" << std::endl;
-  optTarget->getReportCounter();
+
 }
 #endif
 

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -270,7 +270,7 @@ void QMCFixedSampleLinearOptimizeBatched::run()
     previous_linear_methods_run();
 }
 
-bool QMCFixedSampleLinearOptimizeBatched::test_run()
+void QMCFixedSampleLinearOptimizeBatched::test_run()
 {
   // generate samples and compute weights, local energies, and derivative vectors
   start();
@@ -278,11 +278,9 @@ bool QMCFixedSampleLinearOptimizeBatched::test_run()
   testEngineObj->run(*optTarget, get_root_name());
 
   finish();
-
-  return true;
 }
 
-bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
+void QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
 {
   start();
   bool Valid(true);
@@ -511,7 +509,7 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
   }
 
   finish();
-  return (optTarget->getReportCounter() > 0);
+  optTarget->getReportCounter();
 }
 
 /** Parses the xml input file for parameter definitions for the wavefunction
@@ -1073,7 +1071,7 @@ void QMCFixedSampleLinearOptimizeBatched::solveShiftsWithoutLMYEngine(
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #ifdef HAVE_LMY_ENGINE
-bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
+void QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
 {
   EngineObj->setStoringSamples(options_LMY_.store_samples);
 
@@ -1569,11 +1567,11 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
 
   //app_log() << "block first second third end " << options_LMY_.block_first << options_LMY_.block_second << options_LMY_.block_third << endl;
   // return whether the cost function's report counter is positive
-  return (optTarget->getReportCounter() > 0);
+  optTarget->getReportCounter();
 }
 #endif
 
-bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
+void QMCFixedSampleLinearOptimizeBatched::one_shift_run()
 {
   // ensure the cost function is set to compute derivative vectors
   optTarget->setneedGrads(true);
@@ -1779,7 +1777,7 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
   finish();
 
   // return whether the cost function's report counter is positive
-  return (optTarget->getReportCounter() > 0);
+  optTarget->getReportCounter();
 }
 
 bool QMCFixedSampleLinearOptimizeBatched::stochastic_reconfiguration_conjugate_gradient()
@@ -1937,7 +1935,7 @@ bool QMCFixedSampleLinearOptimizeBatched::stochastic_reconfiguration_conjugate_g
 
 #ifdef HAVE_LMY_ENGINE
 //Function for optimizing using gradient descent
-bool QMCFixedSampleLinearOptimizeBatched::descent_run()
+void QMCFixedSampleLinearOptimizeBatched::descent_run()
 {
   //Compute Lagrangian derivatives needed for parameter updates with engine_checkConfigurations, which is called inside engine_start
   engine_start();
@@ -1973,14 +1971,14 @@ bool QMCFixedSampleLinearOptimizeBatched::descent_run()
   }
 
   finish();
-  return (optTarget->getReportCounter() > 0);
+  optTarget->getReportCounter();
 }
 #endif
 
 
 //Function for controlling the alternation between sections of descent optimization and BLM optimization.
 #ifdef HAVE_LMY_ENGINE
-bool QMCFixedSampleLinearOptimizeBatched::hybrid_run()
+void QMCFixedSampleLinearOptimizeBatched::hybrid_run()
 {
   app_log() << "This method name is: " << MinMethod << std::endl;
 
@@ -2009,7 +2007,7 @@ bool QMCFixedSampleLinearOptimizeBatched::hybrid_run()
     descent_run();
 
   app_log() << "Finished a hybrid step" << std::endl;
-  return (optTarget->getReportCounter() > 0);
+  optTarget->getReportCounter();
 }
 #endif
 

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -235,7 +235,7 @@ void QMCFixedSampleLinearOptimizeBatched::generateSamples()
   optTarget->setRootName(get_root_name());
 }
 
-bool QMCFixedSampleLinearOptimizeBatched::run()
+void QMCFixedSampleLinearOptimizeBatched::run()
 {
   if (do_output_matrices_csv_ && !output_matrices_initialized_)
   {
@@ -249,31 +249,44 @@ bool QMCFixedSampleLinearOptimizeBatched::run()
   if (doGradientTest)
   {
     app_log() << "Doing gradient test run" << std::endl;
-    return test_run();
+    test_run();
+    return;
   }
 #ifdef HAVE_LMY_ENGINE
   if (options_LMY_.doHybrid)
   {
     app_log() << "Doing hybrid run" << std::endl;
-    return hybrid_run();
+    hybrid_run();
+    return;
   }
-
   // if requested, perform the update via the adaptive three-shift or single-shift method
   if (options_LMY_.current_optimizer_type == OptimizerType::ADAPTIVE)
-    return adaptive_three_shift_run();
+  {
+    adaptive_three_shift_run();
+    return;
+  }
 
   if (options_LMY_.current_optimizer_type == OptimizerType::DESCENT)
-    return descent_run();
+  {
+    descent_run();
+    return;
+  }
 
 #endif
 
   if (options_LMY_.current_optimizer_type == OptimizerType::ONESHIFTONLY)
-    return one_shift_run();
+  {
+    one_shift_run();
+    return;
+  }
 
   if (options_LMY_.current_optimizer_type == OptimizerType::STOCHASTIC_RECONFIGURATION_CG)
-    return stochastic_reconfiguration_conjugate_gradient();
+  {
+    stochastic_reconfiguration_conjugate_gradient();
+    return;
+  }
 
-  return previous_linear_methods_run();
+  previous_linear_methods_run();
 }
 
 bool QMCFixedSampleLinearOptimizeBatched::test_run()

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -67,7 +67,7 @@ public:
   void setWaveFunctionNode(xmlNodePtr cur) { wfNode = cur; }
 
   ///Run the Optimization algorithm.
-  bool run() override;
+  void run() override;
   ///preprocess xml node
   void process(xmlNodePtr cur) override;
   ///process xml node value (parameters for both VMC and OPT) for the actual optimization

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -107,28 +107,28 @@ private:
                     const RealType ic) const;
 
   // perform the adaptive three-shift update
-  bool adaptive_three_shift_run();
+  void adaptive_three_shift_run();
 
   // perform the single-shift update, no sample regeneration
-  bool one_shift_run();
+  void one_shift_run();
 
   // simple stochastic reconfig
   bool stochastic_reconfiguration_conjugate_gradient();
 
   // perform optimization using a gradient descent algorithm
-  bool descent_run();
+  void descent_run();
 
   // Previous linear optimizers ("quartic" and "rescale")
-  bool previous_linear_methods_run();
+  void previous_linear_methods_run();
 
 
 #ifdef HAVE_LMY_ENGINE
   // use hybrid approach of descent and blocked linear method for optimization
-  bool hybrid_run();
+  void hybrid_run();
 #endif
 
   // Perform test of gradients
-  bool test_run();
+  void test_run();
 
   std::unique_ptr<GradientTest> testEngineObj;
 

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -113,7 +113,7 @@ private:
   void one_shift_run();
 
   // simple stochastic reconfig
-  bool stochastic_reconfiguration_conjugate_gradient();
+  void stochastic_reconfiguration_conjugate_gradient();
 
   // perform optimization using a gradient descent algorithm
   void descent_run();

--- a/src/QMCDrivers/WaveFunctionTester.cpp
+++ b/src/QMCDrivers/WaveFunctionTester.cpp
@@ -98,7 +98,7 @@ WaveFunctionTester::~WaveFunctionTester() {}
  small displacement for the ith particle.
 */
 
-bool WaveFunctionTester::run()
+void WaveFunctionTester::run()
 {
   std::array<char, 16> fname;
   if (std::snprintf(fname.data(), fname.size(), "wftest.%03d", OHMMS::Controller->rank()) < 0)
@@ -156,7 +156,7 @@ bool WaveFunctionTester::run()
 
   //RealType ene = H.evaluate(W);
   //app_log() << " Energy " << ene << std::endl;
-  return true;
+  return;
 }
 
 void WaveFunctionTester::runCloneTest()

--- a/src/QMCDrivers/WaveFunctionTester.h
+++ b/src/QMCDrivers/WaveFunctionTester.h
@@ -55,7 +55,7 @@ public:
 
   ~WaveFunctionTester() override;
 
-  bool run() override;
+  void run() override;
   bool put(xmlNodePtr q) override;
 
 private:

--- a/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
+++ b/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
@@ -175,7 +175,7 @@ public:
     CHECK(determineNumCrowds(4, 2) == 2);
   }
 
-  bool run() override { return false; }
+  void run() override { return; }
 
   int get_num_crowds() { return crowds_.size(); }
 


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

QMCDriverInterface::run() returns bool but there is no consumer. The source of true/false came from from WFOpt.
With the return value removed, several variables and functions in WFOpt can be removed. 


## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

laptop

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
