### PR TITLE
Workaround GCC 15 incorrect results in complex build CI testing on Intel SPR and GNR.

### DIFF
--- a/src/QMCWaveFunctions/LCAO/SoaAtomicBasisSet.h
+++ b/src/QMCWaveFunctions/LCAO/SoaAtomicBasisSet.h
@@ -708,6 +708,10 @@ public:
           MultiRnl.evaluate(r_new, phi_r);
           ///Phase for PBC containing the phase for the nearest image displacement and the correction due to the Distance table.
           const ValueType Phase = periodic_image_phase_factors_[iter] * correctphase;
+#if defined(QMC_COMPLEX) && defined(__GNUC__) && (__GNUC__ >= 15)
+          //workaround GCC 15 incorrect results in "LCAOrbitalSet batched PBC DiamondC" test on Intel SPR and GNR when built as complex.
+          #pragma GCC novector
+#endif
           for (size_t ib = 0; ib < BasisSetSize; ++ib)
             psi[ib] += ylm_v[LM[ib]] * phi_r[NL[ib]] * Phase;
         }


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Workaround GCC 15 complex build variant failing in "LCAOrbitalSet batched PBC DiamondC" of `test_wavefunction_sposet` and other unit test on Intel SPR and GNR. The problematic code is never intended to be vectorized due to multiple indirect access and AO is not performance critical by its scaling nature. I simply turn off GCC vectorization as a good enough fix without further spending time on it. This is not an alignment issue as failure is not sporadic.

Failure in CI.
On SPR. https://github.com/QMCPACK/qmcpack/actions/runs/31813498677/job/94809492200
On GNR. https://github.com/QMCPACK/qmcpack/actions/runs/31855235169/job/94938634331?pr=6126

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Bugfix

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

On JLSE. gcc 15.2 from OpenSUSE. GCC 14.3, 13.3, 12.2 tested OK without workaround.

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
