### PR TITLE
Nexus: fix reading QMCPACK input files with <include/> elements

### DIFF
--- a/nexus/nexus/tests/test_xmlreader.py
+++ b/nexus/nexus/tests/test_xmlreader.py
@@ -332,6 +332,11 @@ def test_find_pair():
     assert(s[i1:i2]=='</qmc>')
     i1,i2 = find_pair(s,['</','>'],i2)
     assert(s[i1:i2]=='</simulation>')
+
+    # A right delimiter can remain after the final left delimiter.  In this
+    # case, no pair is present and both locations should report not found.
+    i1,i2 = find_pair('<simulation><project/></simulation>',['<include','/>'])
+    assert((i1,i2)==(-1,-1))
 #end def test_find_pair
 
 

--- a/nexus/nexus/xmlreader.py
+++ b/nexus/nexus/xmlreader.py
@@ -71,8 +71,11 @@ def find_pair(s, pairs, start = 0, end = None):
     right_pair  = pairs[1]
 
     start_loc = s.find(left_pair, start, end)
+    if start_loc == -1:
+        return -1, -1
+    #end if
     end_loc   = s.find(right_pair, start_loc + len(left_pair), end)
-    if start_loc == -1 or end_loc == -1:
+    if end_loc == -1:
         return start_loc, end_loc
 
     return start_loc, end_loc+len(right_pair)


### PR DESCRIPTION

This PR fixes a small, but longstanding, bug in Nexus. 

Originally, Nexus could read QMCPACK input files containing `<include/>` XML elements, but at some point this broke.  This PR provides a very localized fix.

GPT 5.6 Sol was used.