### PR TITLE
Fix #5537 remove estimator input types

### DIFF
--- a/src/Estimators/EnergyDensityEstimator.cpp
+++ b/src/Estimators/EnergyDensityEstimator.cpp
@@ -52,7 +52,7 @@ auto NEEnergyDensityEstimator::extractIonPositionsAndCharge(const ParticleSet& p
 NEEnergyDensityEstimator::NEEnergyDensityEstimator(const EnergyDensityInput& input,
                                                    const PSPool& pset_pool,
                                                    DataLocality data_locality)
-    : OperatorEstBase(data_locality, input.get_name(), input.get_type()),
+    : OperatorEstBase(data_locality, input.get_name(), std::string{EnergyDensityInput::type_tag}),
       input_(input),
       pset_dynamic_(getParticleSet(pset_pool, input.get_dynamic()))
 {
@@ -88,7 +88,7 @@ NEEnergyDensityEstimator::NEEnergyDensityEstimator(const EnergyDensityInput& inp
 }
 
 NEEnergyDensityEstimator::NEEnergyDensityEstimator(const NEEnergyDensityEstimator& ede, const DataLocality dl)
-    : OperatorEstBase(dl, ede.input_.get_name(), ede.input_.get_type()),
+    : OperatorEstBase(dl, ede.input_.get_name(), std::string{EnergyDensityInput::type_tag}),
       input_(ede.input_),
       pset_dynamic_(ede.pset_dynamic_),
       pset_static_(ede.pset_static_),

--- a/src/Estimators/EnergyDensityInput.cpp
+++ b/src/Estimators/EnergyDensityInput.cpp
@@ -20,7 +20,6 @@ EnergyDensityInput::EnergyDensityInput(xmlNodePtr cur)
   input_section_.readXML(cur);
   auto setIfInInput = LAMBDA_setIfInInput;
   setIfInInput(name_, "name");
-  setIfInInput(type_, "type");
   setIfInInput(dynamic_, "dynamic");
   setIfInInput(static_, "static");
   setIfInInput(ion_points_, "ion_points");

--- a/src/Estimators/EnergyDensityInput.h
+++ b/src/Estimators/EnergyDensityInput.h
@@ -44,9 +44,9 @@ public:
     EnergyDensityInputSection()
     {
       section_name = type_tag;
-      attributes   = {"name", "dynamic", "static", "ion_points", "type"};
+      attributes   = {"name", "dynamic", "static", "ion_points"};
       parameters   = {"reference_points", "spacegrid"};
-      strings      = {"name", "type", "dynamic", "static"};
+      strings      = {"name", "dynamic", "static"};
       bools        = {"ion_points"};
       delegates    = {"reference_points", "spacegrid"};
       multiple     = {"spacegrid"};
@@ -64,7 +64,6 @@ public:
   EnergyDensityInput(xmlNodePtr cur);
 
   const std::string& get_name() const { return name_; }
-  const std::string& get_type() const { return type_; }
   const std::string& get_dynamic() const { return dynamic_; }
   const std::string& get_static() const { return static_; }
   ReferencePointsInput get_ref_points_input() const { return ref_points_input_; }
@@ -73,7 +72,6 @@ public:
 
 private:
   std::string name_{type_tag};
-  std::string type_{type_tag};
   std::string dynamic_{"e"};
   std::string static_{}; // There can't be a default for this since
                          // some systems, heg namely don't

--- a/src/Estimators/MagnetizationDensity.cpp
+++ b/src/Estimators/MagnetizationDensity.cpp
@@ -14,7 +14,9 @@
 namespace qmcplusplus
 {
 MagnetizationDensity::MagnetizationDensity(MagnetizationDensityInput&& minput, const Lattice& lat)
-    : OperatorEstBase(DataLocality::crowd, minput.get_name(), minput.get_type()), input_(minput), lattice_(lat)
+    : OperatorEstBase(DataLocality::crowd, minput.get_name(), std::string{MagnetizationDensityInput::type_tag}),
+      input_(minput),
+      lattice_(lat)
 {
   //Pull consistent corner, grids, etc., from already inititalized input.
   //DerivedParameters does the sanity checks and consistent initialization of these variables.

--- a/src/Estimators/MagnetizationDensityInput.cpp
+++ b/src/Estimators/MagnetizationDensityInput.cpp
@@ -27,7 +27,6 @@ MagnetizationDensityInput::MagnetizationDensityInput(xmlNodePtr cur)
   auto setIfInInput = LAMBDA_setIfInInput;
   setIfInInput(nsamples_, "samples");
   setIfInInput(name_, "name");
-  setIfInInput(type_, "type");
   setIfInInput(integrator_, "integrator");
   have_center_ = setIfInInput(center_, "center");
   have_corner_ = setIfInInput(corner_, "corner");

--- a/src/Estimators/MagnetizationDensityInput.h
+++ b/src/Estimators/MagnetizationDensityInput.h
@@ -49,7 +49,6 @@ public:
    */
   MagnetizationDensityInput(const MagnetizationDensityInput&) = default;
   const std::string& get_name() const { return name_; }
-  const std::string& get_type() const { return type_; }
   PosType get_corner() const { return corner_; }
   PosType get_center() const { return center_; }
   PosType get_grid() const { return grid_real_; }
@@ -86,13 +85,13 @@ public:
     {
       // clang-format off
       section_name  = type_tag;
-      attributes    = {"name", "type"};
+      attributes    = {"name"};
       parameters    = {"integrator",
                        "corner", "center", "samples", "grid", "dr"
                       };
       bools         = {};
       enums         = {"integrator"};
-      strings       = {"name", "type"};
+      strings       = {"name"};
       multi_strings = {};
       integers      = {"samples"};
       reals         = {};
@@ -109,7 +108,6 @@ private:
   MagnetizationDensityInputSection input_section_;
   //Default Values
   std::string name_{type_tag};
-  std::string type_{type_tag};
   Integrator integrator_ = Integrator::SIMPSONS;
   int nsamples_          = 9; //Number of grid points for spin quadrature, or samples for Monte Carlo.
 

--- a/src/Estimators/MomentumDistribution.cpp
+++ b/src/Estimators/MomentumDistribution.cpp
@@ -24,7 +24,7 @@ MomentumDistribution::MomentumDistribution(MomentumDistributionInput&& mdi,
                                            const PosType& twist_in,
                                            const Lattice& lattice_in,
                                            DataLocality dl)
-    : OperatorEstBase(dl, mdi.get_name(), mdi.get_type()),
+    : OperatorEstBase(dl, mdi.get_name(), std::string{MomentumDistributionInput::type_tag}),
       input_(std::move(mdi)),
       twist(twist_in),
       lattice(lattice_in),

--- a/src/Estimators/MomentumDistributionInput.cpp
+++ b/src/Estimators/MomentumDistributionInput.cpp
@@ -20,7 +20,6 @@ MomentumDistributionInput::MomentumDistributionInput(xmlNodePtr cur)
 
   auto setIfInInput = [&](auto& var, const std::string& tag) -> bool { return input_section_.setIfInInput(var, tag); };
   setIfInInput(name_, "name");
-  setIfInInput(type_, "type");
   setIfInInput(samples_, "samples");
   setIfInInput(kmax_, "kmax");
   setIfInInput(kmax0_, "kmax0");

--- a/src/Estimators/MomentumDistributionInput.h
+++ b/src/Estimators/MomentumDistributionInput.h
@@ -35,8 +35,8 @@ public:
     MomentumDistributionInputSection()
     {
       section_name = type_tag;
-      attributes   = {"type", "name", "samples", "kmax", "kmax0", "kmax1", "kmax2"};
-      strings      = {"type", "name"};
+      attributes   = {"name", "samples", "kmax", "kmax0", "kmax1", "kmax2"};
+      strings      = {"name"};
       integers     = {"samples"};
       reals        = {"kmax", "kmax0", "kmax1", "kmax2"};
       // default_values = {{"name", std::string("nofk")}, {"samples", int(40)}, {"kmax", Real(0.0)},
@@ -55,7 +55,6 @@ private:
   MomentumDistributionInputSection input_section_;
 
   std::string name_{type_tag};
-  std::string type_{type_tag};
   ///number of samples
   int samples_ = 40;
   //maximum k-value in the k-grid in cartesian coordinates
@@ -67,7 +66,6 @@ private:
 
 public:
   const std::string& get_name() const { return name_; }
-  const std::string& get_type() const { return type_; }
   const int& get_samples() const { return samples_; }
   const Real& get_kmax() const { return kmax_; }
   const Real& get_kmax0() const { return kmax0_; }

--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -47,7 +47,7 @@ OneBodyDensityMatrices::OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obd
                                                const SpeciesSet& species,
                                                const SPOMap& spomap,
                                                const ParticleSet& pset_target)
-    : OperatorEstBase(DataLocality::crowd, obdmi.get_name(), obdmi.get_type()),
+    : OperatorEstBase(DataLocality::crowd, obdmi.get_name(), std::string{OneBodyDensityMatricesInput::type_tag}),
       input_(obdmi),
       lattice_(std::move(lattice)),
       species_(species),

--- a/src/Estimators/OneBodyDensityMatricesInput.cpp
+++ b/src/Estimators/OneBodyDensityMatricesInput.cpp
@@ -27,7 +27,6 @@ OneBodyDensityMatricesInput::OneBodyDensityMatricesInput(xmlNodePtr cur)
   input_section_.readXML(cur);
   auto setIfInInput = LAMBDA_setIfInInput;
   setIfInInput(name_, "name");
-  setIfInInput(name_, "type");
   setIfInInput(energy_matrix_, "energy_matrix");
   setIfInInput(use_drift_, "use_drift");
   setIfInInput(normalized_, "normalized");

--- a/src/Estimators/OneBodyDensityMatricesInput.h
+++ b/src/Estimators/OneBodyDensityMatricesInput.h
@@ -72,7 +72,7 @@ public:
     {
       // clang-format off
       section_name  = "OneBodyDensityMatrices";
-      attributes    = {"name", "type"};
+      attributes    = {"name"};
       parameters    = {"basis", "energy_matrix", "integrator", "evaluator", "scale",
                        "corner", "center", "points", "samples", "warmup", "timestep",
                        "use_drift", "check_overlap", "check_derivatives", "acceptance_ratio", "rstats",
@@ -80,7 +80,7 @@ public:
       bools         = {"energy_matrix", "use_drift", "normalized", "volume_normed",
                        "check_overlap", "check_derivatives", "rstats", "acceptance_ratio"};
       enums         = {"integrator", "evaluator"};
-      strings       = {"name", "type"};
+      strings       = {"name"};
       multi_strings = {"basis"};
       integers      = {"points", "samples"};
       reals         = {"scale", "timestep"};
@@ -131,11 +131,9 @@ private:
   int warmup_samples_ = 30;
   std::vector<std::string> basis_sets_;
   std::string name_{type_tag};
-  std::string type_{type_tag};
 
 public:
   const std::string& get_name() const { return name_; }
-  const std::string& get_type() const { return type_; }
   bool get_energy_matrix() const { return energy_matrix_; }
   bool get_use_drift() const { return use_drift_; }
   bool get_normalized() const { return normalized_; }

--- a/src/Estimators/PairCorrelationEstimator.cpp
+++ b/src/Estimators/PairCorrelationEstimator.cpp
@@ -21,7 +21,7 @@ PairCorrelationEstimator::PairCorrelationEstimator(const PairCorrelationInput& p
                                                    const PSPool& pset_pool,
                                                    ParticleSet& elecs,
                                                    DataLocality data_locality)
-    : OperatorEstBase(data_locality, pci.get_name(), pci.get_type()), input_(pci)
+    : OperatorEstBase(data_locality, pci.get_name(), std::string{PairCorrelationInput::type_tag}), input_(pci)
 {
   num_species_ = elecs.groups();
   n_vec_.resize(num_species_, 0);

--- a/src/Estimators/PairCorrelationInput.cpp
+++ b/src/Estimators/PairCorrelationInput.cpp
@@ -20,7 +20,6 @@ PairCorrelationInput::PairCorrelationInput(xmlNodePtr cur)
   input_section_.readXML(cur);
   auto setIfInInput = LAMBDA_setIfInInput;
   setIfInInput(name_, "name");
-  setIfInInput(type_, "type");
   explicit_set_nbins_ = setIfInInput(nbins_, "num_bin");
   explicit_set_rmax_  = setIfInInput(rmax_, "rmax");
   explicit_set_delta_ = setIfInInput(delta_, "dr");

--- a/src/Estimators/PairCorrelationInput.h
+++ b/src/Estimators/PairCorrelationInput.h
@@ -32,8 +32,8 @@ public:
     {
       section_name            = type_tag;
       section_name_alternates = {"gofr"};
-      attributes              = {"type", "name", "num_bin", "rmax", "dr", "debug", "sources"};
-      strings                 = {"type", "name"};
+      attributes              = {"name", "num_bin", "rmax", "dr", "debug", "sources"};
+      strings                 = {"name"};
       multi_strings           = {"sources"};
       reals                   = {"dr", "rmax"};
       integers                = {"num_bin"};
@@ -47,7 +47,6 @@ private:
   PairCorrelationInputSection input_section_;
 
   std::string name_{type_tag};
-  std::string type_{type_tag};
   std::vector<std::string> sources_{"e"};
   Real rmax_{10};
   bool explicit_set_rmax_{false};
@@ -59,7 +58,6 @@ private:
 
 public:
   std::string get_name() const { return name_; }
-  std::string get_type() const { return type_; }
   const std::vector<std::string>& get_sources() const { return sources_; }
   Real get_rmax() const { return rmax_; }
   Real get_delta() const { return delta_; }

--- a/src/Estimators/PerParticleHamiltonianLogger.cpp
+++ b/src/Estimators/PerParticleHamiltonianLogger.cpp
@@ -20,7 +20,9 @@ namespace qmcplusplus
 using namespace std::string_literals;
 
 PerParticleHamiltonianLogger::PerParticleHamiltonianLogger(PerParticleHamiltonianLoggerInput&& input, int rank)
-    : OperatorEstBase(DataLocality::crowd, input.get_name(), input.get_type()), input_(input), rank_(rank)
+    : OperatorEstBase(DataLocality::crowd, input.get_name(), std::string{PerParticleHamiltonianLoggerInput::type_tag}),
+      input_(input),
+      rank_(rank)
 {
   labeled_crowd_log_values_ = {{"local_potential"s, local_potential_values_},
                                {"local_energy"s, local_energy_values_},

--- a/src/Estimators/PerParticleHamiltonianLogger.cpp
+++ b/src/Estimators/PerParticleHamiltonianLogger.cpp
@@ -36,7 +36,7 @@ PerParticleHamiltonianLogger::PerParticleHamiltonianLogger(PerParticleHamiltonia
 }
 
 PerParticleHamiltonianLogger::PerParticleHamiltonianLogger(PerParticleHamiltonianLogger& pphl, DataLocality dl)
-    : OperatorEstBase(dl, pphl.getMyName(), pphl.getMyType()),
+    : OperatorEstBase(dl, pphl.getMyName(), std::string{PerParticleHamiltonianLoggerInput::type_tag}),
       rank_estimator_(makeOptionalRef(pphl)),
       input_(pphl.input_)
 {

--- a/src/Estimators/PerParticleHamiltonianLoggerInput.cpp
+++ b/src/Estimators/PerParticleHamiltonianLoggerInput.cpp
@@ -20,6 +20,5 @@ PerParticleHamiltonianLoggerInput::PerParticleHamiltonianLoggerInput(xmlNodePtr 
   auto setIfInInput = LAMBDA_setIfInInput;
   setIfInInput(to_stdout_, "to_stdout");
   setIfInInput(name_, "name");
-  setIfInInput(name_, "type");
 }
 } // namespace qmcplusplus

--- a/src/Estimators/PerParticleHamiltonianLoggerInput.h
+++ b/src/Estimators/PerParticleHamiltonianLoggerInput.h
@@ -33,9 +33,9 @@ public:
     PerParticleHamiltonianLoggerInputSection()
     {
       section_name = type_tag;
-      attributes   = {"to_stdout", "validate_per_particle_sum", "type", "name"};
+      attributes   = {"to_stdout", "validate_per_particle_sum", "name"};
       bools        = {"to_stdout", "validate_per_particle_sum"};
-      strings      = {"type", "name"};
+      strings      = {"name"};
     }
     PerParticleHamiltonianLoggerInputSection(const PerParticleHamiltonianLoggerInputSection& other) = default;
   };
@@ -47,13 +47,11 @@ public:
   PerParticleHamiltonianLoggerInput() = default;
 
   const std::string& get_name() const { return name_; }
-  const std::string& get_type() const { return type_; }
   bool get_to_stdout() const { return to_stdout_; }
 
 private:
   PerParticleHamiltonianLoggerInputSection input_section_;
   std::string name_{type_tag};
-  std::string type_{type_tag};
   bool to_stdout_ = false;
 };
 } // namespace qmcplusplus

--- a/src/Estimators/SelfHealingOverlap.cpp
+++ b/src/Estimators/SelfHealingOverlap.cpp
@@ -20,7 +20,7 @@
 namespace qmcplusplus
 {
 SelfHealingOverlap::SelfHealingOverlap(SelfHealingOverlapInput&& inp_, const TrialWaveFunction& wfn, DataLocality dl)
-    : OperatorEstBase(dl, inp_.get_name(), inp_.get_type()),
+    : OperatorEstBase(dl, inp_.get_name(), std::string{SelfHealingOverlapInput::type_tag}),
       input_(std::move(inp_)),
       wf_type(no_wf),
       use_param_deriv(input_.input_section_.get<bool>("param_deriv"))

--- a/src/Estimators/SelfHealingOverlapInput.cpp
+++ b/src/Estimators/SelfHealingOverlapInput.cpp
@@ -17,7 +17,6 @@ SelfHealingOverlapInput::SelfHealingOverlapInput(xmlNodePtr cur)
   input_section_.readXML(cur);
   auto setIfInInput = LAMBDA_setIfInInput;
   setIfInInput(name_, "name");
-  setIfInInput(type_, "type");
 }
 
 } // namespace qmcplusplus

--- a/src/Estimators/SelfHealingOverlapInput.h
+++ b/src/Estimators/SelfHealingOverlapInput.h
@@ -34,8 +34,8 @@ public:
     SelfHealingOverlapInputSection()
     {
       section_name   = type_tag;
-      attributes     = {"type", "name", "param_deriv"};
-      strings        = {"type", "name"};
+      attributes     = {"name", "param_deriv"};
+      strings        = {"name"};
       bools          = {"param_deriv"};
       default_values = {{"param_deriv", false}};
     }
@@ -43,7 +43,6 @@ public:
   };
 
   std::string get_name() const { return name_; }
-  std::string get_type() const { return type_; }
 
   SelfHealingOverlapInput(xmlNodePtr cur);
   /** default copy constructor
@@ -56,7 +55,6 @@ public:
 
 private:
   std::string name_{type_tag};
-  std::string type_{type_tag};
 };
 
 } // namespace qmcplusplus

--- a/src/Estimators/SpinDensityInput.cpp
+++ b/src/Estimators/SpinDensityInput.cpp
@@ -23,7 +23,6 @@ SpinDensityInput::SpinDensityInput(xmlNodePtr cur)
   auto setIfInInput = LAMBDA_setIfInInput;
 
   setIfInInput(name_, "name");
-  setIfInInput(type_, "type");
   setIfInInput(write_report_, "report");
   setIfInInput(save_memory_, "save_memory");
   have_dr_     = setIfInInput(dr_, "dr");

--- a/src/Estimators/SpinDensityInput.h
+++ b/src/Estimators/SpinDensityInput.h
@@ -45,9 +45,9 @@ public:
     {
       // clang-format off
       section_name = type_tag;
-      attributes   = {"name", "type", "report", "save_memory"};
+      attributes   = {"name", "report", "save_memory"};
       parameters   = {"dr", "grid", "corner", "center", "cell"};
-      strings      = {"name", "type"};
+      strings      = {"name"};
       bools        = {"report", "save_memory"};
       positions    = {"dr", "grid", "corner", "center"};
       multi_reals  = {"cell"};
@@ -69,7 +69,6 @@ public:
   bool get_write_report() const { return write_report_; }
   bool get_save_memory() const { return save_memory_; }
   const std::string& get_name() const { return name_; }
-  const std::string& get_type() const { return type_; }
 
   struct DerivedParameters
   {
@@ -93,7 +92,6 @@ private:
 
   ///name of this Estimator
   std::string name_{type_tag};
-  std::string type_{type_tag};
 
   Lattice cell_;
   PosType corner_;

--- a/src/Estimators/SpinDensityNew.cpp
+++ b/src/Estimators/SpinDensityNew.cpp
@@ -21,7 +21,7 @@
 namespace qmcplusplus
 {
 SpinDensityNew::SpinDensityNew(SpinDensityInput&& input, const SpeciesSet& species, DataLocality dl)
-    : OperatorEstBase(dl, input.get_name(), input.get_type()),
+    : OperatorEstBase(dl, input.get_name(), std::string{SpinDensityInput::type_tag}),
       input_(std::move(input)),
       species_(species),
       species_size_(getSpeciesSize(species))
@@ -48,7 +48,7 @@ SpinDensityNew::SpinDensityNew(SpinDensityInput&& input,
                                const Lattice& lattice,
                                const SpeciesSet& species,
                                const DataLocality dl)
-    : OperatorEstBase(dl, input.get_name(), input.get_type()),
+    : OperatorEstBase(dl, input.get_name(), std::string{SpinDensityInput::type_tag}),
       input_(std::move(input)),
       species_(species),
       species_size_(getSpeciesSize(species)),

--- a/src/Estimators/StructureFactorEstimator.cpp
+++ b/src/Estimators/StructureFactorEstimator.cpp
@@ -30,7 +30,7 @@ StructureFactorEstimator::StructureFactorEstimator(const StructureFactorInput& s
                                                    const ParticleSet& pset_ions,
                                                    const ParticleSet& pset_elec,
                                                    DataLocality data_locality)
-    : OperatorEstBase(data_locality, sfi.get_name(), sfi.get_type()),
+    : OperatorEstBase(data_locality, sfi.get_name(), std::string{StructureFactorInput::type_tag}),
       input_(sfi),
       elns_(pset_elec),
       elec_num_species_(elns_.getSpeciesSet().getTotalNum()),

--- a/src/Estimators/StructureFactorInput.cpp
+++ b/src/Estimators/StructureFactorInput.cpp
@@ -21,7 +21,6 @@ StructureFactorInput::StructureFactorInput(xmlNodePtr cur)
 
   auto setIfInInput = [&](auto& var, const std::string& tag) -> bool { return input_section_.setIfInInput(var, tag); };
   setIfInInput(name_, "name");
-  setIfInInput(type_, "type");
   setIfInInput(write_hdf5_, "writehdf5");
   setIfInInput(write_rho_, "writerho");
   setIfInInput(write_ion_ion_, "writeionion");

--- a/src/Estimators/StructureFactorInput.h
+++ b/src/Estimators/StructureFactorInput.h
@@ -37,8 +37,8 @@ public:
     StructureFactorInputSection()
     {
       section_name = type_tag;
-      attributes   = {"type", "name", "source", "target", "hdf5", "writerho", "writeionion"};
-      strings      = {"type", "name", "source", "target"};
+      attributes   = {"name", "source", "target", "hdf5", "writerho", "writeionion"};
+      strings      = {"name", "source", "target"};
       bools        = {"hdf5", "writerho", "writeionion"};
     }
     // clang-format: on
@@ -55,7 +55,6 @@ private:
   StructureFactorInputSection input_section_;
 
   std::string name_{type_tag};
-  std::string type_{type_tag};
   std::string source_;
   std::string target_;
   bool write_hdf5_{false};
@@ -64,7 +63,6 @@ private:
 
 public:
   std::string get_name() const { return name_; }
-  std::string get_type() const { return type_; }
   std::string get_source() const { return source_; }
   std::string get_target() const { return target_; }
   bool get_write_hdf5() const { return write_hdf5_; }

--- a/src/Estimators/tests/test_EstimatorManagerInput.cpp
+++ b/src/Estimators/tests/test_EstimatorManagerInput.cpp
@@ -151,50 +151,25 @@ TEST_CASE("EstimatorManagerInput::MergeConstructor", "[estimators]")
 
 TEST_CASE("EstimatorManagerInput::Name")
 {
-  // This test case covers the logic of name and type initialization when
-  // they are missing input as well as there proper handling within
-  // the various estimator input classes.
-  //
-  // This seems better to test at the integration level than at
-  // individual input since the emni and the est inputs must work
-  // together to have these always have the semantics expected.
-  //
-  // It should also cover breakage in the canned estimator manager
-  // input mocking.
+  // This test case covers name initialization when it is missing from input.
+  // It also covers breakage in the canned estimator manager input mocking.
   using namespace testing;
   Libxml2Document estimators_doc = createEstimatorManagerNewInputXML();
   EstimatorManagerInput emi_local(estimators_doc.getRoot());
 
-  auto checkNameType = [](EstimatorManagerInput& emi, auto ent) {
+  auto checkName = [](EstimatorManagerInput& emi, auto ent) {
     using EstimatorInput = typename decltype(ent)::Type;
     auto indexes         = emi.getEstimatorTypeIndexes<EstimatorInput>();
     for (auto index : indexes)
     {
       auto& eden_input = std::get<EstimatorInput>(emi.get_estimator_inputs()[index]);
       CHECK(eden_input.get_name() == ent.name);
-      CHECK(eden_input.get_type() == ent.type);
     }
   };
-  checkNameType(emi_local, ExpectedEstimatorInputNameType<EnergyDensityInput>{});
-  checkNameType(emi_local, ExpectedEstimatorInputNameType<OneBodyDensityMatricesInput>{});
-  checkNameType(emi_local, ExpectedEstimatorInputNameType<MomentumDistributionInput>{});
-  checkNameType(emi_local, ExpectedEstimatorInputNameType<StructureFactorInput>{});
-
-  // auto& estimator_inputs = emi_merged.get_estimator_inputs();
-  // auto eden_indexes      = emi_merged.getEstimatorTypeIndexes<EnergyDensityInput>();
-  // for (auto eden_index : eden_indexes)
-  // {
-  //   auto& eden_input = std::get<EnergyDensityInput>(estimator_inputs[eden_index]);
-  //   CHECK(eden_input.get_name() == "EDcell");
-  //   CHECK(eden_input.get_type() == "EnergyDensity");
-  // }
-  // auto one_body_indexes = emi_merged.getEstimatorTypeIndexes<EnergyDensityInput>();
-  // for (auto one_body_index : one_body_indexes)
-  // {
-  //   auto& one_body_input = std::get<OneBodyDensityMatricesInput>(estimator_inputs[one_body_index]);
-  //   CHECK(one_body_input.get_name() == "OneBodyDensityMatrices");
-  //   CHECK(one_body_input.get_type() == "OneBodyDensityMatrices");
-  // }
+  checkName(emi_local, ExpectedEstimatorInputName<EnergyDensityInput>{});
+  checkName(emi_local, ExpectedEstimatorInputName<OneBodyDensityMatricesInput>{});
+  checkName(emi_local, ExpectedEstimatorInputName<MomentumDistributionInput>{});
+  checkName(emi_local, ExpectedEstimatorInputName<StructureFactorInput>{});
 }
 
 } // namespace qmcplusplus

--- a/src/Estimators/tests/test_EstimatorManagerInput.h
+++ b/src/Estimators/tests/test_EstimatorManagerInput.h
@@ -19,38 +19,34 @@ namespace qmcplusplus::testing
 {
 
 template<typename T>
-struct ExpectedEstimatorInputNameType;
+struct ExpectedEstimatorInputName;
 
 template<>
-struct ExpectedEstimatorInputNameType<EnergyDensityInput>
+struct ExpectedEstimatorInputName<EnergyDensityInput>
 {
   using Type = EnergyDensityInput;
   std::string name{"EDcell"};
-  std::string type{"EnergyDensity"};
 };
 
 template<>
-struct ExpectedEstimatorInputNameType<OneBodyDensityMatricesInput>
+struct ExpectedEstimatorInputName<OneBodyDensityMatricesInput>
 {
   using Type = OneBodyDensityMatricesInput;
   std::string name{"OneBodyDensityMatrices"};
-  std::string type{"OneBodyDensityMatrices"};
 };
 
 template<>
-struct ExpectedEstimatorInputNameType<MomentumDistributionInput>
+struct ExpectedEstimatorInputName<MomentumDistributionInput>
 {
   using Type = MomentumDistributionInput;
   std::string name{"nofk"};
-  std::string type{"MomentumDistribution"};
 };
 
 template<>
-struct ExpectedEstimatorInputNameType<StructureFactorInput>
+struct ExpectedEstimatorInputName<StructureFactorInput>
 {
   using Type = StructureFactorInput;
   std::string name{"sk1"};
-  std::string type{"StructureFactor"};
 };
 
 } // namespace qmcplusplus::testing


### PR DESCRIPTION
## Proposed changes
Address #5537
The estimator type is an input selector not an input string.
This removes it from the input classes.  There remains a copy of the string type_tag's of the Estimators made in the OperatorEstBase that is used by the EstimatorManger that I would like to refactor away but how to do that is a bit of a trickier problem.

This should have no functional effect on the code at all.  But it makes the input classes reflect the actual semantics of the code more clearly.

This removes the inaccurate semantics from the input classes which I think is more important and differs the OperatorEstBase copy that stalled this fix out in the past.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation or build script changes

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
Ubuntu 24.04
LLVM 21.1.4


## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
