### PR TITLE
Fix AFQMC using deprecated iterator from Multi

### DIFF
--- a/src/AFQMC/Estimators/BackPropagatedEstimator.hpp
+++ b/src/AFQMC/Estimators/BackPropagatedEstimator.hpp
@@ -197,13 +197,13 @@ public:
 
       int n0, n1;
       std::tie(n0, n1) = FairDivideBoundary(TG.getLocalTGRank(), int(get<2>(Refs.sizes())), TG.getNCoresPerTG());
-      boost::multi::array_ref<ComplexType, 3> Refs_(to_address(Refs.origin()), Refs.extensions());
+      boost::multi::array_ref<ComplexType, 3> Refs_(to_address(Refs.base()), Refs.extents());
 
       // 2. setup back propagated references
       wfn0.getReferencesForBackPropagation(Refs_[0]);
       for (int iw = 1; iw < wset.size(); ++iw)
         for (int ref = 0; ref < nrefs; ++ref)
-          copy_n(Refs_[0][ref].origin() + n0, n1 - n0, Refs_[iw][ref].origin() + n0);
+          copy_n(Refs_[0][ref].base() + n0, n1 - n0, Refs_[iw][ref].base() + n0);
       TG.TG_local().barrier();
 
       //3. propagate backwards the references

--- a/src/AFQMC/Estimators/FullObsHandler.hpp
+++ b/src/AFQMC/Estimators/FullObsHandler.hpp
@@ -52,7 +52,7 @@ class FullObsHandler : public AFQMCInfo
   using shared_pointer       = typename sharedAllocator::pointer;
   using const_shared_pointer = typename sharedAllocator::const_pointer;
 
-  using devCMatrix_ptr = boost::multi::array_ptr<ComplexType, 2, device_ptr<ComplexType>>;
+  using devCMatrix_ptr = boost::multi::detail::array_ptr<ComplexType, 2, device_ptr<ComplexType>>;
 
   using sharedCVector      = boost::multi::array<ComplexType, 1, sharedAllocator>;
   using sharedCVector_ref  = boost::multi::array_ref<ComplexType, 1, shared_pointer>;
@@ -178,12 +178,12 @@ public:
     if (TG.TG_local().root())
     {
       ma::scal(ComplexType(1.0 / block_size), denominator);
-      TG.TG_heads().reduce_in_place_n(to_address(denominator.origin()), denominator.num_elements(), std::plus<>(), 0);
+      TG.TG_heads().reduce_in_place_n(to_address(denominator.base()), denominator.num_elements(), std::plus<>(), 0);
     }
 
     for (auto& v : properties)
       v.print(iblock, dump, denominator);
-    fill_n(denominator.origin(), denominator.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(denominator.base(), denominator.num_elements(), ComplexType(0.0, 0.0));
   }
 
   template<class WlkSet, class MatR, class CVec, class MatD>
@@ -202,16 +202,16 @@ public:
                          shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
     StaticSHMVector DevOv(iextensions<1u>{2 * nw},
                           shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
-    sharedCMatrix_ref G2D(G4D.origin(), {nw, dm_size});
+    sharedCMatrix_ref G2D(G4D.base(), {nw, dm_size});
 
     if (G4D_host.num_elements() != G4D.num_elements())
     {
-      G4D_host = mpi3C4Tensor(G4D.extensions(), shared_allocator<ComplexType>{TG.TG_local()});
+      G4D_host = mpi3C4Tensor(G4D.extents(), shared_allocator<ComplexType>{TG.TG_local()});
       TG.TG_local().barrier();
     }
 
     stdCVector Xw(iextensions<1u>{nw});
-    std::fill_n(Xw.origin(), Xw.num_elements(), ComplexType(1.0, 0.0));
+    std::fill_n(Xw.base(), Xw.num_elements(), ComplexType(1.0, 0.0));
     stdCVector Ov(iextensions<1u>{2 * nw});
     stdCMatrix detR(DevdetR);
 
@@ -262,13 +262,13 @@ public:
         {
           SMA.emplace_back(wset[iw].SlaterMatrixN(Alpha));
           SMB.emplace_back(wset[iw].SlaterMatrixN(Beta));
-          GA.emplace_back(make_device_ptr(G2D[iw].origin()), iextensions<2u>{NMO, NMO});
-          GB.emplace_back(make_device_ptr(G2D[iw].origin()) + NMO * NMO, iextensions<2u>{NMO, NMO});
+          GA.emplace_back(make_device_ptr(G2D[iw].base()), iextensions<2u>{NMO, NMO});
+          GB.emplace_back(make_device_ptr(G2D[iw].base()) + NMO * NMO, iextensions<2u>{NMO, NMO});
           RefsA.emplace_back(wset[iw].SlaterMatrixAux(Alpha));
           RefsB.emplace_back(wset[iw].SlaterMatrixAux(Beta));
-          copy_n(Refs[iw][iref].origin(), (*RefsA.back()).num_elements(), (*RefsA.back()).origin());
-          copy_n(Refs[iw][iref].origin() + (*RefsA.back()).num_elements(), (*RefsB.back()).num_elements(),
-                 (*RefsB.back()).origin());
+          copy_n(Refs[iw][iref].base(), (*RefsA.back()).num_elements(), (*RefsA.back()).base());
+          copy_n(Refs[iw][iref].base() + (*RefsA.back()).num_elements(), (*RefsB.back()).num_elements(),
+                 (*RefsB.back()).base());
         }
         wfn0.DensityMatrix(RefsA, SMA, GA, DevOv.sliced(0, nw), LogOverlapFactor, false, false);
         wfn0.DensityMatrix(RefsB, SMB, GB, DevOv.sliced(nw, 2 * nw), LogOverlapFactor, false, false);
@@ -278,15 +278,15 @@ public:
         for (int iw = 0; iw < nw; iw++)
         {
           SMA.emplace_back(wset[iw].SlaterMatrixN(Alpha));
-          GA.emplace_back(make_device_ptr(G2D[iw].origin()), iextensions<2u>{NMO, NMO});
+          GA.emplace_back(make_device_ptr(G2D[iw].base()), iextensions<2u>{NMO, NMO});
           RefsA.emplace_back(wset[iw].SlaterMatrixAux(Alpha));
-          copy_n(Refs[iw][iref].origin(), (*RefsA.back()).num_elements(), (*RefsA.back()).origin());
+          copy_n(Refs[iw][iref].base(), (*RefsA.back()).num_elements(), (*RefsA.back()).base());
         }
         wfn0.DensityMatrix(RefsA, SMA, GA, DevOv.sliced(0, nw), LogOverlapFactor, false, false);
       }
 
       //2. calculate and accumulate appropriate weights
-      copy_n(DevOv.origin(), 2 * nw, Ov.origin());
+      copy_n(DevOv.base(), 2 * nw, Ov.base());
       if (nrefs > 1)
       {
         if (walker_type == CLOSED)
@@ -314,7 +314,7 @@ public:
       TG.TG_local().barrier();
       int i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(TG.TG_local().rank(), int(G4D_host.num_elements()), TG.TG_local().size());
-      copy_n(make_device_ptr(G4D.origin()) + i0, iN - i0, to_address(G4D_host.origin()) + i0);
+      copy_n(make_device_ptr(G4D.base()) + i0, iN - i0, to_address(G4D_host.base()) + i0);
       TG.TG_local().barrier();
 
       //3. accumulate references

--- a/src/AFQMC/Estimators/MixedRDMEstimator.h
+++ b/src/AFQMC/Estimators/MixedRDMEstimator.h
@@ -130,8 +130,8 @@ public:
         std::string padded_iblock = std::string(n_zero - std::to_string(iblock).length(), '0') + std::to_string(iblock);
 
         using std::get;
-        boost::multi::array_ref<ComplexType, 1> wOvlp_(wOvlp.origin(), {get<0>(wOvlp.sizes()) * get<1>(wOvlp.sizes())});
-        boost::multi::array_ref<ComplexType, 1> wDMsum_(wDMsum.origin(), {get<0>(wDMsum.sizes()) * get<1>(wDMsum.sizes())});
+        boost::multi::array_ref<ComplexType, 1> wOvlp_(wOvlp.base(), {get<0>(wOvlp.sizes()) * get<1>(wOvlp.sizes())});
+        boost::multi::array_ref<ComplexType, 1> wDMsum_(wDMsum.base(), {get<0>(wDMsum.sizes()) * get<1>(wDMsum.sizes())});
         dump.write(DMAverage, "one_rdm_" + padded_iblock);
         dump.write(denom_average, "one_rdm_denom_" + padded_iblock);
         dump.write(wOvlp_, "one_rdm_walker_overlaps_" + padded_iblock);

--- a/src/AFQMC/Estimators/Observables/atomcentered_correlators.hpp
+++ b/src/AFQMC/Estimators/Observables/atomcentered_correlators.hpp
@@ -167,13 +167,13 @@ public:
       NAO = orbs.back();
       S   = CTensor({2, NAO, NMO}, make_node_allocator<ComplexType>(TG));
       XY  = CMatrix({NAO, NAO}, make_node_allocator<ComplexType>(TG));
-      CMatrix_ref S_(make_device_ptr(S[0].origin()), {NAO, NMO});
+      CMatrix_ref S_(make_device_ptr(S[0].base()), {NAO, NMO});
       if (!dump.readEntry(S_, "Left"))
       {
         app_error() << " Error in atomcentered_correlators: Problems reading Left. " << std::endl;
         APP_ABORT("");
       }
-      stdCMatrix_ref S2_(to_address(S[1].origin()), {NAO, NMO});
+      stdCMatrix_ref S2_(to_address(S[1].base()), {NAO, NMO});
       if (!dump.readEntry(S2_, "Right"))
       {
         app_error() << " Error in atomcentered_correlators: Problems reading Right. " << std::endl;
@@ -218,9 +218,9 @@ public:
     }
 
     DMAverage1D = mpi3CTensor({nave, 3, nsites}, shared_allocator<ComplexType>{TG.TG_local()});
-    fill_n(DMAverage1D.origin(), DMAverage1D.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage1D.base(), DMAverage1D.num_elements(), ComplexType(0.0, 0.0));
     DMAverage2D = mpi3CTensor({nave, 3, ns2}, shared_allocator<ComplexType>{TG.TG_local()});
-    fill_n(DMAverage2D.origin(), DMAverage2D.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage2D.base(), DMAverage2D.num_elements(), ComplexType(0.0, 0.0));
   }
 
   template<class MatG, class MatG_host, class HostCVec1, class HostCVec2, class HostCVec3>
@@ -245,7 +245,7 @@ public:
     assert(Xw.size() == nw);
     assert(ovlp.size() >= nw);
     assert(G.num_elements() == G_host.num_elements());
-    assert(G.extensions() == G_host.extensions());
+    assert(G.extents() == G_host.extents());
 
     int nsp;
     if (walker_type == CLOSED)
@@ -279,9 +279,9 @@ public:
       }
       if (shapes.size() < 2 * nw * nsites * nsites)
         shapes = IVector(iextensions<1u>{2 * nw * nsites * nsites}, IAllocator{});
-      fill_n(denom.origin(), denom.num_elements(), ComplexType(0.0, 0.0));
-      fill_n(DMWork1D.origin(), DMWork1D.num_elements(), ComplexType(0.0, 0.0));
-      fill_n(DMWork2D.origin(), DMWork2D.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(denom.base(), denom.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(DMWork1D.base(), DMWork1D.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(DMWork2D.base(), DMWork2D.num_elements(), ComplexType(0.0, 0.0));
     }
     else
     {
@@ -300,11 +300,11 @@ public:
     int iw0(0);
     int i0, iN;
     int nwbatch(nw);
-    std::vector<decltype(ma::pointer_dispatch(S.origin()))> Aarray;
+    std::vector<decltype(ma::pointer_dispatch(S.base()))> Aarray;
     Aarray.reserve(nwbatch * nsites * nsites);
-    std::vector<decltype(ma::pointer_dispatch(S.origin()))> Barray;
+    std::vector<decltype(ma::pointer_dispatch(S.base()))> Barray;
     Barray.reserve(nwbatch * nsites * nsites);
-    std::vector<decltype(ma::pointer_dispatch(S.origin()))> Carray;
+    std::vector<decltype(ma::pointer_dispatch(S.base()))> Carray;
     Carray.reserve(nwbatch * nsites * nsites);
     LocalTGBufferManager buffer_manager;
     while (iw0 < nw)
@@ -326,9 +326,9 @@ public:
         // QwI[iw] = X * G[iw][is] =  S[0] * G[iw][is]
         for (int iw = 0; iw < nwlk; ++iw)
         {
-          Aarray.emplace_back(ma::pointer_dispatch(S[0][i0].origin()));
-          Barray.emplace_back(ma::pointer_dispatch(G[iw0 + iw][is].origin()));
-          Carray.emplace_back(ma::pointer_dispatch(QwI[iw][i0].origin()));
+          Aarray.emplace_back(ma::pointer_dispatch(S[0][i0].base()));
+          Barray.emplace_back(ma::pointer_dispatch(G[iw0 + iw][is].base()));
+          Carray.emplace_back(ma::pointer_dispatch(QwI[iw][i0].base()));
         }
         // careful with fortran ordering
         gemmBatched('N', 'N', NMO, int(iN - i0), NMO, ComplexType(1.0), Barray.data(), NMO, Aarray.data(), NMO,
@@ -341,8 +341,8 @@ public:
         // MwIJ[iw] = QwI * Y =  QwI * T(S[1])
         for (int iw = 0; iw < nwlk; ++iw)
         {
-          Barray.emplace_back(ma::pointer_dispatch(S[1].origin()));
-          Aarray.emplace_back(ma::pointer_dispatch(MwIJ[iw][i0].origin()));
+          Barray.emplace_back(ma::pointer_dispatch(S[1].base()));
+          Aarray.emplace_back(ma::pointer_dispatch(MwIJ[iw][i0].base()));
         }
         // careful with fortran ordering
         gemmBatched('T', 'N', NAO, int(iN - i0), NMO, ComplexType(1.0), Barray.data(), NMO, Carray.data(), NMO,
@@ -356,14 +356,14 @@ public:
           for (int I = 0; I < nsites; ++I, ++p)
             if (p % TG.TG_local().size() == TG.TG_local().rank())
             {
-              Aarray.emplace_back(ma::pointer_dispatch(devNwI[iw].origin() + I));
-              Barray.emplace_back(ma::pointer_dispatch(MwIJ[iw][orbs[I]].origin() + orbs[I]));
+              Aarray.emplace_back(ma::pointer_dispatch(devNwI[iw].base() + I));
+              Barray.emplace_back(ma::pointer_dispatch(MwIJ[iw][orbs[I]].base() + orbs[I]));
               shapes[nt++] = int(orbs[I + 1] - orbs[I]);
             }
         using ma::batched_diagonal_sum;
         batched_diagonal_sum(shapes.data(), Barray.data(), NAO, ComplexType(1.0), Aarray.data(), int(Aarray.size()));
 
-        fill_n(devNwIJ.origin(), devNwIJ.num_elements(), ComplexType(0.0));
+        fill_n(devNwIJ.base(), devNwIJ.num_elements(), ComplexType(0.0));
 
         // NwIJ[iw][I][J] = sum_ij MwIJ[iw][Ij][Jj] * XY[Jj][Ii]
         Aarray.clear();
@@ -374,9 +374,9 @@ public:
             for (int J = 0; J < nsites; ++J, ++p)
               if (p % TG.TG_local().size() == TG.TG_local().rank())
               {
-                Aarray.emplace_back(ma::pointer_dispatch(MwIJ[iw][orbs[I]].origin() + orbs[J]));
-                Barray.emplace_back(ma::pointer_dispatch(XY[orbs[J]].origin() + orbs[I]));
-                Carray.emplace_back(ma::pointer_dispatch(devNwIJ[iw][I].origin() + J));
+                Aarray.emplace_back(ma::pointer_dispatch(MwIJ[iw][orbs[I]].base() + orbs[J]));
+                Barray.emplace_back(ma::pointer_dispatch(XY[orbs[J]].base() + orbs[I]));
+                Carray.emplace_back(ma::pointer_dispatch(devNwIJ[iw][I].base() + J));
                 shapes[nt++] = int(orbs[I + 1] - orbs[I]);
                 shapes[nt++] = int(orbs[J + 1] - orbs[J]);
               }
@@ -386,7 +386,7 @@ public:
         TG.TG_local().barrier();
 
         // testing !!!
-        //        fill_n(devNwIJ.origin(),devNwIJ.num_elements(),ComplexType(0.0));
+        //        fill_n(devNwIJ.base(),devNwIJ.num_elements(),ComplexType(0.0));
         //        TG.TG_local().barrier();
 
         // NwIJ[iw][I][J] = sum_ij MwIJ[iw][Ij][Jj] * MwJI[iw][Jj][Ii]
@@ -398,9 +398,9 @@ public:
             for (int J = 0; J < nsites; ++J, ++p)
               if (p % TG.TG_local().size() == TG.TG_local().rank())
               {
-                Aarray.emplace_back(ma::pointer_dispatch(MwIJ[iw][orbs[I]].origin() + orbs[J]));
-                Barray.emplace_back(ma::pointer_dispatch(MwIJ[iw][orbs[J]].origin() + orbs[I]));
-                Carray.emplace_back(ma::pointer_dispatch(devNwIJ[iw][I].origin() + J));
+                Aarray.emplace_back(ma::pointer_dispatch(MwIJ[iw][orbs[I]].base() + orbs[J]));
+                Barray.emplace_back(ma::pointer_dispatch(MwIJ[iw][orbs[J]].base() + orbs[I]));
+                Carray.emplace_back(ma::pointer_dispatch(devNwIJ[iw][I].base() + J));
                 shapes[nt++] = int(orbs[I + 1] - orbs[I]);
                 shapes[nt++] = int(orbs[J + 1] - orbs[J]);
               }
@@ -410,9 +410,9 @@ public:
         TG.TG_local().barrier();
 
         std::tie(i0, iN) = FairDivideBoundary(TG.TG_local().rank(), int(devNwIJ.num_elements()), TG.TG_local().size());
-        copy_n(devNwIJ.origin() + i0, (iN - i0), NwIJ[is][iw0].origin() + i0);
+        copy_n(devNwIJ.base() + i0, (iN - i0), NwIJ[is][iw0].base() + i0);
         std::tie(i0, iN) = FairDivideBoundary(TG.TG_local().rank(), int(devNwI.num_elements()), TG.TG_local().size());
-        copy_n(devNwI.origin() + i0, (iN - i0), NwI[is][iw0].origin() + i0);
+        copy_n(devNwI.base() + i0, (iN - i0), NwI[is][iw0].base() + i0);
       }
       iw0 += nwlk;
     }
@@ -431,9 +431,9 @@ public:
         continue;
       if (walker_type == CLOSED)
       {
-        stdCMatrix_ref DMcc(to_address(DMWork2D[iw][0].origin()), {nsites, nsites});
-        stdCMatrix_ref DMss(to_address(DMWork2D[iw][1].origin()), {nsites, nsites});
-        stdCMatrix_ref DMcs(to_address(DMWork2D[iw][2].origin()), {nsites, nsites});
+        stdCMatrix_ref DMcc(to_address(DMWork2D[iw][0].base()), {nsites, nsites});
+        stdCMatrix_ref DMss(to_address(DMWork2D[iw][1].base()), {nsites, nsites});
+        stdCMatrix_ref DMcs(to_address(DMWork2D[iw][2].base()), {nsites, nsites});
         auto X_(2.0 * Xw[iw]);
         for (int i = 0; i < nsites; i++)
         {
@@ -450,9 +450,9 @@ public:
       }
       else if (walker_type == COLLINEAR)
       {
-        stdCMatrix_ref DMcc(to_address(DMWork2D[iw][0].origin()), {nsites, nsites});
-        stdCMatrix_ref DMss(to_address(DMWork2D[iw][1].origin()), {nsites, nsites});
-        stdCMatrix_ref DMcs(to_address(DMWork2D[iw][2].origin()), {nsites, nsites});
+        stdCMatrix_ref DMcc(to_address(DMWork2D[iw][0].base()), {nsites, nsites});
+        stdCMatrix_ref DMss(to_address(DMWork2D[iw][1].base()), {nsites, nsites});
+        stdCMatrix_ref DMcs(to_address(DMWork2D[iw][2].base()), {nsites, nsites});
         auto X_(Xw[iw]);
         for (int i = 0; i < nsites; i++)
         {
@@ -491,14 +491,14 @@ public:
       for (int iw = 0; iw < nw; iw++)
         denom[iw] = wgt[iw] / denom[iw];
       {
-        stdCVector_ref DMAv1D(to_address(DMAverage1D[iav].origin()), {3 * nsites});
-        stdCMatrix_ref DMWork2D_(to_address(DMWork1D.origin()), {nw, 3 * nsites});
+        stdCVector_ref DMAv1D(to_address(DMAverage1D[iav].base()), {3 * nsites});
+        stdCMatrix_ref DMWork2D_(to_address(DMWork1D.base()), {nw, 3 * nsites});
         // DMAverage[iav][t][ij] += sum_iw DMWork[iw][t][ij] * denom[iw] = T( DMWork ) * denom
         ma::product(ComplexType(1.0, 0.0), ma::T(DMWork2D_), denom, ComplexType(1.0, 0.0), DMAv1D);
       }
       {
-        stdCVector_ref DMAv1D(to_address(DMAverage2D[iav].origin()), {3 * ns2});
-        stdCMatrix_ref DMWork2D_(to_address(DMWork2D.origin()), {nw, 3 * ns2});
+        stdCVector_ref DMAv1D(to_address(DMAverage2D[iav].base()), {3 * ns2});
+        stdCMatrix_ref DMWork2D_(to_address(DMWork2D.base()), {nw, 3 * ns2});
         // DMAverage[iav][t][ij] += sum_iw DMWork[iw][t][ij] * denom[iw] = T( DMWork ) * denom
         ma::product(ComplexType(1.0, 0.0), ma::T(DMWork2D_), denom, ComplexType(1.0, 0.0), DMAv1D);
       }
@@ -515,9 +515,9 @@ public:
     if (TG.TG_local().root())
     {
       ma::scal(ComplexType(1.0 / block_size), DMAverage1D);
-      TG.TG_heads().reduce_in_place_n(to_address(DMAverage1D.origin()), DMAverage1D.num_elements(), std::plus<>(), 0);
+      TG.TG_heads().reduce_in_place_n(to_address(DMAverage1D.base()), DMAverage1D.num_elements(), std::plus<>(), 0);
       ma::scal(ComplexType(1.0 / block_size), DMAverage2D);
-      TG.TG_heads().reduce_in_place_n(to_address(DMAverage2D.origin()), DMAverage2D.num_elements(), std::plus<>(), 0);
+      TG.TG_heads().reduce_in_place_n(to_address(DMAverage2D.base()), DMAverage2D.num_elements(), std::plus<>(), 0);
       if (writer)
       {
         dump.push(std::string("ATOM_CORRELATORS"));
@@ -529,7 +529,7 @@ public:
             dump.push(std::string("Average_") + std::to_string(i));
             std::string padded_iblock =
                 std::string(n_zero - std::to_string(iblock).length(), '0') + std::to_string(iblock);
-            stdCVector_ref DMAverage2D_(to_address(DMAverage2D[i][t].origin()), {ns2});
+            stdCVector_ref DMAverage2D_(to_address(DMAverage2D[i][t].base()), {ns2});
             dump.write(DMAverage2D_, "correlator2D_" + type_id2D[t] + padded_iblock);
             dump.write(Wsum[i], "denominator_" + padded_iblock);
             dump.pop();
@@ -544,7 +544,7 @@ public:
             dump.push(std::string("Average_") + std::to_string(i));
             std::string padded_iblock =
                 std::string(n_zero - std::to_string(iblock).length(), '0') + std::to_string(iblock);
-            stdCVector_ref DMAverage1D_(to_address(DMAverage1D[i][t].origin()), {nsites});
+            stdCVector_ref DMAverage1D_(to_address(DMAverage1D[i][t].base()), {nsites});
             dump.write(DMAverage1D_, "correlator1D_" + type_id1D[t] + padded_iblock);
             dump.write(Wsum[i], "denominator_" + padded_iblock);
             dump.pop();
@@ -555,8 +555,8 @@ public:
       }
     }
     TG.TG_local().barrier();
-    fill_n(DMAverage1D.origin(), DMAverage1D.num_elements(), ComplexType(0.0, 0.0));
-    fill_n(DMAverage2D.origin(), DMAverage2D.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage1D.base(), DMAverage1D.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage2D.base(), DMAverage2D.num_elements(), ComplexType(0.0, 0.0));
   }
 
 private:

--- a/src/AFQMC/Estimators/Observables/diagonal2rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/diagonal2rdm.hpp
@@ -107,7 +107,7 @@ public:
       dm_size -= NMO * (NMO - 1) / 2;
 
     DMAverage = mpi3CMatrix({nave, dm_size}, shared_allocator<ComplexType>{TG.TG_local()});
-    fill_n(DMAverage.origin(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage.base(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
   }
 
   template<class MatG, class MatG_host, class HostCVec1, class HostCVec2, class HostCVec3>
@@ -131,7 +131,7 @@ public:
     assert(Xw.size() == nw);
     assert(ovlp.size() >= nw);
     assert(G.num_elements() == G_host.num_elements());
-    assert(G.extensions() == G_host.extensions());
+    assert(G.extents() == G_host.extents());
 
     using std::get;
     // check structure dimensions
@@ -145,8 +145,8 @@ public:
       {
         DMWork = mpi3CMatrix({nw, dm_size}, shared_allocator<ComplexType>{TG.TG_local()});
       }
-      fill_n(denom.origin(), denom.num_elements(), ComplexType(0.0, 0.0));
-      fill_n(DMWork.origin(), DMWork.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(denom.base(), denom.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(DMWork.base(), DMWork.num_elements(), ComplexType(0.0, 0.0));
     }
     else
     {
@@ -163,7 +163,7 @@ public:
       if (iw % TG.TG_local().size() == TG.TG_local().rank())
       {
         denom[iw] += Xw[iw];
-        ComplexType* ptr(DMWork[iw].origin());
+        ComplexType* ptr(DMWork[iw].base());
         if (walker_type == CLOSED)
         {
           auto&& Gu_(G_host[iw][0]);
@@ -238,7 +238,7 @@ public:
         dump.push(std::string("Average_") + std::to_string(iav));
         std::string padded_num = std::string(n_zero - std::to_string(counter).length(), '0') + std::to_string(counter);
         dump.write(wgt, "weights_" + padded_num);
-        stdCMatrix_ref DM(to_address(DMWork.origin()), {nw, dm_size});
+        stdCMatrix_ref DM(to_address(DMWork.base()), {nw, dm_size});
         dump.write(DM, "diag_two_rdm_" + padded_num);
         dump.pop();
         dump.pop();
@@ -274,7 +274,7 @@ public:
     if (TG.TG_local().root())
     {
       ma::scal(ComplexType(1.0 / block_size), DMAverage);
-      TG.TG_heads().reduce_in_place_n(to_address(DMAverage.origin()), DMAverage.num_elements(), std::plus<>(), 0);
+      TG.TG_heads().reduce_in_place_n(to_address(DMAverage.base()), DMAverage.num_elements(), std::plus<>(), 0);
       if (writer)
       {
         dump.push(std::string("DiagTwoRDM"));
@@ -283,7 +283,7 @@ public:
           dump.push(std::string("Average_") + std::to_string(i));
           std::string padded_iblock =
               std::string(n_zero - std::to_string(iblock).length(), '0') + std::to_string(iblock);
-          stdCVector_ref DMAverage_(to_address(DMAverage[i].origin()), {dm_size});
+          stdCVector_ref DMAverage_(to_address(DMAverage[i].base()), {dm_size});
           dump.write(DMAverage_, "diag_two_rdm_" + padded_iblock);
           dump.write(Wsum[i], "denominator_" + padded_iblock);
           dump.pop();
@@ -292,7 +292,7 @@ public:
       }
     }
     TG.TG_local().barrier();
-    fill_n(DMAverage.origin(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage.base(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
   }
 
 private:

--- a/src/AFQMC/Estimators/Observables/full1rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full1rdm.hpp
@@ -137,7 +137,7 @@ public:
         dim[0] = R.size();
         dim[1] = 0;
         // conjugate rotation matrix
-        std::transform(R.origin(), R.origin() + R.num_elements(), R.origin(),
+        std::transform(R.base(), R.base() + R.num_elements(), R.base(),
                        [](const auto& c) { return std::conj(c); });
         stdIMatrix I;
         if (print_from_list)
@@ -151,15 +151,15 @@ public:
         }
         TG.Node().broadcast_n(dim, 2, 0);
         XRot = sharedCMatrix({dim[0], NMO}, make_node_allocator<ComplexType>(TG));
-        copy_n(R.origin(), R.num_elements(), make_device_ptr(XRot.origin()));
+        copy_n(R.base(), R.num_elements(), make_device_ptr(XRot.base()));
         if (TG.Node().root())
-          TG.Cores().broadcast_n(to_address(XRot.origin()), XRot.num_elements(), 0);
+          TG.Cores().broadcast_n(to_address(XRot.base()), XRot.num_elements(), 0);
         if (print_from_list)
         {
           index_list = mpi3IMatrix({dim[1], 2}, shared_allocator<int>{TG.Node()});
-          copy_n(I.origin(), I.num_elements(), make_device_ptr(index_list.origin()));
+          copy_n(I.base(), I.num_elements(), make_device_ptr(index_list.base()));
           if (TG.Node().root())
-            TG.Cores().broadcast_n(to_address(index_list.origin()), index_list.num_elements(), 0);
+            TG.Cores().broadcast_n(to_address(index_list.base()), index_list.num_elements(), 0);
         }
 
         dump.pop();
@@ -170,12 +170,12 @@ public:
         TG.Node().broadcast_n(dim, 2, 0);
         XRot = sharedCMatrix({dim[0], NMO}, make_node_allocator<ComplexType>(TG));
         if (TG.Node().root())
-          TG.Cores().broadcast_n(to_address(XRot.origin()), XRot.num_elements(), 0);
+          TG.Cores().broadcast_n(to_address(XRot.base()), XRot.num_elements(), 0);
         if (print_from_list)
         {
           index_list = mpi3IMatrix({dim[1], 2}, shared_allocator<int>{TG.Node()});
           if (TG.Node().root())
-            TG.Cores().broadcast_n(to_address(index_list.origin()), index_list.num_elements(), 0);
+            TG.Cores().broadcast_n(to_address(index_list.base()), index_list.num_elements(), 0);
         }
       }
       TG.Node().barrier();
@@ -221,7 +221,7 @@ public:
     writer = (TG.getGlobalRank() == 0);
 
     DMAverage = mpi3CMatrix({nave, dm_size}, shared_allocator<ComplexType>{TG.TG_local()});
-    fill_n(DMAverage.origin(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage.base(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
   }
 
   template<class MatG, class MatG_host, class HostCVec1, class HostCVec2, class HostCVec3>
@@ -244,7 +244,7 @@ public:
     assert(Xw.size() == nw);
     assert(ovlp.size() >= nw);
     assert(G.num_elements() == G_host.num_elements());
-    assert(G.extensions() == G_host.extensions());
+    assert(G.extents() == G_host.extents());
 
     using std::get;
     // check structure dimensions
@@ -258,8 +258,8 @@ public:
       {
         DMWork = mpi3CMatrix({nw, dm_size}, shared_allocator<ComplexType>{TG.TG_local()});
       }
-      fill_n(denom.origin(), denom.num_elements(), ComplexType(0.0, 0.0));
-      fill_n(DMWork.origin(), DMWork.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(denom.base(), denom.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(DMWork.base(), DMWork.num_elements(), ComplexType(0.0, 0.0));
     }
     else
     {
@@ -306,7 +306,7 @@ public:
         dump.push(std::string("Average_") + std::to_string(iav));
         std::string padded_num = std::string(n_zero - std::to_string(counter).length(), '0') + std::to_string(counter);
         dump.write(wgt, "weights_" + padded_num);
-        stdCMatrix_ref DM(to_address(DMWork.origin()), {nw, dm_size});
+        stdCMatrix_ref DM(to_address(DMWork.base()), {nw, dm_size});
         dump.write(DM, "one_rdm_" + padded_num);
         dump.pop();
         dump.pop();
@@ -344,7 +344,7 @@ public:
     if (TG.TG_local().root())
     {
       ma::scal(ComplexType(1.0 / block_size), DMAverage);
-      TG.TG_heads().reduce_in_place_n(to_address(DMAverage.origin()), DMAverage.num_elements(), std::plus<>(), 0);
+      TG.TG_heads().reduce_in_place_n(to_address(DMAverage.base()), DMAverage.num_elements(), std::plus<>(), 0);
       if (writer)
       {
         dump.push(std::string("FullOneRDM"));
@@ -353,7 +353,7 @@ public:
           dump.push(std::string("Average_") + std::to_string(i));
           std::string padded_iblock =
               std::string(n_zero - std::to_string(iblock).length(), '0') + std::to_string(iblock);
-          stdCVector_ref DMAverage_(to_address(DMAverage[i].origin()), {dm_size});
+          stdCVector_ref DMAverage_(to_address(DMAverage[i].base()), {dm_size});
           dump.write(DMAverage_, "one_rdm_" + padded_iblock);
           dump.write(Wsum[i], "denominator_" + padded_iblock);
           dump.pop();
@@ -362,7 +362,7 @@ public:
       }
     }
     TG.TG_local().barrier();
-    fill_n(DMAverage.origin(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage.base(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
   }
 
 private:
@@ -412,7 +412,7 @@ private:
     int i0, iN;
     std::tie(i0, iN) = FairDivideBoundary(TG.TG_local().rank(), dm_size, TG.TG_local().size());
 
-    stdCMatrix_ref G2D(to_address(G.origin()), {nw, dm_size});
+    stdCMatrix_ref G2D(to_address(G.base()), {nw, dm_size});
 
     for (int iw = 0; iw < nw; iw++)
     {
@@ -462,7 +462,7 @@ private:
         denom[iw] += Xw[iw];
       ma::product(XRot.sliced(i0, iN), G[iw][0], T1);
       ma::product(T1, ma::H(XRot), T2);
-      copy_n(T2.origin(), T2.num_elements(), Grot.origin());
+      copy_n(T2.base(), T2.num_elements(), Grot.base());
       if (print_from_list)
       {
         for (int i = 0; i < index_list.size(); i++)
@@ -480,7 +480,7 @@ private:
       {
         ma::product(XRot.sliced(i0, iN), G[iw][1], T1);
         ma::product(T1, ma::H(XRot), T2);
-        copy_n(T2.origin(), T2.num_elements(), Grot.origin());
+        copy_n(T2.base(), T2.num_elements(), Grot.base());
         if (print_from_list)
         {
           for (int i = 0, ie = index_list.size(); i < ie; i++)

--- a/src/AFQMC/Estimators/Observables/full2rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full2rdm.hpp
@@ -131,13 +131,13 @@ public:
         dim[0] = R.size();
         dim[1] = 0;
         // conjugate rotation matrix
-        std::transform(R.origin(), R.origin() + R.num_elements(), R.origin(),
+        std::transform(R.base(), R.base() + R.num_elements(), R.base(),
                        [](const auto& c) { return std::conj(c); });
         TG.Node().broadcast_n(dim, 2, 0);
         XRot = sharedCMatrix({dim[0], NMO}, make_node_allocator<ComplexType>(TG));
-        copy_n(R.origin(), R.num_elements(), make_device_ptr(XRot.origin()));
+        copy_n(R.base(), R.num_elements(), make_device_ptr(XRot.base()));
         if (TG.Node().root())
-          TG.Cores().broadcast_n(to_address(XRot.origin()), XRot.num_elements(), 0);
+          TG.Cores().broadcast_n(to_address(XRot.base()), XRot.num_elements(), 0);
 
         dump.pop();
         dump.close();
@@ -147,7 +147,7 @@ public:
         TG.Node().broadcast_n(dim, 2, 0);
         XRot = sharedCMatrix({dim[0], NMO}, make_node_allocator<ComplexType>(TG));
         if (TG.Node().root())
-          TG.Cores().broadcast_n(to_address(XRot.origin()), XRot.num_elements(), 0);
+          TG.Cores().broadcast_n(to_address(XRot.base()), XRot.num_elements(), 0);
       }
       TG.Node().barrier();
 
@@ -173,7 +173,7 @@ public:
     writer = (TG.getGlobalRank() == 0);
 
     DMAverage = mpi3CMatrix({nave, dm_size}, shared_allocator<ComplexType>{TG.TG_local()});
-    fill_n(DMAverage.origin(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage.base(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
   }
 
   template<class MatG, class MatG_host, class HostCVec1, class HostCVec2, class HostCVec3>
@@ -196,7 +196,7 @@ public:
     assert(Xw.size() == nw);
     assert(ovlp.size() >= nw);
     assert(G.num_elements() == G_host.num_elements());
-    assert(G.extensions() == G_host.extensions());
+    assert(G.extents() == G_host.extents());
 
     using std::get;
     // check structure dimensions
@@ -210,8 +210,8 @@ public:
       {
         DMWork = mpi3CMatrix({nw, dm_size}, shared_allocator<ComplexType>{TG.TG_local()});
       }
-      fill_n(denom.origin(), denom.num_elements(), ComplexType(0.0, 0.0));
-      fill_n(DMWork.origin(), DMWork.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(denom.base(), denom.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(DMWork.base(), DMWork.num_elements(), ComplexType(0.0, 0.0));
     }
     else
     {
@@ -254,7 +254,7 @@ public:
     if (TG.TG_local().root())
     {
       ma::scal(ComplexType(1.0 / block_size), DMAverage);
-      TG.TG_heads().reduce_in_place_n(to_address(DMAverage.origin()), DMAverage.num_elements(), std::plus<>(), 0);
+      TG.TG_heads().reduce_in_place_n(to_address(DMAverage.base()), DMAverage.num_elements(), std::plus<>(), 0);
       if (writer)
       {
         dump.push(std::string("FullTwoRDM"));
@@ -263,7 +263,7 @@ public:
           dump.push(std::string("Average_") + std::to_string(i));
           std::string padded_iblock =
               std::string(n_zero - std::to_string(iblock).length(), '0') + std::to_string(iblock);
-          stdCVector_ref DMAverage_(to_address(DMAverage[i].origin()), {dm_size});
+          stdCVector_ref DMAverage_(to_address(DMAverage[i].base()), {dm_size});
           dump.write(DMAverage_, "two_rdm_" + padded_iblock);
           dump.write(Wsum[i], "denominator_" + padded_iblock);
           dump.pop();
@@ -272,7 +272,7 @@ public:
       }
     }
     TG.TG_local().barrier();
-    fill_n(DMAverage.origin(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage.base(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
   }
 
 private:
@@ -320,13 +320,13 @@ private:
     size_t N = size_t(dN) * M2;
     DeviceBufferManager buffer_manager;
     StaticMatrix R({dN, NMO * NMO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CMatrix_ref Q(R.origin(), {NMO * NMO, NMO});
-    CVector_ref R1D(R.origin(), R.num_elements());
-    CVector_ref Q1D(Q.origin(), Q.num_elements());
+    CMatrix_ref Q(R.base(), {NMO * NMO, NMO});
+    CVector_ref R1D(R.base(), R.num_elements());
+    CVector_ref Q1D(Q.base(), Q.num_elements());
 
     // put this in shared memory!!!
     StaticMatrix Gt({NMO, NMO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CMatrix_ref GtC(Gt.origin(), {NMO * NMO, 1});
+    CMatrix_ref GtC(Gt.base(), {NMO * NMO, 1});
 #if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     if (Grot.size() < R.num_elements())
       Grot = stdCVector(iextensions<1u>(R.num_elements()));
@@ -343,15 +343,15 @@ private:
         if (TG.TG_local().root())
           denom[iw] += Xw[iw];
 
-        CMatrix_ref Gup(make_device_ptr(G[iw][0].origin()), {NMO * NMO, 1});
-        CMatrix_ref Gdn(make_device_ptr(G[iw][1].origin()), {NMO * NMO, 1});
+        CMatrix_ref Gup(make_device_ptr(G[iw][0].base()), {NMO * NMO, 1});
+        CMatrix_ref Gdn(make_device_ptr(G[iw][1].base()), {NMO * NMO, 1});
         // use ger !!!!
 
         //  (a,a,a,a)
         ma::product(Gup.sliced(i0, iN), ma::T(Gup), R);
 #if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
         using std::copy_n;
-        copy_n(R.origin(), R.num_elements(), Grot.origin());
+        copy_n(R.base(), R.num_elements(), Grot.base());
         ma::axpy(Xw[iw], Grot, DMWork[iw].sliced(size_t(i0) * M2, size_t(iN) * M2));
 #else
         ma::axpy(Xw[iw], R1D, DMWork[iw].sliced(size_t(i0) * M2, size_t(iN) * M2));
@@ -365,7 +365,7 @@ private:
           ma::product(ComplexType(-1.0), GtC, G[iw][0].sliced(i, i + 1), ComplexType(0.0), Q);
 #if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
           using std::copy_n;
-          copy_n(Q.origin(), Q.num_elements(), Grot.origin());
+          copy_n(Q.base(), Q.num_elements(), Grot.base());
           ma::axpy(Xw[iw], Grot.sliced(0, Q.num_elements()),
                    DMWork[iw].sliced(size_t(i * NMO) * M2, size_t((i + 1) * NMO) * M2));
 #else
@@ -377,7 +377,7 @@ private:
         ma::product(Gup.sliced(i0, iN), ma::T(Gdn), R);
 #if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
         using std::copy_n;
-        copy_n(R.origin(), R.num_elements(), Grot.origin());
+        copy_n(R.base(), R.num_elements(), Grot.base());
         ma::axpy(Xw[iw], Grot, DMWork[iw].sliced(M4 + size_t(i0) * M2, M4 + size_t(iN) * M2));
 #else
         ma::axpy(Xw[iw], R1D, DMWork[iw].sliced(M4 + size_t(i0) * M2, M4 + size_t(iN) * M2));
@@ -387,7 +387,7 @@ private:
         ma::product(Gdn.sliced(i0, iN), ma::T(Gdn), R);
 #if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
         using std::copy_n;
-        copy_n(R.origin(), R.num_elements(), Grot.origin());
+        copy_n(R.base(), R.num_elements(), Grot.base());
         ma::axpy(Xw[iw], Grot, DMWork[iw].sliced(2 * M4 + size_t(i0) * M2, 2 * M4 + size_t(iN) * M2));
 #else
         ma::axpy(Xw[iw], R1D, DMWork[iw].sliced(2 * M4 + size_t(i0) * M2, 2 * M4 + size_t(iN) * M2));
@@ -401,7 +401,7 @@ private:
           ma::product(ComplexType(-1.0), GtC, G[iw][1].sliced(i, i + 1), ComplexType(0.0), Q);
 #if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
           using std::copy_n;
-          copy_n(Q.origin(), Q.num_elements(), Grot.origin());
+          copy_n(Q.base(), Q.num_elements(), Grot.base());
           ma::axpy(Xw[iw], Grot.sliced(0, Q.num_elements()),
                    DMWork[iw].sliced(2 * M4 + size_t(i * NMO) * M2, 2 * M4 + size_t((i + 1) * NMO) * M2));
 #else
@@ -415,8 +415,8 @@ private:
       /*
       int N = dN*NMO*NMO;
       set_buffer(N);
-      CMatrix_ref R( Buff.origin(), {dN,NMO*NMO});
-      CVector_ref R1D( Buff.origin(), {dN*NMO*NMO});
+      CMatrix_ref R( Buff.base(), {dN,NMO*NMO});
+      CVector_ref R1D( Buff.base(), {dN*NMO*NMO});
 #if defined(ENABLE_CUDA)
       if(Grot.size() < R.num_elements()) 
         Grot = stdCVector(iextensions<1u>(R.num_elements()));
@@ -427,13 +427,13 @@ private:
 
         if(TG.TG_local().root()) denom[iw] += Xw[iw];
 
-        CMatrix_ref Gw( to_address(G[iw].origin()), {G[0].num_elements(),1});
+        CMatrix_ref Gw( to_address(G[iw].base()), {G[0].num_elements(),1});
         // use ger later
         ma::product( Gw.sliced(i0,iN), ma::T(Gw), R );
 
 #if defined(ENABLE_CUDA)
         using std::copy_n;
-        copy_n(R.origin(),R.num_elements(),Grot.origin());
+        copy_n(R.base(),R.num_elements(),Grot.base());
         ma::axpy( Xw[iw], Grot, DMWork[iw].sliced(i0*NMO*NMO,iN*NMO*NMO) );
 #else
         ma::axpy( Xw[iw], R.sliced(i0,iN), DMWork[iw].sliced(i0,iN) );
@@ -459,8 +459,8 @@ private:
     int sz = nX * (NMO + (iN-i0)); 
     int npts = (iN-i0)*nX;
     set_buffer(sz);
-    CMatrix_ref T1(Buff.origin(),{(iN-i0),NMO});
-    CMatrix_ref T2(T1.origin()+T1.num_elements(),{(iN-i0),nX});
+    CMatrix_ref T1(Buff.base(),{(iN-i0),NMO});
+    CMatrix_ref T2(T1.base()+T1.num_elements(),{(iN-i0),nX});
     if(Grot.size() != npts) 
       Grot = stdCVector(iextensions<1u>(npts));
 
@@ -471,12 +471,12 @@ private:
       if(TG.TG_local().root()) denom[iw] += Xw[iw];
       ma::product(XRot.sliced(i0,iN),G[iw][0],T1);
       ma::product(T1,ma::H(XRot),T2);
-      copy_n(T2.origin(),T2.num_elements(),Grot.origin());      
+      copy_n(T2.base(),T2.num_elements(),Grot.base());      
       ma::axpy( Xw[iw], Grot, DMWork[iw].sliced(i0*nX,i0*nX+npts) );
       if(walker_type == COLLINEAR) {
         ma::product(XRot.sliced(i0,iN),G[iw][1],T1);
         ma::product(T1,ma::H(XRot),T2);
-        copy_n(T2.origin(),T2.num_elements(),Grot.origin());
+        copy_n(T2.base(),T2.num_elements(),Grot.base());
         ma::axpy( Xw[iw], Grot, DMWork[iw].sliced((nX+i0)*nX,(nX+i0)*nX+npts) );
       }
     }

--- a/src/AFQMC/Estimators/Observables/generalizedFockMatrix.hpp
+++ b/src/AFQMC/Estimators/Observables/generalizedFockMatrix.hpp
@@ -107,7 +107,7 @@ public:
     writer = (TG.getGlobalRank() == 0);
 
     DMAverage = mpi3CTensor({2, nave, dm_size}, shared_allocator<ComplexType>{TG.TG_local()});
-    fill_n(DMAverage.origin(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage.base(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
   }
 
   template<class MatG, class MatG_host, class HostCVec1, class HostCVec2, class HostCVec3>
@@ -130,7 +130,7 @@ public:
     assert(Xw.size() == nw);
     assert(ovlp.size() >= nw);
     assert(G.num_elements() == G_host.num_elements());
-    assert(G.extensions() == G_host.extensions());
+    assert(G.extents() == G_host.extents());
     assert(G[0].num_elements() == dm_size);
 
     using std::get;
@@ -145,8 +145,8 @@ public:
       {
         DMWork = mpi3CTensor({3, nw, dm_size}, shared_allocator<ComplexType>{TG.TG_local()});
       }
-      fill_n(denom.origin(), denom.num_elements(), ComplexType(0.0, 0.0));
-      fill_n(DMWork.origin(), DMWork.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(denom.base(), denom.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(DMWork.base(), DMWork.num_elements(), ComplexType(0.0, 0.0));
     }
     else
     {
@@ -170,7 +170,7 @@ public:
     {
       for (int iw = 0; iw < nw; iw++)
       {
-        copy_n(make_device_ptr(gFock[ic][iw].origin()) + i0, (iN - i0), to_address(DMWork[2][iw].origin()) + i0);
+        copy_n(make_device_ptr(gFock[ic][iw].base()) + i0, (iN - i0), to_address(DMWork[2][iw].base()) + i0);
         ma::axpy(Xw[iw], DMWork[2][iw].sliced(i0, iN), DMWork[ic][iw].sliced(i0, iN));
       }
     }
@@ -206,7 +206,7 @@ public:
     if (TG.TG_local().root())
     {
       ma::scal(ComplexType(1.0 / block_size), DMAverage);
-      TG.TG_heads().reduce_in_place_n(to_address(DMAverage.origin()), DMAverage.num_elements(), std::plus<>(), 0);
+      TG.TG_heads().reduce_in_place_n(to_address(DMAverage.base()), DMAverage.num_elements(), std::plus<>(), 0);
       if (writer)
       {
         dump.push(std::string("GenFockPlus"));
@@ -215,7 +215,7 @@ public:
           dump.push(std::string("Average_") + std::to_string(i));
           std::string padded_iblock =
               std::string(n_zero - std::to_string(iblock).length(), '0') + std::to_string(iblock);
-          stdCVector_ref DMAverage_(to_address(DMAverage[0][i].origin()), {dm_size});
+          stdCVector_ref DMAverage_(to_address(DMAverage[0][i].base()), {dm_size});
           dump.write(DMAverage_, "gfockp_" + padded_iblock);
           dump.write(Wsum[i], "denominator_" + padded_iblock);
           dump.pop();
@@ -227,7 +227,7 @@ public:
           dump.push(std::string("Average_") + std::to_string(i));
           std::string padded_iblock =
               std::string(n_zero - std::to_string(iblock).length(), '0') + std::to_string(iblock);
-          stdCVector_ref DMAverage_(to_address(DMAverage[1][i].origin()), {dm_size});
+          stdCVector_ref DMAverage_(to_address(DMAverage[1][i].base()), {dm_size});
           dump.write(DMAverage_, "gfockm_" + padded_iblock);
           dump.write(Wsum[i], "denominator_" + padded_iblock);
           dump.pop();
@@ -236,7 +236,7 @@ public:
       }
     }
     TG.TG_local().barrier();
-    fill_n(DMAverage.origin(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage.base(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
   }
 
 private:

--- a/src/AFQMC/Estimators/Observables/n2r.hpp
+++ b/src/AFQMC/Estimators/Observables/n2r.hpp
@@ -173,7 +173,7 @@ public:
             APP_ABORT("");
           }
           using std::copy_n;
-          copy_n(orb.origin(), dm_size, ma::pointer_dispatch(Orbitals[kn].origin()));
+          copy_n(orb.base(), dm_size, ma::pointer_dispatch(Orbitals[kn].base()));
         }
       }
       dump.pop();
@@ -192,7 +192,7 @@ public:
     writer = (TG.getGlobalRank() == 0);
 
     DMAverage = mpi3CMatrix({nave, dm_size}, shared_allocator<ComplexType>{TG.TG_local()});
-    fill_n(DMAverage.origin(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage.base(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
   }
 
   template<class MatG, class MatG_host, class HostCVec1, class HostCVec2, class HostCVec3>
@@ -216,7 +216,7 @@ public:
     assert(Xw.size() == nw);
     assert(ovlp.size() >= nw);
     assert(G.num_elements() == G_host.num_elements());
-    assert(G.extensions() == G_host.extensions());
+    assert(G.extents() == G_host.extents());
 
     int nsp;
     if (walker_type == CLOSED)
@@ -236,8 +236,8 @@ public:
       {
         DMWork = mpi3CMatrix({nw, dm_size}, shared_allocator<ComplexType>{TG.TG_local()});
       }
-      fill_n(denom.origin(), denom.num_elements(), ComplexType(0.0, 0.0));
-      fill_n(DMWork.origin(), DMWork.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(denom.base(), denom.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(DMWork.base(), DMWork.num_elements(), ComplexType(0.0, 0.0));
     }
     else
     {
@@ -254,12 +254,12 @@ public:
     // G[spin][r] = sum_ij conj( Psi(i,r) ) * G[spin][i][j] * Psi(j,r) = sum_i conj( Psi(i,r) ) T1[i][r]
     int N = dm_size * NMO + dm_size;
     set_buffer(N);
-    auxCMatrix_ref T(Buff.origin(), {NMO, dm_size});
-    auxCVector_ref Gr(Buff.origin() + T.num_elements(), iextensions<1u>{dm_size});
+    auxCMatrix_ref T(Buff.base(), {NMO, dm_size});
+    auxCVector_ref Gr(Buff.base() + T.num_elements(), iextensions<1u>{dm_size});
 
     int N2 = nsp * (iN - i0);
     set_buffer2(N2);
-    stdCMatrix_ref Gr_(Buff2.origin(), {nsp, (iN - i0)});
+    stdCMatrix_ref Gr_(Buff2.base(), {nsp, (iN - i0)});
 
     // change batched_dot to a ** interface to make it more general and useful
 
@@ -268,30 +268,30 @@ public:
       if (TG.TG_local().root())
         denom[iw] += Xw[iw];
       auto&& Gu = G[iw][0];
-      auto&& Orb0N(Orbitals(Orbitals.extension(0), {i0, iN}));
-      auto&& T0N(T(T.extension(0), {i0, iN}));
+      auto&& Orb0N(Orbitals(get<0>(Orbitals.extents()), {i0, iN}));
+      auto&& T0N(T(get<0>(T.extents()), {i0, iN}));
       ma::product(Gu, Orb0N, T0N);
       using ma::batched_dot;
-      batched_dot('H', 'T', (iN - i0), NMO, ComplexType(1.0), ma::pointer_dispatch(Orb0N.origin()), Orb0N.stride(),
-                  ma::pointer_dispatch(T0N.origin()), T0N.stride(), ComplexType(0.0),
-                  ma::pointer_dispatch(Gr.origin()) + i0, 1);
+      batched_dot('H', 'T', (iN - i0), NMO, ComplexType(1.0), ma::pointer_dispatch(Orb0N.base()), Orb0N.stride(),
+                  ma::pointer_dispatch(T0N.base()), T0N.stride(), ComplexType(0.0),
+                  ma::pointer_dispatch(Gr.base()) + i0, 1);
       /*
-      fill_n(Gr.origin(),dm_size,ComplexType(0.0,0.0));
+      fill_n(Gr.base(),dm_size,ComplexType(0.0,0.0));
       for(int i=0; i<NMO; i++) {
-        ComplexType* O_(Orbitals[i].origin());
-        ComplexType* T_(T[i].origin());
-        ComplexType* G_(Gr.origin());
+        ComplexType* O_(Orbitals[i].base());
+        ComplexType* T_(T[i].base());
+        ComplexType* G_(Gr.base());
         for(int j=0; j<dm_size; j++, O_++, T_++, G_++)
           (*G_) += std::conj(*O_) * (*T_); 
       }  
 */
       using std::copy_n;
-      copy_n(ma::pointer_dispatch(Gr.origin()) + i0, (iN - i0), Gr_[0].origin());
+      copy_n(ma::pointer_dispatch(Gr.base()) + i0, (iN - i0), Gr_[0].base());
 
       if (walker_type == CLOSED)
       {
-        auto Gur(Gr_[0].origin());
-        auto DM(to_address(DMWork[iw].origin()) + i0);
+        auto Gur(Gr_[0].base());
+        auto DM(to_address(DMWork[iw].base()) + i0);
         auto X_(2.0 * Xw[iw]);
         for (int ir = i0; ir < iN; ir++, Gur++, DM++)
           (*DM) += X_ * (*Gur) * (*Gur);
@@ -300,15 +300,15 @@ public:
       {
         auto&& Gd = G[iw][1];
         ma::product(Gd, Orb0N, T0N);
-        batched_dot('H', 'T', (iN - i0), NMO, ComplexType(1.0), ma::pointer_dispatch(Orb0N.origin()), Orb0N.stride(),
-                    ma::pointer_dispatch(T0N.origin()), T0N.stride(), ComplexType(0.0),
-                    ma::pointer_dispatch(Gr.origin()) + i0, 1);
+        batched_dot('H', 'T', (iN - i0), NMO, ComplexType(1.0), ma::pointer_dispatch(Orb0N.base()), Orb0N.stride(),
+                    ma::pointer_dispatch(T0N.base()), T0N.stride(), ComplexType(0.0),
+                    ma::pointer_dispatch(Gr.base()) + i0, 1);
         using std::copy_n;
-        copy_n(ma::pointer_dispatch(Gr.origin()) + i0, (iN - i0), Gr_[1].origin());
+        copy_n(ma::pointer_dispatch(Gr.base()) + i0, (iN - i0), Gr_[1].base());
 
-        auto Gur(Gr_[0].origin());
-        auto Gdr(Gr_[1].origin());
-        auto DM(to_address(DMWork[iw].origin()) + i0);
+        auto Gur(Gr_[0].base());
+        auto Gdr(Gr_[1].base());
+        auto DM(to_address(DMWork[iw].base()) + i0);
         auto X_(2.0 * Xw[iw]);
         for (int ir = i0; ir < iN; ir++, Gur++, DM++)
           (*DM) += X_ * (*Gur) * (*Gdr);
@@ -348,7 +348,7 @@ public:
     if (TG.TG_local().root())
     {
       ma::scal(ComplexType(1.0 / block_size), DMAverage);
-      TG.TG_heads().reduce_in_place_n(to_address(DMAverage.origin()), DMAverage.num_elements(), std::plus<>(), 0);
+      TG.TG_heads().reduce_in_place_n(to_address(DMAverage.base()), DMAverage.num_elements(), std::plus<>(), 0);
       if (writer)
       {
         dump.push(std::string("N2R"));
@@ -357,7 +357,7 @@ public:
           dump.push(std::string("Average_") + std::to_string(i));
           std::string padded_iblock =
               std::string(n_zero - std::to_string(iblock).length(), '0') + std::to_string(iblock);
-          stdCVector_ref DMAverage_(to_address(DMAverage[i].origin()), {dm_size});
+          stdCVector_ref DMAverage_(to_address(DMAverage[i].base()), {dm_size});
           dump.write(DMAverage_, "n2r_" + padded_iblock);
           dump.write(Wsum[i], "denominator_" + padded_iblock);
           dump.pop();
@@ -366,7 +366,7 @@ public:
       }
     }
     TG.TG_local().barrier();
-    fill_n(DMAverage.origin(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage.base(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
   }
 
 private:
@@ -408,14 +408,14 @@ private:
     if (Buff.num_elements() < N)
       Buff = auxCVector(iextensions<1u>(N), aux_alloc);
     using std::fill_n;
-    fill_n(Buff.origin(), N, ComplexType(0.0));
+    fill_n(Buff.base(), N, ComplexType(0.0));
   }
   void set_buffer2(size_t N)
   {
     if (Buff2.num_elements() < N)
       Buff2 = stdCVector(iextensions<1u>(N));
     using std::fill_n;
-    fill_n(Buff2.origin(), N, ComplexType(0.0));
+    fill_n(Buff2.base(), N, ComplexType(0.0));
   }
 };
 

--- a/src/AFQMC/Estimators/Observables/realspace_correlators.hpp
+++ b/src/AFQMC/Estimators/Observables/realspace_correlators.hpp
@@ -171,8 +171,8 @@ public:
             APP_ABORT("");
           }
           using std::copy_n;
-          copy_n(orb.origin(), npoints, ma::pointer_dispatch(Orbitals[kn].origin()));
-          copy_n(orb.origin(), npoints, host_orb[kn].origin());
+          copy_n(orb.base(), npoints, ma::pointer_dispatch(Orbitals[kn].base()));
+          copy_n(orb.base(), npoints, host_orb[kn].base());
         }
       }
       dump.pop();
@@ -204,7 +204,7 @@ public:
     }
 
     DMAverage = mpi3CTensor({nave, 3, dm_size}, shared_allocator<ComplexType>{TG.TG_local()});
-    fill_n(DMAverage.origin(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage.base(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
   }
 
   template<class MatG, class MatG_host, class HostCVec1, class HostCVec2, class HostCVec3>
@@ -232,7 +232,7 @@ public:
     assert(Xw.size() == nw);
     assert(ovlp.size() >= nw);
     assert(G.num_elements() == G_host.num_elements());
-    assert(G.extensions() == G_host.extensions());
+    assert(G.extents() == G_host.extents());
 
     int nsp;
     if (walker_type == CLOSED)
@@ -255,8 +255,8 @@ public:
       {
         Gr_host = mpi3C4Tensor({nw, nsp, npts, npts}, shared_allocator<ComplexType>{TG.TG_local()});
       }
-      fill_n(denom.origin(), denom.num_elements(), ComplexType(0.0, 0.0));
-      fill_n(DMWork.origin(), DMWork.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(denom.base(), denom.num_elements(), ComplexType(0.0, 0.0));
+      fill_n(DMWork.base(), DMWork.num_elements(), ComplexType(0.0, 0.0));
     }
     else
     {
@@ -273,9 +273,9 @@ public:
       LocalTGBufferManager buffer_manager;
       StaticMatrix T({nw * nsp * NMO, npts}, buffer_manager.get_generator().template get_allocator<ComplexType>());
       StaticMatrix Gr({nsp * nw, npts * npts}, buffer_manager.get_generator().template get_allocator<ComplexType>());
-      CTensor_ref Gr3D(make_device_ptr(Gr.origin()), {nw, nsp, npts * npts});
-      CTensor_ref T3D(make_device_ptr(T.origin()), {nw, nsp, NMO * npts});
-      CMatrix_ref G2D(make_device_ptr(G.origin()), {nw * nsp * NMO, NMO});
+      CTensor_ref Gr3D(make_device_ptr(Gr.base()), {nw, nsp, npts * npts});
+      CTensor_ref T3D(make_device_ptr(T.base()), {nw, nsp, NMO * npts});
+      CMatrix_ref G2D(make_device_ptr(G.base()), {nw * nsp * NMO, NMO});
 
       // T1[iw][ispin][i][r] = sum_j G[iw][ispin][i][j] * Psi(j,r)
       int i0, iN;
@@ -285,26 +285,26 @@ public:
 
       // G[iw][ispin][r][r'] = sum_ij conj( Psi(i,r) ) * G[iw][ispin][i][j] * Psi(j,r')
       //                     = sum_i conj( Psi(i,r) ) T1[iw][ispin][i][r'] = H(Psi) * T1
-      std::vector<decltype(ma::pointer_dispatch(Orbitals.origin()))> Aarray;
+      std::vector<decltype(ma::pointer_dispatch(Orbitals.base()))> Aarray;
       Aarray.reserve(nw * nsp);
-      std::vector<decltype(ma::pointer_dispatch(Orbitals.origin()))> Barray;
+      std::vector<decltype(ma::pointer_dispatch(Orbitals.base()))> Barray;
       Barray.reserve(nw * nsp);
-      std::vector<decltype(ma::pointer_dispatch(Orbitals.origin()))> Carray;
+      std::vector<decltype(ma::pointer_dispatch(Orbitals.base()))> Carray;
       Carray.reserve(nw * nsp);
       for (int iw = 0, p = 0; iw < nw; ++iw)
         for (int ispin = 0; ispin < nsp; ++ispin, ++p)
           if (p % TG.TG_local().size() == TG.TG_local().rank())
           {
-            Aarray.emplace_back(ma::pointer_dispatch(Orbitals.origin()));
-            Barray.emplace_back(ma::pointer_dispatch(T3D[iw][ispin].origin()));
-            Carray.emplace_back(ma::pointer_dispatch(Gr3D[iw][ispin].origin()));
+            Aarray.emplace_back(ma::pointer_dispatch(Orbitals.base()));
+            Barray.emplace_back(ma::pointer_dispatch(T3D[iw][ispin].base()));
+            Carray.emplace_back(ma::pointer_dispatch(Gr3D[iw][ispin].base()));
           }
       // careful with fortran ordering
       gemmBatched('N', 'C', npts, npts, NMO, ComplexType(1.0), Barray.data(), npts, Aarray.data(), npts,
                   ComplexType(0.0), Carray.data(), npts, int(Aarray.size()));
       TG.TG_local().barrier();
       std::tie(i0, iN) = FairDivideBoundary(TG.TG_local().rank(), int(Gr.num_elements()), TG.TG_local().size());
-      copy_n(Gr.origin() + i0, (iN - i0), Gr_host.origin() + i0);
+      copy_n(Gr.base() + i0, (iN - i0), Gr_host.base() + i0);
     }
     TG.TG_local().barrier();
 
@@ -322,9 +322,9 @@ public:
       if (walker_type == CLOSED)
       {
         auto&& Gur(Gr_host[iw][0]);
-        stdCMatrix_ref DMcc(to_address(DMWork[iw][0].origin()), {npts, npts});
-        stdCMatrix_ref DMss(to_address(DMWork[iw][1].origin()), {npts, npts});
-        stdCMatrix_ref DMcs(to_address(DMWork[iw][2].origin()), {npts, npts});
+        stdCMatrix_ref DMcc(to_address(DMWork[iw][0].base()), {npts, npts});
+        stdCMatrix_ref DMss(to_address(DMWork[iw][1].base()), {npts, npts});
+        stdCMatrix_ref DMcs(to_address(DMWork[iw][2].base()), {npts, npts});
         auto X_(2.0 * Xw[iw]);
         for (int i = 0; i < npts; i++)
           for (int j = 0; j < npts; j++)
@@ -341,9 +341,9 @@ public:
       {
         auto&& Gur(Gr_host[iw][0]);
         auto&& Gdr(Gr_host[iw][1]);
-        stdCMatrix_ref DMcc(to_address(DMWork[iw][0].origin()), {npts, npts});
-        stdCMatrix_ref DMss(to_address(DMWork[iw][1].origin()), {npts, npts});
-        stdCMatrix_ref DMcs(to_address(DMWork[iw][2].origin()), {npts, npts});
+        stdCMatrix_ref DMcc(to_address(DMWork[iw][0].base()), {npts, npts});
+        stdCMatrix_ref DMss(to_address(DMWork[iw][1].base()), {npts, npts});
+        stdCMatrix_ref DMcs(to_address(DMWork[iw][2].base()), {npts, npts});
         auto X_(Xw[iw]);
         for (int i = 0; i < npts; i++)
           for (int j = 0; j < npts; j++)
@@ -362,9 +362,9 @@ public:
         APP_ABORT(" Noncollinear not implemented \n\n\n");
         auto&& Gur(Gr_host[iw][0]);
         auto&& Gdr(Gr_host[iw][1]);
-        stdCMatrix_ref DMcc(to_address(DMWork[iw][0].origin()), {npts, npts});
-        stdCMatrix_ref DMss(to_address(DMWork[iw][1].origin()), {npts, npts});
-        stdCMatrix_ref DMcs(to_address(DMWork[iw][2].origin()), {npts, npts});
+        stdCMatrix_ref DMcc(to_address(DMWork[iw][0].base()), {npts, npts});
+        stdCMatrix_ref DMss(to_address(DMWork[iw][1].base()), {npts, npts});
+        stdCMatrix_ref DMcs(to_address(DMWork[iw][2].base()), {npts, npts});
         auto X_(Xw[iw]);
         for (int i = 0; i < npts; i++)
           for (int j = 0; j < npts; j++)
@@ -392,8 +392,8 @@ public:
     {
       for (int iw = 0; iw < nw; iw++)
         denom[iw] = wgt[iw] / denom[iw];
-      stdCVector_ref DMAv1D(to_address(DMAverage[iav].origin()), {3 * dm_size});
-      stdCMatrix_ref DMWork2D(to_address(DMWork.origin()), {nw, 3 * dm_size});
+      stdCVector_ref DMAv1D(to_address(DMAverage[iav].base()), {3 * dm_size});
+      stdCMatrix_ref DMWork2D(to_address(DMWork.base()), {nw, 3 * dm_size});
       // DMAverage[iav][t][ij] += sum_iw DMWork[iw][t][ij] * denom[iw] = T( DMWork ) * denom
       ma::product(ComplexType(1.0, 0.0), ma::T(DMWork2D), denom, ComplexType(1.0, 0.0), DMAv1D);
     }
@@ -409,7 +409,7 @@ public:
     if (TG.TG_local().root())
     {
       ma::scal(ComplexType(1.0 / block_size), DMAverage);
-      TG.TG_heads().reduce_in_place_n(to_address(DMAverage.origin()), DMAverage.num_elements(), std::plus<>(), 0);
+      TG.TG_heads().reduce_in_place_n(to_address(DMAverage.base()), DMAverage.num_elements(), std::plus<>(), 0);
       if (writer)
       {
         dump.push(std::string("OD2RDM"));
@@ -421,7 +421,7 @@ public:
             dump.push(std::string("Average_") + std::to_string(i));
             std::string padded_iblock =
                 std::string(n_zero - std::to_string(iblock).length(), '0') + std::to_string(iblock);
-            stdCVector_ref DMAverage_(to_address(DMAverage[i][t].origin()), {dm_size});
+            stdCVector_ref DMAverage_(to_address(DMAverage[i][t].base()), {dm_size});
             dump.write(DMAverage_, "od2rdm_" + type_id[t] + padded_iblock);
             dump.write(Wsum[i], "denominator_" + padded_iblock);
             dump.pop();
@@ -432,7 +432,7 @@ public:
       }
     }
     TG.TG_local().barrier();
-    fill_n(DMAverage.origin(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
+    fill_n(DMAverage.base(), DMAverage.num_elements(), ComplexType(0.0, 0.0));
   }
 
 private:

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -196,7 +196,7 @@ void reduced_density_matrix(boost::mpi3::communicator& world)
     if (type == CLOSED)
     {
       REQUIRE(read_data.num_elements() >= NMO * NMO);
-      boost::multi::array_ref<ComplexType, 2> BPRDM(read_data.origin(), {NMO, NMO});
+      boost::multi::array_ref<ComplexType, 2> BPRDM(read_data.base(), {NMO, NMO});
       ma::scal(1.0 / denom, BPRDM);
       ComplexType trace = ComplexType(0.0);
       for (int i = 0; i < NMO; i++)
@@ -204,13 +204,13 @@ void reduced_density_matrix(boost::mpi3::communicator& world)
       CHECK(trace.real() == Approx(NAEA));
       boost::multi::array<ComplexType, 2, Allocator> Gw({1, NMO * NMO}, alloc_);
       wfn.MixedDensityMatrix(wset, Gw, false, true);
-      boost::multi::array_ref<ComplexType, 2, pointer> G(Gw.origin(), {NMO, NMO});
+      boost::multi::array_ref<ComplexType, 2, pointer> G(Gw.base(), {NMO, NMO});
       verify_approx(G, BPRDM);
     }
     else if (type == COLLINEAR)
     {
       REQUIRE(read_data.num_elements() >= 2 * NMO * NMO);
-      boost::multi::array_ref<ComplexType, 3> BPRDM(read_data.origin(), {2, NMO, NMO});
+      boost::multi::array_ref<ComplexType, 3> BPRDM(read_data.base(), {2, NMO, NMO});
       ma::scal(1.0 / denom, BPRDM[0]);
       ma::scal(1.0 / denom, BPRDM[1]);
       ComplexType trace = ComplexType(0.0);
@@ -219,7 +219,7 @@ void reduced_density_matrix(boost::mpi3::communicator& world)
       CHECK(trace.real() == Approx(NAEA + NAEB));
       boost::multi::array<ComplexType, 2, Allocator> Gw({1, 2 * NMO * NMO}, alloc_);
       wfn.MixedDensityMatrix(wset, Gw, false, true);
-      boost::multi::array_ref<ComplexType, 3, pointer> G(Gw.origin(), {2, NMO, NMO});
+      boost::multi::array_ref<ComplexType, 3, pointer> G(Gw.base(), {2, NMO, NMO});
       verify_approx(G, BPRDM);
     }
     else

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
@@ -132,7 +132,7 @@ public:
     //   >0: Calculate, with rho^+ contribution. LQKbln data located at Qmap[Q]-1
     number_of_symmetric_Q = 0;
     local_nCV             = 0;
-    std::fill_n(Q2vbias.origin(), nkpts, 0);
+    std::fill_n(Q2vbias.base(), nkpts, 0);
     for (int Q = 0; Q < nkpts; Q++)
     {
       if (Q > kminus[Q])
@@ -188,19 +188,19 @@ public:
     //if(comm->root())
     {
       using std::copy_n;
-      copy_n(vMF.origin(), vMF.num_elements(), vMF_.origin());
+      copy_n(vMF.base(), vMF.num_elements(), vMF_.base());
     }
     comm->barrier();
 
     boost::multi::array<ComplexType, 2> P0({NMO, NMO});
-    boost::multi::array_ref<ComplexType, 1> P0D(to_address(P0.origin()), {P0.num_elements()});
-    std::fill_n(P0D.origin(), P0D.num_elements(), ComplexType(0));
+    boost::multi::array_ref<ComplexType, 1> P0D(to_address(P0.base()), {P0.num_elements()});
+    std::fill_n(P0D.base(), P0D.num_elements(), ComplexType(0));
     vHS(vMF_, P0D);
     if (TG.TG().size() > 1)
-      TG.TG().all_reduce_in_place_n(P0D.origin(), P0D.num_elements(), std::plus<>());
+      TG.TG().all_reduce_in_place_n(P0D.base(), P0D.num_elements(), std::plus<>());
 
     boost::multi::array<ComplexType, 2> P1({npol * NMO, npol * NMO});
-    std::fill_n(P1.origin(), P1.num_elements(), ComplexType(0.0));
+    std::fill_n(P1.base(), P1.num_elements(), ComplexType(0.0));
 
     // add spin-dependent H1
     for (int K = 0, nk0 = 0; K < nkpts; ++K)
@@ -375,12 +375,12 @@ public:
       {
         assert(get<0>(KEright->sizes()) == nwalk && get<1>(KEright->sizes()) == local_nCV);
         assert(KEright->stride() == get<1>(KEright->sizes()));
-        Krptr = to_address(KEright->origin());
+        Krptr = to_address(KEright->base());
       }
       else
 #endif
       {
-        Krptr = to_address(SM_TMats.origin());
+        Krptr = to_address(SM_TMats.base());
         cnt += nwalk * local_nCV;
       }
 #if defined(MIXED_PRECISION)
@@ -394,12 +394,12 @@ public:
       {
         assert(get<0>(KEleft->sizes()) == nwalk && get<1>(KEleft->sizes()) == local_nCV);
         assert(KEleft->stride() == get<1>(KEleft->sizes()));
-        Klptr = to_address(KEleft->origin());
+        Klptr = to_address(KEleft->base());
       }
       else
 #endif
       {
-        Klptr = to_address(SM_TMats.origin()) + cnt;
+        Klptr = to_address(SM_TMats.base()) + cnt;
         cnt += nwalk * local_nCV;
       }
       if (comm->root())
@@ -415,17 +415,17 @@ public:
     SpMatrix_ref Kr(Krptr, {long(Knr), long(Knc)});
 
     for (int n = 0; n < nwalk; n++)
-      std::fill_n(E[n].origin(), 3, ComplexType(0.));
+      std::fill_n(E[n].base(), 3, ComplexType(0.));
 
     assert(Gc.num_elements() == nwalk * (nocca_tot + noccb_tot) * npol * nmo_tot);
-    boost::multi::array_cref<ComplexType, 3> G3Da(to_address(Gc.origin()), {nocca_tot * npol, nmo_tot, nwalk});
-    boost::multi::array_cref<ComplexType, 3> G3Db(to_address(Gc.origin()) + G3Da.num_elements() * (nspin - 1),
+    boost::multi::array_cref<ComplexType, 3> G3Da(to_address(Gc.base()), {nocca_tot * npol, nmo_tot, nwalk});
+    boost::multi::array_cref<ComplexType, 3> G3Db(to_address(Gc.base()) + G3Da.num_elements() * (nspin - 1),
                                                   {noccb_tot, nmo_tot, nwalk});
 
 
     // with yet another mapping, it is possible to reduce the memory usage here!
     // avoiding for now!
-    Sp4Tensor_ref GKK(to_address(SM_TMats.origin()) + cnt, {nspin, nkpts, nkpts, nwalk * npol * nmo_max * nocca_max});
+    Sp4Tensor_ref GKK(to_address(SM_TMats.base()) + cnt, {nspin, nkpts, nkpts, nwalk * npol * nmo_max * nocca_max});
     GKaKjw_to_GKKwaj(nd, Gc, GKK, nocca_tot, noccb_tot, nmo_tot, nmo_max * nocca_max);
     comm->barrier();
 
@@ -440,20 +440,20 @@ public:
       {
 #ifdef MIXED_PRECISION
         // must use Gc since GKK is is SP
-        boost::multi::array_ref<ComplexType, 3> haj_K(to_address(haj[nd * nkpts + K].origin()),
+        boost::multi::array_ref<ComplexType, 3> haj_K(to_address(haj[nd * nkpts + K].base()),
                                                       {nelpk[nd][K], npol, nopk[K]});
         for (int a = 0; a < nelpk[nd][K]; ++a)
           for (int pol = 0; pol < npol; ++pol)
             ma::product(ComplexType(1.), ma::T(G3Da[(na + a) * npol + pol].sliced(nk, nk + nopk[K])), haj_K[a][pol],
-                        ComplexType(1.), E(E.extension(0), 0));
+                        ComplexType(1.), E(get<0>(E.extents()), 0));
         na += nelpk[nd][K];
         if (walker_type == COLLINEAR)
         {
-          boost::multi::array_ref<ComplexType, 2> haj_Kb(haj_K.origin() + haj_K.num_elements(),
+          boost::multi::array_ref<ComplexType, 2> haj_Kb(haj_K.base() + haj_K.num_elements(),
                                                          {nelpk[nd][nkpts + K], nopk[K]});
           for (int b = 0; b < nelpk[nd][nkpts + K]; ++b)
             ma::product(ComplexType(1.), ma::T(G3Db[nb + b].sliced(nk, nk + nopk[K])), haj_Kb[b], ComplexType(1.),
-                        E(E.extension(0), 0));
+                        E(get<0>(E.extents()), 0));
           nb += nelpk[nd][nkpts + K];
         }
         nk += nopk[K];
@@ -462,16 +462,16 @@ public:
         nk = nopk[K];
         {
           na = nelpk[nd][K];
-          CVector_ref haj_K(to_address(haj[nd * nkpts + K].origin()), {na * npol * nk});
-          SpMatrix_ref Gaj(to_address(GKK[0][K][K].origin()), {nwalk, na * npol * nk});
-          ma::product(ComplexType(1.), Gaj, haj_K, ComplexType(1.), E(E.extension(0), 0));
+          CVector_ref haj_K(to_address(haj[nd * nkpts + K].base()), {na * npol * nk});
+          SpMatrix_ref Gaj(to_address(GKK[0][K][K].base()), {nwalk, na * npol * nk});
+          ma::product(ComplexType(1.), Gaj, haj_K, ComplexType(1.), E(get<0>(E.extents()), 0));
         }
         if (walker_type == COLLINEAR)
         {
           na = nelpk[nd][nkpts + K];
-          CVector_ref haj_K(to_address(haj[nd * nkpts + K].origin()) + nelpk[nd][K] * nk, {na * nk});
-          SpMatrix_ref Gaj(to_address(GKK[1][K][K].origin()), {nwalk, na * nk});
-          ma::product(ComplexType(1.), Gaj, haj_K, ComplexType(1.), E(E.extension(0), 0));
+          CVector_ref haj_K(to_address(haj[nd * nkpts + K].base()) + nelpk[nd][K] * nk, {na * nk});
+          SpMatrix_ref Gaj(to_address(GKK[1][K][K].base()), {nwalk, na * nk});
+          ma::product(ComplexType(1.), Gaj, haj_K, ComplexType(1.), E(get<0>(E.extents()), 0));
         }
 #endif
       }
@@ -483,12 +483,12 @@ public:
       if (TMats.num_elements() < local_memory_needs)
         TMats.reextent({local_memory_needs, 1});
       cnt = 0;
-      SpMatrix_ref Kr_local(TMats.origin(), {nwalk, nchol_max});
+      SpMatrix_ref Kr_local(TMats.base(), {nwalk, nchol_max});
       cnt += Kr_local.num_elements();
-      SpMatrix_ref Kl_local(TMats.origin() + cnt, {nwalk, nchol_max});
+      SpMatrix_ref Kl_local(TMats.base() + cnt, {nwalk, nchol_max});
       cnt += Kl_local.num_elements();
-      std::fill_n(Kr_local.origin(), Kr_local.num_elements(), SPComplexType(0.0));
-      std::fill_n(Kl_local.origin(), Kl_local.num_elements(), SPComplexType(0.0));
+      std::fill_n(Kr_local.base(), Kr_local.num_elements(), SPComplexType(0.0));
+      std::fill_n(Kl_local.base(), Kl_local.num_elements(), SPComplexType(0.0));
       SPRealType scl = (walker_type == CLOSED ? 2.0 : 1.0);
       size_t nqk     = 1;
       for (int Q = 0; Q < nkpts; ++Q)
@@ -512,18 +512,18 @@ public:
               int na    = nelpk[nd][Ka];
               int nk    = nopk[Kk];
 
-              SpMatrix_ref Gwal(GKK[0][Ka][Kl].origin(), {nwalk * na, npol * nl});
-              SpMatrix_ref Gwbk(GKK[0][Kb][Kk].origin(), {nwalk * nb, npol * nk});
-              SpMatrix_ref Lank(to_address(LQKank[nd * nspin * nkpts + Q][Ka].origin()), {na * nchol, npol * nk});
-              auto bnl_ptr(to_address(LQKank[nd * nspin * nkpts + Qm][Kb].origin()));
+              SpMatrix_ref Gwal(GKK[0][Ka][Kl].base(), {nwalk * na, npol * nl});
+              SpMatrix_ref Gwbk(GKK[0][Kb][Kk].base(), {nwalk * nb, npol * nk});
+              SpMatrix_ref Lank(to_address(LQKank[nd * nspin * nkpts + Q][Ka].base()), {na * nchol, npol * nk});
+              auto bnl_ptr(to_address(LQKank[nd * nspin * nkpts + Qm][Kb].base()));
               if (Qmap[Q] > 0)
-                bnl_ptr = to_address(LQKbnl[nd * nspin * number_of_symmetric_Q + Qmap[Q] - 1][Kb].origin());
+                bnl_ptr = to_address(LQKbnl[nd * nspin * number_of_symmetric_Q + Qmap[Q] - 1][Kb].base());
               SpMatrix_ref Lbnl(bnl_ptr, {nb * nchol, npol * nl});
 
-              SpMatrix_ref Twban(TMats.origin() + cnt, {nwalk * nb, na * nchol});
-              Sp4Tensor_ref T4Dwban(TMats.origin() + cnt, {nwalk, nb, na, nchol});
-              SpMatrix_ref Twabn(Twban.origin() + Twban.num_elements(), {nwalk * na, nb * nchol});
-              Sp4Tensor_ref T4Dwabn(Twban.origin() + Twban.num_elements(), {nwalk, na, nb, nchol});
+              SpMatrix_ref Twban(TMats.base() + cnt, {nwalk * nb, na * nchol});
+              Sp4Tensor_ref T4Dwban(TMats.base() + cnt, {nwalk, nb, na, nchol});
+              SpMatrix_ref Twabn(Twban.base() + Twban.num_elements(), {nwalk * na, nb * nchol});
+              Sp4Tensor_ref T4Dwabn(Twban.base() + Twban.num_elements(), {nwalk, na, nb, nchol});
 
               if (na > 0 && nb > 0)
                 ma::product(Gwal, ma::T(Lbnl), Twabn);
@@ -568,18 +568,18 @@ public:
                 int na    = nelpk[nd][nkpts + Ka];
                 int nk    = nopk[Kk];
 
-                SpMatrix_ref Gwal(GKK[1][Ka][Kl].origin(), {nwalk * na, nl});
-                SpMatrix_ref Gwbk(GKK[1][Kb][Kk].origin(), {nwalk * nb, nk});
-                SpMatrix_ref Lank(to_address(LQKank[(nd * nspin + 1) * nkpts + Q][Ka].origin()), {na * nchol, nk});
-                auto bnl_ptr(to_address(LQKank[(nd * nspin + 1) * nkpts + Qm][Kb].origin()));
+                SpMatrix_ref Gwal(GKK[1][Ka][Kl].base(), {nwalk * na, nl});
+                SpMatrix_ref Gwbk(GKK[1][Kb][Kk].base(), {nwalk * nb, nk});
+                SpMatrix_ref Lank(to_address(LQKank[(nd * nspin + 1) * nkpts + Q][Ka].base()), {na * nchol, nk});
+                auto bnl_ptr(to_address(LQKank[(nd * nspin + 1) * nkpts + Qm][Kb].base()));
                 if (Qmap[Q] > 0)
-                  bnl_ptr = to_address(LQKbnl[(nd * nspin + 1) * number_of_symmetric_Q + Qmap[Q] - 1][Kb].origin());
+                  bnl_ptr = to_address(LQKbnl[(nd * nspin + 1) * number_of_symmetric_Q + Qmap[Q] - 1][Kb].base());
                 SpMatrix_ref Lbnl(bnl_ptr, {nb * nchol, nl});
 
-                SpMatrix_ref Twban(TMats.origin() + cnt, {nwalk * nb, na * nchol});
-                Sp4Tensor_ref T4Dwban(TMats.origin() + cnt, {nwalk, nb, na, nchol});
-                SpMatrix_ref Twabn(Twban.origin() + Twban.num_elements(), {nwalk * na, nb * nchol});
-                Sp4Tensor_ref T4Dwabn(Twban.origin() + Twban.num_elements(), {nwalk, na, nb, nchol});
+                SpMatrix_ref Twban(TMats.base() + cnt, {nwalk * nb, na * nchol});
+                Sp4Tensor_ref T4Dwban(TMats.base() + cnt, {nwalk, nb, na, nchol});
+                SpMatrix_ref Twabn(Twban.base() + Twban.num_elements(), {nwalk * na, nb * nchol});
+                Sp4Tensor_ref T4Dwabn(Twban.base() + Twban.num_elements(), {nwalk, na, nb, nchol});
 
                 if (na > 0 && nb > 0)
                   ma::product(Gwal, ma::T(Lbnl), Twabn);
@@ -625,8 +625,8 @@ public:
         } // to release the lock
         if (addEJ && haveKE)
         {
-          std::fill_n(Kr_local.origin(), Kr_local.num_elements(), SPComplexType(0.0));
-          std::fill_n(Kl_local.origin(), Kl_local.num_elements(), SPComplexType(0.0));
+          std::fill_n(Kr_local.base(), Kr_local.num_elements(), SPComplexType(0.0));
+          std::fill_n(Kl_local.base(), Kl_local.num_elements(), SPComplexType(0.0));
         }
       } // Q
     }
@@ -662,14 +662,14 @@ public:
         size_t i0, iN;
         std::tie(i0, iN) =
             FairDivideBoundary(size_t(comm->rank()), size_t(KEleft->num_elements()), size_t(comm->size()));
-        copy_n_cast(Klptr + i0, iN - i0, to_address(KEleft->origin()) + i0);
+        copy_n_cast(Klptr + i0, iN - i0, to_address(KEleft->base()) + i0);
       }
       if (getKr)
       {
         size_t i0, iN;
         std::tie(i0, iN) =
             FairDivideBoundary(size_t(comm->rank()), size_t(KEright->num_elements()), size_t(comm->size()));
-        copy_n_cast(Krptr + i0, iN - i0, to_address(KEright->origin()) + i0);
+        copy_n_cast(Krptr + i0, iN - i0, to_address(KEright->base()) + i0);
       }
 #endif
       comm->barrier();
@@ -745,12 +745,12 @@ public:
       {
         assert(get<0>(KEright->sizes()) == nwalk && get<1>(KEright->sizes()) == local_nCV);
         assert(KEright->stride() == get<1>(KEright->sizes()));
-        Krptr = to_address(KEright->origin());
+        Krptr = to_address(KEright->base());
       }
       else
 #endif
       {
-        Krptr = to_address(SM_TMats.origin());
+        Krptr = to_address(SM_TMats.base());
         cnt += nwalk * local_nCV;
       }
 #if defined(MIXED_PRECISION)
@@ -764,12 +764,12 @@ public:
       {
         assert(get<0>(KEleft->sizes()) == nwalk && get<1>(KEleft->sizes()) == local_nCV);
         assert(KEleft->stride() == get<1>(KEleft->sizes()));
-        Klptr = to_address(KEleft->origin());
+        Klptr = to_address(KEleft->base());
       }
       else
 #endif
       {
-        Klptr = to_address(SM_TMats.origin()) + cnt;
+        Klptr = to_address(SM_TMats.base()) + cnt;
         cnt += nwalk * local_nCV;
       }
       if (comm->root())
@@ -785,14 +785,14 @@ public:
     SpMatrix_ref Kr(Krptr, {long(Knr), long(Knc)});
 
     for (int n = 0; n < nwalk; n++)
-      std::fill_n(E[n].origin(), 3, ComplexType(0.));
+      std::fill_n(E[n].base(), 3, ComplexType(0.));
 
     assert(Gc.num_elements() == nwalk * (nocca_tot + noccb_tot) * nmo_tot);
-    boost::multi::array_cref<ComplexType, 3> G3Da(to_address(Gc.origin()), {nocca_tot, nmo_tot, nwalk});
-    boost::multi::array_cref<ComplexType, 3> G3Db(to_address(Gc.origin()) + G3Da.num_elements() * (nspin - 1),
+    boost::multi::array_cref<ComplexType, 3> G3Da(to_address(Gc.base()), {nocca_tot, nmo_tot, nwalk});
+    boost::multi::array_cref<ComplexType, 3> G3Db(to_address(Gc.base()) + G3Da.num_elements() * (nspin - 1),
                                                   {noccb_tot, nmo_tot, nwalk});
 
-    Sp4Tensor_ref GKK(to_address(SM_TMats.origin()) + cnt, {nspin, nkpts, nkpts, nwalk * nmo_max * nocca_max});
+    Sp4Tensor_ref GKK(to_address(SM_TMats.base()) + cnt, {nspin, nkpts, nkpts, nwalk * nmo_max * nocca_max});
     cnt += GKK.num_elements();
     GKaKjw_to_GKKwaj(nd, Gc, GKK, nocca_tot, noccb_tot, nmo_tot, nmo_max * nocca_max);
     comm->barrier();
@@ -809,19 +809,19 @@ public:
       for (int K = 0; K < nkpts; ++K)
       {
 #ifdef MIXED_PRECISION
-        boost::multi::array_ref<ComplexType, 2> haj_K(to_address(haj[nd * nkpts + K].origin()),
+        boost::multi::array_ref<ComplexType, 2> haj_K(to_address(haj[nd * nkpts + K].base()),
                                                       {nelpk[nd][K], nopk[K]});
         for (int a = 0; a < nelpk[nd][K]; ++a)
           ma::product(ComplexType(1.), ma::T(G3Da[na + a].sliced(nk, nk + nopk[K])), haj_K[a], ComplexType(1.),
-                      E(E.extension(0), 0));
+                      E(get<0>(E.extents()), 0));
         na += nelpk[nd][K];
         if (walker_type == COLLINEAR)
         {
-          boost::multi::array_ref<ComplexType, 2> haj_Kb(haj_K.origin() + haj_K.num_elements(),
+          boost::multi::array_ref<ComplexType, 2> haj_Kb(haj_K.base() + haj_K.num_elements(),
                                                          {nelpk[nd][nkpts + K], nopk[K]});
           for (int b = 0; b < nelpk[nd][nkpts + K]; ++b)
             ma::product(ComplexType(1.), ma::T(G3Db[nb + b].sliced(nk, nk + nopk[K])), haj_Kb[b], ComplexType(1.),
-                        E(E.extension(0), 0));
+                        E(get<0>(E.extents()), 0));
           nb += nelpk[nd][nkpts + K];
         }
         nk += nopk[K];
@@ -829,16 +829,16 @@ public:
         nk = nopk[K];
         {
           na = nelpk[nd][K];
-          CVector_ref haj_K(to_address(haj[nd * nkpts + K].origin()), {na * nk});
-          SpMatrix_ref Gaj(to_address(GKK[0][K][K].origin()), {nwalk, na * nk});
-          ma::product(ComplexType(1.), Gaj, haj_K, ComplexType(1.), E(E.extension(0), 0));
+          CVector_ref haj_K(to_address(haj[nd * nkpts + K].base()), {na * nk});
+          SpMatrix_ref Gaj(to_address(GKK[0][K][K].base()), {nwalk, na * nk});
+          ma::product(ComplexType(1.), Gaj, haj_K, ComplexType(1.), E(get<0>(E.extents()), 0));
         }
         if (walker_type == COLLINEAR)
         {
           na = nelpk[nd][nkpts + K];
-          CVector_ref haj_K(to_address(haj[nd * nkpts + K].origin()) + nelpk[nd][K] * nk, {na * nk});
-          SpMatrix_ref Gaj(to_address(GKK[1][K][K].origin()), {nwalk, na * nk});
-          ma::product(ComplexType(1.), Gaj, haj_K, ComplexType(1.), E(E.extension(0), 0));
+          CVector_ref haj_K(to_address(haj[nd * nkpts + K].base()) + nelpk[nd][K] * nk, {na * nk});
+          SpMatrix_ref Gaj(to_address(GKK[1][K][K].base()), {nwalk, na * nk});
+          ma::product(ComplexType(1.), Gaj, haj_K, ComplexType(1.), E(get<0>(E.extents()), 0));
         }
 #endif
       }
@@ -905,18 +905,18 @@ public:
                 int na    = nelpk[nd][Ka];
                 int nk    = nopk[Kk];
 
-                SpMatrix_ref Gal(GKK[0][Ka][Kl].origin() + n * na * nl, {na, nl});
-                SpMatrix_ref Gbk(GKK[0][Kb][Kk].origin() + n * nb * nk, {nb, nk});
-                SpMatrix_ref Lank(to_address(LQKank[nd * nspin * nkpts + Q][Ka].origin()), {na * nchol, nk});
-                auto bnl_ptr(to_address(LQKank[nd * nspin * nkpts + Qm][Kb].origin()));
+                SpMatrix_ref Gal(GKK[0][Ka][Kl].base() + n * na * nl, {na, nl});
+                SpMatrix_ref Gbk(GKK[0][Kb][Kk].base() + n * nb * nk, {nb, nk});
+                SpMatrix_ref Lank(to_address(LQKank[nd * nspin * nkpts + Q][Ka].base()), {na * nchol, nk});
+                auto bnl_ptr(to_address(LQKank[nd * nspin * nkpts + Qm][Kb].base()));
                 if (Q == Qm)
-                  bnl_ptr = to_address(LQKbnl[nd * nspin * number_of_symmetric_Q + Qmap[Q] - 1][Kb].origin());
+                  bnl_ptr = to_address(LQKbnl[nd * nspin * number_of_symmetric_Q + Qmap[Q] - 1][Kb].base());
                 SpMatrix_ref Lbnl(bnl_ptr, {nb * nchol, nl});
 
-                SpMatrix_ref Tban(TMats.origin() + local_cnt, {nb, na * nchol});
-                Sp3Tensor_ref T3Dban(TMats.origin() + local_cnt, {nb, na, nchol});
-                SpMatrix_ref Tabn(Tban.origin() + Tban.num_elements(), {na, nb * nchol});
-                Sp3Tensor_ref T3Dabn(Tban.origin() + Tban.num_elements(), {na, nb, nchol});
+                SpMatrix_ref Tban(TMats.base() + local_cnt, {nb, na * nchol});
+                Sp3Tensor_ref T3Dban(TMats.base() + local_cnt, {nb, na, nchol});
+                SpMatrix_ref Tabn(Tban.base() + Tban.num_elements(), {na, nb * nchol});
+                Sp3Tensor_ref T3Dabn(Tban.base() + Tban.num_elements(), {na, nb, nchol});
 
                 if (na > 0 && nb > 0)
                   ma::product(Gal, ma::T(Lbnl), Tabn);
@@ -944,18 +944,18 @@ public:
                   int na    = nelpk[nd][nkpts + Ka];
                   int nk    = nopk[Kk];
 
-                  SpMatrix_ref Gal(GKK[1][Ka][Kl].origin() + n * na * nl, {na, nl});
-                  SpMatrix_ref Gbk(GKK[1][Kb][Kk].origin() + n * nb * nk, {nb, nk});
-                  SpMatrix_ref Lank(to_address(LQKank[(nd * nspin + 1) * nkpts + Q][Ka].origin()), {na * nchol, nk});
-                  auto bnl_ptr(to_address(LQKank[(nd * nspin + 1) * nkpts + Qm][Kb].origin()));
+                  SpMatrix_ref Gal(GKK[1][Ka][Kl].base() + n * na * nl, {na, nl});
+                  SpMatrix_ref Gbk(GKK[1][Kb][Kk].base() + n * nb * nk, {nb, nk});
+                  SpMatrix_ref Lank(to_address(LQKank[(nd * nspin + 1) * nkpts + Q][Ka].base()), {na * nchol, nk});
+                  auto bnl_ptr(to_address(LQKank[(nd * nspin + 1) * nkpts + Qm][Kb].base()));
                   if (Q == Qm)
-                    bnl_ptr = to_address(LQKbnl[(nd * nspin + 1) * number_of_symmetric_Q + Qmap[Q] - 1][Kb].origin());
+                    bnl_ptr = to_address(LQKbnl[(nd * nspin + 1) * number_of_symmetric_Q + Qmap[Q] - 1][Kb].base());
                   SpMatrix_ref Lbnl(bnl_ptr, {nb * nchol, nl});
 
-                  SpMatrix_ref Tban(TMats.origin() + local_cnt, {nb, na * nchol});
-                  Sp3Tensor_ref T3Dban(TMats.origin() + local_cnt, {nb, na, nchol});
-                  SpMatrix_ref Tabn(Tban.origin() + Tban.num_elements(), {na, nb * nchol});
-                  Sp3Tensor_ref T3Dabn(Tban.origin() + Tban.num_elements(), {na, nb, nchol});
+                  SpMatrix_ref Tban(TMats.base() + local_cnt, {nb, na * nchol});
+                  Sp3Tensor_ref T3Dban(TMats.base() + local_cnt, {nb, na, nchol});
+                  SpMatrix_ref Tabn(Tban.base() + Tban.num_elements(), {na, nb * nchol});
+                  Sp3Tensor_ref T3Dabn(Tban.base() + Tban.num_elements(), {na, nb, nchol});
 
                   if (na > 0 && nb > 0)
                     ma::product(Gal, ma::T(Lbnl), Tabn);
@@ -982,12 +982,12 @@ public:
       if (TMats.num_elements() < local_memory_needs)
         TMats.reextent({local_memory_needs, 1});
       cnt = 0;
-      SpMatrix_ref Kr_local(TMats.origin(), {nwalk, nchol_max});
+      SpMatrix_ref Kr_local(TMats.base(), {nwalk, nchol_max});
       cnt += Kr_local.num_elements();
-      SpMatrix_ref Kl_local(TMats.origin() + cnt, {nwalk, nchol_max});
+      SpMatrix_ref Kl_local(TMats.base() + cnt, {nwalk, nchol_max});
       cnt += Kl_local.num_elements();
-      std::fill_n(Kr_local.origin(), Kr_local.num_elements(), SPComplexType(0.0));
-      std::fill_n(Kl_local.origin(), Kl_local.num_elements(), SPComplexType(0.0));
+      std::fill_n(Kr_local.base(), Kr_local.num_elements(), SPComplexType(0.0));
+      std::fill_n(Kl_local.base(), Kl_local.num_elements(), SPComplexType(0.0));
       size_t nqk = 1;
       for (int Q = 0; Q < nkpts; ++Q)
       {
@@ -1005,12 +1005,12 @@ public:
             int na    = nelpk[nd][Ka];
             int nk    = nopk[Kk];
 
-            Sp3Tensor_ref Gwal(GKK[0][Ka][Kl].origin(), {nwalk, na, nl});
-            Sp3Tensor_ref Gwbk(GKK[0][Ka][Kk].origin(), {nwalk, na, nk});
-            Sp3Tensor_ref Lank(to_address(LQKank[nd * nspin * nkpts + Q][Ka].origin()), {na, nchol, nk});
-            SPComplexType* bnl_ptr(to_address(LQKank[nd * nspin * nkpts + Qm][Ka].origin()));
+            Sp3Tensor_ref Gwal(GKK[0][Ka][Kl].base(), {nwalk, na, nl});
+            Sp3Tensor_ref Gwbk(GKK[0][Ka][Kk].base(), {nwalk, na, nk});
+            Sp3Tensor_ref Lank(to_address(LQKank[nd * nspin * nkpts + Q][Ka].base()), {na, nchol, nk});
+            SPComplexType* bnl_ptr(to_address(LQKank[nd * nspin * nkpts + Qm][Ka].base()));
             if (Q == Qm)
-              bnl_ptr = to_address(LQKbnl[nd * nspin * number_of_symmetric_Q + Qmap[Q] - 1][Ka].origin());
+              bnl_ptr = to_address(LQKbnl[nd * nspin * number_of_symmetric_Q + Qmap[Q] - 1][Ka].base());
             Sp3Tensor_ref Lbnl(bnl_ptr, {na, nchol, nl});
 
             // Twan = sum_l G[w][a][l] L[a][n][l]
@@ -1035,12 +1035,12 @@ public:
               int na    = nelpk[nd][nkpts + Ka];
               int nk    = nopk[Kk];
 
-              Sp3Tensor_ref Gwal(GKK[1][Ka][Kl].origin(), {nwalk, na, nl});
-              Sp3Tensor_ref Gwbk(GKK[1][Ka][Kk].origin(), {nwalk, na, nk});
-              Sp3Tensor_ref Lank(to_address(LQKank[(nd * nspin + 1) * nkpts + Q][Ka].origin()), {na, nchol, nk});
-              auto bnl_ptr(to_address(LQKank[(nd * nspin + 1) * nkpts + Qm][Ka].origin()));
+              Sp3Tensor_ref Gwal(GKK[1][Ka][Kl].base(), {nwalk, na, nl});
+              Sp3Tensor_ref Gwbk(GKK[1][Ka][Kk].base(), {nwalk, na, nk});
+              Sp3Tensor_ref Lank(to_address(LQKank[(nd * nspin + 1) * nkpts + Q][Ka].base()), {na, nchol, nk});
+              auto bnl_ptr(to_address(LQKank[(nd * nspin + 1) * nkpts + Qm][Ka].base()));
               if (Q == Qm)
-                bnl_ptr = to_address(LQKbnl[(nd * nspin + 1) * number_of_symmetric_Q + Qmap[Q] - 1][Ka].origin());
+                bnl_ptr = to_address(LQKbnl[(nd * nspin + 1) * number_of_symmetric_Q + Qmap[Q] - 1][Ka].base());
               Sp3Tensor_ref Lbnl(bnl_ptr, {na, nchol, nl});
 
               // Twan = sum_l G[w][a][l] L[a][n][l]
@@ -1066,8 +1066,8 @@ public:
         } // to release the lock
         if (haveKE)
         {
-          std::fill_n(Kr_local.origin(), Kr_local.num_elements(), SPComplexType(0.0));
-          std::fill_n(Kl_local.origin(), Kl_local.num_elements(), SPComplexType(0.0));
+          std::fill_n(Kr_local.base(), Kr_local.num_elements(), SPComplexType(0.0));
+          std::fill_n(Kl_local.base(), Kl_local.num_elements(), SPComplexType(0.0));
         }
       } // Q
       comm->barrier();
@@ -1092,14 +1092,14 @@ public:
         size_t i0, iN;
         std::tie(i0, iN) =
             FairDivideBoundary(size_t(comm->rank()), size_t(KEleft->num_elements()), size_t(comm->size()));
-        copy_n_cast(Klptr + i0, iN - i0, to_address(KEleft->origin()) + i0);
+        copy_n_cast(Klptr + i0, iN - i0, to_address(KEleft->base()) + i0);
       }
       if (getKr)
       {
         size_t i0, iN;
         std::tie(i0, iN) =
             FairDivideBoundary(size_t(comm->rank()), size_t(KEright->num_elements()), size_t(comm->size()));
-        copy_n_cast(Krptr + i0, iN - i0, to_address(KEright->origin()) + i0);
+        copy_n_cast(Krptr + i0, iN - i0, to_address(KEright->base()) + i0);
       }
       comm->barrier();
 #endif
@@ -1121,8 +1121,8 @@ public:
   {
     using BType = typename std::decay<MatB>::type::element;
     using AType = typename std::decay<MatA>::type::element;
-    boost::multi::array_ref<BType, 2> v_(to_address(v.origin()), {1, v.size()});
-    boost::multi::array_ref<AType, 2> X_(to_address(X.origin()), {X.size(), 1});
+    boost::multi::array_ref<BType, 2> v_(to_address(v.base()), {1, v.size()});
+    boost::multi::array_ref<AType, 2> X_(to_address(X.base()), {X.size(), 1});
     return vHS(X_, v_, a, c);
   }
 
@@ -1150,28 +1150,28 @@ public:
       TMats.reextent({static_cast<ptrdiff_t>(local_memory_needs), 1});
 
     using vType = typename std::decay<MatB>::type::element;
-    boost::multi::array_ref<vType, 3> v3D(to_address(v.origin()), {nwalk, nmo_tot, nmo_tot});
+    boost::multi::array_ref<vType, 3> v3D(to_address(v.base()), {nwalk, nmo_tot, nmo_tot});
 
     sp_pointer Xptr(nullptr);
     // I WANT C++17!!!!!!
     using XType = typename std::decay<MatA>::type::element;
     if (std::is_same<SPComplexType, XType>::value)
     {
-      Xptr = reinterpret_cast<sp_pointer>(to_address(Xw.origin()));
+      Xptr = reinterpret_cast<sp_pointer>(to_address(Xw.base()));
     }
     else
     {
       size_t mem_needs = Xw.num_elements();
       set_shm_buffer(mem_needs);
-      Xptr = to_address(SM_TMats.origin());
+      Xptr = to_address(SM_TMats.base());
       {
         size_t i0, iN;
         std::tie(i0, iN) = FairDivideBoundary(size_t(comm->rank()), size_t(Xw.num_elements()), size_t(comm->size()));
-        copy_n_cast(to_address(Xw.origin()) + i0, iN - i0, Xptr + i0);
+        copy_n_cast(to_address(Xw.base()) + i0, iN - i0, Xptr + i0);
       }
       comm->barrier();
     }
-    SpMatrix_ref X(Xptr, Xw.extensions());
+    SpMatrix_ref X(Xptr, Xw.extents());
 
     // "rotate" X
     //  XIJ = 0.5*a*(Xn+ -i*Xn-), XJI = 0.5*a*(Xn+ +i*Xn-)
@@ -1182,8 +1182,8 @@ public:
       int nq = Q2vbias[Q];
       int nc0, ncN;
       std::tie(nc0, ncN) = FairDivideBoundary(comm->rank(), ncholpQ[Q], comm->size());
-      auto Xnp           = to_address(X[nq + nc0].origin());
-      auto Xnm           = to_address(X[nq + ncholpQ[Q] + nc0].origin());
+      auto Xnp           = to_address(X[nq + nc0].base());
+      auto Xnm           = to_address(X[nq + ncholpQ[Q] + nc0].base());
       for (int n = nc0; n < ncN; ++n)
       {
         for (int nw = 0; nw < nwalk; ++nw, ++Xnp, ++Xnm)
@@ -1206,8 +1206,8 @@ public:
         int nqm0 = Q2vbias[Qm];
         int nc0, ncN;
         std::tie(nc0, ncN) = FairDivideBoundary(comm->rank(), ncholpQ[Q], comm->size());
-        auto Xnp           = to_address(X[nq + nc0].origin());
-        auto Xnm           = to_address(X[nqm0 + ncholpQ[Q] + nc0].origin());
+        auto Xnp           = to_address(X[nq + nc0].base());
+        auto Xnm           = to_address(X[nqm0 + ncholpQ[Q] + nc0].base());
         for (int n = nc0; n < ncN; ++n)
           for (int nw = 0; nw < nwalk; ++nw, ++Xnp, ++Xnm)
             *Xnp = ((*Xnp) + (*Xnm));
@@ -1217,7 +1217,7 @@ public:
     {
       size_t i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(size_t(comm->rank()), size_t(v.num_elements()), size_t(comm->size()));
-      auto v_          = to_address(v.origin()) + i0;
+      auto v_          = to_address(v.base()) + i0;
       for (size_t i = i0; i < iN; ++i, ++v_)
         *v_ *= c;
     }
@@ -1246,9 +1246,9 @@ public:
           // v[nw][i(in K)][k(in Q(K))] += sum_n LQK[i][k][n] X[Q][n+][nw]
           if (Q <= kminus[Q])
           {
-            SpMatrix_ref vik(TMats.origin(), {nwalk, ni * nk});
-            Sp3Tensor_ref vik3D(TMats.origin(), {nwalk, ni, nk});
-            SpMatrix_ref Likn(to_address(LQKikn[Q][K].origin()), {ni * nk, nchol});
+            SpMatrix_ref vik(TMats.base(), {nwalk, ni * nk});
+            Sp3Tensor_ref vik3D(TMats.base(), {nwalk, ni, nk});
+            SpMatrix_ref Likn(to_address(LQKikn[Q][K].base()), {ni * nk, nchol});
             ma::product(T(X.sliced(nc0, nc0 + nchol)), T(Likn), vik);
             for (int nw = 0; nw < nwalk; nw++)
               for (int i = 0; i < ni; i++)
@@ -1256,16 +1256,16 @@ public:
           }
           else
           { // use L(-Q)(Kk)*
-            SpMatrix_ref vki(TMats.origin(), {nwalk, nk * ni});
-            Sp3Tensor_ref vki3D(TMats.origin(), {nwalk, nk, ni});
-            SpMatrix_ref Likn(to_address(LQKikn[kminus[Q]][QK].origin()), {nk * ni, nchol});
+            SpMatrix_ref vki(TMats.base(), {nwalk, nk * ni});
+            Sp3Tensor_ref vki3D(TMats.base(), {nwalk, nk, ni});
+            SpMatrix_ref Likn(to_address(LQKikn[kminus[Q]][QK].base()), {nk * ni, nchol});
             ma::product(T(X.sliced(nc0, nc0 + nchol)), H(Likn), vki);
             for (int nw = 0; nw < nwalk; nw++)
             {
               const auto&& vki_n(vki3D[nw]);
               for (int i = 0; i < ni; i++)
               {
-                auto v3D_ni(to_address(v3D[nw][ni0 + i].origin()) + nk0);
+                auto v3D_ni(to_address(v3D[nw][ni0 + i].base()) + nk0);
                 for (int k = 0; k < nk; k++, ++v3D_ni)
                   *v3D_ni += static_cast<vType>(vki_n[k][i]);
               }
@@ -1291,9 +1291,9 @@ public:
             int ni0   = std::accumulate(nopk.begin(), nopk.begin() + K, 0);
             int nk    = nopk[QKToK2[Q][K]];
             int nk0   = std::accumulate(nopk.begin(), nopk.begin() + QKToK2[Q][K], 0);
-            SpMatrix_ref Likn(to_address(LQKikn[Q][K].origin()), {ni * nk, nchol});
-            SpMatrix_ref vik(TMats.origin(), {nwalk, ni * nk});
-            Sp3Tensor_ref vik3D(TMats.origin(), {nwalk, ni, nk});
+            SpMatrix_ref Likn(to_address(LQKikn[Q][K].base()), {ni * nk, nchol});
+            SpMatrix_ref vik(TMats.base(), {nwalk, ni * nk});
+            Sp3Tensor_ref vik3D(TMats.base(), {nwalk, ni, nk});
             // v[nw][k(in Q(K))][i(in K)] += sum_n conj(LQK[i][k][n]) X[Q][n-][nw]
             ma::product(T(X.sliced(nc0 + nchol, nc0 + 2 * nchol)), H(Likn), vik);
             for (int nw = 0; nw < nwalk; nw++)
@@ -1301,7 +1301,7 @@ public:
               const auto&& vik3D_n = vik3D[nw];
               for (int k = 0; k < nk; k++)
               {
-                auto v3D_nk = to_address(v3D[nw][nk0 + k].origin()) + ni0;
+                auto v3D_nk = to_address(v3D[nw][nk0 + k].base()) + ni0;
                 for (int i = 0; i < ni; i++, ++v3D_nk)
                   *v3D_nk += static_cast<vType>(vik3D_n[i][k]);
               }
@@ -1323,8 +1323,8 @@ public:
   {
     using BType = typename std::decay<MatB>::type::element;
     using AType = typename std::decay<MatA>::type::element;
-    boost::multi::array_ref<BType, 2> v_(to_address(v.origin()), {v.size(), 1});
-    boost::multi::array_cref<AType, 2> G_(to_address(G.origin()), {G.size(), 1});
+    boost::multi::array_ref<BType, 2> v_(to_address(v.base()), {v.size(), 1});
+    boost::multi::array_cref<AType, 2> G_(to_address(G.base()), {G.size(), 1});
     return vbias(G_, v_, a, c, k);
   }
 
@@ -1365,15 +1365,15 @@ public:
       local_memory_needs += nmo_max * npol * nwalk; // for transposed G
     if (TMats.num_elements() < local_memory_needs)
       TMats.reextent({local_memory_needs, 1});
-    SpMatrix_ref vlocal(TMats.origin(), {2 * nchol_max, nwalk});
-    std::fill_n(vlocal.origin(), vlocal.num_elements(), SPComplexType(0.0));
+    SpMatrix_ref vlocal(TMats.base(), {2 * nchol_max, nwalk});
+    std::fill_n(vlocal.base(), vlocal.num_elements(), SPComplexType(0.0));
 
     assert(Gw.num_elements() == nwalk * (nocca_tot + noccb_tot) * npol * nmo_tot);
     const_sp_pointer Gptr(nullptr);
     // I WANT C++17!!!!!!
     if (std::is_same<SPComplexType, GType>::value)
     {
-      Gptr = reinterpret_cast<const_sp_pointer>(to_address(Gw.origin()));
+      Gptr = reinterpret_cast<const_sp_pointer>(to_address(Gw.base()));
     }
     else
     {
@@ -1382,9 +1382,9 @@ public:
       {
         size_t i0, iN;
         std::tie(i0, iN) = FairDivideBoundary(size_t(comm->rank()), size_t(Gw.num_elements()), size_t(comm->size()));
-        copy_n_cast(to_address(Gw.origin()) + i0, iN - i0, to_address(SM_TMats.origin()) + i0);
+        copy_n_cast(to_address(Gw.base()) + i0, iN - i0, to_address(SM_TMats.base()) + i0);
       }
-      Gptr = to_address(SM_TMats.origin());
+      Gptr = to_address(SM_TMats.base());
       comm->barrier();
     }
 
@@ -1420,20 +1420,20 @@ public:
 
           if (walker_type == NONCOLLINEAR)
           {
-            Sp3Tensor_ref Lank(to_address(LQKank[nd * nspin * nkpts + Q][K].origin()), {na, nchol, npol * nk});
+            Sp3Tensor_ref Lank(to_address(LQKank[nd * nspin * nkpts + Q][K].base()), {na, nchol, npol * nk});
             // v1[Q][n][nw] += sum_K sum_a_p_k LQK[a][n][p][k] G[a][p][k][nw]
             for (int a = 0; a < na; ++a)
             {
-              SpMatrix_ref Ga(to_address(vlocal.origin()) + vlocal.num_elements(), {npol * nk, nwalk});
-              SpMatrix_ref Ga_(Ga.origin(), {npol, nk * nwalk});
+              SpMatrix_ref Ga(to_address(vlocal.base()) + vlocal.num_elements(), {npol * nk, nwalk});
+              SpMatrix_ref Ga_(Ga.base(), {npol, nk * nwalk});
               for (int p = 0; p < npol; p++)
-                copy_n(to_address(G3Da[na0 + a][p][nk0].origin()), nk * nwalk, Ga_[p].origin());
+                copy_n(to_address(G3Da[na0 + a][p][nk0].base()), nk * nwalk, Ga_[p].base());
               ma::product(one, Lank[a], Ga, one, v1);
             }
           }
           else
           {
-            Sp3Tensor_ref Lank(to_address(LQKank[nd * nspin * nkpts + Q][K].origin()), {na, nchol, nk});
+            Sp3Tensor_ref Lank(to_address(LQKank[nd * nspin * nkpts + Q][K].base()), {na, nchol, nk});
 
             // v1[Q][n][nw] += sum_K sum_a_k LQK[a][n][k] G[a][k][nw]
             for (int a = 0; a < na; ++a)
@@ -1452,7 +1452,7 @@ public:
             int nk0   = std::accumulate(nopk.begin(), nopk.begin() + QKToK2[Q][K], 0);
             auto&& v1 = vlocal({0, nchol}, {0, nwalk});
 
-            Sp3Tensor_ref Lank(to_address(LQKank[(nd * nspin + 1) * nkpts + Q][K].origin()), {na, nchol, nk});
+            Sp3Tensor_ref Lank(to_address(LQKank[(nd * nspin + 1) * nkpts + Q][K].base()), {na, nchol, nk});
 
             // v1[Q][n][nw] += sum_K sum_a_k LQK[a][n][k] G[a][k][nw]
             for (int a = 0; a < na; ++a)
@@ -1481,7 +1481,7 @@ public:
           }
         } // to release the lock
         if (haveV)
-          std::fill_n(vlocal.origin(), vlocal.num_elements(), SPComplexType(0.0));
+          std::fill_n(vlocal.base(), vlocal.num_elements(), SPComplexType(0.0));
       }
     }
     // add second contribution when Q==(-Q)
@@ -1504,22 +1504,22 @@ public:
 
             if (walker_type == NONCOLLINEAR)
             {
-              Sp3Tensor_ref Lbnl(to_address(LQKbnl[nd * nspin * number_of_symmetric_Q + Qmap[Q] - 1][K].origin()),
+              Sp3Tensor_ref Lbnl(to_address(LQKbnl[nd * nspin * number_of_symmetric_Q + Qmap[Q] - 1][K].base()),
                                  {na, nchol, npol * nk});
 
               // v1[Q][n][nw] += sum_K sum_a_s_k LQK[b][n][s][l] G[b][s][l][nw]
               for (int a = 0; a < na; ++a)
               {
-                SpMatrix_ref Ga(to_address(vlocal.origin()) + vlocal.num_elements(), {npol * nk, nwalk});
-                SpMatrix_ref Ga_(Ga.origin(), {npol, nk * nwalk});
+                SpMatrix_ref Ga(to_address(vlocal.base()) + vlocal.num_elements(), {npol * nk, nwalk});
+                SpMatrix_ref Ga_(Ga.base(), {npol, nk * nwalk});
                 for (int p = 0; p < npol; p++)
-                  copy_n(to_address(G3Da[na0 + a][p][nk0].origin()), nk * nwalk, Ga_[p].origin());
+                  copy_n(to_address(G3Da[na0 + a][p][nk0].base()), nk * nwalk, Ga_[p].base());
                 ma::product(one, Lbnl[a], Ga, one, v1);
               }
             }
             else
             {
-              Sp3Tensor_ref Lbnl(to_address(LQKbnl[nd * nspin * number_of_symmetric_Q + Qmap[Q] - 1][K].origin()),
+              Sp3Tensor_ref Lbnl(to_address(LQKbnl[nd * nspin * number_of_symmetric_Q + Qmap[Q] - 1][K].base()),
                                  {na, nchol, nk});
 
               // v1[Q][n][nw] += sum_K sum_a_k LQK[b][n][l] G[b][l][nw]
@@ -1539,7 +1539,7 @@ public:
               int nk0   = std::accumulate(nopk.begin(), nopk.begin() + QKToK2[Q][K], 0);
               auto&& v1 = vlocal({0, nchol}, {0, nwalk});
 
-              Sp3Tensor_ref Lbnl(to_address(LQKbnl[(nd * nspin + 1) * number_of_symmetric_Q + Qmap[Q] - 1][K].origin()),
+              Sp3Tensor_ref Lbnl(to_address(LQKbnl[(nd * nspin + 1) * number_of_symmetric_Q + Qmap[Q] - 1][K].base()),
                                  {na, nchol, nk});
 
               // v1[Q][n][nw] += sum_K sum_a_k LQK[b][n][l] G[b][l][nw]
@@ -1559,7 +1559,7 @@ public:
             }
           } // to release the lock
           if (haveV)
-            std::fill_n(vlocal.origin(), vlocal.num_elements(), SPComplexType(0.0));
+            std::fill_n(vlocal.base(), vlocal.num_elements(), SPComplexType(0.0));
         }
       }
     }
@@ -1678,10 +1678,10 @@ private:
     int nkpts = nopk.size();
     assert(GKaKj.num_elements() == (nocca_tot + noccb_tot) * npol * nmo_tot * nwalk);
     assert(GKKaj.num_elements() == nspin * nkpts * nkpts * npol * akmax * nwalk);
-    boost::multi::array_cref<ComplexType, 4> Gca(to_address(GKaKj.origin()), {nocca_tot, npol, nmo_tot, nwalk});
-    boost::multi::array_cref<ComplexType, 3> Gcb(to_address(GKaKj.origin()) + Gca.num_elements(),
+    boost::multi::array_cref<ComplexType, 4> Gca(to_address(GKaKj.base()), {nocca_tot, npol, nmo_tot, nwalk});
+    boost::multi::array_cref<ComplexType, 3> Gcb(to_address(GKaKj.base()) + Gca.num_elements(),
                                                  {noccb_tot, nmo_tot, nwalk});
-    boost::multi::array_ref<SPComplexType, 4> GKK(to_address(GKKaj.origin()),
+    boost::multi::array_ref<SPComplexType, 4> GKK(to_address(GKKaj.base()),
                                                   {nspin, nkpts, nkpts, nwalk * npol * akmax});
     int na0 = 0;
     for (int Ka = 0, Kaj = 0; Ka < nkpts; Ka++)
@@ -1696,13 +1696,13 @@ private:
           nj0 += nj;
           continue;
         }
-        auto G_(to_address(GKK[0][Ka][Kj].origin()));
+        auto G_(to_address(GKK[0][Ka][Kj].base()));
         int naj = na * nj * npol;
         for (int a = 0, asj = 0; a < na; a++)
         {
           for (int p = 0; p < npol; p++)
           {
-            auto Gc_(to_address(Gca[na0 + a][p][nj0].origin()));
+            auto Gc_(to_address(Gca[na0 + a][p][nj0].base()));
             for (int j = 0; j < nj; j++, asj++)
             {
               for (int w = 0, waj = 0; w < nwalk; w++, ++Gc_, waj += naj)
@@ -1733,11 +1733,11 @@ private:
             nj0 += nj;
             continue;
           }
-          auto G_(to_address(GKK[1][Ka][Kj].origin()));
+          auto G_(to_address(GKK[1][Ka][Kj].base()));
           int naj = na * nj;
           for (int a = 0, aj = 0; a < na; a++)
           {
-            auto Gc_(to_address(Gcb[na0 + a][nj0].origin()));
+            auto Gc_(to_address(Gcb[na0 + a][nj0].base()));
             for (int j = 0; j < nj; j++, aj++)
             {
               for (int w = 0, waj = 0; w < nwalk; w++, ++Gc_, waj += naj)

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorizationIO.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorizationIO.hpp
@@ -156,7 +156,7 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
   TGwfn.Global().broadcast_n(kminus.data(), kminus.size(), 0);
   TGwfn.Global().broadcast_n(gQ.data(), gQ.size(), 0);
   if (TGwfn.Node().root())
-    TGwfn.Cores().broadcast_n(std::addressof(*QKtok2.origin()), QKtok2.num_elements(), 0);
+    TGwfn.Cores().broadcast_n(std::addressof(*QKtok2.base()), QKtok2.num_elements(), 0);
 
   int Q0 = -1; // stores the index of the Q=(0,0,0) Q-point
                // this must always exist
@@ -209,7 +209,7 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
   if (TGwfn.Global().root())
   {
     {
-      boost::multi::array_ref<ComplexType, 2> H1_(std::addressof(*H1.origin()),
+      boost::multi::array_ref<ComplexType, 2> H1_(std::addressof(*H1.base()),
                                                   {H1.shape()[0], H1.shape()[1] * H1.shape()[2]});
       if (!dump.read(H1_, "KPH1"))
       {
@@ -218,7 +218,7 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
       }
     }
     {
-      boost::multi::array_ref<ComplexType, 2> vn0_(std::addressof(*vn0.origin()),
+      boost::multi::array_ref<ComplexType, 2> vn0_(std::addressof(*vn0.base()),
                                                    {vn0.shape()[0], vn0.shape()[1] * vn0.shape()[2]});
       if (!dump.read(vn0_, "KPv0"))
       {
@@ -231,7 +231,7 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
       if (Q > kminus[Q])
         continue;
       // to avoid reallocation, will abort if sizes don't match
-      boost::multi::array_ref<SPComplexType, 2> LQ(std::addressof(*LQKikn[Q].origin()),
+      boost::multi::array_ref<SPComplexType, 2> LQ(std::addressof(*LQKikn[Q].base()),
                                                    {LQKikn[Q].shape()[0], LQKikn[Q].shape()[1]});
       if (!dump.read(LQ, std::string("L") + std::to_string(Q)))
       {
@@ -242,13 +242,13 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
   }
   if (TGwfn.Node().root())
   {
-    TGwfn.Cores().broadcast_n(std::addressof(*H1.origin()), H1.num_elements(), 0);
-    TGwfn.Cores().broadcast_n(std::addressof(*vn0.origin()), vn0.num_elements(), 0);
+    TGwfn.Cores().broadcast_n(std::addressof(*H1.base()), H1.num_elements(), 0);
+    TGwfn.Cores().broadcast_n(std::addressof(*vn0.base()), vn0.num_elements(), 0);
     for (int Q = 0; Q < nkpts; Q++)
     {
       if (Q > kminus[Q])
         continue;
-      TGwfn.Cores().broadcast_n(std::addressof(*LQKikn[Q].origin()), LQKikn[Q].num_elements(), 0);
+      TGwfn.Cores().broadcast_n(std::addressof(*LQKikn[Q].base()), LQKikn[Q].num_elements(), 0);
     }
   }
 
@@ -286,8 +286,8 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
     }
   }
   TGwfn.Node().barrier();
-  int nocc_max = *std::max_element(std::addressof(*nocc_per_kp.origin()),
-                                   std::addressof(*nocc_per_kp.origin()) + nocc_per_kp.num_elements());
+  int nocc_max = *std::max_element(std::addressof(*nocc_per_kp.base()),
+                                   std::addressof(*nocc_per_kp.base()) + nocc_per_kp.num_elements());
 
 
   std::vector<shmSpMatrix> LQKank;
@@ -295,7 +295,7 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
   shmCMatrix haj({ndet * nkpts, (type == COLLINEAR ? 2 : 1) * nocc_max * nmo_max},
                  shared_allocator<ComplexType>{TGwfn.Node()});
   if (TGwfn.Node().root())
-    std::fill_n(haj.origin(), haj.num_elements(), ComplexType(0.0));
+    std::fill_n(haj.base(), haj.num_elements(), ComplexType(0.0));
   int ank_max = nocc_max * nchol_max * nmo_max;
   for (int nd = 0; nd < ndet; nd++)
   {
@@ -319,11 +319,11 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
       {
         if (nt % TGwfn.Node().size() == TGwfn.Node().rank())
         {
-          std::fill_n(std::addressof(*LQKank[nq0 + Q][K].origin()), LQKank[nq0 + Q][K].num_elements(),
+          std::fill_n(std::addressof(*LQKank[nq0 + Q][K].base()), LQKank[nq0 + Q][K].num_elements(),
                       SPComplexType(0.0));
           if (type == COLLINEAR)
           {
-            std::fill_n(std::addressof(*LQKank[nq0 + nkpts + 1 + Q][K].origin()),
+            std::fill_n(std::addressof(*LQKank[nq0 + nkpts + 1 + Q][K].base()),
                         LQKank[nq0 + nkpts + 1 + Q][K].num_elements(), SPComplexType(0.0));
           }
         }
@@ -355,13 +355,13 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
               { // Alpha
                 auto Psi = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[2 * nd], K);
                 assert(Psi.shape()[0] == na);
-                boost::multi::array_ref<ComplexType, 2> haj_r(std::addressof(*haj[nd * nkpts + K].origin()), {na, ni});
+                boost::multi::array_ref<ComplexType, 2> haj_r(std::addressof(*haj[nd * nkpts + K].base()), {na, ni});
                 ma::product(Psi, H1[K]({0, ni}, {0, ni}), haj_r);
               }
               { // Beta
                 auto Psi = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[2 * nd + 1], K);
                 assert(Psi.shape()[0] == nb);
-                boost::multi::array_ref<ComplexType, 2> haj_r(std::addressof(*haj[nd * nkpts + K].origin()) + na * ni,
+                boost::multi::array_ref<ComplexType, 2> haj_r(std::addressof(*haj[nd * nkpts + K].base()) + na * ni,
                                                               {nb, ni});
                 ma::product(Psi, H1[K]({0, ni}, {0, ni}), haj_r);
               }
@@ -370,7 +370,7 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
             {
               auto Psi = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[nd], K);
               assert(Psi.shape()[0] == na);
-              boost::multi::array_ref<ComplexType, 2> haj_r(std::addressof(*haj[nd * nkpts + K].origin()), {na, ni});
+              boost::multi::array_ref<ComplexType, 2> haj_r(std::addressof(*haj[nd * nkpts + K].base()), {na, ni});
               ma::product(ComplexType(2.0), Psi, H1[K]({0, ni}, {0, ni}), ComplexType(0.0), haj_r);
             }
           }
@@ -390,13 +390,13 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
                     if (K_ < QKtok2[Q][K_])
                       kpos++;
                 }
-                Sp3Tensor_ref Likn(std::addressof(*LQKikn[Q][kpos].origin()), {ni, nk, nchol});
-                Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + Q][K].origin()), {na, nchol, nk});
+                Sp3Tensor_ref Likn(std::addressof(*LQKikn[Q][kpos].base()), {ni, nk, nchol});
+                Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + Q][K].base()), {na, nchol, nk});
                 ma_rotate::getLank(Psi, Likn, Lank, buff);
                 if (Q == Q0)
                 {
                   assert(K == QK);
-                  Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + nkpts][K].origin()), {na, nchol, nk});
+                  Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + nkpts][K].base()), {na, nchol, nk});
                   ma_rotate::getLank_from_Lkin(Psi, Likn, Lank, buff);
                 }
               }
@@ -410,8 +410,8 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
                     if (K_ < QKtok2[Q][K_])
                       kpos++;
                 }
-                Sp3Tensor_ref Lkin(std::addressof(*LQKikn[Qm][QK].origin()), {nk, ni, nchol});
-                Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + Q][K].origin()), {na, nchol, nk});
+                Sp3Tensor_ref Lkin(std::addressof(*LQKikn[Qm][QK].base()), {nk, ni, nchol});
+                Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + Q][K].base()), {na, nchol, nk});
                 ma_rotate::getLank_from_Lkin(Psi, Lkin, Lank, buff);
               }
             }
@@ -429,13 +429,13 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
                     if (K_ < QKtok2[Q][K_])
                       kpos++;
                 }
-                Sp3Tensor_ref Likn(std::addressof(*LQKikn[Q][kpos].origin()), {ni, nk, nchol});
-                Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + nkpts + 1 + Q][K].origin()), {nb, nchol, nk});
+                Sp3Tensor_ref Likn(std::addressof(*LQKikn[Q][kpos].base()), {ni, nk, nchol});
+                Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + nkpts + 1 + Q][K].base()), {nb, nchol, nk});
                 ma_rotate::getLank(Psi, Likn, Lank, buff);
                 if (Q == Q0)
                 {
                   assert(K == QK);
-                  Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + nkpts + 1 + nkpts][K].origin()), {nb, nchol, nk});
+                  Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + nkpts + 1 + nkpts][K].base()), {nb, nchol, nk});
                   ma_rotate::getLank_from_Lkin(Psi, Likn, Lank, buff);
                 }
               }
@@ -449,8 +449,8 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
                     if (K_ < QKtok2[Q][K_])
                       kpos++;
                 }
-                Sp3Tensor_ref Lkin(std::addressof(*LQKikn[Qm][QK].origin()), {nk, ni, nchol});
-                Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + nkpts + 1 + Q][K].origin()), {nb, nchol, nk});
+                Sp3Tensor_ref Lkin(std::addressof(*LQKikn[Qm][QK].base()), {nk, ni, nchol});
+                Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + nkpts + 1 + Q][K].base()), {nb, nchol, nk});
                 ma_rotate::getLank_from_Lkin(Psi, Lkin, Lank, buff);
               }
             }
@@ -470,13 +470,13 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
                   if (K_ < QKtok2[Q][K_])
                     kpos++;
               }
-              Sp3Tensor_ref Likn(std::addressof(*LQKikn[Q][kpos].origin()), {ni, nk, nchol});
-              Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + Q][K].origin()), {na, nchol, nk});
+              Sp3Tensor_ref Likn(std::addressof(*LQKikn[Q][kpos].base()), {ni, nk, nchol});
+              Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + Q][K].base()), {na, nchol, nk});
               ma_rotate::getLank(Psi, Likn, Lank, buff);
               if (Q == Q0)
               {
                 assert(K == QK);
-                Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + nkpts][K].origin()), {na, nchol, nk});
+                Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + nkpts][K].base()), {na, nchol, nk});
                 ma_rotate::getLank_from_Lkin(Psi, Likn, Lank, buff);
               }
             }
@@ -490,8 +490,8 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
                   if (K_ < QKtok2[Q][K_])
                     kpos++;
               }
-              Sp3Tensor_ref Lkin(std::addressof(*LQKikn[Qm][kpos].origin()), {nk, ni, nchol});
-              Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + Q][K].origin()), {na, nchol, nk});
+              Sp3Tensor_ref Lkin(std::addressof(*LQKikn[Qm][kpos].base()), {nk, ni, nchol});
+              Sp3Tensor_ref Lank(std::addressof(*LQKank[nq0 + Q][K].base()), {na, nchol, nk});
               ma_rotate::getLank_from_Lkin(Psi, Lkin, Lank, buff);
             }
           }
@@ -502,9 +502,9 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
   TGwfn.Global().barrier();
   if (TGwfn.Node().root())
   {
-    TGwfn.Cores().all_reduce_in_place_n(std::addressof(*haj.origin()), haj.num_elements(), std::plus<>());
+    TGwfn.Cores().all_reduce_in_place_n(std::addressof(*haj.base()), haj.num_elements(), std::plus<>());
     for (int Q = 0; Q < LQKank.size(); Q++)
-      TGwfn.Cores().all_reduce_in_place_n(std::addressof(*LQKank[Q].origin()), LQKank[Q].num_elements(), std::plus<>());
+      TGwfn.Cores().all_reduce_in_place_n(std::addressof(*LQKank[Q].base()), LQKank[Q].num_elements(), std::plus<>());
   }
   TGwfn.Node().barrier();
 
@@ -562,12 +562,12 @@ inline void writeKP3IndexFactorization(hdf_archive& dump,
     dump.write(QKToK2, "QKTok2");
     dump.write(gQ, "gQ");
     {
-      boost::multi::array_ref<ComplexType, 2> H1_(std::addressof(*H1.origin()),
+      boost::multi::array_ref<ComplexType, 2> H1_(std::addressof(*H1.base()),
                                                   {H1.shape()[0], H1.shape()[1] * H1.shape()[2]});
       dump.write(H1_, "KPH1");
     }
     {
-      boost::multi::array_ref<ComplexType, 2> vn0_(std::addressof(*vn0.origin()),
+      boost::multi::array_ref<ComplexType, 2> vn0_(std::addressof(*vn0.base()),
                                                    {vn0.shape()[0], vn0.shape()[1] * vn0.shape()[2]});
       dump.write(vn0_, "KPv0");
     }

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
@@ -163,7 +163,7 @@ public:
         //LQKank(std::move(move_vector<LQKankMatrix>(std::move(vak),TG.Node()))),
         LQKank(std::move(move_vector<LQKankMatrix>(std::move(vak)))),
         //needs_copy(true),
-        needs_copy(not std::is_same<decltype(ma::pointer_dispatch(LQKank[0].origin())), sp_pointer>::value),
+        needs_copy(not std::is_same<decltype(ma::pointer_dispatch(LQKank[0].base())), sp_pointer>::value),
         LQKakn(std::move(move_vector<shmSpMatrix>(std::move(vakn)))),
         LQKbnl(std::move(move_vector<shmSpMatrix>(std::move(vbl)))),
         LQKbln(std::move(move_vector<shmSpMatrix>(std::move(vbln)))),
@@ -177,20 +177,20 @@ public:
         distribution(gQ.begin(), gQ.end()),
         KKTransID({nopk.size(), nopk.size()}, IAllocator{allocator_}),
         dev_nopk(nopk),
-        dev_i0pk(typename IVector::extensions_type{nopk.size()}, IAllocator{allocator_}),
+        dev_i0pk(typename IVector::extents_type{nopk.size()}, IAllocator{allocator_}),
         dev_kminus(kminus),
         dev_ncholpQ(ncholpQ),
-        dev_Q2vbias(typename IVector::extensions_type{nopk.size()}, IAllocator{allocator_}),
+        dev_Q2vbias(typename IVector::extents_type{nopk.size()}, IAllocator{allocator_}),
         dev_Qmap(Qmap),
         dev_nelpk(nelpk),
-        dev_a0pk(typename IMatrix::extensions_type{get<0>(nelpk.sizes()), get<1>(nelpk.sizes())}, IAllocator{allocator_}),
+        dev_a0pk(typename IMatrix::extents_type{get<0>(nelpk.sizes()), get<1>(nelpk.sizes())}, IAllocator{allocator_}),
         dev_QKToK2(QKToK2),
         EQ(nopk.size() + 2)
   {
     using std::get;
     using std::copy_n;
     using std::fill_n;
-    nocc_max = *std::max_element(nelpk.origin(), nelpk.origin() + nelpk.num_elements());
+    nocc_max = *std::max_element(nelpk.base(), nelpk.base() + nelpk.num_elements());
     fill_n(EQ.data(), EQ.size(), 0);
     int nkpts = nopk.size();
     // Defines behavior over Q vector:
@@ -200,7 +200,7 @@ public:
     number_of_symmetric_Q = 0;
     number_of_Q_points    = 0;
     local_nCV             = 0;
-    std::fill_n(Q2vbias.origin(), nkpts, -1);
+    std::fill_n(Q2vbias.base(), nkpts, -1);
     for (int Q = 0; Q < nkpts; Q++)
     {
       if (Q > kminus[Q])
@@ -235,27 +235,27 @@ public:
         assert(Qmap[Q] <= number_of_symmetric_Q);
       }
     }
-    copy_n(Q2vbias.data(), nkpts, dev_Q2vbias.origin());
+    copy_n(Q2vbias.data(), nkpts, dev_Q2vbias.base());
     // setup dev integer arrays
     std::vector<int> i0(nkpts);
     // dev_nopk
     i0[0] = 0;
     for (int i = 1; i < nkpts; i++)
       i0[i] = i0[i - 1] + nopk[i - 1];
-    copy_n(i0.data(), nkpts, dev_i0pk.origin());
+    copy_n(i0.data(), nkpts, dev_i0pk.base());
     // dev_nelpk
     for (int n = 0; n < nelpk.size(); n++)
     {
       i0[0] = 0;
       for (int i = 1; i < nkpts; i++)
         i0[i] = i0[i - 1] + nelpk[n][i - 1];
-      copy_n(i0.data(), nkpts, dev_a0pk[n].origin());
+      copy_n(i0.data(), nkpts, dev_a0pk[n].base());
       if (walker_type == COLLINEAR)
       {
         i0[0] = 0;
         for (int i = 1; i < nkpts; i++)
           i0[i] = i0[i - 1] + nelpk[n][nkpts + i - 1];
-        copy_n(i0.data(), nkpts, dev_a0pk[n].origin() + nkpts);
+        copy_n(i0.data(), nkpts, dev_a0pk[n].base() + nkpts);
       }
     }
     // setup copy/transpose tags
@@ -264,7 +264,7 @@ public:
     // 3: ignore
     // -P: copy from [Ki][Kj] and transpose from [nkpts+P-1][]
     boost::multi::array<int, 2> KKid({nkpts, nkpts});
-    std::fill_n(KKid.origin(), KKid.num_elements(), 3); // ignore everything by default
+    std::fill_n(KKid.base(), KKid.num_elements(), 3); // ignore everything by default
     for (int Q = 0; Q < nkpts; ++Q)
     { // momentum conservation index
       if (Qmap[Q] < 0)
@@ -296,7 +296,7 @@ public:
         }
       }
     }
-    copy_n(KKid.origin(), KKid.num_elements(), KKTransID.origin());
+    copy_n(KKid.base(), KKid.num_elements(), KKTransID.base());
 
     long memank = 0;
     if (needs_copy)
@@ -346,16 +346,16 @@ public:
 
     CVector vMF_(vMF);
     CVector P0D(iextensions<1u>{NMO * NMO});
-    fill_n(P0D.origin(), P0D.num_elements(), ComplexType(0));
+    fill_n(P0D.base(), P0D.num_elements(), ComplexType(0));
     vHS(vMF_, P0D);
     if (TG_.TG().size() > 1)
-      TG_.TG().all_reduce_in_place_n(to_address(P0D.origin()), P0D.num_elements(), std::plus<>());
+      TG_.TG().all_reduce_in_place_n(to_address(P0D.base()), P0D.num_elements(), std::plus<>());
 
     boost::multi::array<ComplexType, 2> P0({NMO, NMO});
-    copy_n(P0D.origin(), NMO * NMO, P0.origin());
+    copy_n(P0D.base(), NMO * NMO, P0.base());
 
     boost::multi::array<ComplexType, 2> P1({npol * NMO, npol * NMO});
-    std::fill_n(P1.origin(), P1.num_elements(), ComplexType(0.0));
+    std::fill_n(P1.base(), P1.num_elements(), ComplexType(0.0));
 
     // add spin-dependent H1
     for (int K = 0, nk0 = 0; K < nkpts; ++K)
@@ -543,15 +543,15 @@ public:
     }
     StaticMatrix Kl({Knr, Knc}, device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
     StaticMatrix Kr({Knr, Knc}, device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    fill_n(Kr.origin(), Knr * Knc, SPComplexType(0.0));
-    fill_n(Kl.origin(), Knr * Knc, SPComplexType(0.0));
+    fill_n(Kr.base(), Knr * Knc, SPComplexType(0.0));
+    fill_n(Kl.base(), Knr * Knc, SPComplexType(0.0));
 
     for (int n = 0; n < nwalk; n++)
-      fill_n(E[n].origin(), 3, ComplexType(0.));
+      fill_n(E[n].base(), 3, ComplexType(0.));
 
     assert(Gc.num_elements() == nwalk * (nocca_tot + noccb_tot) * npol * nmo_tot);
-    C3Tensor_cref G3Da(make_device_ptr(Gc.origin()), {nocca_tot * npol, nmo_tot, nwalk});
-    C3Tensor_cref G3Db(make_device_ptr(Gc.origin()) + G3Da.num_elements() * (nspin - 1), {noccb_tot, nmo_tot, nwalk});
+    C3Tensor_cref G3Da(make_device_ptr(Gc.base()), {nocca_tot * npol, nmo_tot, nwalk});
+    C3Tensor_cref G3Db(make_device_ptr(Gc.base()) + G3Da.num_elements() * (nspin - 1), {noccb_tot, nmo_tot, nwalk});
 
     // later on, rewrite routine to loop over spins, to avoid storage of both spin
     // components simultaneously
@@ -567,7 +567,7 @@ public:
     if (addH1)
     {
       for (int n = 0; n < nwalk; n++)
-        fill_n(E[n].origin(), 1, ComplexType(E0));
+        fill_n(E[n].base(), 1, ComplexType(E0));
       // must use Gc since GKK is is SP
 #if defined(MIXED_PRECISION)
       int na = 0, nk = 0;
@@ -577,7 +577,7 @@ public:
       {
 #if defined(MIXED_PRECISION)
         int ni(nopk[K]);
-        CMatrix_ref haj_K(make_device_ptr(haj[nd * nkpts + K].origin()), {nocc_max, npol * nmo_max});
+        CMatrix_ref haj_K(make_device_ptr(haj[nd * nkpts + K].base()), {nocc_max, npol * nmo_max});
         for (int a = 0; a < nelpk[nd][K]; ++a)
           for (int pol = 0; pol < npol; ++pol)
             ma::product(ComplexType(1.), ma::T(G3Da[(na + a) * npol + pol].sliced(nk, nk + ni)),
@@ -585,7 +585,7 @@ public:
         na += nelpk[nd][K];
         if (walker_type == COLLINEAR)
         {
-          boost::multi::array_ref<ComplexType, 2, pointer> haj_Kb(haj_K.origin() + haj_K.num_elements(),
+          boost::multi::array_ref<ComplexType, 2, pointer> haj_Kb(haj_K.base() + haj_K.num_elements(),
                                                                   {nocc_max, nmo_max});
           for (int b = 0; b < nelpk[nd][nkpts + K]; ++b)
             ma::product(ComplexType(1.), ma::T(G3Db[nb + b].sliced(nk, nk + ni)), haj_Kb[b].sliced(0, ni),
@@ -595,14 +595,14 @@ public:
         nk += ni;
 #else
         {
-          CVector_ref haj_K(make_device_ptr(haj[nd * nkpts + K].origin()), {nocc_max * npol * nmo_max});
-          SpMatrix_ref Gaj(GKK[0][K][K].origin(), {nwalk, nocc_max * npol * nmo_max});
+          CVector_ref haj_K(make_device_ptr(haj[nd * nkpts + K].base()), {nocc_max * npol * nmo_max});
+          SpMatrix_ref Gaj(GKK[0][K][K].base(), {nwalk, nocc_max * npol * nmo_max});
           ma::product(ComplexType(1.), Gaj, haj_K, ComplexType(1.), E({0, nwalk}, 0));
         }
         if (walker_type == COLLINEAR)
         {
-          CVector_ref haj_K(make_device_ptr(haj[nd * nkpts + K].origin()) + nocc_max * nmo_max, {nocc_max * nmo_max});
-          SpMatrix_ref Gaj(GKK[1][K][K].origin(), {nwalk, nocc_max * nmo_max});
+          CVector_ref haj_K(make_device_ptr(haj[nd * nkpts + K].base()) + nocc_max * nmo_max, {nocc_max * nmo_max});
+          SpMatrix_ref Gaj(GKK[1][K][K].base(), {nwalk, nocc_max * nmo_max});
           ma::product(ComplexType(1.), Gaj, haj_K, ComplexType(1.), E({0, nwalk}, 0));
         }
 #endif
@@ -629,7 +629,7 @@ public:
 
       StaticIVector IMats(iextensions<1u>{batch_size},
                           device_buffer_manager.get_generator().template get_allocator<int>());
-      fill_n(IMats.origin(), IMats.num_elements(), 0);
+      fill_n(IMats.base(), IMats.num_elements(), 0);
       StaticVector dev_scl_factors(iextensions<1u>{batch_size},
                                    device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
       Static3Tensor T1({batch_size, nwalk * nocc_max, nocc_max * nchol_max},
@@ -646,8 +646,8 @@ public:
       if (needs_copy)
       {
         // data will be copied here
-        LQptr  = LBuff.origin();
-        LQmptr = LBuff.origin() + mem_ank;
+        LQptr  = LBuff.base();
+        LQmptr = LBuff.base() + mem_ank;
       }
 
       for (int spin = 0; spin < nspin; ++spin)
@@ -671,19 +671,19 @@ public:
           if (!needs_copy)
           {
             // set to local array origin
-            LQptr  = make_device_ptr(LQKank[nd * nspin * nkpts + spin * nkpts + Q].origin());
-            LQmptr = make_device_ptr(LQKank[nd * nspin * nkpts + spin * nkpts + Qm].origin());
+            LQptr  = make_device_ptr(LQKank[nd * nspin * nkpts + spin * nkpts + Q].base());
+            LQmptr = make_device_ptr(LQKank[nd * nspin * nkpts + spin * nkpts + Qm].base());
           }
 
-          SpMatrix_ref LQ(LQptr, LQKank[nd * nspin * nkpts + spin * nkpts + Q].extensions());
-          SpMatrix_ref LQm(LQmptr, LQKank[nd * nspin * nkpts + spin * nkpts + Qm].extensions());
+          SpMatrix_ref LQ(LQptr, LQKank[nd * nspin * nkpts + spin * nkpts + Q].extents());
+          SpMatrix_ref LQm(LQmptr, LQKank[nd * nspin * nkpts + spin * nkpts + Qm].extents());
 
           if (needs_copy)
           {
-            copy_n(to_address(LQKank[nd * nspin * nkpts + spin * nkpts + Q].origin()), LQ.num_elements(), LQ.origin());
+            copy_n(to_address(LQKank[nd * nspin * nkpts + spin * nkpts + Q].base()), LQ.num_elements(), LQ.base());
             if (Q != Qm)
-              copy_n(to_address(LQKank[nd * nspin * nkpts + spin * nkpts + Qm].origin()), LQm.num_elements(),
-                     LQm.origin());
+              copy_n(to_address(LQKank[nd * nspin * nkpts + spin * nkpts + Qm].base()), LQm.num_elements(),
+                     LQm.base());
           }
 
           for (int Ka = 0; Ka < nkpts; ++Ka)
@@ -700,15 +700,15 @@ public:
               if (Qmap[Q] > 0)
                 Aarray.push_back(sp_pointer(
                     LQKbnl[nd * nspin * number_of_symmetric_Q + spin * number_of_symmetric_Q + Qmap[Q] - 1][Kb]
-                        .origin()));
+                        .base()));
               else
-                Aarray.push_back(sp_pointer(LQm[Kb].origin()));
+                Aarray.push_back(sp_pointer(LQm[Kb].base()));
 
-              Barray.push_back(GKK[spin][Ka][Kl_].origin());
-              Carray.push_back(T1[batch_cnt++].origin());
-              Aarray.push_back(sp_pointer(LQ[Ka].origin()));
-              Barray.push_back(GKK[spin][Kb][Kk].origin());
-              Carray.push_back(T1[batch_cnt++].origin());
+              Barray.push_back(GKK[spin][Ka][Kl_].base());
+              Carray.push_back(T1[batch_cnt++].base());
+              Aarray.push_back(sp_pointer(LQ[Ka].base()));
+              Barray.push_back(GKK[spin][Kb][Kk].base());
+              Carray.push_back(T1[batch_cnt++].base());
 
               if (Qmap[Q] > 0 || Ka == Kb)
                 scl_factors.push_back(SPComplexType(-scl * 0.5));
@@ -721,18 +721,18 @@ public:
                             Aarray.data(), npol * nmo_max, Barray.data(), npol * nmo_max, SPComplexType(0.0),
                             Carray.data(), nocc_max * nchol_max, Aarray.size());
 
-                copy_n(scl_factors.data(), scl_factors.size(), dev_scl_factors.origin());
+                copy_n(scl_factors.data(), scl_factors.size(), dev_scl_factors.base());
                 using ma::batched_dot_wabn_wban;
-                batched_dot_wabn_wban(scl_factors.size(), nwalk, nocc_max, nchol_max, dev_scl_factors.origin(),
-                                      T1.origin(), to_address(E[0].origin()) + 1, E.stride());
+                batched_dot_wabn_wban(scl_factors.size(), nwalk, nocc_max, nchol_max, dev_scl_factors.base(),
+                                      T1.base(), to_address(E[0].base()) + 1, E.stride());
 
                 if (addEJ)
                 {
                   int nc0 = Q2vbias[Q] / 2; //std::accumulate(ncholpQ.begin(),ncholpQ.begin()+Q,0);
-                  copy_n(kdiag.data(), kdiag.size(), IMats.origin());
+                  copy_n(kdiag.data(), kdiag.size(), IMats.base());
                   using ma::batched_Tab_to_Klr;
                   batched_Tab_to_Klr(kdiag.size(), nwalk, nocc_max, nchol_max, local_nCV, ncholpQ[Q], nc0,
-                                     IMats.origin(), T1.origin(), Kl.origin(), Kr.origin());
+                                     IMats.base(), T1.base(), Kl.base(), Kr.base());
                 }
 
                 // reset
@@ -752,18 +752,18 @@ public:
                         Aarray.data(), npol * nmo_max, Barray.data(), npol * nmo_max, SPComplexType(0.0), Carray.data(),
                         nocc_max * nchol_max, Aarray.size());
 
-            copy_n(scl_factors.data(), scl_factors.size(), dev_scl_factors.origin());
+            copy_n(scl_factors.data(), scl_factors.size(), dev_scl_factors.base());
             using ma::batched_dot_wabn_wban;
-            batched_dot_wabn_wban(scl_factors.size(), nwalk, nocc_max, nchol_max, dev_scl_factors.origin(), T1.origin(),
-                                  to_address(E[0].origin()) + 1, E.stride());
+            batched_dot_wabn_wban(scl_factors.size(), nwalk, nocc_max, nchol_max, dev_scl_factors.base(), T1.base(),
+                                  to_address(E[0].base()) + 1, E.stride());
 
             if (addEJ)
             {
               int nc0 = Q2vbias[Q] / 2; //std::accumulate(ncholpQ.begin(),ncholpQ.begin()+Q,0);
-              copy_n(kdiag.data(), kdiag.size(), IMats.origin());
+              copy_n(kdiag.data(), kdiag.size(), IMats.base());
               using ma::batched_Tab_to_Klr;
-              batched_Tab_to_Klr(kdiag.size(), nwalk, nocc_max, nchol_max, local_nCV, ncholpQ[Q], nc0, IMats.origin(),
-                                 T1.origin(), Kl.origin(), Kr.origin());
+              batched_Tab_to_Klr(kdiag.size(), nwalk, nocc_max, nchol_max, local_nCV, ncholpQ[Q], nc0, IMats.base(),
+                                 T1.base(), Kl.base(), Kr.base());
             }
           }
         } // Q
@@ -781,12 +781,12 @@ public:
       using ma::adotpby;
       for (int n = 0; n < nwalk; ++n)
       {
-        adotpby(SPComplexType(0.5 * scl * scl), Kl[n], Kr[n], ComplexType(0.0), E[n].origin() + 2);
+        adotpby(SPComplexType(0.5 * scl * scl), Kl[n], Kr[n], ComplexType(0.0), E[n].base() + 2);
       }
       if (getKr)
-        copy_n_cast(Kr.origin(), Kr.num_elements(), make_device_ptr(KEright->origin()));
+        copy_n_cast(Kr.base(), Kr.num_elements(), make_device_ptr(KEright->base()));
       if (getKl)
-        copy_n_cast(Kl.origin(), Kl.num_elements(), make_device_ptr(KEleft->origin()));
+        copy_n_cast(Kl.base(), Kl.num_elements(), make_device_ptr(KEleft->base()));
     }
   }
 
@@ -851,11 +851,11 @@ public:
         if(getKr) {
           assert(KEright->size(0) == nwalk && KEright->size(1) == local_nCV);
           assert(KEright->stride() == KEright->size(1));
-          Krptr = make_device_ptr(KEright->origin());
+          Krptr = make_device_ptr(KEright->base());
         } else 
 #endif
         {
-          Krptr = BTMats.origin();
+          Krptr = BTMats.base();
           cnt += nwalk*local_nCV;
         }
 #if defined(MIXED_PRECISION)
@@ -867,11 +867,11 @@ public:
         if(getKl) {
           assert(KEleft->size(0) == nwalk && KEleft->size(1) == local_nCV);
           assert(KEleft->stride() == KEleft->size(1));
-          Klptr = make_device_ptr(KEleft->origin());
+          Klptr = make_device_ptr(KEleft->base());
         } else 
 #endif
         {
-          Klptr = BTMats.origin()+cnt;
+          Klptr = BTMats.base()+cnt;
           cnt += nwalk*local_nCV;
         }
         fill_n(Krptr,Knr*Knc,SPComplexType(0.0));
@@ -883,14 +883,14 @@ public:
       SpMatrix_ref Kr(Krptr,{Knr,Knc});
 
       for(int n=0; n<nwalk; n++) 
-        fill_n(E[n].origin(),3,ComplexType(0.));
+        fill_n(E[n].base(),3,ComplexType(0.));
 
       assert(Gc.num_elements() == nwalk*(nocca_tot+noccb_tot)*nmo_tot);
-      C3Tensor_cref G3Da(make_device_ptr(Gc.origin()),{nocca_tot,nmo_tot,nwalk} );
-      C3Tensor_cref G3Db(make_device_ptr(Gc.origin())+G3Da.num_elements()*(nspin-1),
+      C3Tensor_cref G3Da(make_device_ptr(Gc.base()),{nocca_tot,nmo_tot,nwalk} );
+      C3Tensor_cref G3Db(make_device_ptr(Gc.base())+G3Da.num_elements()*(nspin-1),
                             {noccb_tot,nmo_tot,nwalk} );
 
-      Sp4Tensor_ref GKK(BTMats.origin()+cnt,
+      Sp4Tensor_ref GKK(BTMats.base()+cnt,
                         {nspin,nkpts,nkpts,nwalk*nmo_max*nocca_max});
       cnt+=GKK.num_elements();
       GKaKjw_to_GKKwaj(G3Da,GKK[0],nelpk[nd].sliced(0,nkpts),dev_nelpk[nd],dev_a0pk[nd]);
@@ -909,14 +909,14 @@ public:
           E[n][0] = E0;  
         for(int K=0; K<nkpts; ++K) {
 #if defined(MIXED_PRECISION) 
-          CMatrix_ref haj_K(make_device_ptr(haj[nd*nkpts+K].origin()),{nocc_max,nmo_max});
+          CMatrix_ref haj_K(make_device_ptr(haj[nd*nkpts+K].base()),{nocc_max,nmo_max});
           for(int a=0; a<nelpk[nd][K]; ++a)
             ma::product(ComplexType(1.),ma::T(G3Da[na+a].sliced(nk,nk+nopk[K])),
                                         haj_K[a].sliced(0,nopk[K]),
                         ComplexType(1.),E({0,nwalk},0));
           na+=nelpk[nd][K];
           if(walker_type==COLLINEAR) {
-            boost::multi::array_ref<ComplexType,2,pointer> haj_Kb(haj_K.origin()+haj_K.num_elements(),
+            boost::multi::array_ref<ComplexType,2,pointer> haj_Kb(haj_K.base()+haj_K.num_elements(),
                                                       {nocc_max,nmo_max});
             for(int b=0; b<nelpk[nd][nkpts+K]; ++b)
               ma::product(ComplexType(1.),ma::T(G3Db[nb+b].sliced(nk,nk+nopk[K])),
@@ -929,14 +929,14 @@ public:
           nk = nopk[K];
           {
             na = nelpk[nd][K];
-            CVector_ref haj_K(make_device_ptr(haj[nd*nkpts+K].origin()),{nocc_max*nmo_max});
-            SpMatrix_ref Gaj(GKK[0][K][K].origin(),{nwalk,nocc_max*nmo_max});
+            CVector_ref haj_K(make_device_ptr(haj[nd*nkpts+K].base()),{nocc_max*nmo_max});
+            SpMatrix_ref Gaj(GKK[0][K][K].base(),{nwalk,nocc_max*nmo_max});
             ma::product(ComplexType(1.),Gaj,haj_K,ComplexType(1.),E({0,nwalk},0));
           }
           if(walker_type==COLLINEAR) {
             na = nelpk[nd][nkpts+K];
-            CVector_ref haj_K(make_device_ptr(haj[nd*nkpts+K].origin())+nocc_max*nmo_max,{nocc_max*nmo_max});
-            SpMatrix_ref Gaj(GKK[1][K][K].origin(),{nwalk,nocc_max*nmo_max});
+            CVector_ref haj_K(make_device_ptr(haj[nd*nkpts+K].base())+nocc_max*nmo_max,{nocc_max*nmo_max});
+            SpMatrix_ref Gaj(GKK[1][K][K].base(),{nwalk,nocc_max*nmo_max});
             ma::product(ComplexType(1.),Gaj,haj_K,ComplexType(1.),E({0,nwalk},0));
           }
 #endif
@@ -973,7 +973,7 @@ public:
         if(TMats.num_elements() < local_memory_needs) { 
           TMats = std::move(SpVector(iextensions<1u>{local_memory_needs})); 
           using std::fill_n;
-          fill_n(TMats.origin(),TMats.num_elements(),SPComplexType(0.0));
+          fill_n(TMats.base(),TMats.num_elements(),SPComplexType(0.0));
         }
         size_t local_cnt=0; 
         RealType scl = (walker_type==CLOSED?2.0:1.0);
@@ -993,18 +993,18 @@ public:
                   int na = nelpk[nd][Ka];
                   int nk = nopk[Kk];
 
-                  SpMatrix_ref Gal(GKK[0][Ka][Kl].origin()+n*na*nl,{na,nl});
-                  SpMatrix_ref Gbk(GKK[0][Kb][Kk].origin()+n*nb*nk,{nb,nk});
-                  SpMatrix_ref Lank(sp_pointer(LQKank[nd*nspin*nkpts+Q][Ka].origin()),
+                  SpMatrix_ref Gal(GKK[0][Ka][Kl].base()+n*na*nl,{na,nl});
+                  SpMatrix_ref Gbk(GKK[0][Kb][Kk].base()+n*nb*nk,{nb,nk});
+                  SpMatrix_ref Lank(sp_pointer(LQKank[nd*nspin*nkpts+Q][Ka].base()),
                                                  {na*nchol,nk});
-                  auto bnl_ptr(sp_pointer(LQKank[nd*nspin*nkpts+Qm][Kb].origin()));
-                  if( Q == Qm ) bnl_ptr = sp_pointer(LQKbnl[nd*nspin*number_of_symmetric_Q+Qmap[Q]-1][Kb].origin());
+                  auto bnl_ptr(sp_pointer(LQKank[nd*nspin*nkpts+Qm][Kb].base()));
+                  if( Q == Qm ) bnl_ptr = sp_pointer(LQKbnl[nd*nspin*number_of_symmetric_Q+Qmap[Q]-1][Kb].base());
                   SpMatrix_ref Lbnl(bnl_ptr,{nb*nchol,nl});
 
-                  SpMatrix_ref Tban(TMats.origin()+local_cnt,{nb,na*nchol});
-                  Sp3Tensor_ref T3Dban(TMats.origin()+local_cnt,{nb,na,nchol});
-                  SpMatrix_ref Tabn(Tban.origin()+Tban.num_elements(),{na,nb*nchol});
-                  Sp3Tensor_ref T3Dabn(Tban.origin()+Tban.num_elements(),{na,nb,nchol});
+                  SpMatrix_ref Tban(TMats.base()+local_cnt,{nb,na*nchol});
+                  Sp3Tensor_ref T3Dban(TMats.base()+local_cnt,{nb,na,nchol});
+                  SpMatrix_ref Tabn(Tban.base()+Tban.num_elements(),{na,nb*nchol});
+                  Sp3Tensor_ref T3Dabn(Tban.base()+Tban.num_elements(),{na,nb,nchol});
 
                   ma::product(Gal,ma::T(Lbnl),Tabn);
                   ma::product(Gbk,ma::T(Lank),Tban);
@@ -1029,19 +1029,19 @@ public:
                     int na = nelpk[nd][nkpts+Ka];
                     int nk = nopk[Kk];
 
-                    SpMatrix_ref Gal(GKK[1][Ka][Kl].origin()+n*na*nl,{na,nl});
-                    SpMatrix_ref Gbk(GKK[1][Kb][Kk].origin()+n*nb*nk,{nb,nk});
-                    SpMatrix_ref Lank(sp_pointer(LQKank[(nd*nspin+1)*nkpts+Q][Ka].origin()),
+                    SpMatrix_ref Gal(GKK[1][Ka][Kl].base()+n*na*nl,{na,nl});
+                    SpMatrix_ref Gbk(GKK[1][Kb][Kk].base()+n*nb*nk,{nb,nk});
+                    SpMatrix_ref Lank(sp_pointer(LQKank[(nd*nspin+1)*nkpts+Q][Ka].base()),
                                                  {na*nchol,nk});
-                    auto bnl_ptr(sp_pointer(LQKank[nd*nspin*nkpts+Qm][Kb].origin()));
+                    auto bnl_ptr(sp_pointer(LQKank[nd*nspin*nkpts+Qm][Kb].base()));
                     if( Q == Qm ) bnl_ptr = sp_pointer(LQKbnl[(nd*nspin+1)*number_of_symmetric_Q+
-                                                                Qmap[Q]-1][Kb].origin());
+                                                                Qmap[Q]-1][Kb].base());
                     SpMatrix_ref Lbnl(bnl_ptr,{nb*nchol,nl});
 
-                    SpMatrix_ref Tban(TMats.origin()+local_cnt,{nb,na*nchol});
-                    Sp3Tensor_ref T3Dban(TMats.origin()+local_cnt,{nb,na,nchol});
-                    SpMatrix_ref Tabn(Tban.origin()+Tban.num_elements(),{na,nb*nchol});
-                    Sp3Tensor_ref T3Dabn(Tban.origin()+Tban.num_elements(),{na,nb,nchol});
+                    SpMatrix_ref Tban(TMats.base()+local_cnt,{nb,na*nchol});
+                    Sp3Tensor_ref T3Dban(TMats.base()+local_cnt,{nb,na,nchol});
+                    SpMatrix_ref Tabn(Tban.base()+Tban.num_elements(),{na,nb*nchol});
+                    Sp3Tensor_ref T3Dabn(Tban.base()+Tban.num_elements(),{na,nb,nchol});
   
                     ma::product(Gal,ma::T(Lbnl),Tabn);
                     ma::product(Gbk,ma::T(Lank),Tban);
@@ -1065,15 +1065,15 @@ public:
         if(TMats.num_elements() < local_memory_needs) { 
           TMats = std::move(SpVector(iextensions<1u>{local_memory_needs}));
           using std::fill_n;
-          fill_n(TMats.origin(),TMats.num_elements(),SPComplexType(0.0));
+          fill_n(TMats.base(),TMats.num_elements(),SPComplexType(0.0));
         }
         cnt=0; 
-        SpMatrix_ref Kr_local(TMats.origin(),{nwalk,nchol_max}); 
+        SpMatrix_ref Kr_local(TMats.base(),{nwalk,nchol_max}); 
         cnt+=Kr_local.num_elements();
-        SpMatrix_ref Kl_local(TMats.origin()+cnt,{nwalk,nchol_max}); 
+        SpMatrix_ref Kl_local(TMats.base()+cnt,{nwalk,nchol_max}); 
         cnt+=Kl_local.num_elements();
-        fill_n(Kr_local.origin(),Kr_local.num_elements(),SPComplexType(0.0));
-        fill_n(Kl_local.origin(),Kl_local.num_elements(),SPComplexType(0.0));
+        fill_n(Kr_local.base(),Kr_local.num_elements(),SPComplexType(0.0));
+        fill_n(Kl_local.base(),Kl_local.num_elements(),SPComplexType(0.0));
         size_t nqk=1;  
         for(int Q=0; Q<nkpts; ++Q) {
           bool haveKE=false;
@@ -1088,12 +1088,12 @@ public:
               int na = nelpk[nd][Ka];
               int nk = nopk[Kk];
 
-              Sp3Tensor_ref Gwal(GKK[0][Ka][Kl].origin(),{nwalk,na,nl});
-              Sp3Tensor_ref Gwbk(GKK[0][Ka][Kk].origin(),{nwalk,na,nk});
-              Sp3Tensor_ref Lank(sp_pointer(LQKank[nd*nspin*nkpts+Q][Ka].origin()),
+              Sp3Tensor_ref Gwal(GKK[0][Ka][Kl].base(),{nwalk,na,nl});
+              Sp3Tensor_ref Gwbk(GKK[0][Ka][Kk].base(),{nwalk,na,nk});
+              Sp3Tensor_ref Lank(sp_pointer(LQKank[nd*nspin*nkpts+Q][Ka].base()),
                                                  {na,nchol,nk});
-              auto bnl_ptr(sp_pointer(LQKank[nd*nspin*nkpts+Qm][Ka].origin()));
-              if( Q == Qm ) bnl_ptr = sp_pointer(LQKbnl[nd*nspin*number_of_symmetric_Q+Qmap[Q]-1][Ka].origin());
+              auto bnl_ptr(sp_pointer(LQKank[nd*nspin*nkpts+Qm][Ka].base()));
+              if( Q == Qm ) bnl_ptr = sp_pointer(LQKbnl[nd*nspin*number_of_symmetric_Q+Qmap[Q]-1][Ka].base());
               Sp3Tensor_ref Lbnl(bnl_ptr,{na,nchol,nl});
 
               // Twan = sum_l G[w][a][l] L[a][n][l]
@@ -1119,12 +1119,12 @@ public:
                 int na = nelpk[nd][nkpts+Ka];
                 int nk = nopk[Kk];
 
-                Sp3Tensor_ref Gwal(GKK[1][Ka][Kl].origin(),{nwalk,na,nl});
-                Sp3Tensor_ref Gwbk(GKK[1][Ka][Kk].origin(),{nwalk,na,nk});
-                Sp3Tensor_ref Lank(sp_pointer(LQKank[(nd*nspin+1)*nkpts+Q][Ka].origin()),
+                Sp3Tensor_ref Gwal(GKK[1][Ka][Kl].base(),{nwalk,na,nl});
+                Sp3Tensor_ref Gwbk(GKK[1][Ka][Kk].base(),{nwalk,na,nk});
+                Sp3Tensor_ref Lank(sp_pointer(LQKank[(nd*nspin+1)*nkpts+Q][Ka].base()),
                                                  {na,nchol,nk});
-                auto bnl_ptr(sp_pointer(LQKank[(nd*nspin+1)*nkpts+Qm][Ka].origin()));
-                if( Q == Qm ) bnl_ptr = sp_pointer(LQKbnl[(nd*nspin+1)*number_of_symmetric_Q+Qmap[Q]-1][Ka].origin());
+                auto bnl_ptr(sp_pointer(LQKank[(nd*nspin+1)*nkpts+Qm][Ka].base()));
+                if( Q == Qm ) bnl_ptr = sp_pointer(LQKbnl[(nd*nspin+1)*number_of_symmetric_Q+Qmap[Q]-1][Ka].base());
                 Sp3Tensor_ref Lbnl(bnl_ptr,{na,nchol,nl});
 
                 // Twan = sum_l G[w][a][l] L[a][n][l]
@@ -1151,8 +1151,8 @@ public:
             }
           } // to release the lock
           if(haveKE) { 
-            fill_n(Kr_local.origin(),Kr_local.num_elements(),SPComplexType(0.0));
-            fill_n(Kl_local.origin(),Kl_local.num_elements(),SPComplexType(0.0));
+            fill_n(Kr_local.base(),Kr_local.num_elements(),SPComplexType(0.0));
+            fill_n(Kl_local.base(),Kl_local.num_elements(),SPComplexType(0.0));
           }  
         } // Q
         nqk=0;  
@@ -1188,8 +1188,8 @@ public:
   {
     using BType = typename std::decay<MatB>::type::element;
     using AType = typename std::decay<MatA>::type::element;
-    boost::multi::array_ref<AType, 2, decltype(X.origin())> X_(X.origin(), {X.size(), 1});
-    boost::multi::array_ref<BType, 2, decltype(v.origin())> v_(v.origin(), {1, v.size()});
+    boost::multi::array_ref<AType, 2, decltype(X.base())> X_(X.base(), {X.size(), 1});
+    boost::multi::array_ref<BType, 2, decltype(v.base())> v_(v.base(), {1, v.size()});
     return vHS(X_, v_, a, c);
   }
 
@@ -1221,18 +1221,18 @@ public:
 
     Static3Tensor vKK({nkpts + number_of_symmetric_Q, nkpts, nwalk * nmo_max * nmo_max},
                       device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    fill_n(vKK.origin(), vKK.num_elements(), SPComplexType(0.0));
+    fill_n(vKK.base(), vKK.num_elements(), SPComplexType(0.0));
     Static4Tensor XQnw({nkpts, 2, nchol_max, nwalk},
                        device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    fill_n(XQnw.origin(), XQnw.num_elements(), SPComplexType(0.0));
+    fill_n(XQnw.base(), XQnw.num_elements(), SPComplexType(0.0));
 
     // "rotate" X
     //  XIJ = 0.5*a*(Xn+ -i*Xn-), XJI = 0.5*a*(Xn+ +i*Xn-)
 #if defined(MIXED_PRECISION)
-    StaticMatrix Xdev(X.extensions(), device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    copy_n_cast(make_device_ptr(X.origin()), X.num_elements(), Xdev.origin());
+    StaticMatrix Xdev(X.extents(), device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    copy_n_cast(make_device_ptr(X.base()), X.num_elements(), Xdev.base());
 #else
-    SpMatrix_ref Xdev(make_device_ptr(X.origin()), X.extensions());
+    SpMatrix_ref Xdev(make_device_ptr(X.base()), X.extents());
 #endif
     for (int Q = 0; Q < nkpts; ++Q)
     {
@@ -1278,9 +1278,9 @@ public:
         for (int K = 0; K < nkpts; ++K)
         { // K is the index of the kpoint pair of (i,k)
           int QK = QKToK2[Q][K];
-          Aarray.push_back(sp_pointer(LQKikn[Q][K].origin()));
-          Barray.push_back(XQnw[Q][0].origin());
-          Carray.push_back(vKK[K][QK].origin());
+          Aarray.push_back(sp_pointer(LQKikn[Q][K].base()));
+          Barray.push_back(XQnw[Q][0].base());
+          Carray.push_back(vKK[K][QK].base());
         }
       }
     }
@@ -1302,9 +1302,9 @@ public:
         for (int K = 0; K < nkpts; ++K)
         { // K is the index of the kpoint pair of (i,k)
           int QK = QKToK2[Q][K];
-          Aarray.push_back(sp_pointer(LQKikn[kminus[Q]][QK].origin()));
-          Barray.push_back(XQnw[Q][0].origin());
-          Carray.push_back(vKK[K][QK].origin());
+          Aarray.push_back(sp_pointer(LQKikn[kminus[Q]][QK].base()));
+          Barray.push_back(XQnw[Q][0].base());
+          Carray.push_back(vKK[K][QK].base());
         }
       }
       else if (Qmap[Q] > 0)
@@ -1312,9 +1312,9 @@ public:
         for (int K = 0; K < nkpts; ++K)
         { // K is the index of the kpoint pair of (i,k)
           int QK = QKToK2[Q][K];
-          Aarray.push_back(sp_pointer(LQKikn[Q][K].origin()));
-          Barray.push_back(XQnw[Q][1].origin());
-          Carray.push_back(vKK[nkpts + Qmap[Q] - 1][QK].origin());
+          Aarray.push_back(sp_pointer(LQKikn[Q][K].base()));
+          Barray.push_back(XQnw[Q][1].base());
+          Carray.push_back(vKK[nkpts + Qmap[Q] - 1][QK].base());
         }
       }
     }
@@ -1324,7 +1324,7 @@ public:
 
 
     using vType = typename std::decay<MatB>::type::element;
-    boost::multi::array_ref<vType, 3, decltype(make_device_ptr(v.origin()))> v3D(make_device_ptr(v.origin()),
+    boost::multi::array_ref<vType, 3, decltype(make_device_ptr(v.base()))> v3D(make_device_ptr(v.base()),
                                                                                  {nwalk, nmo_tot, nmo_tot});
     vKKwij_to_vwKiKj(vKK, v3D);
     // do I need to "rotate" back, can be done if necessary
@@ -1342,8 +1342,8 @@ public:
   {
     using BType = typename std::decay<MatB>::type::element;
     using AType = typename std::decay<MatA>::type::element;
-    boost::multi::array_ref<BType, 2, decltype(v.origin())> v_(v.origin(), {v.size(), 1});
-    boost::multi::array_ref<AType const, 2, decltype(G.origin())> G_(G.origin(), {G.size(), 1});
+    boost::multi::array_ref<BType, 2, decltype(v.base())> v_(v.base(), {v.size(), 1});
+    boost::multi::array_ref<AType const, 2, decltype(G.base())> G_(G.base(), {G.size(), 1});
     return vbias(G_, v_, a, c, k);
   }
 
@@ -1402,10 +1402,10 @@ public:
     assert(G.num_elements() == nwalk * (nocca_tot + noccb_tot) * npol * nmo_tot);
     // MAM: use reshape when available, then no need to deal with types
     using GType = typename std::decay<MatA>::type::element;
-    boost::multi::array_ref<GType const, 3, decltype(make_device_ptr(G.origin()))> G3Da(make_device_ptr(G.origin()),
+    boost::multi::array_ref<GType const, 3, decltype(make_device_ptr(G.base()))> G3Da(make_device_ptr(G.base()),
                                                                                         {nocca_tot * npol, nmo_tot,
                                                                                          nwalk});
-    boost::multi::array_ref<GType const, 3, decltype(make_device_ptr(G.origin()))> G3Db(make_device_ptr(G.origin()) +
+    boost::multi::array_ref<GType const, 3, decltype(make_device_ptr(G.base()))> G3Db(make_device_ptr(G.base()) +
                                                                                             G3Da.num_elements() *
                                                                                                 (nspin - 1),
                                                                                         {noccb_tot, nmo_tot, nwalk});
@@ -1420,8 +1420,8 @@ public:
                        device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
       Static3Tensor GQ({nkpts, nkpts * nocc_max * npol * nmo_max, nwalk},
                        device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
-      fill_n(v1.origin(), v1.num_elements(), SPComplexType(0.0));
-      fill_n(GQ.origin(), GQ.num_elements(), SPComplexType(0.0));
+      fill_n(v1.base(), v1.num_elements(), SPComplexType(0.0));
+      fill_n(GQ.base(), GQ.num_elements(), SPComplexType(0.0));
 
       if (spin == 0)
         GKaKjw_to_GQKajw(G3Da, GQ, nelpk[nd], dev_nelpk[nd], dev_a0pk[nd]);
@@ -1443,15 +1443,15 @@ public:
           continue;
         // v_[Q][n][w] = sum_Kak LQ[Kak][n]*G[Q][Kak][w]
         //             F: -->   G[Kak][w] * LQ[Kak][n]
-        Aarray.push_back(GQ[Q].origin());
-        Barray.push_back(sp_pointer(LQKakn[nd * nspin * nkpts + spin * nkpts + Q].origin()));
-        Carray.push_back(v1[Q].origin());
+        Aarray.push_back(GQ[Q].base());
+        Barray.push_back(sp_pointer(LQKakn[nd * nspin * nkpts + spin * nkpts + Q].base()));
+        Carray.push_back(v1[Q].base());
         if (Qmap[Q] > 0)
         {
-          Aarray.push_back(GQ[Q].origin());
+          Aarray.push_back(GQ[Q].base());
           Barray.push_back(sp_pointer(
-              LQKbln[nd * nspin * number_of_symmetric_Q + spin * number_of_symmetric_Q + Qmap[Q] - 1].origin()));
-          Carray.push_back(v1[nkpts + Qmap[Q] - 1].origin());
+              LQKbln[nd * nspin * number_of_symmetric_Q + spin * number_of_symmetric_Q + Qmap[Q] - 1].base()));
+          Carray.push_back(v1[nkpts + Qmap[Q] - 1].base());
         }
       }
       gemmBatched('N', 'T', nwalk, nchol_max, Kak, SPComplexType(1.0), Aarray.data(), nwalk, Barray.data(), nchol_max,
@@ -1601,8 +1601,8 @@ private:
     assert(GKKaj.num_elements() >= nkpts * nkpts * nwalk * nocc_max * npol * nmo_max);
 
     using ma::KaKjw_to_KKwaj;
-    KaKjw_to_KKwaj(nwalk, nkpts, npol, nmo_max, nmo_tot, nocc_max, dev_nopk.origin(), dev_i0pk.origin(),
-                   dev_no.origin(), dev_a0.origin(), GKaKj.origin(), GKKaj.origin());
+    KaKjw_to_KKwaj(nwalk, nkpts, npol, nmo_max, nmo_tot, nocc_max, dev_nopk.base(), dev_i0pk.base(),
+                   dev_no.base(), dev_a0.base(), GKaKj.base(), GKKaj.base());
   }
 
   template<class MatA, class MatB, class IVec, class IVec2>
@@ -1619,8 +1619,8 @@ private:
     assert(GQKaj.num_elements() >= nkpts * nkpts * nwalk * nocc_max * npol * nmo_max);
 
     using ma::KaKjw_to_QKajw;
-    KaKjw_to_QKajw(nwalk, nkpts, npol, nmo_max, nmo_tot, nocc_max, dev_nopk.origin(), dev_i0pk.origin(),
-                   dev_no.origin(), dev_a0.origin(), dev_QKToK2.origin(), GKaKj.origin(), GQKaj.origin());
+    KaKjw_to_QKajw(nwalk, nkpts, npol, nmo_max, nmo_tot, nocc_max, dev_nopk.base(), dev_i0pk.base(),
+                   dev_no.base(), dev_a0.base(), dev_QKToK2.base(), GKaKj.base(), GQKaj.base());
   }
 
 
@@ -1639,8 +1639,8 @@ private:
     int nkpts   = nopk.size();
 
     using ma::vKKwij_to_vwKiKj;
-    vKKwij_to_vwKiKj(nwalk, nkpts, nmo_max, nmo_tot, KKTransID.origin(), dev_nopk.origin(), dev_i0pk.origin(),
-                     vKK.origin(), vKiKj.origin());
+    vKKwij_to_vwKiKj(nwalk, nkpts, nmo_max, nmo_tot, KKTransID.base(), dev_nopk.base(), dev_i0pk.base(),
+                     vKK.base(), vKiKj.base());
   }
 
   template<class MatA, class MatB>
@@ -1654,10 +1654,10 @@ private:
     int nchol_max = *std::max_element(ncholpQ.begin(), ncholpQ.end());
 
     using ma::vbias_from_v1;
-    // using make_device_ptr(vbias.origin()) to catch errors here
-    vbias_from_v1(nwalk, nkpts, nchol_max, dev_Qmap.origin(), dev_kminus.origin(), dev_ncholpQ.origin(),
-                  dev_Q2vbias.origin(), static_cast<BType>(a), v1.origin(),
-                  to_address(make_device_ptr(vbias.origin())));
+    // using make_device_ptr(vbias.base()) to catch errors here
+    vbias_from_v1(nwalk, nkpts, nchol_max, dev_Qmap.base(), dev_kminus.base(), dev_ncholpQ.base(),
+                  dev_Q2vbias.base(), static_cast<BType>(a), v1.base(),
+                  to_address(make_device_ptr(vbias.base())));
   }
 };
 

--- a/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
@@ -144,9 +144,9 @@ public:
       {
         int nG = nGpk[Q];
         boost::multi::array<SPComplexType, 2> T({nG * rotnu, nG * rotnu});
-        std::copy_n(to_address(rotMuv[Q].origin()), rotMuv[Q].num_elements(), T.origin());
-        boost::multi::array_ref<SPComplexType, 4> Muv(to_address(rotMuv[Q].origin()), {nG, nG, rotnu, rotnu});
-        boost::multi::array_ref<SPComplexType, 4> T_(T.origin(), {nG, rotnu, nG, rotnu});
+        std::copy_n(to_address(rotMuv[Q].base()), rotMuv[Q].num_elements(), T.base());
+        boost::multi::array_ref<SPComplexType, 4> Muv(to_address(rotMuv[Q].base()), {nG, nG, rotnu, rotnu});
+        boost::multi::array_ref<SPComplexType, 4> T_(T.base(), {nG, rotnu, nG, rotnu});
         for (int G1 = 0; G1 < nG; G1++)
           for (int G2 = 0; G2 < nG; G2++)
             for (int u = 0; u < rotnu; u++)
@@ -209,12 +209,12 @@ public:
 
     // making a copy of vMF since it will be modified
     set_shm_buffer(vMF.size(0));
-    boost::multi::array_ref<ComplexType, 1> vMF_(to_address(SM_TMats.origin()), {vMF.size(0)});
+    boost::multi::array_ref<ComplexType, 1> vMF_(to_address(SM_TMats.base()), {vMF.size(0)});
 
-    boost::multi::array_ref<ComplexType, 1> P1D(to_address(P1.origin()), {NMO * NMO});
-    std::fill_n(P1D.origin(), P1D.num_elements(), ComplexType(0));
+    boost::multi::array_ref<ComplexType, 1> P1D(to_address(P1.base()), {NMO * NMO});
+    std::fill_n(P1D.base(), P1D.num_elements(), ComplexType(0));
     vHS(vMF_, P1D);
-    TG.TG().all_reduce_in_place_n(P1D.origin(), P1D.num_elements(), std::plus<>());
+    TG.TG().all_reduce_in_place_n(P1D.base(), P1D.num_elements(), std::plus<>());
 
     // add H1 + vn0 and symmetrize
     using ma::conj;
@@ -290,11 +290,11 @@ public:
       noccb_tot = std::accumulate(nelpk[nd].begin() + nkpts, nelpk[nd].begin() + 2 * nkpts, 0);
 
     for (int n = 0; n < nwalk; n++)
-      std::fill_n(E[n].origin(), 3, ComplexType(0.));
+      std::fill_n(E[n].base(), 3, ComplexType(0.));
 
     assert(Gc.num_elements() == nwalk * (nocca_tot + noccb_tot) * nmo_tot);
-    boost::multi::array_cref<ComplexType, 3> G3Da(to_address(Gc.origin()), {nwalk, nocca_tot, nmo_tot});
-    boost::multi::array_cref<ComplexType, 3> G3Db(to_address(Gc.origin()) + G3Da.num_elements() * (nspin - 1),
+    boost::multi::array_cref<ComplexType, 3> G3Da(to_address(Gc.base()), {nwalk, nocca_tot, nmo_tot});
+    boost::multi::array_cref<ComplexType, 3> G3Db(to_address(Gc.base()) + G3Da.num_elements() * (nspin - 1),
                                                   {nwalk, noccb_tot, nmo_tot});
 
     if (addH1)
@@ -304,7 +304,7 @@ public:
         E[n][0] = E0;
       for (int K = 0; K < nkpts; ++K)
       {
-        boost::multi::array_ref<ComplexType, 2> haj_K(to_address(haj[nd * nkpts + K].origin()),
+        boost::multi::array_ref<ComplexType, 2> haj_K(to_address(haj[nd * nkpts + K].base()),
                                                       {nelpk[nd][K], nopk[K]});
         for (int n = 0; n < nwalk; ++n)
         {
@@ -317,7 +317,7 @@ public:
         na += nelpk[nd][K];
         if (walker_type == COLLINEAR)
         {
-          boost::multi::array_ref<ComplexType, 2> haj_Kb(haj_K.origin() + haj_K.num_elements(),
+          boost::multi::array_ref<ComplexType, 2> haj_Kb(haj_K.base() + haj_K.num_elements(),
                                                          {nelpk[nd][nkpts + K], nopk[K]});
           for (int n = 0; n < nwalk; ++n)
           {
@@ -364,22 +364,22 @@ public:
       {
         assert(KEright->size(0) == nwalk && KEright->size(1) == nGu);
         assert(KEright->stride() == KEright->size(1));
-        Krptr = to_address(KEright->origin());
+        Krptr = to_address(KEright->base());
       }
       else
       {
-        Krptr = to_address(SM_TMats.origin()) + cnt;
+        Krptr = to_address(SM_TMats.base()) + cnt;
         cnt += nwalk * nGu;
       }
       if (getKl)
       {
         assert(KEleft->size(0) == nwalk && KEleft->size(1) == nGu);
         assert(KEleft->stride() == KEleft->size(1));
-        Klptr = to_address(KEleft->origin());
+        Klptr = to_address(KEleft->base());
       }
       else
       {
-        Klptr = to_address(SM_TMats.origin()) + cnt;
+        Klptr = to_address(SM_TMats.base()) + cnt;
         cnt += nwalk * nGu;
       }
       if (comm->root())
@@ -406,17 +406,17 @@ public:
         TMats.reextent({local_memory_needs, 1});
 
       // Fuv[k1][k2][u][v] = sum_a_l rotcPua[u][k1][a] * G[k1][a][k2][l] rotPiu[k2][l][v]
-      boost::multi::array_ref<SPComplexType, 4> Fuv(to_address(SM_TMats.origin()) + cnt, {nkpts, nkpts, rotnu, rotnu});
+      boost::multi::array_ref<SPComplexType, 4> Fuv(to_address(SM_TMats.base()) + cnt, {nkpts, nkpts, rotnu, rotnu});
       cnt += Fuv.num_elements();
 
       size_t cnt_local = 0;
-      boost::multi::array_ref<SPComplexType, 2> TAv(TMats.origin() + cnt_local, {nocca_tot, rotnu});
+      boost::multi::array_ref<SPComplexType, 2> TAv(TMats.base() + cnt_local, {nocca_tot, rotnu});
       cnt_local += TAv.num_elements();
 
       // avoiding vectors for now
-      SpVector_ref Zu(TMats.origin() + cnt_local, {rotnu});
+      SpVector_ref Zu(TMats.base() + cnt_local, {rotnu});
       cnt_local += Zu.num_elements();
-      std::fill_n(Zu.origin(), Zu.num_elements(), SPComplexType(0.0));
+      std::fill_n(Zu.base(), Zu.num_elements(), SPComplexType(0.0));
 
       for (int n = 0; n < nwalk; ++n)
       {
@@ -452,33 +452,33 @@ public:
             {
               if ((nqk++) % comm->size() == comm->rank())
               {
-                boost::multi::array_ref<SPComplexType, 4> Muv(to_address(rotMuv[Q].origin()), {nG, nG, rotnu, rotnu});
+                boost::multi::array_ref<SPComplexType, 4> Muv(to_address(rotMuv[Q].base()), {nG, nG, rotnu, rotnu});
                 auto&& KlQa(Kl[n].sliced(nqGa, nqGa + rotnu));
                 auto&& KrQa(Kr[n].sliced(nqGa, nqGa + rotnu));
-                std::fill_n(KlQa.origin(), KlQa.num_elements(), SPComplexType(0.0));
-                std::fill_n(KrQa.origin(), KrQa.num_elements(), SPComplexType(0.0));
+                std::fill_n(KlQa.base(), KlQa.num_elements(), SPComplexType(0.0));
+                std::fill_n(KrQa.base(), KrQa.num_elements(), SPComplexType(0.0));
                 // Kl(n,Q,Ga,u) = sum_K_in_Ga F(K,Q[K],u,u)
                 for (int Ka = 0; Ka < nkpts; ++Ka)
                 {
                   if (QKToG[Q][Ka] != Ga)
                     continue;
                   int Kk = QKToK2[Q][Ka];
-                  auto f_(Fuv[Ka][Kk].origin());
-                  auto ku_(KlQa.origin());
+                  auto f_(Fuv[Ka][Kk].base());
+                  auto ku_(KlQa.base());
                   for (int u = 0; u < rotnu; u++, ku_++, f_ += (rotnu + 1))
                     (*ku_) += (*f_);
                 }
                 // Kr(n,Q,Ga,u) = sum_Gl sum_v M(Q,Ga,Gl)(u,v) sum_K_in_Gl F(Q[K],K,u,u)
                 for (int Gl = 0; Gl < nG; ++Gl)
                 {
-                  std::fill_n(Zu.origin(), Zu.num_elements(), SPComplexType(0.0));
+                  std::fill_n(Zu.base(), Zu.num_elements(), SPComplexType(0.0));
                   for (int Kl = 0; Kl < nkpts; ++Kl)
                   {
                     if (QKToG[Q][Kl] != Gl)
                       continue;
                     int Kb = QKToK2[Q][Kl];
-                    auto f_(Fuv[Kb][Kl].origin());
-                    auto zu_(Zu.origin());
+                    auto f_(Fuv[Kb][Kl].base());
+                    auto zu_(Zu.base());
                     for (int u = 0; u < rotnu; u++, zu_++, f_ += (rotnu + 1))
                       (*zu_) += (*f_);
                   }
@@ -486,12 +486,12 @@ public:
                 }
                 /*
                   for(int Gb=0; Gb<nG; ++Gb) {
-                    std::fill_n(Zu.origin(),Zu.num_elements(),SPComplexType(0.0));
+                    std::fill_n(Zu.base(),Zu.num_elements(),SPComplexType(0.0));
                     for(int Kb=0; Kb<nkpts; ++Kb) {
                       if(QKToG[Q][Kb] != Gb) continue;
                       int Kl = QKToK2[kminus[Q]][Kb];
-                      auto f_(Fuv[Kb][Kl].origin());
-                      auto zu_(Zu.origin());
+                      auto f_(Fuv[Kb][Kl].base());
+                      auto zu_(Zu.base());
                       for(int u=0; u<rotnu; u++, zu_++, f_ += (rotnu+1))
                         (*zu_) += (*f_);
                     }
@@ -511,7 +511,7 @@ public:
         for (int Q = 0; Q < nkpts; ++Q)
         { // momentum conservation index
           int nG = nGpk[Q];
-          boost::multi::array_ref<SPComplexType, 4> Muv(to_address(rotMuv[Q].origin()), {nG, nG, rotnu, rotnu});
+          boost::multi::array_ref<SPComplexType, 4> Muv(to_address(rotMuv[Q].base()), {nG, nG, rotnu, rotnu});
           for (int K1 = 0; K1 < nkpts; ++K1)
           {
             for (int K2 = 0; K2 < nkpts; ++K2)
@@ -523,9 +523,9 @@ public:
                 // EXX += sum_u_v Muv[u][v] * Fuv[K1][K2][u][v] * Fuv[QK2][QK1][v][u]
                 ComplexType E_(0.0);
                 //                  int nq = nG2pk[Q] + QKToG[Q][K1]*nG + QKToG[Q][K2];
-                auto F1_(to_address(Fuv[K1][K2].origin()));
-                auto muv_(Muv[QKToG[Q][K1]][QKToG[Q][K1]].origin());
-                auto F2_(to_address(Fuv[QK2][QK1].origin()));
+                auto F1_(to_address(Fuv[K1][K2].base()));
+                auto muv_(Muv[QKToG[Q][K1]][QKToG[Q][K1]].base());
+                auto F2_(to_address(Fuv[QK2][QK1].base()));
                 for (int u = 0; u < rotnu; ++u, ++F2_)
                 {
                   auto Fv_(F2_);
@@ -591,8 +591,8 @@ public:
            typename = void>
   void vHS(MatA& X, MatB&& v, double a = 1., double c = 0.)
   {
-    boost::multi::array_ref<ComplexType, 2> X_(to_address(X.origin()), {X.size(0), 1});
-    boost::multi::array_ref<ComplexType, 2> v_(to_address(v.origin()), {1, v.size(0)});
+    boost::multi::array_ref<ComplexType, 2> X_(to_address(X.base()), {X.size(0), 1});
+    boost::multi::array_ref<ComplexType, 2> v_(to_address(v.base()), {1, v.size(0)});
     vHS(X_, v_, a, c);
   }
 
@@ -619,14 +619,14 @@ public:
     if (TMats.num_elements() < local_memory_needs)
       TMats.reextent({local_memory_needs, 1});
     size_t cnt = 0;
-    SpMatrix_ref Twu(TMats.origin(), {nwalk, nu});
+    SpMatrix_ref Twu(TMats.base(), {nwalk, nu});
     cnt += Twu.num_elements();
-    auto vik_ptr(TMats.origin() + cnt);
+    auto vik_ptr(TMats.base() + cnt);
     cnt += nwalk * nmo_max * nmo_max;
-    auto Qniu_ptr(TMats.origin() + cnt);
+    auto Qniu_ptr(TMats.base() + cnt);
     cnt += nwalk * nu * nmo_max;
 
-    Sp3Tensor_ref v3D(to_address(v.origin()), {nwalk, nmo_tot, nmo_tot});
+    Sp3Tensor_ref v3D(to_address(v.base()), {nwalk, nmo_tot, nmo_tot});
 
     // "rotate" X
     //  XIJ = 0.5*a*(Xn+ -i*Xn-), XJI = 0.5*a*(Xn+ +i*Xn-)
@@ -634,8 +634,8 @@ public:
     {
       int nc0, ncN;
       std::tie(nc0, ncN) = FairDivideBoundary(comm->rank(), ncholpQ[Q], comm->size());
-      auto Xnp           = to_address(X[nq + nc0].origin());
-      auto Xnm           = to_address(X[nq + ncholpQ[Q] + nc0].origin());
+      auto Xnp           = to_address(X[nq + nc0].base());
+      auto Xnm           = to_address(X[nq + ncholpQ[Q] + nc0].base());
       for (int n = nc0; n < ncN; ++n)
       {
         for (int nw = 0; nw < nwalk; ++nw, ++Xnp, ++Xnm)
@@ -651,7 +651,7 @@ public:
     {
       size_t i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(size_t(comm->rank()), size_t(v.num_elements()), size_t(comm->size()));
-      auto v_          = to_address(v.origin()) + i0;
+      auto v_          = to_address(v.base()) + i0;
       for (size_t i = i0; i < iN; ++i, ++v_)
         *v_ *= c;
     }
@@ -685,10 +685,10 @@ public:
             auto Qniu_(Qniu_ptr);
             for (int n = 0; n < nwalk; ++n)
             {
-              auto p_(to_address(Piu[ni0].origin()));
+              auto p_(to_address(Piu[ni0].base()));
               for (int i = 0; i < ni; ++i)
               {
-                auto Tu(Twu[n].origin());
+                auto Tu(Twu[n].base());
                 for (int u = 0; u < nu; ++u, ++p_, ++Qniu_, ++Tu)
                   (*Qniu_) = (*Tu) * conj(*p_);
               }
@@ -698,10 +698,10 @@ public:
 
             // it is possible to add the second half here by calculating the (Q*,K*) pair that maps
             // to the JI term corresponding to this (Q,K) pair. Not doing it for now
-            auto vik_(vik.origin());
+            auto vik_(vik.base());
             for (int n = 0; n < nwalk; n++)
             {
-              auto v_(v3D[n][ni0].origin() + nk0);
+              auto v_(v3D[n][ni0].base() + nk0);
               for (int i = 0; i < ni; i++, vik_ += nk, v_ += nmo_tot)
                 ma::axpy(nk, one, vik_, 1, v_, 1);
             }
@@ -738,10 +738,10 @@ public:
             auto Qnku_(Qniu_ptr);
             for (int n = 0; n < nwalk; ++n)
             {
-              auto p_(to_address(Piu[nk0].origin()));
+              auto p_(to_address(Piu[nk0].base()));
               for (int k = 0; k < nk; ++k)
               {
-                auto Tu(Twu[n].origin());
+                auto Tu(Twu[n].base());
                 for (int u = 0; u < nu; ++u, ++p_, ++Qnku_, ++Tu)
                   (*Qnku_) = (*Tu) * conj(*p_);
               }
@@ -751,10 +751,10 @@ public:
 
             // it is possible to add the second half here by calculating the (Q*,K*) pair that maps
             // to the JI term corresponding to this (Q,K) pair. Not doing it for now
-            auto vki_(vki.origin());
+            auto vki_(vki.base());
             for (int n = 0; n < nwalk; n++)
             {
-              auto v_(v3D[n][nk0].origin() + ni0);
+              auto v_(v3D[n][nk0].base() + ni0);
               for (int k = 0; k < nk; k++, vki_ += ni, v_ += nmo_tot)
                 ma::axpy(ni, one, vki_, 1, v_, 1);
             }
@@ -774,8 +774,8 @@ public:
            typename = void>
   void vbias(MatA const& G, MatB&& v, double a = 1., double c = 0., int k = 0)
   {
-    boost::multi::array_cref<ComplexType, 2> G_(to_address(G.origin()), {1, G.size(0)});
-    boost::multi::array_ref<ComplexType, 2> v_(to_address(v.origin()), {v.size(0), 1});
+    boost::multi::array_cref<ComplexType, 2> G_(to_address(G.base()), {1, G.size(0)});
+    boost::multi::array_ref<ComplexType, 2> v_(to_address(v.base()), {v.size(0), 1});
     vbias(G_, v_, a, c, k);
   }
 
@@ -829,15 +829,15 @@ public:
     size_t cnt                = 0;
     if (TMats.num_elements() < local_memory_needs)
       TMats.reextent({local_memory_needs, 1});
-    SpMatrix_ref vlocal(TMats.origin() + cnt, {nchol_max, 2 * nwalk});
+    SpMatrix_ref vlocal(TMats.base() + cnt, {nchol_max, 2 * nwalk});
     cnt += vlocal.num_elements();
-    auto Tua_ptr(TMats.origin() + cnt);
+    auto Tua_ptr(TMats.base() + cnt);
     cnt += (nu * nocca_max);
-    std::fill_n(vlocal.origin(), vlocal.num_elements(), SPComplexType(0.0));
-    SpMatrix_ref Fwu(TMats.origin() + cnt, {2 * nwalk, nu});
+    std::fill_n(vlocal.base(), vlocal.num_elements(), SPComplexType(0.0));
+    SpMatrix_ref Fwu(TMats.base() + cnt, {2 * nwalk, nu});
     cnt += Fwu.num_elements();
-    boost::multi::array_cref<ComplexType, 3> G3Da(to_address(G.origin()), {nwalk, nocca_tot, nmo_tot});
-    boost::multi::array_cref<ComplexType, 3> G3Db(to_address(G.origin()) + G3Da.num_elements() * (nspin - 1),
+    boost::multi::array_cref<ComplexType, 3> G3Da(to_address(G.base()), {nwalk, nocca_tot, nmo_tot});
+    boost::multi::array_cref<ComplexType, 3> G3Db(to_address(G.base()) + G3Da.num_elements() * (nspin - 1),
                                                   {nwalk, noccb_tot, nmo_tot});
     /*
 Timer.reset("T0");
@@ -856,13 +856,13 @@ Timer.start("T0");
       {
         int nG    = nGpk[Q];
         int nchol = ncholpQ[Q];
-        std::fill_n(vlocal.origin(), vlocal.num_elements(), SPComplexType(0.0));
+        std::fill_n(vlocal.base(), vlocal.num_elements(), SPComplexType(0.0));
         auto&& vloc = vlocal.sliced(0, nchol);
         auto&& v1   = vlocal({0, nchol}, {0, nwalk});
         auto&& v2   = vlocal({0, nchol}, {nwalk, 2 * nwalk});
         for (int G = 0; G < nG; ++G)
         {
-          std::fill_n(Fwu.origin(), Fwu.num_elements(), SPComplexType(0.0));
+          std::fill_n(Fwu.base(), Fwu.num_elements(), SPComplexType(0.0));
           for (int K = 0; K < nkpts; ++K)
           {
             if (QKToG[Q][K] != G)
@@ -884,7 +884,7 @@ Timer.start("T0");
             auto&& Piu2_(Piu.sliced(nk02, nk02 + nk2));
             SpMatrix_ref Tua2(Tua_ptr, {nu, na2});
 
-            auto Fu1(Fwu.origin());
+            auto Fu1(Fwu.base());
             for (int n = 0; n < nwalk; n++)
             {
               // Tua = sum_k T(Piu(k,u)) T(G[n](a,k))
@@ -893,8 +893,8 @@ Timer.start("T0");
               //Timer.stop("T1");
               //Timer.start("T3");
               // Fwu[w][u] = sum_a cPua(u,a) T(u,a)
-              auto Tua1_a(Tua1.origin());
-              auto cPua_nd_u(cPua_nd.origin() + na01);
+              auto Tua1_a(Tua1.base());
+              auto cPua_nd_u(cPua_nd.base() + na01);
               for (int u = 0; u < nu; u++, ++Fu1, cPua_nd_u += nA)
               {
                 auto cPua_nd_a(cPua_nd_u);
@@ -904,7 +904,7 @@ Timer.start("T0");
               //Timer.stop("T3");
             }
             // If LIK_n == conj(LKI_n), then v1(Q) = v2(-Q) and there is no need to calculate both components
-            auto Fu2(Fwu.origin() + nwalk * nu);
+            auto Fu2(Fwu.base() + nwalk * nu);
             for (int n = 0; n < nwalk; n++)
             {
               //Timer.start("T1");
@@ -912,8 +912,8 @@ Timer.start("T0");
               //Timer.stop("T1");
               //Timer.start("T3");
               // Fwu[w][u] = sum_a cPua(u,a) T(u,a)
-              auto Tua2_a(Tua2.origin());
-              auto cPua_nd_u(cPua_nd.origin() + na02);
+              auto Tua2_a(Tua2.base());
+              auto cPua_nd_u(cPua_nd.base() + na02);
               for (int u = 0; u < nu; u++, ++Fu2, cPua_nd_u += nA)
               {
                 auto cPua_nd_a(cPua_nd_u);
@@ -941,11 +941,11 @@ Timer.start("T0");
         /*
           for(int i=0; i<nchol; ++i) {
             // v+ = 0.5*a*(v1+v2)
-            axpy(nwalk, halfa, v1[i].origin(), 1, v[nc0+i].origin(), 1);
-            axpy(nwalk, halfa, v2[i].origin(), 1, v[nc0+i].origin(), 1);
+            axpy(nwalk, halfa, v1[i].base(), 1, v[nc0+i].base(), 1);
+            axpy(nwalk, halfa, v2[i].base(), 1, v[nc0+i].base(), 1);
           // v- = -0.5*a*i*(v1-v2)
-            axpy(nwalk, minusimhalfa, v1[i].origin(), 1, v[nc0+nchol+i].origin(), 1);
-            axpy(nwalk, imhalfa, v2[i].origin(), 1, v[nc0+nchol+i].origin(), 1);
+            axpy(nwalk, minusimhalfa, v1[i].base(), 1, v[nc0+nchol+i].base(), 1);
+            axpy(nwalk, imhalfa, v2[i].base(), 1, v[nc0+nchol+i].base(), 1);
           }
 */
       }

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
@@ -136,10 +136,10 @@ public:
     CMatrix H1({NMO, NMO});
 
     // add sum_n vMF*Spvn, vMF has local contribution only!
-    boost::multi::array_ref<ComplexType, 1> H1D(H1.origin(), {NMO * NMO});
-    std::fill_n(H1D.origin(), H1D.num_elements(), ComplexType(0));
+    boost::multi::array_ref<ComplexType, 1> H1D(H1.base(), {NMO * NMO});
+    std::fill_n(H1D.base(), H1D.num_elements(), ComplexType(0));
     vHS(vMF, H1D);
-    TG.TG().all_reduce_in_place_n(H1D.origin(), H1D.num_elements(), std::plus<>());
+    TG.TG().all_reduce_in_place_n(H1D.base(), H1D.num_elements(), std::plus<>());
 
     // add hij + vn0 and symmetrize
     using ma::conj;
@@ -268,12 +268,12 @@ public:
       {
         assert(get<0>(KEleft->sizes()) == nwalk && get<1>(KEleft->sizes()) == local_nCV);
         assert(KEleft->stride() == get<1>(KEleft->sizes()));
-        Klptr = to_address(KEleft->origin());
+        Klptr = to_address(KEleft->base());
       }
       else
 #endif
       {
-        Klptr = to_address(SM_TMats.origin()) + cnt;
+        Klptr = to_address(SM_TMats.base()) + cnt;
         cnt += Knr * Knc;
       }
       if (TG.TG_local().root())
@@ -286,7 +286,7 @@ public:
     SpCMatrix_ref Kl(Klptr, {long(Knr), long(Knc)});
 
     for (int n = 0; n < nwalk; n++)
-      std::fill_n(E[n].origin(), 3, ComplexType(0.));
+      std::fill_n(E[n].base(), 3, ComplexType(0.));
 
 
     // one-body contribution
@@ -294,9 +294,9 @@ public:
     // not parallelized for now, since it would require customization of Wfn
     if (addH1)
     {
-      boost::multi::array_cref<ComplexType, 1> haj_ref(to_address(haj[nd].origin()),
+      boost::multi::array_cref<ComplexType, 1> haj_ref(to_address(haj[nd].base()),
                                                        iextensions<1u>{haj[nd].num_elements()});
-      ma::product(ComplexType(1.), Gc, haj_ref, ComplexType(1.), E(E.extension(0), 0));
+      ma::product(ComplexType(1.), Gc, haj_ref, ComplexType(1.), E(get<0>(E.extents()), 0));
       for (int i = 0; i < nwalk; i++)
         E[i][0] += E0;
     }
@@ -313,43 +313,43 @@ public:
         size_t cnt_(cnt);
         SPComplexType* ptr(nullptr);
 #if defined(MIXED_PRECISION)
-        ptr = to_address(SM_TMats.origin()) + cnt_;
+        ptr = to_address(SM_TMats.base()) + cnt_;
         cnt_ += nwalk * nel[ispin] * NMO;
         for (int n = 0; n < nwalk; ++n)
         {
           if (n % TG.TG_local().size() != TG.TG_local().rank())
             continue;
-          copy_n_cast(to_address(Gc[n].origin()) + is0, nel[ispin] * NMO, ptr + n * nel[ispin] * NMO);
+          copy_n_cast(to_address(Gc[n].base()) + is0, nel[ispin] * NMO, ptr + n * nel[ispin] * NMO);
         }
         TG.TG_local().barrier();
 #else
         if (nspin == 1)
         {
-          ptr = to_address(Gc.origin());
+          ptr = const_cast<SPComplexType*>(to_address(Gc.base()));
         }
         else
         {
-          ptr = to_address(SM_TMats.origin()) + cnt_;
+          ptr = to_address(SM_TMats.base()) + cnt_;
           cnt_ += nwalk * nel[ispin] * NMO;
           for (int n = 0; n < nwalk; ++n)
           {
             if (n % TG.TG_local().size() != TG.TG_local().rank())
               continue;
-            std::copy_n(to_address(Gc[n].origin()) + is0, nel[ispin] * NMO, ptr + n * nel[ispin] * NMO);
+            std::copy_n(to_address(Gc[n].base()) + is0, nel[ispin] * NMO, ptr + n * nel[ispin] * NMO);
           }
           TG.TG_local().barrier();
         }
 #endif
 
         SpCMatrix_ref GF(ptr, {nwalk * nel[ispin], NMO});
-        SpCMatrix_ref Lan(to_address(Lank[nd * nspin + ispin].origin()), {nel[ispin] * local_nCV, NMO});
-        SpCMatrix_ref Twban(to_address(SM_TMats.origin()) + cnt_, {nwalk * nel[ispin], nel[ispin] * local_nCV});
-        SpC4Tensor_ref T4Dwban(Twban.origin(), {nwalk, nel[ispin], nel[ispin], local_nCV});
+        SpCMatrix_ref Lan(to_address(Lank[nd * nspin + ispin].base()), {nel[ispin] * local_nCV, NMO});
+        SpCMatrix_ref Twban(to_address(SM_TMats.base()) + cnt_, {nwalk * nel[ispin], nel[ispin] * local_nCV});
+        SpC4Tensor_ref T4Dwban(Twban.base(), {nwalk, nel[ispin], nel[ispin], local_nCV});
 
         long i0, iN;
         std::tie(i0, iN) =
             FairDivideBoundary(long(TG.TG_local().rank()), long(nel[ispin] * local_nCV), long(TG.TG_local().size()));
-        ma::product(GF, ma::T(Lan.sliced(i0, iN)), Twban(Twban.extension(0), {i0, iN}));
+        ma::product(GF, ma::T(Lan.sliced(i0, iN)), Twban(get<0>(Twban.extents()), {i0, iN}));
         TG.TG_local().barrier();
 
         for (int n = 0, an = 0; n < nwalk; ++n)
@@ -401,7 +401,7 @@ public:
         long i0, iN;
         std::tie(i0, iN) =
             FairDivideBoundary(long(TG.TG_local().rank()), long(KEleft->num_elements()), long(TG.TG_local().size()));
-        copy_n_cast(Klptr + i0, iN - i0, to_address(KEleft->origin()) + i0);
+        copy_n_cast(Klptr + i0, iN - i0, to_address(KEleft->base()) + i0);
       }
 #endif
       if (getKr)
@@ -409,7 +409,7 @@ public:
         long i0, iN;
         std::tie(i0, iN) =
             FairDivideBoundary(long(TG.TG_local().rank()), long(KEright->num_elements()), long(TG.TG_local().size()));
-        copy_n_cast(Klptr + i0, iN - i0, to_address(KEright->origin()) + i0);
+        copy_n_cast(Klptr + i0, iN - i0, to_address(KEright->base()) + i0);
       }
       TG.TG_local().barrier();
     }
@@ -432,8 +432,8 @@ public:
     using AType = typename std::decay<MatA>::type::element;
 
     using std::get;
-    boost::multi::array_ref<      BType, 2> v_(to_address(v.origin()), {get<0>(v.sizes()), 1});
-    boost::multi::array_ref<const AType, 2> X_(to_address(X.origin()), {get<0>(X.sizes()), 1});
+    boost::multi::array_ref<      BType, 2> v_(to_address(v.base()), {get<0>(v.sizes()), 1});
+    boost::multi::array_ref<const AType, 2> X_(to_address(X.base()), {get<0>(X.sizes()), 1});
     return vHS(X_, v_, a, c);
   }
 
@@ -464,33 +464,33 @@ public:
     // setup origin of Xsp and copy_n_cast if necessary
     if (std::is_same<XType, SPComplexType>::value)
     {
-      Xptr = reinterpret_cast<const_sp_pointer>(to_address(X.origin()));
+      Xptr = reinterpret_cast<const_sp_pointer>(to_address(X.base()));
     }
     else
     {
       long i0, iN;
       std::tie(i0, iN) =
           FairDivideBoundary(long(TG.TG_local().rank()), long(X.num_elements()), long(TG.TG_local().size()));
-      copy_n_cast(to_address(X.origin()) + i0, iN - i0, to_address(SM_TMats.origin()) + i0);
-      Xptr = to_address(SM_TMats.origin());
+      copy_n_cast(to_address(X.base()) + i0, iN - i0, to_address(SM_TMats.base()) + i0);
+      Xptr = to_address(SM_TMats.base());
     }
     // setup origin of vsp and copy_n_cast if necessary
     if (std::is_same<vType, SPComplexType>::value)
     {
-      vptr = reinterpret_cast<sp_pointer>(to_address(v.origin()));
+      vptr = reinterpret_cast<sp_pointer>(to_address(v.base()));
     }
     else
     {
       long i0, iN;
       std::tie(i0, iN) =
           FairDivideBoundary(long(TG.TG_local().rank()), long(v.num_elements()), long(TG.TG_local().size()));
-      vptr = to_address(SM_TMats.origin()) + Xmem;
+      vptr = to_address(SM_TMats.base()) + Xmem;
       if (std::abs(c) > 1e-12)
-        copy_n_cast(to_address(v.origin()) + i0, iN - i0, vptr + i0);
+        copy_n_cast(to_address(v.base()) + i0, iN - i0, vptr + i0);
     }
     // setup array references
-    boost::multi::array_cref<SPComplexType const, 2> Xsp(Xptr, X.extensions());
-    boost::multi::array_ref<SPComplexType, 2> vsp(vptr, v.extensions());
+    boost::multi::array_cref<SPComplexType const, 2> Xsp(Xptr, X.extents());
+    boost::multi::array_ref<SPComplexType, 2> vsp(vptr, v.extents());
     TG.TG_local().barrier();
 
     ma::product(SPValueType(a), Likn.sliced(ik0, ikN), Xsp, SPValueType(c), vsp.sliced(ik0, ikN));
@@ -498,7 +498,7 @@ public:
     using std::get;
     if (not std::is_same<vType, SPComplexType>::value)
     {
-      copy_n_cast(to_address(vsp[ik0].origin()), get<1>(vsp.sizes()) * (ikN - ik0), to_address(v[ik0].origin()));
+      copy_n_cast(to_address(vsp[ik0].base()), get<1>(vsp.sizes()) * (ikN - ik0), to_address(v[ik0].base()));
     }
     TG.TG_local().barrier();
   }
@@ -514,8 +514,8 @@ public:
 
     using BType = typename std::decay<MatB>::type::element;
     using AType = typename std::decay<MatA>::type::element;
-    boost::multi::array_ref<BType, 2> v_(to_address(v.origin()), {get<0>(v.sizes()), 1});
-    boost::multi::array_cref<AType, 2> G_(to_address(G.origin()), {get<0>(G.sizes()), 1});
+    boost::multi::array_ref<BType, 2> v_(to_address(v.base()), {get<0>(v.sizes()), 1});
+    boost::multi::array_cref<AType, 2> G_(to_address(G.base()), {get<0>(G.sizes()), 1});
     return vbias(G_, v_, a, c, k);
   }
 
@@ -541,33 +541,33 @@ public:
     // setup origin of Gsp and copy_n_cast if necessary
     if (std::is_same<GType, SPComplexType>::value)
     {
-      Gptr = reinterpret_cast<const_sp_pointer>(to_address(G.origin()));
+      Gptr = reinterpret_cast<const_sp_pointer>(to_address(G.base()));
     }
     else
     {
       long i0, iN;
       std::tie(i0, iN) =
           FairDivideBoundary(long(TG.TG_local().rank()), long(G.num_elements()), long(TG.TG_local().size()));
-      copy_n_cast(to_address(G.origin()) + i0, iN - i0, to_address(SM_TMats.origin()) + i0);
-      Gptr = to_address(SM_TMats.origin());
+      copy_n_cast(to_address(G.base()) + i0, iN - i0, to_address(SM_TMats.base()) + i0);
+      Gptr = to_address(SM_TMats.base());
     }
     // setup origin of vsp and copy_n_cast if necessary
     if (std::is_same<vType, SPComplexType>::value)
     {
-      vptr = reinterpret_cast<sp_pointer>(to_address(v.origin()));
+      vptr = reinterpret_cast<sp_pointer>(to_address(v.base()));
     }
     else
     {
       long i0, iN;
       std::tie(i0, iN) =
           FairDivideBoundary(long(TG.TG_local().rank()), long(v.num_elements()), long(TG.TG_local().size()));
-      vptr = to_address(SM_TMats.origin()) + Gmem;
+      vptr = to_address(SM_TMats.base()) + Gmem;
       if (std::abs(c) > 1e-12)
-        copy_n_cast(to_address(v.origin()) + i0, iN - i0, vptr + i0);
+        copy_n_cast(to_address(v.base()) + i0, iN - i0, vptr + i0);
     }
     // setup array references
-    boost::multi::array_cref<SPComplexType const, 2> Gsp(Gptr, G.extensions());
-    boost::multi::array_ref<SPComplexType, 2> vsp(vptr, v.extensions());
+    boost::multi::array_cref<SPComplexType const, 2> Gsp(Gptr, G.extents());
+    boost::multi::array_ref<SPComplexType, 2> vsp(vptr, v.extents());
     TG.TG_local().barrier();
 
     using std::get;
@@ -581,7 +581,7 @@ public:
 
       if (walker_type == CLOSED)
         a *= 2.0;
-      ma::product(SPValueType(a), ma::T(Lakn(Lakn.extension(0), {ic0, icN})), Gsp, SPValueType(c),
+      ma::product(SPValueType(a), ma::T(Lakn(get<0>(Lakn.extents()), {ic0, icN})), Gsp, SPValueType(c),
                   vsp.sliced(ic0, icN));
     }
     else
@@ -595,14 +595,14 @@ public:
 
       if (walker_type == CLOSED)
         a *= 2.0;
-      ma::product(SPValueType(a), ma::T(Likn(Likn.extension(0), {ic0, icN})), Gsp, SPValueType(c),
+      ma::product(SPValueType(a), ma::T(Likn(get<0>(Likn.extents()), {ic0, icN})), Gsp, SPValueType(c),
                   vsp.sliced(ic0, icN));
     }
     // copy data back if changing precision
     using std::get;
     if (not std::is_same<vType, SPComplexType>::value)
     {
-      copy_n_cast(to_address(vsp[ic0].origin()), get<1>(vsp.sizes()) * (icN - ic0), to_address(v[ic0].origin()));
+      copy_n_cast(to_address(vsp[ic0].base()), get<1>(vsp.sizes()) * (icN - ic0), to_address(v[ic0].base()));
     }
     TG.TG_local().barrier();
   }

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched.hpp
@@ -129,13 +129,13 @@ public:
 
     CVector vMF_(vMF);
     CVector P1D(iextensions<1u>{NMO * NMO});
-    fill_n(P1D.origin(), P1D.num_elements(), ComplexType(0));
+    fill_n(P1D.base(), P1D.num_elements(), ComplexType(0));
     vHS(vMF_, P1D);
     if (TG.TG().size() > 1)
-      TG.TG().all_reduce_in_place_n(to_address(P1D.origin()), P1D.num_elements(), std::plus<>());
+      TG.TG().all_reduce_in_place_n(to_address(P1D.base()), P1D.num_elements(), std::plus<>());
 
     boost::multi::array<ComplexType, 2> P1({NMO, NMO});
-    copy_n(P1D.origin(), NMO * NMO, P1.origin());
+    copy_n(P1D.base(), NMO * NMO, P1.base());
 
     using ma::conj;
 
@@ -181,6 +181,7 @@ public:
               bool addEJ  = true,
               bool addEXX = true)
   {
+    using std::get;
     assert(E.size(1) >= 3);
     assert(nd >= 0);
     assert(nd < haj.size());
@@ -257,12 +258,12 @@ public:
       {
         assert(KEleft->size(0) == nwalk && KEleft->size(1) == local_nCV);
         assert(KEleft->stride() == KEleft->size(1));
-        Klptr = make_device_ptr(KEleft->origin());
+        Klptr = make_device_ptr(KEleft->base());
       }
       else
 #endif
       {
-        Klptr = TBuff.origin() + cnt;
+        Klptr = TBuff.base() + cnt;
         cnt += Knr * Knc;
       }
       fill_n(Klptr, Knr * Knc, SPComplexType(0.0));
@@ -274,7 +275,7 @@ public:
     SpCMatrix_ref Kl(Klptr, {long(Knr), long(Knc)});
 
     for (int n = 0; n < nwalk; n++)
-      std::fill_n(E[n].origin(), 3, ComplexType(0.));
+      std::fill_n(E[n].base(), 3, ComplexType(0.));
 
 
     // one-body contribution
@@ -282,8 +283,8 @@ public:
     // not parallelized for now, since it would require customization of Wfn
     if (addH1)
     {
-      CVector_ref haj_ref(make_device_ptr(haj[nd].origin()), iextensions<1u>{haj[nd].num_elements()});
-      ma::product(ComplexType(1.), Gc, haj_ref, ComplexType(1.), E(E.extension(0), 0));
+      CVector_ref haj_ref(make_device_ptr(haj[nd].base()), iextensions<1u>{haj[nd].num_elements()});
+      ma::product(ComplexType(1.), Gc, haj_ref, ComplexType(1.), E(get<0>(E.extents()), 0));
       for (int i = 0; i < nwalk; i++)
         E[i][0] += E0;
     }
@@ -300,38 +301,38 @@ public:
         size_t cnt_(cnt);
         sp_pointer ptr(nullptr);
 #if defined(MIXED_PRECISION)
-        ptr = TBuff.origin() + cnt_;
+        ptr = TBuff.base() + cnt_;
         cnt_ += nwalk * nel[ispin] * NMO;
         for (int n = 0; n < nwalk; ++n)
         {
-          copy_n_cast(make_device_ptr(Gc[n].origin()) + is0, nel[ispin] * NMO, ptr + n * nel[ispin] * NMO);
+          copy_n_cast(make_device_ptr(Gc[n].base()) + is0, nel[ispin] * NMO, ptr + n * nel[ispin] * NMO);
         }
 #else
         if (nspin == 1)
         {
-          ptr = make_device_ptr(Gc.origin());
+          ptr = make_device_ptr(Gc.base());
         }
         else
         {
-          ptr = TBuff.origin() + cnt_;
+          ptr = TBuff.base() + cnt_;
           cnt_ += nwalk * nel[ispin] * NMO;
           for (int n = 0; n < nwalk; ++n)
           {
             using std::copy_n;
-            copy_n(make_device_ptr(Gc[n].origin()) + is0, nel[ispin] * NMO, ptr + n * nel[ispin] * NMO);
+            copy_n(make_device_ptr(Gc[n].base()) + is0, nel[ispin] * NMO, ptr + n * nel[ispin] * NMO);
           }
         }
 #endif
 
         SpCMatrix_ref GF(ptr, {nwalk * nel[ispin], NMO});
-        SpCMatrix_ref Lan(make_device_ptr(Lank[nd * nspin + ispin].origin()), {nel[ispin] * local_nCV, NMO});
-        SpCMatrix_ref Twban(TBuff.origin() + cnt_, {nwalk * nel[ispin], nel[ispin] * local_nCV});
-        SpC4Tensor_ref T4Dwban(Twban.origin(), {nwalk, nel[ispin], nel[ispin], local_nCV});
+        SpCMatrix_ref Lan(make_device_ptr(Lank[nd * nspin + ispin].base()), {nel[ispin] * local_nCV, NMO});
+        SpCMatrix_ref Twban(TBuff.base() + cnt_, {nwalk * nel[ispin], nel[ispin] * local_nCV});
+        SpC4Tensor_ref T4Dwban(Twban.base(), {nwalk, nel[ispin], nel[ispin], local_nCV});
 
         ma::product(GF, ma::T(Lan), Twban);
 
         using ma::dot_wabn;
-        dot_wabn(nwalk, nel[ispin], local_nCV, SPComplexType(-0.5 * scl), Twban.origin(), to_address(E[0].origin()) + 1,
+        dot_wabn(nwalk, nel[ispin], local_nCV, SPComplexType(-0.5 * scl), Twban.base(), to_address(E[0].base()) + 1,
                  E.stride());
         //          for(int n=0, an=0; n<nwalk; ++n) {
         //            ComplexType E_(0.0);
@@ -349,7 +350,7 @@ public:
           //                ma::axpy(SPComplexType(1.0),T4Dwban[n][a][a],Kl[n]);
           //            }
           using ma::Tab_to_Kl;
-          Tab_to_Kl(nwalk, nel[ispin], local_nCV, Twban.origin(), Kl.origin());
+          Tab_to_Kl(nwalk, nel[ispin], local_nCV, Twban.base(), Kl.base());
         }
         is0 += nel[ispin] * NMO;
 
@@ -368,10 +369,10 @@ public:
         E[n][2] += 0.5 * static_cast<ComplexType>(scl * scl * ma::dot(Kl[n], Kl[n]));
 #if defined(MIXED_PRECISION)
       if (getKl)
-        copy_n_cast(Klptr, KEleft->num_elements(), make_device_ptr(KEleft->origin()));
+        copy_n_cast(Klptr, KEleft->num_elements(), make_device_ptr(KEleft->base()));
 #endif
       if (getKr)
-        copy_n_cast(Klptr, KEright->num_elements(), make_device_ptr(KEright->origin()));
+        copy_n_cast(Klptr, KEright->num_elements(), make_device_ptr(KEright->base()));
     }
   }
 
@@ -393,11 +394,11 @@ public:
 #if defined(MIXED_PRECISION)
     size_t mem_needs = X.num_elements() + v.num_elements();
     set_buffer(mem_needs);
-    SpCVector_ref vsp(TBuff.origin(), v.extensions());
-    SpCVector_ref Xsp(vsp.origin() + vsp.num_elements(), X.extensions());
-    copy_n_cast(make_device_ptr(X.origin()), X.num_elements(), Xsp.origin());
+    SpCVector_ref vsp(TBuff.base(), v.extents());
+    SpCVector_ref Xsp(vsp.base() + vsp.num_elements(), X.extents());
+    copy_n_cast(make_device_ptr(X.base()), X.num_elements(), Xsp.base());
     ma::product(SPValueType(a), Likn, Xsp, SPValueType(c), vsp);
-    copy_n_cast(vsp.origin(), vsp.num_elements(), make_device_ptr(v.origin()));
+    copy_n_cast(vsp.base(), vsp.num_elements(), make_device_ptr(v.base()));
 #else
     ma::product(SPValueType(a), Likn, X, SPValueType(c), v);
 #endif
@@ -415,11 +416,11 @@ public:
 #if defined(MIXED_PRECISION)
     size_t mem_needs = X.num_elements() + v.num_elements();
     set_buffer(mem_needs);
-    SpCMatrix_ref vsp(TBuff.origin(), v.extensions());
-    SpCMatrix_ref Xsp(vsp.origin() + vsp.num_elements(), X.extensions());
-    copy_n_cast(make_device_ptr(X.origin()), X.num_elements(), Xsp.origin());
+    SpCMatrix_ref vsp(TBuff.base(), v.extents());
+    SpCMatrix_ref Xsp(vsp.base() + vsp.num_elements(), X.extents());
+    copy_n_cast(make_device_ptr(X.base()), X.num_elements(), Xsp.base());
     ma::product(SPValueType(a), Likn, Xsp, SPValueType(c), vsp);
-    copy_n_cast(vsp.origin(), vsp.num_elements(), make_device_ptr(v.origin()));
+    copy_n_cast(vsp.base(), vsp.num_elements(), make_device_ptr(v.base()));
 #else
     ma::product(SPValueType(a), Likn, X, SPValueType(c), v);
 #endif
@@ -440,13 +441,13 @@ public:
 #if defined(MIXED_PRECISION)
       size_t mem_needs = G.num_elements() + v.num_elements();
       set_buffer(mem_needs);
-      SpCVector_ref vsp(TBuff.origin(), v.extensions());
-      SpCVector_ref Gsp(vsp.origin() + vsp.num_elements(), G.extensions());
-      copy_n_cast(make_device_ptr(G.origin()), G.num_elements(), Gsp.origin());
+      SpCVector_ref vsp(TBuff.base(), v.extents());
+      SpCVector_ref Gsp(vsp.base() + vsp.num_elements(), G.extents());
+      copy_n_cast(make_device_ptr(G.base()), G.num_elements(), Gsp.base());
       if (walker_type == CLOSED)
         a *= 2.0;
       ma::product(SPComplexType(a), ma::T(Lakn), Gsp, SPComplexType(c), vsp);
-      copy_n_cast(vsp.origin(), vsp.num_elements(), make_device_ptr(v.origin()));
+      copy_n_cast(vsp.base(), vsp.num_elements(), make_device_ptr(v.base()));
 #else
       if (walker_type == CLOSED)
         a *= 2.0;
@@ -462,13 +463,13 @@ public:
 #if defined(MIXED_PRECISION)
       size_t mem_needs = G.num_elements() + v.num_elements();
       set_buffer(mem_needs);
-      SpCVector_ref vsp(TBuff.origin(), v.extensions());
-      SpCVector_ref Gsp(vsp.origin() + vsp.num_elements(), G.extensions());
-      copy_n_cast(make_device_ptr(G.origin()), G.num_elements(), Gsp.origin());
+      SpCVector_ref vsp(TBuff.base(), v.extents());
+      SpCVector_ref Gsp(vsp.base() + vsp.num_elements(), G.extents());
+      copy_n_cast(make_device_ptr(G.base()), G.num_elements(), Gsp.base());
       if (walker_type == CLOSED)
         a *= 2.0;
       ma::product(SPValueType(a), ma::T(Likn), Gsp, SPValueType(c), vsp);
-      copy_n_cast(vsp.origin(), vsp.num_elements(), make_device_ptr(v.origin()));
+      copy_n_cast(vsp.base(), vsp.num_elements(), make_device_ptr(v.base()));
 #else
       if (walker_type == CLOSED)
         a *= 2.0;
@@ -493,13 +494,13 @@ public:
 #if defined(MIXED_PRECISION)
       size_t mem_needs = G.num_elements() + v.num_elements();
       set_buffer(mem_needs);
-      SpCMatrix_ref vsp(TBuff.origin(), v.extensions());
-      SpCMatrix_ref Gsp(vsp.origin() + vsp.num_elements(), G.extensions());
-      copy_n_cast(make_device_ptr(G.origin()), G.num_elements(), Gsp.origin());
+      SpCMatrix_ref vsp(TBuff.base(), v.extents());
+      SpCMatrix_ref Gsp(vsp.base() + vsp.num_elements(), G.extents());
+      copy_n_cast(make_device_ptr(G.base()), G.num_elements(), Gsp.base());
       if (walker_type == CLOSED)
         a *= 2.0;
       ma::product(SPComplexType(a), ma::T(Lakn), Gsp, SPComplexType(c), vsp);
-      copy_n_cast(vsp.origin(), vsp.num_elements(), make_device_ptr(v.origin()));
+      copy_n_cast(vsp.base(), vsp.num_elements(), make_device_ptr(v.base()));
 #else
       if (walker_type == CLOSED)
         a *= 2.0;
@@ -516,13 +517,13 @@ public:
 #if defined(MIXED_PRECISION)
       size_t mem_needs = G.num_elements() + v.num_elements();
       set_buffer(mem_needs);
-      SpCMatrix_ref vsp(TBuff.origin(), v.extensions());
-      SpCMatrix_ref Gsp(vsp.origin() + vsp.num_elements(), G.extensions());
-      copy_n_cast(make_device_ptr(G.origin()), G.num_elements(), Gsp.origin());
+      SpCMatrix_ref vsp(TBuff.base(), v.extents());
+      SpCMatrix_ref Gsp(vsp.base() + vsp.num_elements(), G.extents());
+      copy_n_cast(make_device_ptr(G.base()), G.num_elements(), Gsp.base());
       if (walker_type == CLOSED)
         a *= 2.0;
       ma::product(SPValueType(a), ma::T(Likn), Gsp, SPValueType(c), vsp);
-      copy_n_cast(vsp.origin(), vsp.num_elements(), make_device_ptr(v.origin()));
+      copy_n_cast(vsp.base(), vsp.num_elements(), make_device_ptr(v.base()));
 #else
       if (walker_type == CLOSED)
         a *= 2.0;
@@ -602,7 +603,7 @@ private:
       }
       memory_report();
       using std::fill_n;
-      fill_n(TBuff.origin(), N, SPComplexType(0.0));
+      fill_n(TBuff.base(), N, SPComplexType(0.0));
     }
   }
 };

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
@@ -117,7 +117,7 @@ public:
         local_nCV(0),
         E0(e0_),
         hij(std::move(hij_)),
-        hij_dev(hij.extensions(), make_node_allocator<ComplexType>(TG)),
+        hij_dev(hij.extents(), make_node_allocator<ComplexType>(TG)),
         haj(std::move(haj_)),
         Likn(std::move(vik)),
         Lnak(std::move(move_vector<shmSpC3Tensor>(std::move(vnak)))),
@@ -159,13 +159,13 @@ public:
 
     CVector vMF_(vMF);
     CVector P1D(iextensions<1u>{NMO * NMO});
-    fill_n(P1D.origin(), P1D.num_elements(), ComplexType(0));
+    fill_n(P1D.base(), P1D.num_elements(), ComplexType(0));
     vHS(vMF_, P1D);
     if (TG.TG().size() > 1)
-      TG.TG().all_reduce_in_place_n(to_address(P1D.origin()), P1D.num_elements(), std::plus<>());
+      TG.TG().all_reduce_in_place_n(to_address(P1D.base()), P1D.num_elements(), std::plus<>());
 
     boost::multi::array<ComplexType, 2> P1({NMO, NMO});
-    copy_n(P1D.origin(), NMO * NMO, P1.origin());
+    copy_n(P1D.base(), NMO * NMO, P1.base());
 
     using ma::conj;
 
@@ -272,18 +272,18 @@ public:
       APP_ABORT(" Error: Kr and/or Kl can only be calculated with addEJ=true.\n");
     }
     StaticMatrix Kl({Knr, Knc}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    fill_n(Kl.origin(), Kl.num_elements(), SPComplexType(0.0));
+    fill_n(Kl.base(), Kl.num_elements(), SPComplexType(0.0));
 
     for (int n = 0; n < nwalk; n++)
-      std::fill_n(E[n].origin(), 3, ComplexType(0.));
+      std::fill_n(E[n].base(), 3, ComplexType(0.));
 
     // one-body contribution
     // haj[ndet][nocc*nmo]
     // not parallelized for now, since it would require customization of Wfn
     if (addH1)
     {
-      CVector_ref haj_ref(make_device_ptr(haj[nd].origin()), iextensions<1u>{haj[nd].num_elements()});
-      ma::product(ComplexType(1.), Gc, haj_ref, ComplexType(1.), E(E.extension(0), 0));
+      CVector_ref haj_ref(make_device_ptr(haj[nd].base()), iextensions<1u>{haj[nd].num_elements()});
+      ma::product(ComplexType(1.), Gc, haj_ref, ComplexType(1.), E(get<0>(E.extents()), 0));
       for (int i = 0; i < nwalk; i++)
         E[i][0] += E0;
     }
@@ -309,21 +309,21 @@ public:
       {
         sp_pointer ptr(nullptr);
 #if defined(MIXED_PRECISION)
-        ptr = T1.origin();
+        ptr = T1.base();
         for (int n = 0; n < nwalk; ++n)
-          copy_n_cast(make_device_ptr(Gc[n].origin()) + is0, nel[ispin] * NMO, ptr + n * nel[ispin] * NMO);
+          copy_n_cast(make_device_ptr(Gc[n].base()) + is0, nel[ispin] * NMO, ptr + n * nel[ispin] * NMO);
 #else
         if (nspin == 1)
         {
-          ptr = make_device_ptr(Gc.origin());
+          ptr = make_device_ptr(const_cast<MatB&>(Gc).base());
         }
         else
         {
-          ptr = T1.origin();
+          ptr = T1.base();
           for (int n = 0; n < nwalk; ++n)
           {
             using std::copy_n;
-            copy_n(make_device_ptr(Gc[n].origin()) + is0, nel[ispin] * NMO, ptr + n * nel[ispin] * NMO);
+            copy_n(make_device_ptr(Gc[n].base()) + is0, nel[ispin] * NMO, ptr + n * nel[ispin] * NMO);
           }
         }
 #endif
@@ -334,21 +334,21 @@ public:
         while (nCV < local_nCV)
         {
           int nvecs = std::min(local_nCV - nCV, max_nCV);
-          SpCMatrix_ref Lna(make_device_ptr(Lnak[nd * nspin + ispin][nCV].origin()), {nvecs * nel[ispin], NMO});
+          SpCMatrix_ref Lna(make_device_ptr(Lnak[nd * nspin + ispin][nCV].base()), {nvecs * nel[ispin], NMO});
           StaticMatrix Twbna({nwalk * nel[ispin], nvecs * nel[ispin]},
                              buffer_manager.get_generator().template get_allocator<SPComplexType>());
-          SpC4Tensor_ref T4Dwbna(Twbna.origin(), {nwalk, nel[ispin], nvecs, nel[ispin]});
+          SpC4Tensor_ref T4Dwbna(Twbna.base(), {nwalk, nel[ispin], nvecs, nel[ispin]});
 
           ma::product(GF, ma::T(Lna), Twbna);
 
           using ma::dot_wanb;
-          dot_wanb(nwalk, nel[ispin], nvecs, SPComplexType(-0.5 * scl), Twbna.origin(), to_address(E[0].origin()) + 1,
+          dot_wanb(nwalk, nel[ispin], nvecs, SPComplexType(-0.5 * scl), Twbna.base(), to_address(E[0].base()) + 1,
                    E.stride());
 
           if (addEJ)
           {
             using ma::Tanb_to_Kl;
-            Tanb_to_Kl(nwalk, nel[ispin], nvecs, local_nCV, Twbna.origin(), Kl.origin() + nCV);
+            Tanb_to_Kl(nwalk, nel[ispin], nvecs, local_nCV, Twbna.base(), Kl.base() + nCV);
           }
 
           nCV += max_nCV;
@@ -369,9 +369,9 @@ public:
       for (int n = 0; n < nwalk; ++n)
         E[n][2] += 0.5 * static_cast<ComplexType>(scl * scl * ma::dot(Kl[n], Kl[n]));
       if (getKl)
-        copy_n_cast(Kl.origin(), KEleft->num_elements(), make_device_ptr(KEleft->origin()));
+        copy_n_cast(Kl.base(), KEleft->num_elements(), make_device_ptr(KEleft->base()));
       if (getKr)
-        copy_n_cast(Kl.origin(), KEright->num_elements(), make_device_ptr(KEright->origin()));
+        copy_n_cast(Kl.base(), KEright->num_elements(), make_device_ptr(KEright->base()));
     }
   }
 
@@ -392,8 +392,8 @@ public:
     using AType = typename std::decay<MatA>::type::element;
 
     using std::get;
-    boost::multi::array_ref<BType, 2, decltype(v.origin())> v_(v.origin(), {get<0>(v.sizes()), 1});
-    boost::multi::array_ref<AType, 2, decltype(X.origin())> X_(X.origin(), {get<0>(X.sizes()), 1});
+    boost::multi::array_ref<BType, 2, decltype(v.base())> v_(v.base(), {get<0>(v.sizes()), 1});
+    boost::multi::array_ref<AType, 2, decltype(X.base())> X_(X.base(), {get<0>(X.sizes()), 1});
     return vHS(X_, v_, a, c);
   }
 
@@ -424,31 +424,31 @@ public:
     using qmcplusplus::afqmc::pointer_cast;
     if (std::is_same<XType, SPComplexType>::value)
     {
-      Xptr = pointer_cast<SPComplexType const>(make_device_ptr(X.origin()));
+      Xptr = pointer_cast<SPComplexType const>(make_device_ptr(X.base()));
     }
     else
     {
-      copy_n_cast(make_device_ptr(X.origin()), X.num_elements(), make_device_ptr(SPBuff.origin()));
-      Xptr = make_device_ptr(SPBuff.origin());
+      copy_n_cast(make_device_ptr(X.base()), X.num_elements(), make_device_ptr(SPBuff.base()));
+      Xptr = make_device_ptr(SPBuff.base());
     }
     // setup origin of vsp and copy_n_cast if necessary
     if (std::is_same<vType, SPComplexType>::value)
     {
-      vptr = pointer_cast<SPComplexType>(make_device_ptr(v.origin()));
+      vptr = pointer_cast<SPComplexType>(make_device_ptr(v.base()));
     }
     else
     {
-      vptr = make_device_ptr(SPBuff.origin()) + Xmem;
+      vptr = make_device_ptr(SPBuff.base()) + Xmem;
       if (std::abs(c) > 1e-12)
-        copy_n_cast(make_device_ptr(v.origin()), v.num_elements(), vptr);
+        copy_n_cast(make_device_ptr(v.base()), v.num_elements(), vptr);
     }
     // work
-    boost::multi::array_cref<SPComplexType const, 2, const_sp_pointer> Xsp(Xptr, X.extensions());
-    boost::multi::array_ref<SPComplexType, 2, sp_pointer> vsp(vptr, v.extensions());
+    boost::multi::array_cref<SPComplexType const, 2, const_sp_pointer> Xsp(Xptr, X.extents());
+    boost::multi::array_ref<SPComplexType, 2, sp_pointer> vsp(vptr, v.extents());
     ma::product(SPValueType(a), Likn, Xsp, SPValueType(c), vsp);
     if (not std::is_same<vType, SPComplexType>::value)
     {
-      copy_n_cast(make_device_ptr(vsp.origin()), v.num_elements(), make_device_ptr(v.origin()));
+      copy_n_cast(make_device_ptr(vsp.base()), v.num_elements(), make_device_ptr(v.base()));
     }
   }
 
@@ -461,8 +461,8 @@ public:
   {
     using BType = typename std::decay<MatB>::type::element;
     using AType = typename std::decay<MatA>::type::element;
-    boost::multi::array_ref<BType, 2, decltype(v.origin())> v_(v.origin(), {v.size(), 1});
-    boost::multi::array_ref<AType const, 2, decltype(G.origin())> G_(G.origin(), {G.size(), 1});
+    boost::multi::array_ref<BType, 2, decltype(v.base())> v_(v.base(), {v.size(), 1});
+    boost::multi::array_ref<AType const, 2, decltype(G.base())> G_(G.base(), {G.size(), 1});
     return vbias(G_, v_, a, c, k);
   }
 
@@ -491,27 +491,27 @@ public:
     using qmcplusplus::afqmc::pointer_cast;
     if (std::is_same<GType, SPComplexType>::value)
     {
-      Gptr = pointer_cast<SPComplexType const>(make_device_ptr(G.origin()));
+      Gptr = pointer_cast<SPComplexType const>(make_device_ptr(G.base()));
     }
     else
     {
-      copy_n_cast(make_device_ptr(G.origin()), G.num_elements(), make_device_ptr(SPBuff.origin()));
-      Gptr = make_device_ptr(SPBuff.origin());
+      copy_n_cast(make_device_ptr(G.base()), G.num_elements(), make_device_ptr(SPBuff.base()));
+      Gptr = make_device_ptr(SPBuff.base());
     }
     // setup origin of vsp and copy_n_cast if necessary
     if (std::is_same<vType, SPComplexType>::value)
     {
-      vptr = pointer_cast<SPComplexType>(make_device_ptr(v.origin()));
+      vptr = pointer_cast<SPComplexType>(make_device_ptr(v.base()));
     }
     else
     {
-      vptr = make_device_ptr(SPBuff.origin()) + Gmem;
+      vptr = make_device_ptr(SPBuff.base()) + Gmem;
       if (std::abs(c) > 1e-12)
-        copy_n_cast(make_device_ptr(v.origin()), v.num_elements(), vptr);
+        copy_n_cast(make_device_ptr(v.base()), v.num_elements(), vptr);
     }
     // setup array references
-    boost::multi::array_cref<SPComplexType const, 2, const_sp_pointer> Gsp(Gptr, G.extensions());
-    boost::multi::array_ref<SPComplexType, 2, sp_pointer> vsp(vptr, v.extensions());
+    boost::multi::array_cref<SPComplexType const, 2, const_sp_pointer> Gsp(Gptr, G.extents());
+    boost::multi::array_ref<SPComplexType, 2, sp_pointer> vsp(vptr, v.extents());
 
     using std::get;
 
@@ -534,7 +534,7 @@ public:
         for (int ispin = 0, is0 = 0; ispin < 2; ispin++)
         {
           assert(get<0>(Lnak[ispin].sizes()) == get<0>(v.sizes()));
-          SpCMatrix_ref Ln(make_device_ptr(Lnak[ispin].origin()), {local_nCV, nel[ispin] * NMO});
+          SpCMatrix_ref Ln(make_device_ptr(Lnak[ispin].base()), {local_nCV, nel[ispin] * NMO});
           ma::product(SPComplexType(a), Ln, Gsp.sliced(is0, is0 + nel[ispin] * NMO), SPComplexType(c_[ispin]), vsp);
           is0 += nel[ispin] * NMO;
         }
@@ -544,7 +544,7 @@ public:
         assert(get<1>(G.sizes()) == get<1>(v.sizes()));
         assert(get<1>(Lnak[0].sizes()) * get<2>(Lnak[0].sizes()) == get<0>(G.sizes()));
         assert(get<0>(Lnak[0].sizes()) == get<0>(v.sizes()));
-        SpCMatrix_ref Ln(make_device_ptr(Lnak[0].origin()), {local_nCV, get<1>(Lnak[0].sizes()) * get<2>(Lnak[0].sizes())});
+        SpCMatrix_ref Ln(make_device_ptr(Lnak[0].base()), {local_nCV, get<1>(Lnak[0].sizes()) * get<2>(Lnak[0].sizes())});
         ma::product(SPComplexType(a), Ln, Gsp, SPComplexType(c), vsp);
       }
     }
@@ -559,7 +559,7 @@ public:
     }
     if (not std::is_same<vType, SPComplexType>::value)
     {
-      copy_n_cast(make_device_ptr(vsp.origin()), v.num_elements(), make_device_ptr(v.origin()));
+      copy_n_cast(make_device_ptr(vsp.base()), v.num_elements(), make_device_ptr(v.base()));
     }
   }
 
@@ -598,11 +598,11 @@ public:
     StaticMatrix Fm_({nwalk, nspin * NMO * NMO},
                      buffer_manager.get_generator().template get_allocator<SPComplexType>());
 #else
-    SpCMatrix_ref Fp_(make_device_ptr(Fp.origin()), {nwalk, nspin * NMO * NMO});
-    SpCMatrix_ref Fm_(make_device_ptr(Fm.origin()), {nwalk, nspin * NMO * NMO});
+    SpCMatrix_ref Fp_(make_device_ptr(Fp.base()), {nwalk, nspin * NMO * NMO});
+    SpCMatrix_ref Fm_(make_device_ptr(Fm.base()), {nwalk, nspin * NMO * NMO});
 #endif
-    fill_n(Fp_.origin(), Fp_.num_elements(), SPComplexType(0.0));
-    fill_n(Fm_.origin(), Fm_.num_elements(), SPComplexType(0.0));
+    fill_n(Fp_.base(), Fp_.num_elements(), SPComplexType(0.0));
+    fill_n(Fm_.base(), Fm_.num_elements(), SPComplexType(0.0));
 
     SPComplexType scl = (walker_type == CLOSED ? 2.0 : 1.0);
     std::vector<sp_pointer> Aarray;
@@ -629,33 +629,33 @@ public:
       sp_pointer ptr(nullptr);
       // transpose/cast G
 #if defined(MIXED_PRECISION)
-      ptr = GBuff.origin();
+      ptr = GBuff.base();
       for (int ispin = 0, is0 = 0, ip = 0; ispin < nspin; ispin++, is0 += NMO * NMO)
         for (int n = 0; n < nw; ++n, ip += NMO * NMO)
-          copy_n_cast(make_device_ptr(G[nw0 + n].origin()) + is0, NMO * NMO, ptr + ip);
+          copy_n_cast(make_device_ptr(G[nw0 + n].base()) + is0, NMO * NMO, ptr + ip);
 #else
       if (nspin == 1)
       {
-        ptr = make_device_ptr(G[nw0].origin());
+        ptr = make_device_ptr(G[nw0].base());
       }
       else
       {
-        ptr = GBuff.origin();
+        ptr = GBuff.base();
         using std::copy_n;
         for (int ispin = 0, is0 = 0, ip = 0; ispin < nspin; ispin++, is0 += NMO * NMO)
           for (int n = 0; n < nw; ++n, ip += NMO * NMO)
-            copy_n(make_device_ptr(G[nw0 + n].origin()) + is0, NMO * NMO, ptr + ip);
+            copy_n(make_device_ptr(G[nw0 + n].base()) + is0, NMO * NMO, ptr + ip);
       }
 #endif
       SpCTensor_ref GF(ptr, {nspin, nw * NMO, NMO}); // now contains G in the correct structure [spin][w][i][j]
       StaticMatrix Gt({NMO * NMO, nw}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
-      fill_n(Gt.origin(), Gt.num_elements(), SPComplexType(0.0));
+      fill_n(Gt.base(), Gt.num_elements(), SPComplexType(0.0));
 
       StaticMatrix Rnw({local_nCV, nw}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
       // calculate Rwn
       for (int ispin = 0; ispin < nspin; ispin++)
       {
-        SpCMatrix_ref G_(GF[ispin].origin(), {nw, NMO * NMO});
+        SpCMatrix_ref G_(GF[ispin].base(), {nw, NMO * NMO});
         ma::add(SPComplexType(1.0), Gt, SPComplexType(1.0), ma::T(G_), Gt);
       }
       // R[n,w] = \sum_ik L[n,ik] G[ik,w]
@@ -674,22 +674,22 @@ public:
       }
 
       // L[i,kn]
-      SpRMatrix_ref Ln(make_device_ptr(Likn.origin()), {NMO, NMO * local_nCV});
+      SpRMatrix_ref Ln(make_device_ptr(Likn.base()), {NMO, NMO * local_nCV});
       // T[w,p,t,n] = \sum_{l} L[l,t,n] P[w,l,p]
       StaticMatrix Twptn({nw * NMO, NMO * local_nCV},
                          buffer_manager.get_generator().template get_allocator<SPComplexType>());
       // transpose for faster contraction
       StaticMatrix Taux({nw * NMO, NMO * local_nCV},
                         buffer_manager.get_generator().template get_allocator<SPComplexType>());
-      SpCTensor_ref Taux3D(Taux.origin(), {nw, NMO, NMO * local_nCV});
-      SpCTensor_ref Twptn3D(Twptn.origin(), {nw, NMO, NMO * local_nCV});
-      SpCTensor_ref Twptn3D_(Twptn.origin(), {nw, NMO * NMO, local_nCV});
-      SpCMatrix_ref Ttnwp(Taux.origin(), {NMO * local_nCV, nw * NMO});
-      SpCMatrix_ref Gt_(Gt.origin(), {NMO, nw * NMO});
+      SpCTensor_ref Taux3D(Taux.base(), {nw, NMO, NMO * local_nCV});
+      SpCTensor_ref Twptn3D(Twptn.base(), {nw, NMO, NMO * local_nCV});
+      SpCTensor_ref Twptn3D_(Twptn.base(), {nw, NMO * NMO, local_nCV});
+      SpCMatrix_ref Ttnwp(Taux.base(), {NMO * local_nCV, nw * NMO});
+      SpCMatrix_ref Gt_(Gt.base(), {NMO, nw * NMO});
 
       for (int ispin = 0, is0 = 0; ispin < nspin; ispin++, is0 += NMO * NMO)
       {
-        SpCMatrix_ref G_(GF[ispin].origin(), {nw * NMO, NMO});
+        SpCMatrix_ref G_(GF[ispin].base(), {nw * NMO, NMO});
         ma::transpose(G_, Gt_);
 
         // J = \sum_{iklr} L[i,k,n] L[q,l,n] P[s,p,l] P[r,i,k]
@@ -703,7 +703,7 @@ public:
         // transpose Twptn -> Twtpn=Taux
         using ma::transpose_wabn_to_wban;
         // T[wt,pn]
-        transpose_wabn_to_wban(nw, NMO, NMO, local_nCV, Twptn.origin(), Taux.origin());
+        transpose_wabn_to_wban(nw, NMO, NMO, local_nCV, Twptn.base(), Taux.base());
 
         // add exchange component to Fm_
         Aarray.clear();
@@ -711,9 +711,9 @@ public:
         Carray.clear();
         for (int w = 0; w < nw; w++)
         {
-          Aarray.push_back(Taux3D[w].origin());
-          Barray.push_back(Twptn3D[w].origin());
-          Carray.push_back(Fm_[w].origin() + is0);
+          Aarray.push_back(Taux3D[w].base());
+          Barray.push_back(Twptn3D[w].base());
+          Carray.push_back(Fm_[w].base() + is0);
         }
         using ma::gemmBatched;
         // careful with expected Fortran ordering here!!!
@@ -728,9 +728,9 @@ public:
         Carray.clear();
         for (int w = 0; w < nw; w++)
         {
-          Aarray.push_back(Twptn3D_[w].origin());
-          Barray.push_back(Rwn[w].origin());
-          Carray.push_back(Fm_[w].origin() + is0);
+          Aarray.push_back(Twptn3D_[w].base());
+          Barray.push_back(Rwn[w].base());
+          Carray.push_back(Fm_[w].base() + is0);
         }
         using ma::gemmBatched;
         // careful with expected Fortran ordering here!!!
@@ -740,19 +740,19 @@ public:
 
         // Fp
         // Need Gt_[i][wj]
-        transpose_wabn_to_wban(1, nw, NMO, NMO, G_.origin(), Gt_.origin());
+        transpose_wabn_to_wban(1, nw, NMO, NMO, G_.base(), Gt_.base());
         ma::product(SPValueType(1.0), ma::T(Ln), Gt_, SPValueType(0.0), Ttnwp);
         ma::transpose(Ttnwp, Twptn);
-        transpose_wabn_to_wban(nw, NMO, NMO, local_nCV, Twptn.origin(), Taux.origin());
+        transpose_wabn_to_wban(nw, NMO, NMO, local_nCV, Twptn.base(), Taux.base());
         // add coulomb component to Fp_, same as Fm_ above
         Aarray.clear();
         Barray.clear();
         Carray.clear();
         for (int w = 0; w < nw; w++)
         {
-          Aarray.push_back(Twptn3D_[w].origin());
-          Barray.push_back(Rwn[w].origin());
-          Carray.push_back(Fp_[w].origin() + is0);
+          Aarray.push_back(Twptn3D_[w].base());
+          Barray.push_back(Rwn[w].base());
+          Carray.push_back(Fp_[w].base() + is0);
         }
         using ma::gemmBatched;
         // careful with expected Fortran ordering here!!!
@@ -766,16 +766,16 @@ public:
         Carray.clear();
         for (int w = 0; w < nw; w++)
         {
-          Aarray.push_back(Taux3D[w].origin());
-          Barray.push_back(Twptn3D[w].origin());
-          Carray.push_back(Fp_[w].origin() + is0);
+          Aarray.push_back(Taux3D[w].base());
+          Barray.push_back(Twptn3D[w].base());
+          Carray.push_back(Fp_[w].base() + is0);
 
           // add exchange contribution of <pr||qs>Grs term by adding Lptn to Twptn
           // dispatch directly from here to be able to add to the real part only
           // K1B[p,q] = -\sum_{jl} L[jt,n] L[pl,n] P[jl]
           using ma::axpy;
-          axpy(Likn.num_elements(), SPRealType(-1.0), ma::pointer_dispatch(Likn.origin()), 1,
-               pointer_cast<SPRealType>(ma::pointer_dispatch(Twptn3D_[w].origin())), 2);
+          axpy(Likn.num_elements(), SPRealType(-1.0), ma::pointer_dispatch(Likn.base()), 1,
+               pointer_cast<SPRealType>(ma::pointer_dispatch(Twptn3D_[w].base())), 2);
         }
         using ma::gemmBatched;
         // careful with expected Fortran ordering here!!!
@@ -788,12 +788,12 @@ public:
     }
 
 #if defined(MIXED_PRECISION)
-    copy_n_cast(Fp_.origin(), Fp_.num_elements(), make_device_ptr(Fp.origin()));
-    copy_n_cast(Fm_.origin(), Fm_.num_elements(), make_device_ptr(Fm.origin()));
+    copy_n_cast(Fp_.base(), Fp_.num_elements(), make_device_ptr(Fp.base()));
+    copy_n_cast(Fm_.base(), Fm_.num_elements(), make_device_ptr(Fm.base()));
 #endif
 
-    //fill_n(Fp.origin(),Fp.num_elements(),SPComplexType(0.0));
-    //fill_n(Fm.origin(),Fm.num_elements(),SPComplexType(0.0));
+    //fill_n(Fp.base(),Fp.num_elements(),SPComplexType(0.0));
+    //fill_n(Fm.base(),Fm.num_elements(),SPComplexType(0.0));
     // add one body terms now
     {
       std::vector<pointer> Aarr;
@@ -810,9 +810,9 @@ public:
       {
         for (int w = 0; w < nwalk; w++)
         {
-          Aarr.push_back(make_device_ptr(hij_dev.origin()));
-          Barr.push_back(make_device_ptr(G[w].origin()) + is0);
-          Carr.push_back(make_device_ptr(Fm[w].origin()) + is0);
+          Aarr.push_back(make_device_ptr(hij_dev.base()));
+          Barr.push_back(make_device_ptr(G[w].base()) + is0);
+          Carr.push_back(make_device_ptr(Fm[w].base()) + is0);
         }
       }
       using ma::gemmBatched;
@@ -825,14 +825,14 @@ public:
       Aarr.clear();
       Barr.clear();
       Carr.clear();
-      C4Tensor_ref Fp4D(make_device_ptr(Fp.origin()), {nwalk, nspin, NMO, NMO});
+      C4Tensor_ref Fp4D(make_device_ptr(Fp.base()), {nwalk, nspin, NMO, NMO});
       for (int ispin = 0, is0 = 0; ispin < nspin; ispin++, is0 += NMO * NMO)
       {
         for (int w = 0; w < nwalk; w++)
         {
-          Aarr.push_back(make_device_ptr(hij_dev.origin()));
-          Barr.push_back(make_device_ptr(G[w].origin()) + is0);
-          Carr.push_back(make_device_ptr(Fp[w].origin()) + is0);
+          Aarr.push_back(make_device_ptr(hij_dev.base()));
+          Barr.push_back(make_device_ptr(G[w].base()) + is0);
+          Carr.push_back(make_device_ptr(Fp[w].base()) + is0);
 
           // add diagonal contribution to Fp
           ma::add(ComplexType(1.0), Fp4D[w][ispin], ComplexType(1.0), ma::T(hij_dev), Fp4D[w][ispin]);

--- a/src/AFQMC/HamiltonianOperations/SparseTensor.hpp
+++ b/src/AFQMC/HamiltonianOperations/SparseTensor.hpp
@@ -138,10 +138,10 @@ public:
     CMatrix H1({NMO, NMO});
 
     // add sum_n vMF*Spvn, vMF has local contribution only!
-    boost::multi::array_ref<ComplexType, 1> H1D(H1.origin(), {NMO * NMO});
-    std::fill_n(H1D.origin(), H1D.num_elements(), ComplexType(0));
+    boost::multi::array_ref<ComplexType, 1> H1D(H1.base(), {NMO * NMO});
+    std::fill_n(H1D.base(), H1D.num_elements(), ComplexType(0));
     vHS(vMF, H1D);
-    TG.TG().all_reduce_in_place_n(H1D.origin(), H1D.num_elements(), std::plus<>());
+    TG.TG().all_reduce_in_place_n(H1D.base(), H1D.num_elements(), std::plus<>());
 
     // add hij + vn0 and symmetrize
     using ma::conj;
@@ -204,7 +204,7 @@ public:
       APP_ABORT(" Error in AFQMC/HamiltonianOperations/sparse_matrix_energy::calculate_energy(). Incorrect matrix "
                 "dimensions \n");
     for (int n = 0; n < nwalk; n++)
-      std::fill_n(E[n].origin(), 3, ComplexType(0.));
+      std::fill_n(E[n].base(), 3, ComplexType(0.));
     if (addEJ and getKl)
       assert(get<0>(Kl->sizes()) == nwalk && get<1>(Kl->sizes()) == get<0>(SpvnT[k].sizes()));
     if (addEJ and getKr)
@@ -213,10 +213,10 @@ public:
 #if defined(MIXED_PRECISION)
     size_t mem_needs = Gc.num_elements();
     set_buffer(mem_needs);
-    boost::multi::array_ref<SPComplexType, 2> Gsp(to_address(SM_TMats.origin()), Gc.extensions());
+    boost::multi::array_ref<SPComplexType, 2> Gsp(to_address(SM_TMats.base()), Gc.extents());
     size_t i0, iN;
     std::tie(i0, iN) = FairDivideBoundary(size_t(comm->rank()), size_t(Gc.num_elements()), size_t(comm->size()));
-    copy_n_cast(to_address(Gc.origin()) + i0, iN - i0, to_address(Gsp.origin()) + i0);
+    copy_n_cast(to_address(Gc.base()) + i0, iN - i0, to_address(Gsp.base()) + i0);
     comm->barrier();
 #else
     auto& Gsp(Gc);
@@ -225,9 +225,9 @@ public:
     // one-body contribution
     if (addH1)
     {
-      boost::multi::array_cref<ComplexType, 1> haj_ref(to_address(haj[k].origin()),
+      boost::multi::array_cref<ComplexType, 1> haj_ref(to_address(haj[k].base()),
                                                        iextensions<1u>{haj[k].num_elements()});
-      ma::product(ComplexType(1.), ma::T(Gc), haj_ref, ComplexType(1.), E(E.extension(0), 0));
+      ma::product(ComplexType(1.), ma::T(Gc), haj_ref, ComplexType(1.), E(get<0>(E.extents()), 0));
       for (int i = 0; i < nwalk; i++)
         E[i][0] += E0;
     }
@@ -249,14 +249,14 @@ public:
 
       using std::get;
       // SpvnT*G
-      boost::multi::array_ref<SPComplexType, 2> v_(Gcloc.origin() + SpvnT_view[k].local_origin()[0] * get<1>(Gc.sizes()),
+      boost::multi::array_ref<SPComplexType, 2> v_(Gcloc.base() + SpvnT_view[k].local_origin()[0] * get<1>(Gc.sizes()),
                                                    {long(get<0>(SpvnT_view[k].sizes())), long(get<1>(Gc.sizes()))});
       ma::product(SpvnT_view[k], Gsp, v_);
       if (getKl || getKr)
       {
         for (int wi = 0; wi < get<1>(Gc.sizes()); wi++)
         {
-          auto _v_ = v_(v_.extension(0), wi);
+          auto _v_ = v_(get<0>(v_.extents()), wi);
           if (getKl)
           {
             auto Kli = (*Kl)[wi];
@@ -272,7 +272,7 @@ public:
         }
       }
       for (int wi = 0; wi < get<1>(Gc.sizes()); wi++)
-        E[wi][2] = 0.5 * scl * static_cast<ComplexType>(ma::dot(v_(v_.extension(0), wi), v_(v_.extension(0), wi)));
+        E[wi][2] = 0.5 * scl * static_cast<ComplexType>(ma::dot(v_(get<0>(v_.extents()), wi), v_(get<0>(v_.extents()), wi)));
     }
 #if defined(MIXED_PRECISION)
 #endif
@@ -293,8 +293,8 @@ public:
   {
     using BType = typename std::decay<MatB>::type::element;
     using AType = typename std::decay<MatA>::type::element;
-    boost::multi::array_ref<BType, 2, decltype(v.origin())> v_(v.origin(), {v.size(), 1});
-    boost::multi::array_ref<AType, 2, decltype(X.origin())> X_(X.origin(), {X.size(), 1});
+    boost::multi::array_ref<BType, 2, decltype(v.base())> v_(v.base(), {v.size(), 1});
+    boost::multi::array_ref<AType, 2, decltype(X.base())> X_(X.base(), {X.size(), 1});
     return vHS(X_, v_, a, c);
   }
 
@@ -324,42 +324,42 @@ public:
     // setup origin of Xsp and copy_n_cast if necessary
     if (std::is_same<XType, SPComplexType>::value)
     {
-      Xptr = reinterpret_cast<const_sp_pointer>(to_address(X.origin()));
+      Xptr = reinterpret_cast<const_sp_pointer>(to_address(X.base()));
     }
     else
     {
       long i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(long(comm->rank()), long(X.num_elements()), long(comm->size()));
-      copy_n_cast(to_address(X.origin()) + i0, iN - i0, to_address(SM_TMats.origin()) + i0);
-      Xptr = to_address(SM_TMats.origin());
+      copy_n_cast(to_address(X.base()) + i0, iN - i0, to_address(SM_TMats.base()) + i0);
+      Xptr = to_address(SM_TMats.base());
     }
     // setup origin of vsp and copy_n_cast if necessary
     if (std::is_same<vType, SPComplexType>::value)
     {
-      vptr = reinterpret_cast<sp_pointer>(to_address(v.origin()));
+      vptr = reinterpret_cast<sp_pointer>(to_address(v.base()));
     }
     else
     {
       long i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(long(comm->rank()), long(v.num_elements()), long(comm->size()));
-      vptr             = to_address(SM_TMats.origin()) + Xmem;
+      vptr             = to_address(SM_TMats.base()) + Xmem;
       if (std::abs(c) > 1e-12)
-        copy_n_cast(to_address(v.origin()) + i0, iN - i0, vptr + i0);
+        copy_n_cast(to_address(v.base()) + i0, iN - i0, vptr + i0);
     }
     // setup array references
-    boost::multi::array_cref<SPComplexType, 2> Xsp(Xptr, X.extensions());
-    boost::multi::array_ref<SPComplexType, 2> vsp(vptr, v.extensions());
+    boost::multi::array_cref<SPComplexType, 2> Xsp(Xptr, X.extents());
+    boost::multi::array_ref<SPComplexType, 2> vsp(vptr, v.extents());
     comm->barrier();
 
     using std::get;
-    boost::multi::array_ref<SPComplexType, 2> v_(to_address(vsp[Spvn_view.local_origin()[0]].origin()),
+    boost::multi::array_ref<SPComplexType, 2> v_(to_address(vsp[Spvn_view.local_origin()[0]].base()),
                                                  {long(get<0>(Spvn_view.sizes())), long(get<1>(vsp.sizes()))});
     ma::product(SPValueType(a), Spvn_view, Xsp, SPValueType(c), v_);
 
     // copy data back if changing precision
     if (not std::is_same<vType, SPComplexType>::value)
     {
-      copy_n(to_address(v_.origin()), v_.num_elements(), to_address(v[Spvn_view.local_origin()[0]].origin()));
+      copy_n(to_address(v_.base()), v_.num_elements(), to_address(v[Spvn_view.local_origin()[0]].base()));
     }
     comm->barrier();
   }
@@ -375,8 +375,8 @@ public:
 
     using BType = typename std::decay<MatB>::type::element;
     using AType = typename std::decay<MatA>::type::element;
-    boost::multi::array_ref<BType, 2, decltype(v.origin())> v_(v.origin(), {get<0>(v.sizes()), 1});
-    boost::multi::array_cref<AType, 2, decltype(G.origin())> G_(G.origin(), {get<0>(G.sizes()), 1});
+    boost::multi::array_ref<BType, 2, decltype(v.base())> v_(v.base(), {get<0>(v.sizes()), 1});
+    boost::multi::array_cref<AType, 2, decltype(G.base())> G_(G.base(), {get<0>(G.sizes()), 1});
     return vbias(G_, v_, a, c, k);
   }
 
@@ -410,42 +410,42 @@ public:
     // setup origin of Gsp and copy_n_cast if necessary
     if (std::is_same<GType, SPComplexType>::value)
     {
-      Gptr = reinterpret_cast<const_sp_pointer>(to_address(G.origin()));
+      Gptr = reinterpret_cast<const_sp_pointer>(to_address(G.base()));
     }
     else
     {
       long i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(long(comm->rank()), long(G.num_elements()), long(comm->size()));
-      copy_n_cast(to_address(G.origin()) + i0, iN - i0, to_address(SM_TMats.origin()) + i0);
-      Gptr = to_address(SM_TMats.origin());
+      copy_n_cast(to_address(G.base()) + i0, iN - i0, to_address(SM_TMats.base()) + i0);
+      Gptr = to_address(SM_TMats.base());
     }
     // setup origin of vsp and copy_n_cast if necessary
     if (std::is_same<vType, SPComplexType>::value)
     {
-      vptr = reinterpret_cast<sp_pointer>(to_address(v.origin()));
+      vptr = reinterpret_cast<sp_pointer>(to_address(v.base()));
     }
     else
     {
       long i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(long(comm->rank()), long(v.num_elements()), long(comm->size()));
-      vptr             = to_address(SM_TMats.origin()) + Gmem;
+      vptr             = to_address(SM_TMats.base()) + Gmem;
       if (std::abs(c) > 1e-12)
-        copy_n_cast(to_address(v.origin()) + i0, iN - i0, vptr + i0);
+        copy_n_cast(to_address(v.base()) + i0, iN - i0, vptr + i0);
     }
     // setup array references
-    boost::multi::array_cref<SPComplexType, 2> Gsp(Gptr, G.extensions());
-    boost::multi::array_ref<SPComplexType, 2> vsp(vptr, v.extensions());
+    boost::multi::array_cref<SPComplexType, 2> Gsp(Gptr, G.extents());
+    boost::multi::array_ref<SPComplexType, 2> vsp(vptr, v.extents());
     comm->barrier();
 
     using std::get;
-    boost::multi::array_ref<SPComplexType, 2> v_(to_address(vsp[SpvnT_view[k].local_origin()[0]].origin()),
+    boost::multi::array_ref<SPComplexType, 2> v_(to_address(vsp[SpvnT_view[k].local_origin()[0]].base()),
                                                  {long(get<0>(SpvnT_view[k].sizes())), long(get<1>(vsp.sizes()))});
     ma::product(SpT2(a), SpvnT_view[k], Gsp, SpT2(c), v_);
 
     // copy data back if changing precision
     if (not std::is_same<vType, SPComplexType>::value)
     {
-      copy_n(to_address(v_.origin()), v_.num_elements(), to_address(v[SpvnT_view[k].local_origin()[0]].origin()));
+      copy_n(to_address(v_.base()), v_.num_elements(), to_address(v[SpvnT_view[k].local_origin()[0]].base()));
     }
     comm->barrier();
   }
@@ -527,7 +527,7 @@ private:
     {
       SM_TMats.reextent(iextensions<1u>(N));
       using std::fill_n;
-      fill_n(SM_TMats.origin(), N, SPComplexType(0.0));
+      fill_n(SM_TMats.base(), N, SPComplexType(0.0));
       comm->barrier();
     }
   }

--- a/src/AFQMC/HamiltonianOperations/SparseTensorIO.hpp
+++ b/src/AFQMC/HamiltonianOperations/SparseTensorIO.hpp
@@ -133,15 +133,15 @@ SparseTensor<T1, T2> loadSparseTensor(hdf_archive& dump,
       app_error() << " Error in loadSparseTensor: Problems reading dataset. \n";
       APP_ABORT("");
     }
-    copy_n_cast(H1_.origin(), NMO * NMO, to_address(H1.origin()));
+    copy_n_cast(H1_.base(), NMO * NMO, to_address(H1.base()));
     if (!dump.readEntry(v0, "v0"))
     {
       app_error() << " Error in loadSparseTensor: Problems reading dataset. \n";
       APP_ABORT("");
     }
   }
-  TGwfn.Global().broadcast_n(H1.origin(), H1.num_elements());
-  TGwfn.Global().broadcast_n(v0.origin(), v0.num_elements());
+  TGwfn.Global().broadcast_n(H1.base(), H1.num_elements());
+  TGwfn.Global().broadcast_n(v0.base(), v0.num_elements());
 
   // read half-rotated exchange matrix
   std::vector<T1_shm_csr_matrix> V2;

--- a/src/AFQMC/HamiltonianOperations/THCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOps.hpp
@@ -199,11 +199,11 @@ public:
 
     vHS(vMF_, P1D);
     if (TG.TG_Cores().size() > 1 && TG.TG_local().root())
-      TG.TG_Cores().all_reduce_in_place_n(to_address(P1D.origin()), P1D.num_elements(), std::plus<>());
+      TG.TG_Cores().all_reduce_in_place_n(to_address(P1D.base()), P1D.num_elements(), std::plus<>());
     TG.TG().barrier();
 
     boost::multi::array<ComplexType, 2> H1({NMO, NMO});
-    copy_n(P1D.origin(), NMO * NMO, H1.origin());
+    copy_n(P1D.base(), NMO * NMO, H1.base());
 
     // add hij + vn0 and symmetrize
     using ma::conj;
@@ -269,10 +269,10 @@ public:
     int getKl = Kl != nullptr;
 
     // addH1
-    fill_n(E.origin(), E.num_elements(), ComplexType(0.0));
+    fill_n(E.base(), E.num_elements(), ComplexType(0.0));
     if (addH1)
     {
-      ma::product(ComplexType(1.0), G, haj[k], ComplexType(0.0), E(E.extension(), 0));
+      ma::product(ComplexType(1.0), G, haj[k], ComplexType(0.0), E(E.extent(), 0));
       for (int i = 0; i < nwalk; i++)
         E[i][0] += E0;
     }
@@ -315,16 +315,16 @@ public:
     // setup origin of Gsp and copy_n_cast if necessary
     if (std::is_same<GType, SPComplexType>::value)
     {
-      Gptr = pointer_cast<SPComplexType const>(make_device_ptr(G.origin()));
+      Gptr = pointer_cast<SPComplexType const>(make_device_ptr(G.base()));
     }
     else
     {
       long i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(long(comm->rank()), long(G.num_elements()), long(comm->size()));
-      copy_n_cast(make_device_ptr(G.origin()) + i0, iN - i0, make_device_ptr(Gbuff.origin()) + i0);
-      Gptr = make_device_ptr(Gbuff.origin());
+      copy_n_cast(make_device_ptr(G.base()) + i0, iN - i0, make_device_ptr(Gbuff.base()) + i0);
+      Gptr = make_device_ptr(Gbuff.base());
     }
-    Array_cref<SPComplexType, 2> Gsp(Gptr, G.extensions());
+    Array_cref<SPComplexType, 2> Gsp(Gptr, G.extents());
 
     // Guv[nspin][nu][nv]
     ShmArray<SPComplexType, 3> Guv({nwmax, nu, nv},
@@ -341,30 +341,30 @@ public:
     while (iw < nwalk)
     {
       int nw = std::min(nwmax, nwalk - iw);
-      fill_n(Guu.origin(), Guu.num_elements(), SPComplexType(0.0));
+      fill_n(Guu.base(), Guu.num_elements(), SPComplexType(0.0));
       for (int ispin = 0; ispin < nspin; ++ispin)
       {
         Guv_Guu(ispin, Gsp.sliced(iw, iw + nw), Guv, Guu, Tav, k);
 
         // Gwuv = Gwuv * rotMuv
         using ma::inplace_product;
-        inplace_product(nw, nu, (vN - v0), make_device_ptr(rotMuv.origin()) + v0, nv,
-                        make_device_ptr(Guv.origin()) + v0, nv);
+        inplace_product(nw, nu, (vN - v0), make_device_ptr(rotMuv.base()) + v0, nv,
+                        make_device_ptr(Guv.base()) + v0, nv);
         comm->barrier();
 
         // R[w,u][b] = sum_v Guv[w,u][v] * cPua[v][b]
         long i0, iN;
         std::tie(i0, iN) = FairDivideBoundary(long(comm->rank()), long(nw * nu), long(comm->size()));
-        Array_ref<SPComplexType, 2> Rwub(make_device_ptr(Tav.origin()), {nw * nu, nelec[ispin]});
-        Array_ref<SPComplexType, 2> Guv2D(make_device_ptr(Guv.origin()), {nw * nu, nv});
+        Array_ref<SPComplexType, 2> Rwub(make_device_ptr(Tav.base()), {nw * nu, nelec[ispin]});
+        Array_ref<SPComplexType, 2> Guv2D(make_device_ptr(Guv.base()), {nw * nu, nv});
         ma::product(Guv2D.sliced(i0, iN), rotcPua[k]({0, nv}, {ispin * nup, nup + ispin * ndown}), Rwub.sliced(i0, iN));
         comm->barrier();
 
         //T[w][b][k] = sum_u R[w][u][b] * Piu[k][u]
         // need batching in this case
-        Array_ref<SPComplexType, 3> Rwub3D(Rwub.origin(), {nw, nu, nelec[ispin]});
-        Array_ref<SPComplexType, 3> Twbk(make_device_ptr(Guv.origin()), {nw, nelec[ispin], nmo_});
-        Array_ref<SPComplexType, 2> Twbk2D(Twbk.origin(), {nw, nelec[ispin] * nmo_});
+        Array_ref<SPComplexType, 3> Rwub3D(Rwub.base(), {nw, nu, nelec[ispin]});
+        Array_ref<SPComplexType, 3> Twbk(make_device_ptr(Guv.base()), {nw, nelec[ispin], nmo_});
+        Array_ref<SPComplexType, 2> Twbk2D(Twbk.base(), {nw, nelec[ispin] * nmo_});
         std::vector<decltype(&(Rwub3D[0]))> vRwub;
         std::vector<decltype(&(rotPiu({0, 1}, {0, 1})))> vPku;
         std::vector<decltype(&(Twbk[0]({0, 1}, {0, 1})))> vTwbk;
@@ -383,7 +383,7 @@ public:
         // need to keep vPku on the left hand side in real build
         if (Guv.num_elements() >= 2 * Twbk.num_elements())
         {
-          Array_ref<SPComplexType, 3> Twkb(Twbk.origin() + Twbk.num_elements(), {nw, nmo_, nelec[ispin]});
+          Array_ref<SPComplexType, 3> Twkb(Twbk.base() + Twbk.num_elements(), {nw, nmo_, nelec[ispin]});
           std::vector<decltype(&(Twkb[0].sliced(0, 1)))> vTwkb;
           vTwkb.reserve(nw);
           for (int w = 0; w < nw; ++w)
@@ -523,43 +523,43 @@ public:
       // if Alpha/Beta have different references, allocate the largest and
       // have distinct references for each
       // Guv[nu][nv]
-      boost::multi::array_ref<ComplexType,2> Guv(to_address(SM_TMats.origin()),{nu,nv});
+      boost::multi::array_ref<ComplexType,2> Guv(to_address(SM_TMats.base()),{nu,nv});
       cnt+=Guv.num_elements();
       // Gvv[v]: summed over spin
-      boost::multi::array_ref<ComplexType,1> Gvv(to_address(SM_TMats.origin())+cnt,iextensions<1u>{nv});
+      boost::multi::array_ref<ComplexType,1> Gvv(to_address(SM_TMats.base())+cnt,iextensions<1u>{nv});
       cnt+=Gvv.num_elements();
       // S[nel_][nv]
-      boost::multi::array_ref<ComplexType,2> Scu(to_address(SM_TMats.origin())+cnt,{nel_,nv});
+      boost::multi::array_ref<ComplexType,2> Scu(to_address(SM_TMats.base())+cnt,{nel_,nv});
       cnt+=Scu.num_elements();
       // Qub[nu][nel_]:
-      boost::multi::array_ref<ComplexType,2> Qub(to_address(SM_TMats.origin())+cnt,{nu,nel_});
+      boost::multi::array_ref<ComplexType,2> Qub(to_address(SM_TMats.base())+cnt,{nu,nel_});
       cnt+=Qub.num_elements();
-      boost::multi::array_ref<ComplexType,1> Tuu(to_address(SM_TMats.origin())+cnt,iextensions<1u>{nu});
+      boost::multi::array_ref<ComplexType,1> Tuu(to_address(SM_TMats.base())+cnt,iextensions<1u>{nu});
       cnt+=Tuu.num_elements();
-      boost::multi::array_ref<ComplexType,2> Jcb(to_address(SM_TMats.origin())+cnt,{nel_,nel_});
+      boost::multi::array_ref<ComplexType,2> Jcb(to_address(SM_TMats.base())+cnt,{nel_,nel_});
       cnt+=Jcb.num_elements();
-      boost::multi::array_ref<ComplexType,2> Xcb(to_address(SM_TMats.origin())+cnt,{nel_,nel_});
+      boost::multi::array_ref<ComplexType,2> Xcb(to_address(SM_TMats.base())+cnt,{nel_,nel_});
       cnt+=Xcb.num_elements();
-      boost::multi::array_ref<ComplexType,2> Tub(to_address(SM_TMats.origin())+cnt,{nu,nel_});
+      boost::multi::array_ref<ComplexType,2> Tub(to_address(SM_TMats.base())+cnt,{nu,nel_});
       cnt+=Tub.num_elements();
       assert(cnt <= memory_needs);
       boost::multi::static_array<ComplexType,3,dev_buffer_type> eloc({2,nwalk,3}
                         device_buffer_manager.get_generator().template get_allocator<ComplexType>());
-      std::fill_n(eloc.origin(),eloc.num_elements(),ComplexType(0.0));
+      std::fill_n(eloc.base(),eloc.num_elements(),ComplexType(0.0));
 
       RealType scl = (walker_type==CLOSED?2.0:1.0);
       if(comm->root()) {
-        std::fill_n(to_address(E.origin()),E.num_elements(),ComplexType(0.0));
-        std::fill_n(to_address(Ov[0][1].origin()),nwalk*(Ov.size(1)-1),ComplexType(0.0));
-        std::fill_n(to_address(Ov[1][1].origin()),nwalk*(Ov.size(1)-1),ComplexType(0.0));
+        std::fill_n(to_address(E.base()),E.num_elements(),ComplexType(0.0));
+        std::fill_n(to_address(Ov[0][1].base()),nwalk*(Ov.size(1)-1),ComplexType(0.0));
+        std::fill_n(to_address(Ov[1][1].base()),nwalk*(Ov.size(1)-1),ComplexType(0.0));
         auto Ea = E[0][0];
         auto Eb = E[1][0];
-        boost::multi::array_cref<ComplexType,2> G2DA(to_address(GrefA.origin()),
+        boost::multi::array_cref<ComplexType,2> G2DA(to_address(GrefA.base()),
                                           {nwalk,GrefA[0].num_elements()});
-        ma::product(ComplexType(1.0),G2DA,haj[0],ComplexType(0.0),Ea(Ea.extension(),0));
-        boost::multi::array_cref<ComplexType,2> G2DB(to_address(GrefA.origin()),
+        ma::product(ComplexType(1.0),G2DA,haj[0],ComplexType(0.0),Ea(Ea.extent(),0));
+        boost::multi::array_cref<ComplexType,2> G2DB(to_address(GrefA.base()),
                                           {nwalk,GrefA[0].num_elements()});
-        ma::product(ComplexType(1.0),G2DB,haj[0],ComplexType(0.0),Eb(Eb.extension(),0));
+        ma::product(ComplexType(1.0),G2DB,haj[0],ComplexType(0.0),Eb(Eb.extent(),0));
         for(int i=0; i<nwalk; i++) {
             Ea[i][0] += E0;
             Eb[i][0] += E0;
@@ -570,14 +570,14 @@ public:
 
         { // Alpha
           auto Gw = GrefA[wi];
-          boost::multi::array_cref<ComplexType,1> G1D(to_address(Gw.origin()),
+          boost::multi::array_cref<ComplexType,1> G1D(to_address(Gw.base()),
                                                         iextensions<1u>{Gw.num_elements()});
           Guv_Guu2(Gw,Guv,Gvv,Scu,0);
           if(u0!=uN)
             ma::product(rotMuv.sliced(u0,uN),Gvv,
                       Tuu.sliced(u0,uN));
-          auto Mptr = rotMuv[u0].origin();
-          auto Gptr = to_address(Guv[u0].origin());
+          auto Mptr = rotMuv[u0].base();
+          auto Gptr = to_address(Guv[u0].base());
           for(size_t k=0, kend=(uN-u0)*nv; k<kend; ++k, ++Gptr, ++Mptr)
             (*Gptr) *= (*Mptr);
           if(u0!=uN)
@@ -588,9 +588,9 @@ public:
             ma::product(Scu.sliced(k0,kN),Qub,
                       Xcb.sliced(k0,kN));
           // Tub = rotcPua.*Tu
-          auto rPptr = rotcPua[0][nu0+u0].origin();
-          auto Tuuptr = Tuu.origin()+u0;
-          auto Tubptr = Tub[u0].origin();
+          auto rPptr = rotcPua[0][nu0+u0].base();
+          auto Tuuptr = Tuu.base()+u0;
+          auto Tubptr = Tub[u0].base();
           for(size_t u_=u0; u_<uN; ++u_, ++Tuuptr)
             for(size_t k=0; k<nel_; ++k, ++rPptr, ++Tubptr)
               (*Tubptr) = (*Tuuptr)*(*rPptr);
@@ -611,14 +611,14 @@ public:
 
         { // Beta: Unnecessary in CLOSED walker type (on Walker)
           auto Gw = GrefB[wi];
-          boost::multi::array_cref<ComplexType,1> G1D(to_address(Gw.origin()),
+          boost::multi::array_cref<ComplexType,1> G1D(to_address(Gw.base()),
                                                         iextensions<1u>{Gw.num_elements()});
           Guv_Guu2(Gw,Guv,Gvv,Scu,0);
           if(u0!=uN)
             ma::product(rotMuv.sliced(u0,uN),Gvv,
                       Tuu.sliced(u0,uN));
-          auto Mptr = rotMuv[u0].origin();
-          auto Gptr = to_address(Guv[u0].origin());
+          auto Mptr = rotMuv[u0].base();
+          auto Gptr = to_address(Guv[u0].base());
           for(size_t k=0, kend=(uN-u0)*nv; k<kend; ++k, ++Gptr, ++Mptr)
             (*Gptr) *= (*Mptr);
           if(u0!=uN)
@@ -629,9 +629,9 @@ public:
             ma::product(Scu.sliced(k0,kN),Qub,
                       Xcb.sliced(k0,kN));
           // Tub = rotcPua.*Tu
-          auto rPptr = rotcPua[0][nu0+u0].origin();
-          auto Tuuptr = Tuu.origin()+u0;
-          auto Tubptr = Tub[u0].origin();
+          auto rPptr = rotcPua[0][nu0+u0].base();
+          auto Tuuptr = Tuu.base()+u0;
+          auto Tubptr = Tub[u0].base();
           for(size_t u_=u0; u_<uN; ++u_, ++Tuuptr)
             for(size_t k=0; k<nel_; ++k, ++rPptr, ++Tubptr)
               (*Tubptr) = (*Tuuptr)*(*rPptr);
@@ -647,7 +647,7 @@ public:
         }
 
       }
-      comm->reduce_in_place_n(eloc.origin(),eloc.num_elements(),std::plus<>(),0);
+      comm->reduce_in_place_n(eloc.base(),eloc.num_elements(),std::plus<>(),0);
       if(comm->root()) {
         // add Eref contributions to all configurations
         for(int nd=0; nd<E.size(1); ++nd) {
@@ -674,8 +674,8 @@ public:
   {
     using XType = typename std::decay_t<typename MatA::element>;
     using vType = typename std::decay<MatB>::type::element;
-    boost::multi::array_ref<vType, 2, decltype(v.origin())> v_(v.origin(), {1, v.size()});
-    boost::multi::array_ref<XType const, 2, decltype(X.origin())> X_(X.origin(), {X.size(), 1});
+    boost::multi::array_ref<vType, 2, decltype(v.base())> v_(v.base(), {1, v.size()});
+    boost::multi::array_ref<XType const, 2, decltype(X.base())> X_(X.base(), {X.size(), 1});
     vHS(X_, v_, a, c);
   }
 
@@ -725,46 +725,46 @@ public:
     // setup origin of vsp and copy_n_cast if necessary
     if (std::is_same<vType, SPComplexType>::value)
     {
-      vptr = pointer_cast<SPComplexType>(make_device_ptr(v.origin()));
+      vptr = pointer_cast<SPComplexType>(make_device_ptr(v.base()));
     }
     else
     {
       long i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(long(comm->rank()), long(v.num_elements()), long(comm->size()));
-      vptr             = make_device_ptr(SM_TMats.origin());
+      vptr             = make_device_ptr(SM_TMats.base());
       cnt += size_t(v.num_elements());
       if (std::abs(c) > 1e-12)
-        copy_n_cast(make_device_ptr(v.origin()) + i0, iN - i0, vptr + i0);
+        copy_n_cast(make_device_ptr(v.base()) + i0, iN - i0, vptr + i0);
     }
     // setup origin of Xsp and copy_n_cast if necessary
     if (std::is_same<XType, SPComplexType>::value)
     {
-      Xptr = pointer_cast<SPComplexType const>(make_device_ptr(X.origin()));
+      Xptr = pointer_cast<SPComplexType const>(make_device_ptr(X.base()));
     }
     else
     {
       long i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(long(comm->rank()), long(X.num_elements()), long(comm->size()));
-      copy_n_cast(make_device_ptr(X.origin()) + i0, iN - i0, make_device_ptr(SM_TMats.origin()) + cnt + i0);
-      Xptr = make_device_ptr(SM_TMats.origin()) + cnt;
+      copy_n_cast(make_device_ptr(X.base()) + i0, iN - i0, make_device_ptr(SM_TMats.base()) + cnt + i0);
+      Xptr = make_device_ptr(SM_TMats.base()) + cnt;
       cnt += size_t(X.num_elements());
     }
     // setup array references
-    Array_cref<SPComplexType, 2> Xsp(Xptr, X.extensions());
-    Array_ref<SPComplexType, 2> vsp(vptr, v.extensions());
+    Array_cref<SPComplexType, 2> Xsp(Xptr, X.extents());
+    Array_ref<SPComplexType, 2> vsp(vptr, v.extents());
 
     int u0, uN;
     std::tie(u0, uN) = FairDivideBoundary(comm->rank(), nu, comm->size());
-    Array_ref<SPComplexType, 2> Tuw(make_device_ptr(SM_TMats.origin()) + cnt, {nu, nwalk});
+    Array_ref<SPComplexType, 2> Tuw(make_device_ptr(SM_TMats.base()) + cnt, {nu, nwalk});
     // O[nwalk * nmu * nmu]
 
     using std::get;
 #if defined(QMC_COMPLEX)
     // reinterpret as RealType matrices with 2x the columns
-    Array_ref<SPRealType, 2> Luv_R(pointer_cast<SPRealType>(make_device_ptr(Luv.origin())),
+    Array_ref<SPRealType, 2> Luv_R(pointer_cast<SPRealType>(make_device_ptr(Luv.base())),
                                    {get<0>(Luv.sizes()), 2 * get<1>(Luv.sizes())});
-    Array_cref<SPRealType, 2> X_R(pointer_cast<SPRealType const>(Xsp.origin()), {get<0>(Xsp.sizes()), 2 * get<1>(Xsp.sizes())});
-    Array_ref<SPRealType, 2> Tuw_R(pointer_cast<SPRealType>(Tuw.origin()), {nu, 2 * nwalk});
+    Array_cref<SPRealType, 2> X_R(pointer_cast<SPRealType const>(Xsp.base()), {get<0>(Xsp.sizes()), 2 * get<1>(Xsp.sizes())});
+    Array_ref<SPRealType, 2> Tuw_R(pointer_cast<SPRealType>(Tuw.base()), {nu, 2 * nwalk});
     ma::product(Luv_R.sliced(u0, uN), X_R, Tuw_R.sliced(u0, uN));
 #else
     ma::product(Luv.sliced(u0, uN), Xsp, Tuw.sliced(u0, uN));
@@ -779,27 +779,27 @@ public:
 #if defined(QMC_COMPLEX)
       // Qwiu[w][i][u] = T[u][w] * conj(Piu[i][u])
       // v[w][i][k] = sum_u Qwiu[w][i][u] * Piu[k][u]
-      Array_ref<SPComplexType, 2> Qwiu(Tuw.origin() + Tuw.num_elements(), {nw * nmo_, nu});
+      Array_ref<SPComplexType, 2> Qwiu(Tuw.base() + Tuw.num_elements(), {nw * nmo_, nu});
       using ma::element_wise_Aij_Bjk_Ckij;
-      element_wise_Aij_Bjk_Ckij('C', (kN - k0), nu, nw, make_device_ptr(Piu[k0].origin()), nu,
-                                make_device_ptr(Tuw.origin()) + iw, nwalk, make_device_ptr(Qwiu.origin()) + k0 * nu,
+      element_wise_Aij_Bjk_Ckij('C', (kN - k0), nu, nw, make_device_ptr(Piu[k0].base()), nu,
+                                make_device_ptr(Tuw.base()) + iw, nwalk, make_device_ptr(Qwiu.base()) + k0 * nu,
                                 nmo_, nu);
       comm->barrier();
       // v[w][i][j] = sum_u Qwiu[w][i][u] * Piu[j][u]
-      Array_ref<SPComplexType, 2> v_(vsp[iw].origin(), {nw * nmo_, nmo_});
+      Array_ref<SPComplexType, 2> v_(vsp[iw].base(), {nw * nmo_, nmo_});
       int wk0, wkN;
       std::tie(wk0, wkN) = FairDivideBoundary(comm->rank(), nw * nmo_, comm->size());
       ma::product(SPComplexType(a), Qwiu.sliced(wk0, wkN), T(Piu), SPComplexType(c), v_.sliced(wk0, wkN));
 #else
       // Qwui[w][u][i] = Piu[i][u] * T[u][w]
       // v[w][i][j] = sum_u Piu[i][u] Qwui[w][u][j] // using batched blas
-      Array_ref<SPComplexType, 3> Qwui(Tuw.origin() + Tuw.num_elements(), {nw, nu, nmo_});
+      Array_ref<SPComplexType, 3> Qwui(Tuw.base() + Tuw.num_elements(), {nw, nu, nmo_});
       using ma::element_wise_Aij_Bjk_Ckji;
-      element_wise_Aij_Bjk_Ckji((kN - k0), nu, nw, make_device_ptr(Piu[k0].origin()), nu,
-                                make_device_ptr(Tuw.origin()) + iw, nwalk, make_device_ptr(Qwui.origin()) + k0, nmo_,
+      element_wise_Aij_Bjk_Ckji((kN - k0), nu, nw, make_device_ptr(Piu[k0].base()), nu,
+                                make_device_ptr(Tuw.base()) + iw, nwalk, make_device_ptr(Qwui.base()) + k0, nmo_,
                                 nu * nmo_);
       comm->barrier();
-      Array_ref<SPComplexType, 3> v_(vsp[iw].origin(), {nw, nmo_, nmo_});
+      Array_ref<SPComplexType, 3> v_(vsp[iw].base(), {nw, nmo_, nmo_});
       std::vector<decltype(&(Piu.sliced(0, 1)))> vPiu;
       std::vector<decltype(&(Qwui[0]))> vQui;
       std::vector<decltype(&(v_[0].sliced(0, 1)))> vVij;
@@ -821,7 +821,7 @@ public:
     {
       long i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(long(comm->rank()), long(v.num_elements()), long(comm->size()));
-      copy_n_cast(vsp.origin() + i0, iN - i0, make_device_ptr(v.origin()) + i0);
+      copy_n_cast(vsp.base() + i0, iN - i0, make_device_ptr(v.base()) + i0);
     }
     comm->barrier();
   }
@@ -836,8 +836,8 @@ public:
     using std::get;
     using GType = typename std::decay_t<typename MatA::element>;
     using vType = typename std::decay<MatB>::type::element;
-    boost::multi::array_ref<vType, 2, decltype(v.origin())> v_(v.origin(), {get<0>(v.sizes()), 1});
-    boost::multi::array_ref<GType const, 2, decltype(G.origin())> G_(G.origin(), {1, get<0>(G.sizes())});
+    boost::multi::array_ref<vType, 2, decltype(v.base())> v_(v.base(), {get<0>(v.sizes()), 1});
+    boost::multi::array_ref<GType const, 2, decltype(G.base())> G_(G.base(), {1, get<0>(G.sizes())});
     vbias(G_, v_, a, c, k);
   }
 
@@ -881,68 +881,68 @@ public:
     // setup origin of Gsp and copy_n_cast if necessary
     if (std::is_same<GType, SPComplexType>::value)
     {
-      Gptr = pointer_cast<SPComplexType const>(make_device_ptr(G.origin()));
+      Gptr = pointer_cast<SPComplexType const>(make_device_ptr(G.base()));
     }
     else
     {
       long i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(long(comm->rank()), long(G.num_elements()), long(comm->size()));
-      copy_n_cast(make_device_ptr(G.origin()) + i0, iN - i0, make_device_ptr(SM_TMats.origin()) + i0);
+      copy_n_cast(make_device_ptr(G.base()) + i0, iN - i0, make_device_ptr(SM_TMats.base()) + i0);
       cnt += size_t(G.num_elements());
-      Gptr = make_device_ptr(SM_TMats.origin());
+      Gptr = make_device_ptr(SM_TMats.base());
     }
     // setup origin of vsp and copy_n_cast if necessary
     if (std::is_same<vType, SPComplexType>::value)
     {
-      vptr = pointer_cast<SPComplexType>(make_device_ptr(v.origin()));
+      vptr = pointer_cast<SPComplexType>(make_device_ptr(v.base()));
     }
     else
     {
       long i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(long(comm->rank()), long(v.num_elements()), long(comm->size()));
-      vptr             = make_device_ptr(SM_TMats.origin()) + cnt;
+      vptr             = make_device_ptr(SM_TMats.base()) + cnt;
       cnt += size_t(v.num_elements());
       if (std::abs(c) > 1e-12)
-        copy_n_cast(make_device_ptr(v.origin()) + i0, iN - i0, vptr + i0);
+        copy_n_cast(make_device_ptr(v.base()) + i0, iN - i0, vptr + i0);
     }
     // setup array references
-    Array_cref<SPComplexType, 2> Gsp(Gptr, G.extensions());
-    Array_ref<SPComplexType, 2> vsp(vptr, v.extensions());
+    Array_cref<SPComplexType, 2> Gsp(Gptr, G.extents());
+    Array_ref<SPComplexType, 2> vsp(vptr, v.extents());
 
     using std::get;
     if (haj.size() == 1)
     {
-      Array_ref<SPComplexType, 2> Guu(make_device_ptr(SM_TMats.origin()) + cnt, {nu, nwalk});
+      Array_ref<SPComplexType, 2> Guu(make_device_ptr(SM_TMats.base()) + cnt, {nu, nwalk});
       Guu_from_compact(Gsp, Guu);
 #if defined(QMC_COMPLEX)
       // reinterpret as RealType matrices with 2x the columns
-      Array_ref<SPRealType, 2> Luv_R(pointer_cast<SPRealType>(make_device_ptr(Luv.origin())),
+      Array_ref<SPRealType, 2> Luv_R(pointer_cast<SPRealType>(make_device_ptr(Luv.base())),
                                      {get<0>(Luv.sizes()), 2 * get<1>(Luv.sizes())});
-      Array_ref<SPRealType, 2> Guu_R(pointer_cast<SPRealType>(Guu.origin()), {nu, 2 * nwalk});
-      Array_ref<SPRealType, 2> vsp_R(pointer_cast<SPRealType>(vsp.origin()), {get<0>(vsp.sizes()), 2 * get<1>(vsp.sizes())});
-      ma::product(SPRealType(a), T(Luv_R(Luv_R.extension(), {c0, cN})), Guu_R, SPRealType(c), vsp_R.sliced(c0, cN));
+      Array_ref<SPRealType, 2> Guu_R(pointer_cast<SPRealType>(Guu.base()), {nu, 2 * nwalk});
+      Array_ref<SPRealType, 2> vsp_R(pointer_cast<SPRealType>(vsp.base()), {get<0>(vsp.sizes()), 2 * get<1>(vsp.sizes())});
+      ma::product(SPRealType(a), T(Luv_R(Luv_R.extent(), {c0, cN})), Guu_R, SPRealType(c), vsp_R.sliced(c0, cN));
 #else
-      ma::product(SPRealType(a), T(Luv(Luv.extension(), {c0, cN})), Guu, SPRealType(c), vsp.sliced(c0, cN));
+      ma::product(SPRealType(a), T(Luv(Luv.extent(), {c0, cN})), Guu, SPRealType(c), vsp.sliced(c0, cN));
 #endif
     }
     else
     {
-      Array_ref<SPComplexType, 2> Guu(make_device_ptr(SM_TMats.origin()) + cnt, {nu, nwalk});
+      Array_ref<SPComplexType, 2> Guu(make_device_ptr(SM_TMats.base()) + cnt, {nu, nwalk});
       Guu_from_full(Gsp, Guu);
 #if defined(QMC_COMPLEX)
       // reinterpret as RealType matrices with 2x the columns
-      Array_ref<SPRealType, 2> Luv_R(pointer_cast<SPRealType>(make_device_ptr(Luv.origin())),
+      Array_ref<SPRealType, 2> Luv_R(pointer_cast<SPRealType>(make_device_ptr(Luv.base())),
                                      {get<0>(Luv.sizes()), 2 * get<1>(Luv.sizes())});
-      Array_ref<SPRealType, 2> Guu_R(pointer_cast<SPRealType>(Guu.origin()), {nu, 2 * nwalk});
-      Array_ref<SPRealType, 2> vsp_R(pointer_cast<SPRealType>(vsp.origin()), {get<0>(vsp.sizes()), 2 * get<1>(vsp.sizes())});
-      ma::product(SPRealType(a), T(Luv_R(Luv_R.extension(), {c0, cN})), Guu_R, SPRealType(c), vsp_R.sliced(c0, cN));
+      Array_ref<SPRealType, 2> Guu_R(pointer_cast<SPRealType>(Guu.base()), {nu, 2 * nwalk});
+      Array_ref<SPRealType, 2> vsp_R(pointer_cast<SPRealType>(vsp.base()), {get<0>(vsp.sizes()), 2 * get<1>(vsp.sizes())});
+      ma::product(SPRealType(a), T(Luv_R(Luv_R.extent(), {c0, cN})), Guu_R, SPRealType(c), vsp_R.sliced(c0, cN));
 #else
-      ma::product(SPRealType(a), T(Luv(Luv.extension(), {c0, cN})), Guu, SPRealType(c), vsp.sliced(c0, cN));
+      ma::product(SPRealType(a), T(Luv(Luv.extent(), {c0, cN})), Guu, SPRealType(c), vsp.sliced(c0, cN));
 #endif
     }
     if (not std::is_same<vType, SPComplexType>::value)
     {
-      copy_n_cast(make_device_ptr(vsp[c0].origin()), get<1>(vsp.sizes()) * (cN - c0), make_device_ptr(v[c0].origin()));
+      copy_n_cast(make_device_ptr(vsp[c0].base()), get<1>(vsp.sizes()) * (cN - c0), make_device_ptr(v[c0].base()));
     }
     comm->barrier();
   }
@@ -994,7 +994,7 @@ protected:
     ComplexType a = (walker_type == CLOSED) ? ComplexType(2.0) : ComplexType(1.0);
     Array<SPComplexType, 2> T1({(uN - u0), nw * nel_},
                                device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    Array_cref<SPComplexType, 2> Gw(make_device_ptr(G.origin()), {nw * nel_, nmo_});
+    Array_cref<SPComplexType, 2> Gw(make_device_ptr(G.base()), {nw * nel_, nmo_});
     comm->barrier();
 
     // transposing intermediary to make dot products faster in the next step
@@ -1006,15 +1006,15 @@ protected:
       std::tie(k0, kN) = FairDivideBoundary(comm->rank(), nmo_, comm->size());
       ShmArray<SPComplexType, 2> TGw({nmo_, nw * nel_},
                                      shm_buffer_manager.get_generator().template get_allocator<SPComplexType>());
-      ma::transpose(Gw(Gw.extension(), {k0, kN}), TGw.sliced(k0, kN));
+      ma::transpose(Gw(Gw.extent(), {k0, kN}), TGw.sliced(k0, kN));
       comm->barrier();
       ma::product(ma::T(Piu({0, nmo_}, {u0, uN})), TGw, T1);
     }
 #endif
     // Guu[u][w] = a * sum_n T1[u][w][n] * cPua[u][n]
     using ma::Auwn_Bun_Cuw;
-    Auwn_Bun_Cuw(uN - u0, nw, nel_, SPComplexType(a), T1.origin(), make_device_ptr(cPua[0][u0].origin()),
-                 make_device_ptr(Guu[u0].origin()));
+    Auwn_Bun_Cuw(uN - u0, nw, nel_, SPComplexType(a), T1.base(), make_device_ptr(cPua[0][u0].base()),
+                 make_device_ptr(Guu[u0].base()));
     comm->barrier();
   }
 
@@ -1043,19 +1043,19 @@ protected:
     Array<SPComplexType, 2> T1({nwmax * nmo_, (uN - u0)},
                                device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
     comm->barrier();
-    fill_n(Guu[u0].origin(), nwalk * (uN - u0), ComplexType(0.0));
+    fill_n(Guu[u0].base(), nwalk * (uN - u0), ComplexType(0.0));
 
     APP_ABORT(" Error: Finish Guu_from_full \n\n\n");
     int iw(0);
     while (iw < nwalk)
     {
       int nw = std::min(nwmax, nwalk - iw);
-      Array_cref<SPComplexType, 2> Giw(make_device_ptr(G[iw].origin()), {nw * nmo_, nmo_});
+      Array_cref<SPComplexType, 2> Giw(make_device_ptr(G[iw].base()), {nw * nmo_, nmo_});
       //        ma::product(Giw,Piu({0,nmo_},{u0,uN}),T1);
       // Guu[u+u0][w] = alpha * sum_i T[w][i][u] * P[i][u]
       using ma::Awiu_Biu_Cuw;
-      Awiu_Biu_Cuw(uN - u0, nw, nmo_, SPComplexType(a), T1.origin(), make_device_ptr(Piu.origin()) + u0, nu,
-                   make_device_ptr(Guu[u0].origin()) + iw, nwalk);
+      Awiu_Biu_Cuw(uN - u0, nw, nmo_, SPComplexType(a), T1.base(), make_device_ptr(Piu.base()) + u0, nu,
+                   make_device_ptr(Guu[u0].base()) + iw, nwalk);
       iw += nw;
     }
     comm->barrier();
@@ -1092,8 +1092,8 @@ protected:
     // sync first
     comm->barrier();
 
-    using const_array_ptr = boost::multi::array_ptr<SPComplexType, 2, const_sp_pointer>;
-    using array_ptr       = boost::multi::array_ptr<SPComplexType, 2, sp_pointer>;
+    using const_array_ptr = boost::multi::detail::array_ptr<SPComplexType, 2, const_sp_pointer>;
+    using array_ptr       = boost::multi::detail::array_ptr<SPComplexType, 2, sp_pointer>;
     auto Pua_ptr(&(rotcPua[k]({nu0, nu0 + nu}, {ispin * nup, nup + ispin * ndown})));
 
     std::vector<const_array_ptr> Gwaj;
@@ -1110,7 +1110,7 @@ protected:
 
     for (int iw = 0; iw < nw; ++iw)
     {
-      Gwaj.emplace_back(make_device_ptr(G[iw].origin()) + ispin * nup * nmo_, iextensions<2u>{nelec[ispin], nmo_});
+      Gwaj.emplace_back(make_device_ptr(G[iw].base()) + ispin * nup * nmo_, iextensions<2u>{nelec[ispin], nmo_});
       Pjv.emplace_back(&(rotPiu({0, nmo_}, {v0, vN})));
       Twav.emplace_back(&(Tav[iw]({0, nelec[ispin]}, {v0, vN})));
       Pua.emplace_back(Pua_ptr);
@@ -1122,7 +1122,7 @@ protected:
 #else
     ShmArray<SPComplexType, 3> Gja({nw, nmo_, nelec[ispin]},
                                    shm_buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    Array_ref<SPComplexType, 3> Tva(make_device_ptr(Guv.origin()), {nw, nv, nelec[ispin]});
+    Array_ref<SPComplexType, 3> Tva(make_device_ptr(Guv.base()), {nw, nv, nelec[ispin]});
     std::vector<array_ptr> Gwja;
     std::vector<decltype(&(Tva[0]({0, 1}, {0, 1})))> Twva;
     Twva.reserve(nw);
@@ -1130,7 +1130,7 @@ protected:
     for (int iw = 0; iw < nw; ++iw)
     {
       Twva.emplace_back(&(Tva[iw]({v0, vN}, {0, nelec[ispin]})));
-      Gwja.emplace_back(make_device_ptr(Gja[iw].origin()), iextensions<2u>{nmo_, nelec[ispin]});
+      Gwja.emplace_back(make_device_ptr(Gja[iw].base()), iextensions<2u>{nmo_, nelec[ispin]});
       ma::transpose((*(Gwaj[iw]))({0, nelec[ispin]}, {k0, kN}), (*(Gwja[iw])).sliced(k0, kN));
     }
     comm->barrier();
@@ -1153,12 +1153,12 @@ protected:
       // dispatch these through ma_blas_extensions!!!
       // Gwv = sum_a Twav Pva
       if (nu0 > 0) // calculate Guu from u={0,nu0}
-        Aijk_Bkj_Cik(nw, nelec[ispin], nu0, make_device_ptr(Tav.origin()), get<1>(Tav.strides()), Tav.stride(),
-                     make_device_ptr(rotcPua[k].origin()), rotcPua[k].stride(), make_device_ptr(Guu.origin()), nv);
+        Aijk_Bkj_Cik(nw, nelec[ispin], nu0, make_device_ptr(Tav.base()), get<1>(Tav.strides()), Tav.stride(),
+                     make_device_ptr(rotcPua[k].base()), rotcPua[k].stride(), make_device_ptr(Guu.base()), nv);
       if (nu0 + nu < nv) // calculate Guu from u={nu0+nu,nv}
-        Aijk_Bkj_Cik(nw, nelec[ispin], nv - nu0 - nu, make_device_ptr(Tav.origin()) + nu0 + nu, get<1>(Tav.strides()),
-                     Tav.stride(), make_device_ptr(rotcPua[k][nu0 + nu].origin()), rotcPua[k].stride(),
-                     make_device_ptr(Guu.origin()) + nu0 + nu, nv);
+        Aijk_Bkj_Cik(nw, nelec[ispin], nv - nu0 - nu, make_device_ptr(Tav.base()) + nu0 + nu, get<1>(Tav.strides()),
+                     Tav.stride(), make_device_ptr(rotcPua[k][nu0 + nu].base()), rotcPua[k].stride(),
+                     make_device_ptr(Guu.base()) + nu0 + nu, nv);
     }
     comm->barrier();
   }
@@ -1205,14 +1205,14 @@ protected:
       assert(T1.size(1) == size_t(nv));
 
       ma::product(G,rotPiu({0,nmo_},{v0,vN}),
-                  T1(T1.extension(),{v0,vN}));
+                  T1(T1.extent(),{v0,vN}));
       // This operation might benefit from a 2-D work distribution
       ma::product(rotcPua[k].sliced(nu0,nu0+nu),
-                  T1(T1.extension(),{v0,vN}),
-                  Guv(Guv.extension(),{v0,vN}));
+                  T1(T1.extent(),{v0,vN}),
+                  Guv(Guv.extent(),{v0,vN}));
       for(int v=v0; v<vN; ++v)
         if( v < nu0 || v >= nu0+nu ) {
-          Guu[v] = ma::dot(rotcPua[k][v],T1(T1.extension(),v)); 
+          Guu[v] = ma::dot(rotcPua[k][v],T1(T1.extent(),v)); 
         } else
          Guu[v] = Guv[v-nu0][v];
       comm->barrier();

--- a/src/AFQMC/HamiltonianOperations/THCOpsIO.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOpsIO.hpp
@@ -157,7 +157,7 @@ inline THCOps loadTHCOps(hdf_archive& dump,
       app_error() << " Error in loadTHCOps: Problems reading dataset. \n";
       APP_ABORT("");
     }
-    copy_n_cast(H1_.origin(), NMO * NMO, to_address(H1.origin()));
+    copy_n_cast(H1_.base(), NMO * NMO, to_address(H1.base()));
     if (!dump.readEntry(vn0, "v0"))
     {
       app_error() << " Error in loadTHCOps: Problems reading dataset. \n";
@@ -226,6 +226,7 @@ inline THCOps loadTHCOps(hdf_archive& dump,
   {
     // simple
     using ma::H;
+    using std::get;
     if (type == COLLINEAR)
     {
       boost::multi::array<SPComplexType, 2> A({NMO, NAEA});
@@ -234,11 +235,11 @@ inline THCOps loadTHCOps(hdf_archive& dump,
       {
         // cPua = H(Piu) * conj(A)
         ma::Matrix2MA('T', PsiT[2 * i], A);
-        ma::product(H(Piu), A, cPua[i](cPua[i].extension(0), {0, NAEA}));
-        ma::product(H(rotPiu), A, rotcPua[i](cPua[i].extension(0), {0, NAEA}));
+        ma::product(H(Piu), A, cPua[i](get<0>(cPua[i].extents()), {0, NAEA}));
+        ma::product(H(rotPiu), A, rotcPua[i](get<0>(cPua[i].extents()), {0, NAEA}));
         ma::Matrix2MA('T', PsiT[2 * i + 1], B);
-        ma::product(H(Piu), B, cPua[i](cPua[i].extension(0), {NAEA, NAEA + NAEB}));
-        ma::product(H(rotPiu), B, rotcPua[i](cPua[i].extension(0), {NAEA, NAEA + NAEB}));
+        ma::product(H(Piu), B, cPua[i](get<0>(cPua[i].extents()), {NAEA, NAEA + NAEB}));
+        ma::product(H(rotPiu), B, rotcPua[i](get<0>(cPua[i].extents()), {NAEA, NAEA + NAEB}));
       }
     }
     else
@@ -264,7 +265,7 @@ inline THCOps loadTHCOps(hdf_archive& dump,
     {
       check_wavefunction_consistency(type, &PsiT[nd], &PsiT[nd + skp], NMO, NAEA, NAEB);
       auto hij_(rotateHij(type, &PsiT[nd], &PsiT[nd + skp], H1));
-      std::copy_n(hij_.origin(), hij_.num_elements(), to_address(hij[n].origin()));
+      std::copy_n(hij_.base(), hij_.num_elements(), to_address(hij[n].base()));
     }
   }
   TGwfn.Node().barrier();

--- a/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
+++ b/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
@@ -54,6 +54,7 @@ using namespace afqmc;
 template<class Alloc>
 void ham_ops_basic_serial(boost::mpi3::communicator& world)
 {
+  using std::get;
   using pointer = device_ptr<ComplexType>;
 
   if (check_hamil_wfn_for_utest("ham_ops_basic_serial", UTEST_WFN, UTEST_HAMIL))

--- a/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
+++ b/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
@@ -169,7 +169,7 @@ void ham_ops_basic_serial(boost::mpi3::communicator& world)
     ComplexType Ovlp = SDet.MixedDensityMatrix(devPsiT[0], devOrbMat[0], G.sliced(0, NAEA), 0.0, true);
     if (WTYPE == COLLINEAR)
     {
-      Ovlp *= SDet.MixedDensityMatrix(devPsiT[1], devOrbMat[1](devOrbMat.extension(1), {0, NAEB}),
+      Ovlp *= SDet.MixedDensityMatrix(devPsiT[1], devOrbMat[1](get<1>(devOrbMat.extents()), {0, NAEB}),
                                       G.sliced(NAEA, NAEA + NAEB), 0.0, true);
     }
     CHECK(real(Ovlp) == Approx(1.0));
@@ -183,7 +183,7 @@ void ham_ops_basic_serial(boost::mpi3::communicator& world)
         nr = 1;
         nc = NEL * NPOL * NMO;
       }
-      boost::multi::array_ref<ComplexType, 2, pointer> Gw(make_device_ptr(G.origin()), {nr, nc});
+      boost::multi::array_ref<ComplexType, 2, pointer> Gw(make_device_ptr(G.base()), {nr, nc});
       HOps.energy(Eloc, Gw, 0, TG.getCoreID() == 0);
     }
     Eloc[0][0] = (TG.Node() += ComplexType(Eloc[0][0]));
@@ -219,7 +219,7 @@ void ham_ops_basic_serial(boost::mpi3::communicator& world)
         nr = 1;
         nc = NEL * NPOL * NMO;
       }
-      boost::multi::array_ref<ComplexType, 2, pointer> Gw(make_device_ptr(G.origin()), {nr, nc});
+      boost::multi::array_ref<ComplexType, 2, pointer> Gw(make_device_ptr(G.base()), {nr, nc});
       HOps.vbias(Gw, X, sqrtdt);
     }
     TG.local_barrier();
@@ -304,7 +304,7 @@ void ham_ops_basic_serial(boost::mpi3::communicator& world)
     //}
     //Ovlp = SDet.MixedDensityMatrix(devPsiT[0],devOrbMat[0], G2.sliced(0,NMO),0.0,false);
     //if(WTYPE==COLLINEAR) {
-    //Ovlp *= SDet.MixedDensityMatrix(devPsiT[1],devOrbMat[1](devOrbMat.extension(1),{0,NAEB}), G.sliced(NMO,2*NMO),0.0,false);
+    //Ovlp *= SDet.MixedDensityMatrix(devPsiT[1],devOrbMat[1](get<1>(devOrbMat.extents()),{0,NAEB}), G.sliced(NMO,2*NMO),0.0,false);
     //}
     int nwalk = 1;
     CMatrix Gw2({nwalk, dm_size}, alloc_);
@@ -319,21 +319,21 @@ void ham_ops_basic_serial(boost::mpi3::communicator& world)
         }
       }
     }
-    boost::multi::array_ref<ComplexType, 2, pointer> Gw2_(make_device_ptr(Gw2.origin()), {nwalk, dm_size});
+    boost::multi::array_ref<ComplexType, 2, pointer> Gw2_(make_device_ptr(Gw2.base()), {nwalk, dm_size});
     boost::multi::array<ComplexType, 3, Alloc> GFock({2, nwalk, dm_size}, alloc_);
-    fill_n(GFock.origin(), GFock.num_elements(), ComplexType(0.0));
+    fill_n(GFock.base(), GFock.num_elements(), ComplexType(0.0));
     //for(int i = 0; i < nwalk; i++) {
     //std::cout << Gw2_[i][0] << std::endl;
     //}
     //std::cout << "INIT: " << Gw2_[0][0] << " " << Gw2_[0][NMO*NMO] << std::endl;
     HOps.generalizedFockMatrix(Gw2_, GFock[0], GFock[1]);
-    //boost::multi::array_ref<ComplexType,2,pointer> GR(make_device_ptr(GFock[0][0].origin()), {NMO,NMO});
+    //boost::multi::array_ref<ComplexType,2,pointer> GR(make_device_ptr(GFock[0][0].base()), {NMO,NMO});
     //for(int i = 0; i < nwalk; i++) {
     //std::cout << GFock[0][i][0] << std::endl;
     //}
     //std::cout << "GFOCK: " << GFock[0][0][0] << " " << GFock[1][0][0] << std::endl;
     //std::cout << "Fm: " << std::endl;
-    std::fill_n(Mat.origin(), Mat.num_elements(), 0.0);
+    std::fill_n(Mat.base(), Mat.num_elements(), 0.0);
     ref.readEntry(Mat, "Fha");
     for (int i = 0; i < NMO; i++)
     {
@@ -348,7 +348,7 @@ void ham_ops_basic_serial(boost::mpi3::communicator& world)
       }
     }
     //std::cout << "Fp: " << std::endl;
-    std::fill_n(Mat.origin(), Mat.num_elements(), 0.0);
+    std::fill_n(Mat.base(), Mat.num_elements(), 0.0);
     ref.readEntry(Mat, "Fpa");
     for (int i = 0; i < NMO; i++)
     {

--- a/src/AFQMC/Hamiltonians/FactorizedSparseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/FactorizedSparseHamiltonian.cpp
@@ -63,7 +63,7 @@ SpVType_shm_csr_matrix FactorizedSparseHamiltonian::calculateHSPotentials(double
       if (i != l)
         vn0[l][i] -= 0.5 * ma::conj(vl);
     }
-  TG.Global().all_reduce_in_place_n(vn0.origin(), vn0.num_elements(), std::plus<>());
+  TG.Global().all_reduce_in_place_n(vn0.base(), vn0.num_elements(), std::plus<>());
 
   if (TG.getNumberOfTGs() > 1)
   {

--- a/src/AFQMC/Hamiltonians/HamiltonianFactory.cpp
+++ b/src/AFQMC/Hamiltonians/HamiltonianFactory.cpp
@@ -255,7 +255,7 @@ Hamiltonian HamiltonianFactory::fromHDF5(GlobalTaskGroup& gTG, xmlNodePtr cur)
       app_log() << " Shape of one-body Hamiltonian: (" << NMO << ", " << NMO << ")." << std::endl;
     }
   }
-  TG.Global().broadcast_n(to_address(H1.origin()), H1.num_elements(), 0);
+  TG.Global().broadcast_n(to_address(H1.base()), H1.num_elements(), 0);
 
   // now read the integrals
 #ifdef QMC_COMPLEX

--- a/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
@@ -176,11 +176,11 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
     }
   }
   TG.Global().broadcast_n(&E0, 1, 0);
-  TG.Global().broadcast_n(nmo_per_kp.origin(), nmo_per_kp.size(), 0);
-  TG.Global().broadcast_n(nchol_per_kp.origin(), nchol_per_kp.size(), 0);
-  TG.Global().broadcast_n(kminus.origin(), kminus.size(), 0);
+  TG.Global().broadcast_n(nmo_per_kp.base(), nmo_per_kp.size(), 0);
+  TG.Global().broadcast_n(nchol_per_kp.base(), nchol_per_kp.size(), 0);
+  TG.Global().broadcast_n(kminus.base(), kminus.size(), 0);
   if (TG.Node().root())
-    TG.Cores().broadcast_n(to_address(QKtok2.origin()), QKtok2.num_elements(), 0);
+    TG.Cores().broadcast_n(to_address(QKtok2.base()), QKtok2.num_elements(), 0);
   TG.Node().barrier();
 
   int number_of_symmetric_Q = 0;
@@ -189,7 +189,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
   //   <0: Ignore (handled by another TG)
   //    0: Calculate, without rho^+ contribution
   //   >0: Calculate, with rho^+ contribution. LQKbln data located at Qmap[Q]-1
-  std::fill_n(Qmap.origin(), Qmap.num_elements(), -1);
+  std::fill_n(Qmap.base(), Qmap.num_elements(), -1);
   {
     int ngrp(TGwfn.getNGroupsPerTG());
     int ig(TGwfn.getLocalGroupNumber());
@@ -317,8 +317,8 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
     }
   }
   TG.Node().barrier();
-  int nocc_max = *std::max_element(to_address(nocc_per_kp.origin()),
-                                   to_address(nocc_per_kp.origin()) + nocc_per_kp.num_elements());
+  int nocc_max = *std::max_element(to_address(nocc_per_kp.base()),
+                                   to_address(nocc_per_kp.base()) + nocc_per_kp.num_elements());
 
   /* half-rotate LQ and H1:
    * Given that PsiT = H(SM),
@@ -334,7 +334,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
   shmCMatrix haj({ndet * nkpts, (type == COLLINEAR ? 2 : 1) * nocc_max * npol * nmo_max},
                  shared_allocator<ComplexType>{TG.Node()});
   if (TG.Node().root())
-    std::fill_n(haj.origin(), haj.num_elements(), ComplexType(0.0));
+    std::fill_n(haj.base(), haj.num_elements(), ComplexType(0.0));
   int ank_max = nocc_max * nchol_max * nmo_max;
   for (int nd = 0; nd < ndet; nd++)
   {
@@ -362,10 +362,10 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
       {
         if (nt % TG.Node().size() == TG.Node().rank())
         {
-          std::fill_n(to_address(LQKank[nq0 + Q][K].origin()), LQKank[nq0 + Q][K].num_elements(), SPComplexType(0.0));
+          std::fill_n(to_address(LQKank[nq0 + Q][K].base()), LQKank[nq0 + Q][K].num_elements(), SPComplexType(0.0));
           if (type == COLLINEAR)
           {
-            std::fill_n(to_address(LQKank[nq0 + nkpts + Q][K].origin()), LQKank[nq0 + nkpts + Q][K].num_elements(),
+            std::fill_n(to_address(LQKank[nq0 + nkpts + Q][K].base()), LQKank[nq0 + nkpts + Q][K].num_elements(),
                         SPComplexType(0.0));
           }
         }
@@ -395,9 +395,9 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
       {
         if (nt % TG.Node().size() == TG.Node().rank())
         {
-          std::fill_n(to_address(LQKbnl[nq0 + Q][K].origin()), LQKbnl[nq0 + Q][K].num_elements(), SPComplexType(0.0));
+          std::fill_n(to_address(LQKbnl[nq0 + Q][K].base()), LQKbnl[nq0 + Q][K].num_elements(), SPComplexType(0.0));
           if (type == COLLINEAR)
-            std::fill_n(to_address(LQKbnl[nq0 + number_of_symmetric_Q + Q][K].origin()),
+            std::fill_n(to_address(LQKbnl[nq0 + number_of_symmetric_Q + Q][K].base()),
                         LQKbnl[nq0 + number_of_symmetric_Q + Q][K].num_elements(), SPComplexType(0.0));
         }
       }
@@ -444,14 +444,14 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
           { // Alpha
             auto Psi = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[2 * nd], K);
             assert(get<0>(Psi.sizes()) == na);
-            boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + K].origin()), {na, ni});
+            boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + K].base()), {na, ni});
             if (na > 0)
               ma::product(Psi, H1[K]({0, ni}, {0, ni}), haj_r);
           }
           { // Beta
             auto Psi = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[2 * nd + 1], K);
             assert(get<0>(Psi.sizes()) == nb);
-            boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + K].origin()) + na * ni, {nb, ni});
+            boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + K].base()) + na * ni, {nb, ni});
             if (nb > 0)
               ma::product(Psi, H1[K]({0, ni}, {0, ni}), haj_r);
           }
@@ -461,7 +461,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
           RealType scl = (type == CLOSED ? 2.0 : 1.0);
           auto Psi     = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[nd], K, npol == 2);
           assert(get<0>(Psi.sizes()) == na);
-          boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + K].origin()), {na, npol * ni});
+          boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + K].base()), {na, npol * ni});
           if (na > 0)
             ma::product(ComplexType(scl), Psi, H1[K]({0, npol * ni}, {0, npol * ni}), ComplexType(0.0), haj_r);
         }
@@ -496,14 +496,14 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
               assert(get<0>(Psi.sizes()) == nocc_per_kp[nd][K]);
               if (Q <= Qm)
               {
-                Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].origin()), {ni, nk, nchol});
-                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].origin()), {na, nchol, nk});
+                Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].base()), {ni, nk, nchol});
+                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].base()), {na, nchol, nk});
                 ma_rotate::getLank(Psi, Likn, Lank, buff);
               }
               else
               {
-                Sp3Tensor_ref Lkin(to_address(LQKikn[Qm][QK].origin()), {nk, ni, nchol});
-                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].origin()), {na, nchol, nk});
+                Sp3Tensor_ref Lkin(to_address(LQKikn[Qm][QK].base()), {nk, ni, nchol});
+                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].base()), {na, nchol, nk});
                 ma_rotate::getLank_from_Lkin(Psi, Lkin, Lank, buff);
               }
             }
@@ -512,14 +512,14 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
               assert(get<0>(Psi.sizes()) == nb);
               if (Q <= Qm)
               {
-                Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].origin()), {ni, nk, nchol});
-                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + nkpts + Q][K].origin()), {nb, nchol, nk});
+                Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].base()), {ni, nk, nchol});
+                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + nkpts + Q][K].base()), {nb, nchol, nk});
                 ma_rotate::getLank(Psi, Likn, Lank, buff);
               }
               else
               {
-                Sp3Tensor_ref Lkin(to_address(LQKikn[Qm][QK].origin()), {nk, ni, nchol});
-                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + nkpts + Q][K].origin()), {nb, nchol, nk});
+                Sp3Tensor_ref Lkin(to_address(LQKikn[Qm][QK].base()), {nk, ni, nchol});
+                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + nkpts + Q][K].base()), {nb, nchol, nk});
                 ma_rotate::getLank_from_Lkin(Psi, Lkin, Lank, buff);
               }
             }
@@ -531,14 +531,14 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
             assert(get<0>(Psi.sizes()) == na);
             if (Q <= Qm)
             {
-              Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].origin()), {ni, nk, nchol});
-              Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].origin()), {na, nchol, npol * nk});
+              Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].base()), {ni, nk, nchol});
+              Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].base()), {na, nchol, npol * nk});
               ma_rotate::getLank(Psi, Likn, Lank, buff, npol == 2);
             }
             else
             {
-              Sp3Tensor_ref Lkin(to_address(LQKikn[Qm][QK].origin()), {nk, ni, nchol});
-              Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].origin()), {na, nchol, npol * nk});
+              Sp3Tensor_ref Lkin(to_address(LQKikn[Qm][QK].base()), {nk, ni, nchol});
+              Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].base()), {na, nchol, npol * nk});
               ma_rotate::getLank_from_Lkin(Psi, Lkin, Lank, buff, npol == 2);
             }
           }
@@ -565,7 +565,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
           int ni    = nmo_per_kp[K];
           int nk    = nmo_per_kp[QK];
           int nchol = nchol_per_kp[Q];
-          Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].origin()), {ni, nk, nchol});
+          Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].base()), {ni, nk, nchol});
           // NOTE: LQKbnl is indexed by the K index of 'b', L[Q][Kb]
           using std::get;
 
@@ -573,13 +573,13 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
           {
             { // Alpha
               auto PsiQK = get_PsiK<boost::multi::array<SPComplexType, 2>>(nmo_per_kp, PsiT[2 * nd], QK);
-              Sp3Tensor_ref Lbnl(to_address(LQKbnl[nq0 + Qmap[Q] - 1][QK].origin()), {na, nchol, ni});
+              Sp3Tensor_ref Lbnl(to_address(LQKbnl[nq0 + Qmap[Q] - 1][QK].base()), {na, nchol, ni});
               ma_rotate::getLank_from_Lkin(PsiQK, Likn, Lbnl, buff);
             }
             { // Beta
               auto PsiQK = get_PsiK<boost::multi::array<SPComplexType, 2>>(nmo_per_kp, PsiT[2 * nd + 1], QK);
               assert(get<0>(PsiQK.sizes()) == nb);
-              Sp3Tensor_ref Lbnl(to_address(LQKbnl[nq0 + number_of_symmetric_Q + Qmap[Q] - 1][QK].origin()),
+              Sp3Tensor_ref Lbnl(to_address(LQKbnl[nq0 + number_of_symmetric_Q + Qmap[Q] - 1][QK].base()),
                                  {nb, nchol, ni});
               ma_rotate::getLank_from_Lkin(PsiQK, Likn, Lbnl, buff);
             }
@@ -588,7 +588,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
           {
             auto PsiQK = get_PsiK<SpMatrix>(nmo_per_kp, PsiT[nd], QK, npol == 2);
             assert(get<0>(PsiQK.sizes()) == na);
-            Sp3Tensor_ref Lbnl(to_address(LQKbnl[nq0 + Qmap[Q] - 1][QK].origin()), {na, nchol, npol * ni});
+            Sp3Tensor_ref Lbnl(to_address(LQKbnl[nq0 + Qmap[Q] - 1][QK].base()), {na, nchol, npol * ni});
             ma_rotate::getLank_from_Lkin(PsiQK, Likn, Lbnl, buff, npol == 2);
           }
         }
@@ -598,12 +598,12 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
   Qcomm.barrier();
   if (TG.Node().root())
   {
-    TG.Cores().all_reduce_in_place_n(to_address(haj.origin()), haj.num_elements(), std::plus<>());
+    TG.Cores().all_reduce_in_place_n(to_address(haj.base()), haj.num_elements(), std::plus<>());
     for (int Q = 0; Q < LQKank.size(); Q++)
-      Qcomm_roots.all_reduce_in_place_n(to_address(LQKank[Q].origin()), LQKank[Q].num_elements(), std::plus<>());
+      Qcomm_roots.all_reduce_in_place_n(to_address(LQKank[Q].base()), LQKank[Q].num_elements(), std::plus<>());
     for (int Q = 0; Q < LQKbnl.size(); Q++)
-      Qcomm_roots.all_reduce_in_place_n(to_address(LQKbnl[Q].origin()), LQKbnl[Q].num_elements(), std::plus<>());
-    std::fill_n(to_address(vn0.origin()), vn0.num_elements(), ComplexType(0.0));
+      Qcomm_roots.all_reduce_in_place_n(to_address(LQKbnl[Q].base()), LQKbnl[Q].num_elements(), std::plus<>());
+    std::fill_n(to_address(vn0.base()), vn0.num_elements(), ComplexType(0.0));
   }
   // need to broadcast haj from root of Qcomm with Qsym[0]>=0, to all other ones
   // NOTE NOTE NOTE
@@ -622,7 +622,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
         int Qm = kminus[Q];
         if (Q <= Qm)
         {
-          boost::multi::array_ref<SPComplexType, 2> Likn(to_address(LQKikn[Q][K].origin()),
+          boost::multi::array_ref<SPComplexType, 2> Likn(to_address(LQKikn[Q][K].base()),
                                                          {nmo_per_kp[K], nmo_per_kp[QK] * nchol_per_kp[Q]});
           using ma::H;
 #if defined(MIXED_PRECISION)
@@ -638,7 +638,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
         else
         {
           int QmK = QKtok2[Qm][K];
-          boost::multi::array_ref<SPComplexType, 3> Lkin(to_address(LQKikn[Qm][QK].origin()),
+          boost::multi::array_ref<SPComplexType, 3> Lkin(to_address(LQKikn[Qm][QK].base()),
                                                          {nmo_per_kp[QK], nmo_per_kp[K], nchol_per_kp[Qm]});
           boost::multi::array<SPComplexType, 3> buff3D({nmo_per_kp[K], nmo_per_kp[QK], nchol_per_kp[Qm]});
           using ma::conj;
@@ -646,7 +646,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
             for (int k = 0; k < nmo_per_kp[QK]; k++)
               for (int n = 0; n < nchol_per_kp[Qm]; n++)
                 buff3D[i][k][n] = ma::conj(Lkin[k][i][n]);
-          boost::multi::array_ref<SPComplexType, 2> L_(to_address(buff3D.origin()),
+          boost::multi::array_ref<SPComplexType, 2> L_(to_address(buff3D.base()),
                                                        {nmo_per_kp[K], nmo_per_kp[QK] * nchol_per_kp[Qm]});
           using ma::H;
 #if defined(MIXED_PRECISION)
@@ -709,16 +709,16 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
           if (na == 0 || nb == 0)
             continue;
 
-          SpMatrix_ref Lank(to_address(LQKank[Q][Ka].origin()), {na * nchol, nk});
-          auto bnl_ptr(to_address(LQKank[Qm][Kb].origin()));
+          SpMatrix_ref Lank(to_address(LQKank[Q][Ka].base()), {na * nchol, nk});
+          auto bnl_ptr(to_address(LQKank[Qm][Kb].base()));
           if (Qmap[Q] > 0)
-            bnl_ptr = to_address(LQKbnl[Qmap[Q] - 1][Kb].origin());
+            bnl_ptr = to_address(LQKbnl[Qmap[Q] - 1][Kb].base());
           SpMatrix_ref Lbnl(bnl_ptr, {nb * nchol, nl});
 
           SpMatrix Tban({nb, na * nchol});
-          Sp3Tensor_ref T3ban(Tban.origin(), {nb, na, nchol});
+          Sp3Tensor_ref T3ban(Tban.base(), {nb, na, nchol});
           SpMatrix Tabn({na, nb * nchol});
-          Sp3Tensor_ref T3abn(Tabn.origin(), {na, nb, nchol});
+          Sp3Tensor_ref T3abn(Tabn.base(), {na, nb, nchol});
 
           auto Gal = get_PsiK<boost::multi::array<SPComplexType, 2>>(nmo_per_kp, PsiT[0], Ka, npol == 2);
           auto Gbk = get_PsiK<boost::multi::array<SPComplexType, 2>>(nmo_per_kp, PsiT[0], Kb, npol == 2);
@@ -910,11 +910,11 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
     }
   }
   TG.Global().broadcast_n(&E0, 1, 0);
-  TG.Global().broadcast_n(nmo_per_kp.origin(), nmo_per_kp.size(), 0);
-  TG.Global().broadcast_n(nchol_per_kp.origin(), nchol_per_kp.size(), 0);
-  TG.Global().broadcast_n(kminus.origin(), kminus.size(), 0);
+  TG.Global().broadcast_n(nmo_per_kp.base(), nmo_per_kp.size(), 0);
+  TG.Global().broadcast_n(nchol_per_kp.base(), nchol_per_kp.size(), 0);
+  TG.Global().broadcast_n(kminus.base(), kminus.size(), 0);
   if (TG.Node().root())
-    TG.Cores().broadcast_n(to_address(QKtok2.origin()), QKtok2.num_elements(), 0);
+    TG.Cores().broadcast_n(to_address(QKtok2.base()), QKtok2.num_elements(), 0);
   TG.Node().barrier();
 
   // Defines behavior over Q vector:
@@ -923,7 +923,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
   //   >0: Calculate, with rho^+ contribution. LQKbln data located at Qmap[Q]-1
   int number_of_symmetric_Q = 0;
   int global_origin(0);
-  std::fill_n(Qmap.origin(), Qmap.num_elements(), -1);
+  std::fill_n(Qmap.base(), Qmap.num_elements(), -1);
   {
     int ngrp(TGwfn.getNGroupsPerTG());
     int ig(TGwfn.getLocalGroupNumber());
@@ -987,7 +987,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
   if (distNode.root())
   {
     for (auto& v : LQKikn)
-      std::fill_n(to_address(v.origin()), v.num_elements(), SPComplexType(0.0));
+      std::fill_n(to_address(v.base()), v.num_elements(), SPComplexType(0.0));
     // read LQ
     dump.push("KPFactorized", false);
     // read in compact form and transform to padded
@@ -1005,16 +1005,16 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
           APP_ABORT("");
         }
         assert(L_.size() == nkpts);
-        Sp4Tensor_ref L2(to_address(LQKikn[Q].origin()), {nkpts, nmo_max, nmo_max, nchol_max});
+        Sp4Tensor_ref L2(to_address(LQKikn[Q].base()), {nkpts, nmo_max, nmo_max, nchol_max});
         for (int K = 0; K < nkpts; ++K)
         {
           int QK = QKtok2[Q][K];
           int ni = nmo_per_kp[K];
           int nk = nmo_per_kp[QK];
-          Sp3Tensor_ref L1(to_address(L_[K].origin()), {ni, nk, nchol});
+          Sp3Tensor_ref L1(to_address(L_[K].base()), {ni, nk, nchol});
           for (int i = 0; i < ni; i++)
             for (int k = 0; k < nk; k++)
-              copy_n(L1[i][k].origin(), nchol, L2[K][i][k].origin());
+              copy_n(L1[i][k].base(), nchol, L2[K][i][k].base());
         }
       }
     }
@@ -1060,11 +1060,11 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
     }
   }
   TG.Node().barrier();
-  int nocc_max = *std::max_element(to_address(nocc_per_kp.origin()),
-                                   to_address(nocc_per_kp.origin()) + nocc_per_kp.num_elements());
+  int nocc_max = *std::max_element(to_address(nocc_per_kp.base()),
+                                   to_address(nocc_per_kp.base()) + nocc_per_kp.num_elements());
 
-  int nocc_tot = std::accumulate(to_address(nocc_per_kp.origin()),
-                                 to_address(nocc_per_kp.origin()) + nocc_per_kp.num_elements(), 0);
+  int nocc_tot = std::accumulate(to_address(nocc_per_kp.base()),
+                                 to_address(nocc_per_kp.base()) + nocc_per_kp.num_elements(), 0);
   app_log() << " Total number of electrons: " << nocc_tot << std::endl;
 
   /* half-rotate LQ and H1:
@@ -1078,7 +1078,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
   shmCMatrix haj({ndet * nkpts, (type == COLLINEAR ? 2 : 1) * nocc_max * npol * nmo_max},
                  shared_allocator<ComplexType>{TG.Node()});
   if (TG.Node().root())
-    std::fill_n(to_address(haj.origin()), haj.num_elements(), ComplexType(0.0));
+    std::fill_n(to_address(haj.base()), haj.num_elements(), ComplexType(0.0));
   int ank_max = nocc_max * nchol_max * nmo_max;
   for (int nd = 0; nd < ndet; nd++)
   {
@@ -1098,7 +1098,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
   }
   if (distNode.root())
     for (auto& v : LQKank)
-      std::fill_n(to_address(v.origin()), v.num_elements(), SPComplexType(0.0));
+      std::fill_n(to_address(v.base()), v.num_elements(), SPComplexType(0.0));
 
   std::vector<shmSpMatrix> LQKakn;
   LQKakn.reserve(ndet * nspins * nkpts);
@@ -1124,7 +1124,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
   }
   if (distNode.root())
     for (auto& v : LQKakn)
-      std::fill_n(to_address(v.origin()), v.num_elements(), SPComplexType(0.0));
+      std::fill_n(to_address(v.base()), v.num_elements(), SPComplexType(0.0));
   // NOTE: LQKbnl and LQKbln are indexed by the K index of 'b', L[Q][Kb]
   std::vector<shmSpMatrix> LQKbnl;
   LQKbnl.reserve(ndet * nspins *
@@ -1141,7 +1141,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
   }
   if (distNode.root())
     for (auto& v : LQKbnl)
-      std::fill_n(to_address(v.origin()), v.num_elements(), SPComplexType(0.0));
+      std::fill_n(to_address(v.base()), v.num_elements(), SPComplexType(0.0));
 
   std::vector<shmSpMatrix> LQKbln;
   LQKbln.reserve(ndet * nspins *
@@ -1162,7 +1162,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
   }
   if (distNode.root())
     for (auto& v : LQKbln)
-      std::fill_n(to_address(v.origin()), v.num_elements(), SPComplexType(0.0));
+      std::fill_n(to_address(v.base()), v.num_elements(), SPComplexType(0.0));
 
   int Q0 = -1; // if K=(0,0,0) exists, store index here
   for (int Q = 0; Q < nkpts; Q++)
@@ -1205,7 +1205,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
           { // Alpha
             auto Psi = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[2 * nd], K);
             assert(Psi.size() == na);
-            boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + K].origin()),
+            boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + K].base()),
                                                           {nocc_max, nmo_max});
             if (na > 0)
               ma::product(Psi, H1[K]({0, ni}, {0, ni}), haj_r({0, na}, {0, ni}));
@@ -1213,7 +1213,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
           { // Beta
             auto Psi = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[2 * nd + 1], K);
             assert(Psi.size() == nb);
-            boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + K].origin()) + nocc_max * nmo_max,
+            boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + K].base()) + nocc_max * nmo_max,
                                                           {nocc_max, nmo_max});
             if (nb > 0)
               ma::product(Psi, H1[K]({0, ni}, {0, ni}), haj_r({0, nb}, {0, ni}));
@@ -1224,7 +1224,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
           RealType scl = (type == CLOSED ? 2.0 : 1.0);
           auto Psi     = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[nd], K, npol == 2);
           assert(Psi.size() == na);
-          boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + K].origin()),
+          boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + K].base()),
                                                         {nocc_max, npol * nmo_max});
           if (na > 0)
             ma::product(ComplexType(scl), Psi, H1[K]({0, npol * ni}, {0, npol * ni}), ComplexType(0.0),
@@ -1257,16 +1257,16 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
               assert(Psi.size() == na);
               if (Q <= Qm)
               {
-                Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].origin()), {nmo_max, nmo_max, nchol_max});
-                Sp3Tensor_ref Lakn(to_address(LQKakn[nq0 + Q][K].origin()), {nocc_max, nmo_max, nchol_max});
-                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].origin()), {nocc_max, nchol_max, nmo_max});
+                Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].base()), {nmo_max, nmo_max, nchol_max});
+                Sp3Tensor_ref Lakn(to_address(LQKakn[nq0 + Q][K].base()), {nocc_max, nmo_max, nchol_max});
+                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].base()), {nocc_max, nchol_max, nmo_max});
                 ma_rotate_padded::getLakn_Lank(Psi, Likn, Lakn, Lank);
               }
               else
               {
-                Sp3Tensor_ref Lkin(to_address(LQKikn[Qm][QK].origin()), {nmo_max, nmo_max, nchol_max});
-                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].origin()), {nocc_max, nchol_max, nmo_max});
-                Sp3Tensor_ref Lakn(to_address(LQKakn[nq0 + Q][K].origin()), {nocc_max, nmo_max, nchol_max});
+                Sp3Tensor_ref Lkin(to_address(LQKikn[Qm][QK].base()), {nmo_max, nmo_max, nchol_max});
+                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].base()), {nocc_max, nchol_max, nmo_max});
+                Sp3Tensor_ref Lakn(to_address(LQKakn[nq0 + Q][K].base()), {nocc_max, nmo_max, nchol_max});
                 ma_rotate_padded::getLakn_Lank_from_Lkin(Psi, Lkin, Lakn, Lank, buff);
               }
             }
@@ -1275,16 +1275,16 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
               assert(Psi.size() == nb);
               if (Q <= Qm)
               {
-                Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].origin()), {nmo_max, nmo_max, nchol_max});
-                Sp3Tensor_ref Lakn(to_address(LQKakn[nq0 + nkpts + Q][K].origin()), {nocc_max, nmo_max, nchol_max});
-                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + nkpts + Q][K].origin()), {nocc_max, nchol_max, nmo_max});
+                Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].base()), {nmo_max, nmo_max, nchol_max});
+                Sp3Tensor_ref Lakn(to_address(LQKakn[nq0 + nkpts + Q][K].base()), {nocc_max, nmo_max, nchol_max});
+                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + nkpts + Q][K].base()), {nocc_max, nchol_max, nmo_max});
                 ma_rotate_padded::getLakn_Lank(Psi, Likn, Lakn, Lank);
               }
               else
               {
-                Sp3Tensor_ref Lkin(to_address(LQKikn[Qm][QK].origin()), {nmo_max, nmo_max, nchol_max});
-                Sp3Tensor_ref Lakn(to_address(LQKakn[nq0 + nkpts + Q][K].origin()), {nocc_max, nmo_max, nchol_max});
-                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + nkpts + Q][K].origin()), {nocc_max, nchol_max, nmo_max});
+                Sp3Tensor_ref Lkin(to_address(LQKikn[Qm][QK].base()), {nmo_max, nmo_max, nchol_max});
+                Sp3Tensor_ref Lakn(to_address(LQKakn[nq0 + nkpts + Q][K].base()), {nocc_max, nmo_max, nchol_max});
+                Sp3Tensor_ref Lank(to_address(LQKank[nq0 + nkpts + Q][K].base()), {nocc_max, nchol_max, nmo_max});
                 ma_rotate_padded::getLakn_Lank_from_Lkin(Psi, Lkin, Lakn, Lank, buff);
               }
             }
@@ -1295,16 +1295,16 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
             assert(Psi.size() == na);
             if (Q <= Qm)
             {
-              Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].origin()), {nmo_max, nmo_max, nchol_max});
-              Sp3Tensor_ref Lakn(to_address(LQKakn[nq0 + Q][K].origin()), {nocc_max, npol * nmo_max, nchol_max});
-              Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].origin()), {nocc_max, nchol_max, npol * nmo_max});
+              Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].base()), {nmo_max, nmo_max, nchol_max});
+              Sp3Tensor_ref Lakn(to_address(LQKakn[nq0 + Q][K].base()), {nocc_max, npol * nmo_max, nchol_max});
+              Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].base()), {nocc_max, nchol_max, npol * nmo_max});
               ma_rotate_padded::getLakn_Lank(Psi, Likn, Lakn, Lank, npol == 2);
             }
             else
             {
-              Sp3Tensor_ref Lkin(to_address(LQKikn[Qm][QK].origin()), {nmo_max, nmo_max, nchol_max});
-              Sp3Tensor_ref Lakn(to_address(LQKakn[nq0 + Q][K].origin()), {nocc_max, npol * nmo_max, nchol_max});
-              Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].origin()), {nocc_max, nchol_max, npol * nmo_max});
+              Sp3Tensor_ref Lkin(to_address(LQKikn[Qm][QK].base()), {nmo_max, nmo_max, nchol_max});
+              Sp3Tensor_ref Lakn(to_address(LQKakn[nq0 + Q][K].base()), {nocc_max, npol * nmo_max, nchol_max});
+              Sp3Tensor_ref Lank(to_address(LQKank[nq0 + Q][K].base()), {nocc_max, nchol_max, npol * nmo_max});
               ma_rotate_padded::getLakn_Lank_from_Lkin(Psi, Lkin, Lakn, Lank, buff, npol == 2);
             }
           }
@@ -1328,22 +1328,22 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
           int QK = QKtok2[Q][K];
           int na = nocc_per_kp[nd][QK];
           int nb = (nspins == 2 ? nocc_per_kp[nd][nkpts + QK] : na);
-          Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].origin()), {nmo_max, nmo_max, nchol_max});
+          Sp3Tensor_ref Likn(to_address(LQKikn[Q][K].base()), {nmo_max, nmo_max, nchol_max});
           if (type == COLLINEAR)
           {
             { // Alpha
               auto PsiQK = get_PsiK<boost::multi::array<SPComplexType, 2>>(nmo_per_kp, PsiT[2 * nd], QK);
               assert(PsiQK.size() == na);
-              Sp3Tensor_ref Lbnl(to_address(LQKbnl[nq0 + Qmap[Q] - 1][QK].origin()), {nocc_max, nchol_max, nmo_max});
-              Sp3Tensor_ref Lbln(to_address(LQKbln[nq0 + Qmap[Q] - 1][QK].origin()), {nocc_max, nmo_max, nchol_max});
+              Sp3Tensor_ref Lbnl(to_address(LQKbnl[nq0 + Qmap[Q] - 1][QK].base()), {nocc_max, nchol_max, nmo_max});
+              Sp3Tensor_ref Lbln(to_address(LQKbln[nq0 + Qmap[Q] - 1][QK].base()), {nocc_max, nmo_max, nchol_max});
               ma_rotate_padded::getLakn_Lank_from_Lkin(PsiQK, Likn, Lbln, Lbnl, buff);
             }
             { // Beta
               auto PsiQK = get_PsiK<boost::multi::array<SPComplexType, 2>>(nmo_per_kp, PsiT[2 * nd + 1], QK);
               assert(PsiQK.size() == nb);
-              Sp3Tensor_ref Lbnl(to_address(LQKbnl[nq0 + number_of_symmetric_Q + Qmap[Q] - 1][QK].origin()),
+              Sp3Tensor_ref Lbnl(to_address(LQKbnl[nq0 + number_of_symmetric_Q + Qmap[Q] - 1][QK].base()),
                                  {nocc_max, nchol_max, nmo_max});
-              Sp3Tensor_ref Lbln(to_address(LQKbln[nq0 + number_of_symmetric_Q + Qmap[Q] - 1][QK].origin()),
+              Sp3Tensor_ref Lbln(to_address(LQKbln[nq0 + number_of_symmetric_Q + Qmap[Q] - 1][QK].base()),
                                  {nocc_max, nmo_max, nchol_max});
               ma_rotate_padded::getLakn_Lank_from_Lkin(PsiQK, Likn, Lbln, Lbnl, buff);
             }
@@ -1352,9 +1352,9 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
           {
             auto PsiQK = get_PsiK<SpMatrix>(nmo_per_kp, PsiT[nd], QK, npol == 2);
             assert(PsiQK.size() == na);
-            Sp3Tensor_ref Lbnl(to_address(LQKbnl[nq0 + Qmap[Q] - 1][QK].origin()),
+            Sp3Tensor_ref Lbnl(to_address(LQKbnl[nq0 + Qmap[Q] - 1][QK].base()),
                                {nocc_max, nchol_max, npol * nmo_max});
-            Sp3Tensor_ref Lbln(to_address(LQKbln[nq0 + Qmap[Q] - 1][QK].origin()),
+            Sp3Tensor_ref Lbln(to_address(LQKbln[nq0 + Qmap[Q] - 1][QK].base()),
                                {nocc_max, npol * nmo_max, nchol_max});
             ma_rotate_padded::getLakn_Lank_from_Lkin(PsiQK, Likn, Lbln, Lbnl, buff, npol == 2);
           }
@@ -1366,23 +1366,23 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
 
   if (TG.Node().root())
   {
-    TG.Cores().all_reduce_in_place_n(to_address(haj.origin()), haj.num_elements(), std::plus<>());
-    std::fill_n(to_address(vn0.origin()), vn0.num_elements(), ComplexType(0.0));
+    TG.Cores().all_reduce_in_place_n(to_address(haj.base()), haj.num_elements(), std::plus<>());
+    std::fill_n(to_address(vn0.base()), vn0.num_elements(), ComplexType(0.0));
   }
 
   if (distNode.root())
   {
     for (int Q = 0; Q < LQKank.size(); Q++)
-      Qcomm_roots.all_reduce_in_place_n(to_address(LQKank[Q].origin()), LQKank[Q].num_elements(), std::plus<>());
+      Qcomm_roots.all_reduce_in_place_n(to_address(LQKank[Q].base()), LQKank[Q].num_elements(), std::plus<>());
 
     for (int Q = 0; Q < LQKakn.size(); Q++)
-      Qcomm_roots.all_reduce_in_place_n(to_address(LQKakn[Q].origin()), LQKakn[Q].num_elements(), std::plus<>());
+      Qcomm_roots.all_reduce_in_place_n(to_address(LQKakn[Q].base()), LQKakn[Q].num_elements(), std::plus<>());
 
     for (int Q = 0; Q < LQKbnl.size(); Q++)
-      Qcomm_roots.all_reduce_in_place_n(to_address(LQKbnl[Q].origin()), LQKbnl[Q].num_elements(), std::plus<>());
+      Qcomm_roots.all_reduce_in_place_n(to_address(LQKbnl[Q].base()), LQKbnl[Q].num_elements(), std::plus<>());
 
     for (int Q = 0; Q < LQKbln.size(); Q++)
-      Qcomm_roots.all_reduce_in_place_n(to_address(LQKbln[Q].origin()), LQKbln[Q].num_elements(), std::plus<>());
+      Qcomm_roots.all_reduce_in_place_n(to_address(LQKbln[Q].base()), LQKbln[Q].num_elements(), std::plus<>());
   }
   TG.Node().barrier();
 
@@ -1403,7 +1403,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
         int Qm = kminus[Q];
         if (Q <= Qm)
         {
-          boost::multi::array_ref<SPComplexType, 2> Likn(to_address(LQKikn[Q][K].origin()),
+          boost::multi::array_ref<SPComplexType, 2> Likn(to_address(LQKikn[Q][K].base()),
                                                          {nmo_max, nmo_max * nchol_max});
           using ma::H;
 #if defined(MIXED_PRECISION)
@@ -1419,7 +1419,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
         else
         {
           int QmK = QKtok2[Qm][K];
-          boost::multi::array_ref<SPComplexType, 3> Lkin(to_address(LQKikn[Qm][QK].origin()),
+          boost::multi::array_ref<SPComplexType, 3> Lkin(to_address(LQKikn[Qm][QK].base()),
                                                          {nmo_max, nmo_max, nchol_max});
           boost::multi::array<SPComplexType, 3> buff3D({nmo_max, nmo_max, nchol_max});
           using ma::conj;
@@ -1427,7 +1427,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
             for (int k = 0; k < nmo_max; k++)
               for (int n = 0; n < nchol_max; n++)
                 buff3D[i][k][n] = ma::conj(Lkin[k][i][n]);
-          boost::multi::array_ref<SPComplexType, 2> L_(to_address(buff3D.origin()), {nmo_max, nmo_max * nchol_max});
+          boost::multi::array_ref<SPComplexType, 2> L_(to_address(buff3D.base()), {nmo_max, nmo_max * nchol_max});
           using ma::H;
 #if defined(MIXED_PRECISION)
           boost::multi::array<SPComplexType, 2> v1_({nmo_max, nmo_max});
@@ -1441,12 +1441,12 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
       }
     }
   }
-  TG.Global().all_reduce_in_place_n(vn0_.origin(), vn0_.num_elements(), std::plus<>());
-  copy_n(vn0_.origin(), vn0_.num_elements(), vn0.origin());
+  TG.Global().all_reduce_in_place_n(vn0_.base(), vn0_.num_elements(), std::plus<>());
+  copy_n(vn0_.base(), vn0_.num_elements(), vn0.base());
 
   //  TG.Node().barrier();
   //  if(TG.Node().root())
-  //    TG.Cores().all_reduce_in_place_n(to_address(vn0.origin()),vn0.num_elements(),std::plus<>());
+  //    TG.Cores().all_reduce_in_place_n(to_address(vn0.base()),vn0.num_elements(),std::plus<>());
 
   if (TG.Node().root())
   {
@@ -1490,16 +1490,16 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
           if (na == 0 || nb == 0)
             continue;
 
-          SpMatrix_ref Lank(to_address(LQKank[Q][Ka].origin()), {na * nchol_max, nmo_max});
-          auto bnl_ptr(to_address(LQKank[Qm][Kb].origin()));
+          SpMatrix_ref Lank(to_address(LQKank[Q][Ka].base()), {na * nchol_max, nmo_max});
+          auto bnl_ptr(to_address(LQKank[Qm][Kb].base()));
           if (Qmap[Q] > 0)
-            bnl_ptr = to_address(LQKbnl[Qmap[Q] - 1][Kb].origin());
+            bnl_ptr = to_address(LQKbnl[Qmap[Q] - 1][Kb].base());
           SpMatrix_ref Lbnl(bnl_ptr, {nb * nchol_max, nmo_max});
 
           SpMatrix Tban({nb, na * nchol_max});
-          Sp3Tensor_ref T3ban(Tban.origin(), {nb, na, nchol_max});
+          Sp3Tensor_ref T3ban(Tban.base(), {nb, na, nchol_max});
           SpMatrix Tabn({na, nb * nchol_max});
-          Sp3Tensor_ref T3abn(Tabn.origin(), {na, nb, nchol_max});
+          Sp3Tensor_ref T3abn(Tabn.base(), {na, nb, nchol_max});
 
           auto Gal = get_PsiK<boost::multi::array<SPComplexType, 2>>(nmo_per_kp, PsiT[0], Ka, npol == 2);
           auto Gbk = get_PsiK<boost::multi::array<SPComplexType, 2>>(nmo_per_kp, PsiT[0], Kb, npol == 2);

--- a/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
@@ -190,13 +190,13 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
     }
   }
   TG.Global().broadcast_n(&E0, 1, 0);
-  TG.Global().broadcast_n(nmo_per_kp.origin(), nmo_per_kp.size(), 0);
-  TG.Global().broadcast_n(nchol_per_kp.origin(), nchol_per_kp.size(), 0);
-  TG.Global().broadcast_n(kminus.origin(), kminus.size(), 0);
+  TG.Global().broadcast_n(nmo_per_kp.base(), nmo_per_kp.size(), 0);
+  TG.Global().broadcast_n(nchol_per_kp.base(), nchol_per_kp.size(), 0);
+  TG.Global().broadcast_n(kminus.base(), kminus.size(), 0);
   if (TG.Node().root())
   {
-    TG.Cores().broadcast_n(to_address(QKtok2.origin()), QKtok2.num_elements(), 0);
-    TG.Cores().broadcast_n(to_address(QKtoG.origin()), QKtoG.num_elements(), 0);
+    TG.Cores().broadcast_n(to_address(QKtok2.base()), QKtok2.num_elements(), 0);
+    TG.Cores().broadcast_n(to_address(QKtoG.base()), QKtoG.num_elements(), 0);
   }
   TG.Node().barrier();
 
@@ -265,8 +265,8 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
         int nGm = *std::max_element(QKtoG[Qm].begin(), QKtoG[Qm].end()) + 1;
         if (nG != nGm)
           APP_ABORT(" Error: nG != nGm. \n");
-        auto LQ(to_address(LQGun[Q].origin()));
-        auto LQm(to_address(LQGun[Qm].origin()));
+        auto LQ(to_address(LQGun[Q].base()));
+        auto LQm(to_address(LQGun[Qm].base()));
         for (int Gun = 0; Gun < LQGun[Q].num_elements(); Gun++, ++LQ, ++LQm)
           (*LQ) = ma::conj(*LQm);
       }
@@ -283,7 +283,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
         {
           RealType scl = 1.0/double(nkpts);
           //RealType scl = 1.0/std::sqrt(double(nkpts));
-          auto LQ(to_address(LQGun[Q].origin()));
+          auto LQ(to_address(LQGun[Q].base()));
           for(int Gun=0; Gun<LQGun[Q].num_elements(); Gun++, ++LQ)
             (*LQ) *= scl;
         }
@@ -313,7 +313,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
       /*
       {
         RealType scl = 1.0/double(nkpts);
-        auto MQ(to_address(rotMuv[Q].origin()));
+        auto MQ(to_address(rotMuv[Q].base()));
         for(int u=0; u<rotMuv[Q].num_elements(); u++, ++MQ)
           (*MQ) *= scl*scl;
       }
@@ -386,8 +386,8 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
     }
   }
   TG.Node().barrier();
-  int nocc_max = *std::max_element(to_address(nocc_per_kp.origin()),
-                                   to_address(nocc_per_kp.origin()) + nocc_per_kp.num_elements());
+  int nocc_max = *std::max_element(to_address(nocc_per_kp.base()),
+                                   to_address(nocc_per_kp.base()) + nocc_per_kp.num_elements());
 
   /* half-rotate Piu and H1:
    * Given that PsiT = H(SM),
@@ -401,10 +401,10 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
   shmCMatrix haj({ndet * nkpts, (type == COLLINEAR ? 2 : 1) * nocc_max * nmo_max},
                  shared_allocator<ComplexType>{TG.Node()});
   std::pair<int, int> nel;
-  nel.first = std::accumulate(to_address(nocc_per_kp[0].origin()), to_address(nocc_per_kp[0].origin()) + nkpts, 0);
+  nel.first = std::accumulate(to_address(nocc_per_kp[0].base()), to_address(nocc_per_kp[0].base()) + nkpts, 0);
   if (type == COLLINEAR)
-    nel.second = std::accumulate(to_address(nocc_per_kp[0].origin()) + nkpts,
-                                 to_address(nocc_per_kp[0].origin()) + 2 * nkpts, 0);
+    nel.second = std::accumulate(to_address(nocc_per_kp[0].base()) + nkpts,
+                                 to_address(nocc_per_kp[0].base()) + 2 * nkpts, 0);
   for (int nd = 0; nd < ndet; nd++)
   {
     cPua.emplace_back(shmSpMatrix({nmu, nel.first}, shared_allocator<SPComplexType>{TG.Node()}));
@@ -416,11 +416,11 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
   }
   if (TG.Node().root())
   {
-    std::fill_n(haj.origin(), haj.num_elements(), ComplexType(0.0));
+    std::fill_n(haj.base(), haj.num_elements(), ComplexType(0.0));
     for (auto& v : cPua)
-      std::fill_n(v.origin(), v.num_elements(), SPComplexType(0.0));
+      std::fill_n(v.base(), v.num_elements(), SPComplexType(0.0));
     for (auto& v : rotcPua)
-      std::fill_n(v.origin(), v.num_elements(), SPComplexType(0.0));
+      std::fill_n(v.base(), v.num_elements(), SPComplexType(0.0));
   }
   TG.Node().barrier();
 
@@ -437,14 +437,14 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
           { // Alpha
             auto Psi = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[2 * nd], Q);
             assert(Psi.size(0) == nocc_per_kp[nd][Q]);
-            boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + Q].origin()),
+            boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + Q].base()),
                                                           {nocc_per_kp[nd][Q], nmo_per_kp[Q]});
             ma::product(Psi, H1[Q]({0, nmo_per_kp[Q]}, {0, nmo_per_kp[Q]}), haj_r);
           }
           { // Beta
             auto Psi = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[2 * nd + 1], Q);
             assert(Psi.size(0) == nocc_per_kp[nd][nkpts + Q]);
-            boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + Q].origin()) +
+            boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + Q].base()) +
                                                               nocc_per_kp[nd][Q] * nmo_per_kp[Q],
                                                           {nocc_per_kp[nd][nkpts + Q], nmo_per_kp[Q]});
             ma::product(Psi, H1[Q]({0, nmo_per_kp[Q]}, {0, nmo_per_kp[Q]}), haj_r);
@@ -454,7 +454,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
         {
           auto Psi = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[nd], Q);
           assert(Psi.size(0) == nocc_per_kp[nd][Q]);
-          boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + Q].origin()),
+          boost::multi::array_ref<ComplexType, 2> haj_r(to_address(haj[nd * nkpts + Q].base()),
                                                         {nocc_per_kp[nd][Q], nmo_per_kp[Q]});
           ma::product(ComplexType(2.0), Psi, H1[Q]({0, nmo_per_kp[Q]}, {0, nmo_per_kp[Q]}), ComplexType(0.0), haj_r);
         }
@@ -465,7 +465,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
         {
           APP_ABORT(" Finish .\n");
           auto Psi = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[2 * nd], Q);
-          int ne0  = std::accumulate(to_address(nocc_per_kp[nd].origin()), to_address(nocc_per_kp[nd].origin()) + Q, 0);
+          int ne0  = std::accumulate(to_address(nocc_per_kp[nd].base()), to_address(nocc_per_kp[nd].base()) + Q, 0);
           int ni0  = std::accumulate(nmo_per_kp.begin(), nmo_per_kp.begin() + Q, 0);
           assert(Psi.size(0) == nocc_per_kp[nd][Q]);
           ma::product(ma::H(Piu({ni0, ni0 + nmo_per_kp[Q]}, {0, nmu})), ma::T(Psi),
@@ -474,8 +474,8 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
                       rotcPua[2 * nd]({0, rotnmu}, {ne0, ne0 + Psi.size(0)}));
 
           Psi = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[2 * nd + 1], Q);
-          ne0 = std::accumulate(to_address(nocc_per_kp[nd].origin()) + nkpts,
-                                to_address(nocc_per_kp[nd].origin()) + nkpts + Q, 0);
+          ne0 = std::accumulate(to_address(nocc_per_kp[nd].base()) + nkpts,
+                                to_address(nocc_per_kp[nd].base()) + nkpts + Q, 0);
           assert(Psi.size(0) == nocc_per_kp[nd][nkpts + Q]);
           ma::product(ma::H(Piu({ni0, ni0 + nmo_per_kp[Q]}, {0, nmu})), ma::T(Psi),
                       cPua[2 * nd + 1]({0, nmu}, {ne0, ne0 + Psi.size(0)}));
@@ -485,7 +485,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
         }
         else
         {
-          int ne0  = std::accumulate(to_address(nocc_per_kp[nd].origin()), to_address(nocc_per_kp[nd].origin()) + Q, 0);
+          int ne0  = std::accumulate(to_address(nocc_per_kp[nd].base()), to_address(nocc_per_kp[nd].base()) + Q, 0);
           int ni0  = std::accumulate(nmo_per_kp.begin(), nmo_per_kp.begin() + Q, 0);
           auto Psi = get_PsiK<boost::multi::array<ComplexType, 2>>(nmo_per_kp, PsiT[nd], Q);
           assert(Psi.size(0) == nocc_per_kp[nd][Q]);
@@ -500,12 +500,12 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
   TG.Global().barrier();
   if (TG.Node().root())
   {
-    TG.Cores().all_reduce_in_place_n(to_address(haj.origin()), haj.num_elements(), std::plus<>());
+    TG.Cores().all_reduce_in_place_n(to_address(haj.base()), haj.num_elements(), std::plus<>());
     for (int n = 0; n < cPua.size(); n++)
-      TG.Cores().all_reduce_in_place_n(to_address(cPua[n].origin()), cPua[n].num_elements(), std::plus<>());
+      TG.Cores().all_reduce_in_place_n(to_address(cPua[n].base()), cPua[n].num_elements(), std::plus<>());
     for (int n = 0; n < rotcPua.size(); n++)
-      TG.Cores().all_reduce_in_place_n(to_address(rotcPua[n].origin()), rotcPua[n].num_elements(), std::plus<>());
-    std::fill_n(to_address(vn0.origin()), vn0.num_elements(), ComplexType(0.0));
+      TG.Cores().all_reduce_in_place_n(to_address(rotcPua[n].base()), rotcPua[n].num_elements(), std::plus<>());
+    std::fill_n(to_address(vn0.base()), vn0.num_elements(), ComplexType(0.0));
   }
   TG.Node().barrier();
 
@@ -513,7 +513,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
   // calculate (only Q=0) vn0(I,L) = -0.5 sum_K sum_j sum_n L[0][K][i][j][n] ma::conj(L[0][K][l][j][n])
   for(int K=0; K<nkpts; K++) {
     if(K%TG.Node().size() == TG.Node().rank()) {
-      boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[0][K].origin()),
+      boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[0][K].base()),
                                                    {nmo_per_kp[K],nmo_per_kp[K]*nchol_per_kp[0]});
       using ma::H;
       ma::product(-0.5,Likn,H(Likn),0.0,vn0[K]({0,nmo_per_kp[K]},{0,nmo_per_kp[K]}));
@@ -525,7 +525,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
 
   //  TG.Node().barrier();
   //  if(TG.Node().root())
-  //    TG.Cores().all_reduce_in_place_n(to_address(vn0.origin()),vn0.num_elements(),std::plus<>());
+  //    TG.Cores().all_reduce_in_place_n(to_address(vn0.base()),vn0.num_elements(),std::plus<>());
 
   if (TG.Node().root())
   {
@@ -586,8 +586,8 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
 
   // LIJ[I][J][Q][n] = sum_u u[KI][i][u] u[KJ][j][u] LQGun[Q][G][u][n]
   boost::multi::array<ComplexType, 5> LIJ({nkpts, nkpts, nmo_max, nmo_max, nchol_max});
-  boost::multi::array_ref<ComplexType, 4> LIJ4D(LIJ.origin(), {nkpts, nkpts, nmo_max * nmo_max, nchol_max});
-  std::fill_n(LIJ.origin(), LIJ.num_elements(), 0);
+  boost::multi::array_ref<ComplexType, 4> LIJ4D(LIJ.base(), {nkpts, nkpts, nmo_max * nmo_max, nchol_max});
+  std::fill_n(LIJ.base(), LIJ.num_elements(), 0);
   boost::multi::array<ComplexType, 2> uij({nmo_max * nmo_max, nmu});
   /*
   for(int KI=0, n_=0; KI<nkpts; KI++)
@@ -603,10 +603,10 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
         auto&& uI(Piu[ni0+i]);
         for(int j=0, J=nj0; j<nmo_per_kp[0]; j++, ++J) {
           auto&& uJ(Piu[nj0+j]);
-          auto LIJ_(LIJ[KI][KJ][i][j].origin());
+          auto LIJ_(LIJ[KI][KJ][i][j].base());
           for(int u=0; u<nmu; u++) {
             ComplexType uij = ma::conj(uI[u])*uJ[u];
-            auto lq(to_address(LQGun[Q][nmu*G1+u].origin()));
+            auto lq(to_address(LQGun[Q][nmu*G1+u].base()));
             for(int n=0; n<nchol_per_kp[Q]; n++)
               LIJ_[n] += uij * lq[n];
           }
@@ -616,12 +616,12 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
 //app_log()<<KI <<" " <<KJ <<" " <<Timer.total("T0") <<std::endl;
     }
   }
-  TGwfn.Global().all_reduce_n(LIJ.origin(), LIJ.num_elements(), std::plus<>());
+  TGwfn.Global().all_reduce_n(LIJ.base(), LIJ.num_elements(), std::plus<>());
 
 //  std::ofstream out("thc_ints.dat");
   boost::multi::array<ComplexType,2> IJKL({nmo_max*nmo_max,nmo_max*nmo_max});
   boost::multi::array<ComplexType,2> Muv({nmu,nmu});
-  boost::multi::array_ref<ComplexType,4> IJKL4D(IJKL.origin(),{nmo_max,nmo_max,nmo_max,nmo_max});
+  boost::multi::array_ref<ComplexType,4> IJKL4D(IJKL.base(),{nmo_max,nmo_max,nmo_max,nmo_max});
   ComplexType EX(0.0);
   ComplexType EJ(0.0);
   myTimer Timer;
@@ -638,8 +638,8 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
       int nj0 = std::accumulate(nmo_per_kp.begin(),nmo_per_kp.begin()+KJ,0);
       int nk0 = std::accumulate(nmo_per_kp.begin(),nmo_per_kp.begin()+KK,0);
       int nl0 = std::accumulate(nmo_per_kp.begin(),nmo_per_kp.begin()+KL,0);
-      //boost::multi::array_ref<ComplexType,2> LKI(to_address(LIJ[KI][KK].origin()),{nmo_max*nmo_max,nchol_per_kp[Q]});
-      //boost::multi::array_ref<ComplexType,2> LKL(to_address(LIJ[KL][KJ].origin()),{nmo_max*nmo_max,nchol_per_kp[Q]});
+      //boost::multi::array_ref<ComplexType,2> LKI(to_address(LIJ[KI][KK].base()),{nmo_max*nmo_max,nchol_per_kp[Q]});
+      //boost::multi::array_ref<ComplexType,2> LKL(to_address(LIJ[KL][KJ].base()),{nmo_max*nmo_max,nchol_per_kp[Q]});
       ma::product(LIJ4D[KI][KK]({0,nmo_max*nmo_max},{0,nchol_per_kp[Q]}),
                   ma::H(LIJ4D[KL][KJ]({0,nmo_max*nmo_max},{0,nchol_per_kp[Q]})),IJKL);
 //Timer.stop("T0");
@@ -703,7 +703,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
     LQKikn.emplace_back(
         shmSpMatrix({nkpts, nmo_max * nmo_max * nchol_per_kp[Q]}, shared_allocator<SPComplexType>{TG.Node()}));
     if (TGwfn.Node().root())
-      std::fill_n(LQKikn.back().origin(), LQKikn.back().num_elements(), ComplexType(0.0));
+      std::fill_n(LQKikn.back().base(), LQKikn.back().num_elements(), ComplexType(0.0));
   }
   TGwfn.Node().barrier();
   for (int Q = 0; Q < nkpts; Q++)
@@ -724,11 +724,11 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
             for (int j = 0, J = nj0; j < nmo_per_kp[0]; j++, ++J, ij++)
             {
               auto&& uJ(Piu[nj0 + j]);
-              auto LIJ_(LQKikn[Q][KI].origin() + ij * nchol_per_kp[Q]);
+              auto LIJ_(LQKikn[Q][KI].base() + ij * nchol_per_kp[Q]);
               for (int u = 0; u < nmu; u++)
               {
                 ComplexType uij = ma::conj(uI[u]) * uJ[u];
-                auto lq(to_address(LQGun[Q][nmu * G1 + u].origin()));
+                auto lq(to_address(LQGun[Q][nmu * G1 + u].base()));
                 for (int n = 0; n < nchol_per_kp[Q]; n++)
                   LIJ_[n] += uij * lq[n];
               }
@@ -741,8 +741,8 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
           // right now the code assumes that Q=0 is the gamma point (0,0,0).
           int ni = nmo_per_kp[KI];
           int nj = nmo_per_kp[KJ];
-          boost::multi::array_ref<SPComplexType, 3> LQI(to_address(LQKikn[Q][KI].origin()), {ni, nj, nchol_per_kp[Q]});
-          boost::multi::array_ref<SPComplexType, 3> LQJ(to_address(LQKikn[Q][KJ].origin()), {nj, ni, nchol_per_kp[Q]});
+          boost::multi::array_ref<SPComplexType, 3> LQI(to_address(LQKikn[Q][KI].base()), {ni, nj, nchol_per_kp[Q]});
+          boost::multi::array_ref<SPComplexType, 3> LQJ(to_address(LQKikn[Q][KJ].base()), {nj, ni, nchol_per_kp[Q]});
           if (KJ > KI)
           {
             for (int i = 0; i < ni; i++)
@@ -760,13 +760,13 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
           int KJ = QKtok2[Qm][KI];
           int ni = nmo_per_kp[KI];
           int nj = nmo_per_kp[KJ];
-          boost::multi::array_ref<SPComplexType, 3> LQm(to_address(LQKikn[Qm][KI].origin()), {ni, nj, nchol_per_kp[Q]});
-          boost::multi::array_ref<SPComplexType, 3> LQ(to_address(LQKikn[Q][KJ].origin()), {nj, ni, nchol_per_kp[Q]});
+          boost::multi::array_ref<SPComplexType, 3> LQm(to_address(LQKikn[Qm][KI].base()), {ni, nj, nchol_per_kp[Q]});
+          boost::multi::array_ref<SPComplexType, 3> LQ(to_address(LQKikn[Q][KJ].base()), {nj, ni, nchol_per_kp[Q]});
           for (int i = 0; i < ni; i++)
             for (int j = 0; j < nj; j++)
             {
-              auto LQ_n(LQ[j][i].origin());
-              auto LQm_n(LQm[i][j].origin());
+              auto LQ_n(LQ[j][i].base());
+              auto LQm_n(LQm[i][j].base());
               for (int n = 0; n < nchol_per_kp[Qm]; n++, ++LQ_n, ++LQm_n)
                 (*LQ_n) = ma::conj(*LQm_n);
             }
@@ -786,11 +786,11 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
             for (int j = 0, J = nj0; j < nmo_per_kp[0]; j++, ++J, ij++)
             {
               auto&& uJ(Piu[nj0 + j]);
-              auto LIJ_(LQKikn[Q][KI].origin() + ij * nchol_per_kp[Q]);
+              auto LIJ_(LQKikn[Q][KI].base() + ij * nchol_per_kp[Q]);
               for (int u = 0; u < nmu; u++)
               {
                 ComplexType uij = ma::conj(uI[u]) * uJ[u];
-                auto lq(to_address(LQGun[Q][nmu * G1 + u].origin()));
+                auto lq(to_address(LQGun[Q][nmu * G1 + u].base()));
                 for (int n = 0; n < nchol_per_kp[Q]; n++)
                   LIJ_[n] += uij * lq[n];
               }
@@ -803,7 +803,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
   TGwfn.Global().barrier();
   if (TGwfn.Node().root())
     for (int Q = 0; Q < nkpts; Q++)
-      TGwfn.Cores().all_reduce_in_place_n(to_address(LQKikn[Q].origin()), LQKikn[Q].num_elements(), std::plus<>());
+      TGwfn.Cores().all_reduce_in_place_n(to_address(LQKikn[Q].base()), LQKikn[Q].num_elements(), std::plus<>());
 
   std::vector<shmSpMatrix> LQKank;
   LQKank.reserve(ndet * nspins * (nkpts + 1)); // storing 2 components for Q=0, since it is not assumed symmetric
@@ -831,10 +831,10 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
       {
         if (nt % TG.Node().size() == TG.Node().rank())
         {
-          std::fill_n(to_address(LQKank[nq0 + Q][K].origin()), LQKank[nq0 + Q][K].num_elements(), SPComplexType(0.0));
+          std::fill_n(to_address(LQKank[nq0 + Q][K].base()), LQKank[nq0 + Q][K].num_elements(), SPComplexType(0.0));
           if (type == COLLINEAR)
           {
-            std::fill_n(to_address(LQKank[nq0 + nkpts + 1 + Q][K].origin()),
+            std::fill_n(to_address(LQKank[nq0 + nkpts + 1 + Q][K].base()),
                         LQKank[nq0 + nkpts + 1 + Q][K].num_elements(), SPComplexType(0.0));
           }
         }
@@ -853,27 +853,27 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
               { // Alpha
                 // doing this "by-hand" now
                 auto Psi = get_PsiK<boost::multi::array<SPComplexType,2>>(nmo_per_kp,PsiT[2*nd],QKtok2[Q0][K]);
-                boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[Q0][K].origin()),
+                boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[Q0][K].base()),
                                                            {nmo_per_kp[K],nmo_per_kp[QKtok2[Q0][K]]*nchol_per_kp[Q0]});
-                boost::multi::array_ref<SPComplexType,3> Llbn(to_address(LQKank[nq0+nkpts][K].origin()),
+                boost::multi::array_ref<SPComplexType,3> Llbn(to_address(LQKank[nq0+nkpts][K].base()),
                                                            {nmo_per_kp[K],nocc_per_kp[nd][QKtok2[Q0][K]],nchol_per_kp[Q0]});
                 for(int l=0; l<nmo_per_kp[K]; ++l) {
-                  auto psi_bj = Psi.origin();
+                  auto psi_bj = Psi.base();
                   for(int b=0; b<nocc_per_kp[nd][QKtok2[Q0][K]]; ++b) {
-                    auto Likn_jn = Likn[l].origin();
+                    auto Likn_jn = Likn[l].base();
                     for(int j=0, jn=0; j<nmo_per_kp[QKtok2[Q0][K]]; ++j, ++psi_bj) {
-                      auto Llbn_lbn = Llbn[l][b].origin();
+                      auto Llbn_lbn = Llbn[l][b].base();
                       for(int n=0; n<nchol_per_kp[0]; ++n, ++Likn_jn, ++Llbn_lbn)
                         (*Llbn_lbn) += (*psi_bj) * ma::conj(*Likn_jn);
                     }
                   }
                 }
-                boost::multi::array_ref<SPComplexType,3> Lbnl(to_address(LQKank[nq0+nkpts][K].origin()),
+                boost::multi::array_ref<SPComplexType,3> Lbnl(to_address(LQKank[nq0+nkpts][K].base()),
                                                            {nocc_per_kp[nd][QKtok2[Q0][K]],nchol_per_kp[Q0],nmo_per_kp[K]});
                 boost::multi::array<SPComplexType,3> Llbn_({nmo_per_kp[K],
                                                             nocc_per_kp[nd][QKtok2[Q0][K]],
                                                             nchol_per_kp[Q0]});
-                std::copy_n(Llbn.origin(),Llbn.num_elements(),Llbn_.origin());
+                std::copy_n(Llbn.base(),Llbn.num_elements(),Llbn_.base());
                 for(int l=0; l<nmo_per_kp[K]; ++l)
                   for(int b=0; b<nocc_per_kp[nd][QKtok2[Q0][K]]; ++b)
                     for(int n=0; n<nchol_per_kp[Q0]; ++n)
@@ -883,27 +883,27 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
               { // Beta
                 // doing this "by-hand" now
                 auto Psi = get_PsiK<boost::multi::array<SPComplexType,2>>(nmo_per_kp,PsiT[2*nd+1],QKtok2[Q0][K]);
-                boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[Q0][K].origin()),
+                boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[Q0][K].base()),
                                                            {nmo_per_kp[K],nmo_per_kp[QKtok2[Q0][K]]*nchol_per_kp[0]});
-                boost::multi::array_ref<SPComplexType,3> Llbn(to_address(LQKank[nq0+2*nkpts+1][K].origin()),
+                boost::multi::array_ref<SPComplexType,3> Llbn(to_address(LQKank[nq0+2*nkpts+1][K].base()),
                                                            {nmo_per_kp[K],nocc_per_kp[nd][nkpts+QKtok2[Q0][K]],nchol_per_kp[Q0]});
                 for(int l=0; l<nmo_per_kp[K]; ++l) {
-                  auto psi_bj = Psi.origin();
+                  auto psi_bj = Psi.base();
                   for(int b=0; b<nocc_per_kp[nd][nkpts+QKtok2[Q0][K]]; ++b) {
-                    auto Likn_jn = Likn[l].origin();
+                    auto Likn_jn = Likn[l].base();
                     for(int j=0, jn=0; j<nmo_per_kp[QKtok2[Q0][K]]; ++j, ++psi_bj) {
-                      auto Llbn_lbn = Llbn[l][b].origin();
+                      auto Llbn_lbn = Llbn[l][b].base();
                       for(int n=0; n<nchol_per_kp[Q0]; ++n, ++Likn_jn, ++Llbn_lbn)
                         (*Llbn_lbn) += (*psi_bj) * ma::conj(*Likn_jn);
                     }
                   }
                 }
-                boost::multi::array_ref<SPComplexType,3> Lbnl(to_address(LQKank[nq0+2*nkpts+1][K].origin()),
+                boost::multi::array_ref<SPComplexType,3> Lbnl(to_address(LQKank[nq0+2*nkpts+1][K].base()),
                                                            {nocc_per_kp[nd][QKtok2[Q0][K]],nchol_per_kp[Q0],nmo_per_kp[K]});
                 boost::multi::array<SPComplexType,3> Llbn_({nmo_per_kp[K],
                                                             nocc_per_kp[nd][QKtok2[Q0][K]],
                                                             nchol_per_kp[Q0]});
-                std::copy_n(Llbn.origin(),Llbn.num_elements(),Llbn_.origin());
+                std::copy_n(Llbn.base(),Llbn.num_elements(),Llbn_.base());
                 for(int l=0; l<nmo_per_kp[K]; ++l)
                   for(int b=0; b<nocc_per_kp[nd][QKtok2[Q0][K]]; ++b)
                     for(int n=0; n<nchol_per_kp[Q0]; ++n)
@@ -912,27 +912,27 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
             } else {
               // doing this "by-hand" now
               auto Psi = get_PsiK<boost::multi::array<SPComplexType,2>>(nmo_per_kp,PsiT[nd],QKtok2[Q0][K]);
-              boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[Q0][K].origin()),
+              boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[Q0][K].base()),
                                                          {nmo_per_kp[K],nmo_per_kp[QKtok2[Q0][K]]*nchol_per_kp[Q0]});
-              boost::multi::array_ref<SPComplexType,3> Llbn(to_address(LQKank[nq0+nkpts][K].origin()),
+              boost::multi::array_ref<SPComplexType,3> Llbn(to_address(LQKank[nq0+nkpts][K].base()),
                                                          {nmo_per_kp[K],nocc_per_kp[nd][QKtok2[Q0][K]],nchol_per_kp[Q0]});
               for(int l=0; l<nmo_per_kp[K]; ++l) {
-                auto psi_bj = Psi.origin();
+                auto psi_bj = Psi.base();
                 for(int b=0; b<nocc_per_kp[nd][QKtok2[Q0][K]]; ++b) {
-                  auto Likn_jn = Likn[l].origin();
+                  auto Likn_jn = Likn[l].base();
                   for(int j=0, jn=0; j<nmo_per_kp[QKtok2[Q0][K]]; ++j, ++psi_bj) {
-                    auto Llbn_lbn = Llbn[l][b].origin();
+                    auto Llbn_lbn = Llbn[l][b].base();
                     for(int n=0; n<nchol_per_kp[Q0]; ++n, ++Likn_jn, ++Llbn_lbn)
                       (*Llbn_lbn) += (*psi_bj) * ma::conj(*Likn_jn);
                   }
                 }
               }
-              boost::multi::array_ref<SPComplexType,3> Lbnl(to_address(LQKank[nq0+nkpts][K].origin()),
+              boost::multi::array_ref<SPComplexType,3> Lbnl(to_address(LQKank[nq0+nkpts][K].base()),
                                                          {nocc_per_kp[nd][QKtok2[Q0][K]],nchol_per_kp[Q0],nmo_per_kp[K]});
               boost::multi::array<SPComplexType,3> Llbn_({nmo_per_kp[K],
                                                           nocc_per_kp[nd][QKtok2[Q0][K]],
                                                           nchol_per_kp[Q0]});
-              std::copy_n(Llbn.origin(),Llbn.num_elements(),Llbn_.origin());
+              std::copy_n(Llbn.base(),Llbn.num_elements(),Llbn_.base());
               for(int l=0; l<nmo_per_kp[K]; ++l)
                 for(int b=0; b<nocc_per_kp[nd][QKtok2[Q0][K]]; ++b)
                   for(int n=0; n<nchol_per_kp[Q0]; ++n)
@@ -944,16 +944,16 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
 // change get_PsiK to cast to the value_type of the result
               auto Psi = get_PsiK<boost::multi::array<SPComplexType,2>>(nmo_per_kp,PsiT[2*nd],K);
               assert(Psi.size(0) == nocc_per_kp[nd][K]);
-              boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[Q][K].origin()),
+              boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[Q][K].base()),
                                                            {nmo_per_kp[K],nmo_per_kp[QKtok2[Q][K]]*nchol_per_kp[Q]});
-              boost::multi::array_ref<SPComplexType,2> Lakn(to_address(LQKank[nq0+Q][K].origin()),
+              boost::multi::array_ref<SPComplexType,2> Lakn(to_address(LQKank[nq0+Q][K].base()),
                                                            {nocc_per_kp[nd][K],nmo_per_kp[QKtok2[Q][K]]*nchol_per_kp[Q]});
               ma::product(Psi,Likn,Lakn);
               // transpose to form expected by KP3IndexFactorization
               for(int a=0; a<nocc_per_kp[nd][K]; a++) {
-                boost::multi::array_ref<SPComplexType,2> Lkn(Lakn[a].origin(),
+                boost::multi::array_ref<SPComplexType,2> Lkn(Lakn[a].base(),
                                                            {nmo_per_kp[QKtok2[Q][K]],nchol_per_kp[Q]});
-                boost::multi::array_ref<SPComplexType,2> Lnk(Lakn[a].origin(),
+                boost::multi::array_ref<SPComplexType,2> Lnk(Lakn[a].base(),
                                                            {nchol_per_kp[Q],nmo_per_kp[QKtok2[Q][K]]});
                 buff({0,Lkn.size(0)},{0,Lkn.size(1)}) = Lkn;
                 ma::transpose(buff({0,Lkn.size(0)},{0,Lkn.size(1)}),Lnk);
@@ -963,16 +963,16 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
 // change get_PsiK to cast to the value_type of the result
               auto Psi = get_PsiK<boost::multi::array<SPComplexType,2>>(nmo_per_kp,PsiT[2*nd+1],K);
               assert(Psi.size(0) == nocc_per_kp[nd][nkpts+K]);
-              boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[Q][K].origin()),
+              boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[Q][K].base()),
                                                            {nmo_per_kp[K],nmo_per_kp[QKtok2[Q][K]]*nchol_per_kp[Q]});
-              boost::multi::array_ref<SPComplexType,2> Lakn(to_address(LQKank[nq0+nkpts+1+Q][K].origin()),
+              boost::multi::array_ref<SPComplexType,2> Lakn(to_address(LQKank[nq0+nkpts+1+Q][K].base()),
                                                            {nocc_per_kp[nd][nkpts+K],nmo_per_kp[QKtok2[Q][K]]*nchol_per_kp[Q]});
               ma::product(Psi,Likn,Lakn);
               // transpose to form expected by KP3IndexFactorization
               for(int a=0; a<nocc_per_kp[nd][nkpts+K]; a++) {
-                boost::multi::array_ref<SPComplexType,2> Lkn(Lakn[a].origin(),
+                boost::multi::array_ref<SPComplexType,2> Lkn(Lakn[a].base(),
                                                            {nmo_per_kp[QKtok2[Q][K]],nchol_per_kp[Q]});
-                boost::multi::array_ref<SPComplexType,2> Lnk(Lakn[a].origin(),
+                boost::multi::array_ref<SPComplexType,2> Lnk(Lakn[a].base(),
                                                            {nchol_per_kp[Q],nmo_per_kp[QKtok2[Q][K]]});
                 buff({0,Lkn.size(0)},{0,Lkn.size(1)}) = Lkn;
                 ma::transpose(buff({0,Lkn.size(0)},{0,Lkn.size(1)}),Lnk);
@@ -982,16 +982,16 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
 // change get_PsiK to cast to the value_type of the result
             auto Psi = get_PsiK<boost::multi::array<SPComplexType,2>>(nmo_per_kp,PsiT[nd],K);
             assert(Psi.size(0) == nocc_per_kp[nd][K]);
-            boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[Q][K].origin()),
+            boost::multi::array_ref<SPComplexType,2> Likn(to_address(LQKikn[Q][K].base()),
                                                          {nmo_per_kp[K],nmo_per_kp[QKtok2[Q][K]]*nchol_per_kp[Q]});
-            boost::multi::array_ref<SPComplexType,2> Lakn(to_address(LQKank[nq0+Q][K].origin()),
+            boost::multi::array_ref<SPComplexType,2> Lakn(to_address(LQKank[nq0+Q][K].base()),
                                                          {nocc_per_kp[nd][K],nmo_per_kp[QKtok2[Q][K]]*nchol_per_kp[Q]});
             ma::product(Psi,Likn,Lakn);
             // transpose to form expected by KP3IndexFactorization
             for(int a=0; a<nocc_per_kp[nd][K]; a++) {
-              boost::multi::array_ref<SPComplexType,2> Lkn(Lakn[a].origin(),
+              boost::multi::array_ref<SPComplexType,2> Lkn(Lakn[a].base(),
                                                          {nmo_per_kp[QKtok2[Q][K]],nchol_per_kp[Q]});
-              boost::multi::array_ref<SPComplexType,2> Lnk(Lakn[a].origin(),
+              boost::multi::array_ref<SPComplexType,2> Lnk(Lakn[a].base(),
                                                          {nchol_per_kp[Q],nmo_per_kp[QKtok2[Q][K]]});
               for(int k=0; k<nmo_per_kp[QKtok2[Q][K]]; k++)
                 for(int n=0; n<nchol_per_kp[Q]; n++)
@@ -1007,12 +1007,12 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
   }
   TG.Global().barrier();
   if(TG.Node().root()) {
-    TG.Cores().all_reduce_in_place_n(to_address(haj.origin()),
+    TG.Cores().all_reduce_in_place_n(to_address(haj.base()),
                                      haj.num_elements(),std::plus<>());
     for(int Q=0; Q<LQKank.size(); Q++)
-      TG.Cores().all_reduce_in_place_n(to_address(LQKank[Q].origin()),
+      TG.Cores().all_reduce_in_place_n(to_address(LQKank[Q].base()),
                                        LQKank[Q].num_elements(),std::plus<>());
-    std::fill_n(to_address(vn0.origin()),vn0.num_elements(),ComplexType(0.0));
+    std::fill_n(to_address(vn0.base()),vn0.num_elements(),ComplexType(0.0));
   }
   TG.Node().barrier();
 */
@@ -1022,7 +1022,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
   {
     if (K % TG.Node().size() == TG.Node().rank())
     {
-      boost::multi::array_ref<SPComplexType, 2> Likn(to_address(LQKikn[0][K].origin()),
+      boost::multi::array_ref<SPComplexType, 2> Likn(to_address(LQKikn[0][K].base()),
                                                      {nmo_per_kp[K], nmo_per_kp[K] * nchol_per_kp[0]});
       using ma::H;
       ma::product(-0.5, Likn, H(Likn), 0.0, vn0[K]({0, nmo_per_kp[K]}, {0, nmo_per_kp[K]}));
@@ -1085,9 +1085,9 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
           // right now the code assumes that Q=0 is the gamma point (0,0,0).
           int ni = nmo_per_kp[KI];
           int nj = nmo_per_kp[KJ];
-          boost::multi::array_ref<SPComplexType, 3> LQI(to_address(LQKikn_[Q][KI].origin()),
+          boost::multi::array_ref<SPComplexType, 3> LQI(to_address(LQKikn_[Q][KI].base()),
                                                         {ni, nj, nchol_per_kp_[Q]});
-          boost::multi::array_ref<SPComplexType, 3> LQJ(to_address(LQKikn_[Q][KJ].origin()),
+          boost::multi::array_ref<SPComplexType, 3> LQJ(to_address(LQKikn_[Q][KJ].base()),
                                                         {nj, ni, nchol_per_kp_[Q]});
           if (KJ > KI)
           {
@@ -1106,14 +1106,14 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
           int KJ = QKtok2[Qm][KI];
           int ni = nmo_per_kp[KI];
           int nj = nmo_per_kp[KJ];
-          boost::multi::array_ref<SPComplexType, 3> LQm(to_address(LQKikn_[Qm][KI].origin()),
+          boost::multi::array_ref<SPComplexType, 3> LQm(to_address(LQKikn_[Qm][KI].base()),
                                                         {ni, nj, nchol_per_kp_[Q]});
-          boost::multi::array_ref<SPComplexType, 3> LQ(to_address(LQKikn_[Q][KJ].origin()), {nj, ni, nchol_per_kp_[Q]});
+          boost::multi::array_ref<SPComplexType, 3> LQ(to_address(LQKikn_[Q][KJ].base()), {nj, ni, nchol_per_kp_[Q]});
           for (int i = 0; i < ni; i++)
             for (int j = 0; j < nj; j++)
             {
-              auto LQ_n(LQ[j][i].origin());
-              auto LQm_n(LQm[i][j].origin());
+              auto LQ_n(LQ[j][i].base());
+              auto LQm_n(LQm[i][j].base());
               for (int n = 0; n < nchol_per_kp_[Qm]; n++, ++LQ_n, ++LQm_n)
                 (*LQ_n) = ma::conj(*LQm_n);
             }
@@ -1145,8 +1145,8 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
 
   boost::multi::array<ComplexType, 2> IJKL_({nmo_max * nmo_max, nmo_max * nmo_max});
   boost::multi::array<ComplexType, 2> IJKL({nmo_max * nmo_max, nmo_max * nmo_max});
-  boost::multi::array_ref<ComplexType, 4> IJKL4D(IJKL.origin(), {nmo_max, nmo_max, nmo_max, nmo_max});
-  boost::multi::array_ref<ComplexType, 4> IJKL4D_(IJKL_.origin(), {nmo_max, nmo_max, nmo_max, nmo_max});
+  boost::multi::array_ref<ComplexType, 4> IJKL4D(IJKL.base(), {nmo_max, nmo_max, nmo_max, nmo_max});
+  boost::multi::array_ref<ComplexType, 4> IJKL4D_(IJKL_.base(), {nmo_max, nmo_max, nmo_max, nmo_max});
   for (int KI = 0, n_ = 0; KI < nkpts; KI++)
     for (int KL = 0; KL < nkpts; KL++)
     {
@@ -1157,13 +1157,13 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
         //if( not (KI==KK && KL == KJ) ) continue;
         if ((n_++) % TGwfn.Global().size() == TGwfn.Global().rank())
         {
-          boost::multi::array_ref<ComplexType, 2> LKI(to_address(LQKikn[Q][KI].origin()),
+          boost::multi::array_ref<ComplexType, 2> LKI(to_address(LQKikn[Q][KI].base()),
                                                       {nmo_max * nmo_max, nchol_per_kp[Q]});
-          boost::multi::array_ref<ComplexType, 2> LKL(to_address(LQKikn[Q][KL].origin()),
+          boost::multi::array_ref<ComplexType, 2> LKL(to_address(LQKikn[Q][KL].base()),
                                                       {nmo_max * nmo_max, nchol_per_kp[Q]});
-          boost::multi::array_ref<ComplexType, 2> LKI_(to_address(LQKikn_[Q][KI].origin()),
+          boost::multi::array_ref<ComplexType, 2> LKI_(to_address(LQKikn_[Q][KI].base()),
                                                        {nmo_max * nmo_max, nchol_per_kp_[Q]});
-          boost::multi::array_ref<ComplexType, 2> LKL_(to_address(LQKikn_[Q][KL].origin()),
+          boost::multi::array_ref<ComplexType, 2> LKL_(to_address(LQKikn_[Q][KL].base()),
                                                        {nmo_max * nmo_max, nchol_per_kp_[Q]});
           ma::product(LKI, ma::H(LKL), IJKL);
           ma::product(LKI_, ma::H(LKL_), IJKL_);
@@ -1182,7 +1182,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
     }
   /*
   boost::multi::array<ComplexType,2> IJKL({nmo_max*nmo_max,nmo_max*nmo_max});
-  boost::multi::array_ref<ComplexType,4> IJKL4D(IJKL.origin(),{nmo_max,nmo_max,nmo_max,nmo_max});
+  boost::multi::array_ref<ComplexType,4> IJKL4D(IJKL.base(),{nmo_max,nmo_max,nmo_max,nmo_max});
   ComplexType EX(0.0);
   ComplexType EJ(0.0);
   for(int KI=0; KI<nkpts; KI++)
@@ -1191,8 +1191,8 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
     {
       int Q = KK2Q[KI][KK];
       int KJ = QKtok2[Q][KL];
-      boost::multi::array_ref<ComplexType,2> LKI(to_address(LQKikn[Q][KI].origin()),{nmo_max*nmo_max,nchol_per_kp[Q]});
-      boost::multi::array_ref<ComplexType,2> LKL(to_address(LQKikn[Q][KL].origin()),{nmo_max*nmo_max,nchol_per_kp[Q]});
+      boost::multi::array_ref<ComplexType,2> LKI(to_address(LQKikn[Q][KI].base()),{nmo_max*nmo_max,nchol_per_kp[Q]});
+      boost::multi::array_ref<ComplexType,2> LKL(to_address(LQKikn[Q][KL].base()),{nmo_max*nmo_max,nchol_per_kp[Q]});
       ma::product(LKI,ma::H(LKL),IJKL);
       for(int i=0; i<nmo_per_kp[0]; i++)
       for(int k=0; k<nmo_per_kp[0]; k++)

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
@@ -143,7 +143,7 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
         APP_ABORT("");
       }
     }
-    RMatrix_ref h1_(to_address(H1.origin()), H1.extensions());
+    RMatrix_ref h1_(to_address(H1.base()), H1.extents());
     if (!dump.readEntry(h1_, std::string("hcore")))
     {
       app_error() << " Error in RealDenseHamiltonian::getHamiltonianOperations():"
@@ -155,7 +155,7 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
   {
     // read L
     dump.push("DenseFactorized", false);
-    SpRMatrix_ref L(to_address(Likn.origin()), Likn.extensions());
+    SpRMatrix_ref L(to_address(Likn.base()), Likn.extents());
     hyperslab_proxy<SpRMatrix_ref, 2> hslab(L,
                                             std::array<size_t, 2>{static_cast<size_t>(NMO * NMO),
                                                                   static_cast<size_t>(global_ncvecs)},
@@ -205,7 +205,7 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
 
   // for simplicity
   CMatrix H1C({NMO, NMO});
-  copy_n_cast(to_address(H1.origin()), NMO * NMO, H1C.origin());
+  copy_n_cast(to_address(H1.base()), NMO * NMO, H1C.base());
 
   int nt = 0;
   for (int nd = 0; nd < ndet; nd++)
@@ -215,15 +215,15 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
       continue;
     if (type == COLLINEAR)
     {
-      CMatrix_ref haj_r(to_address(haj[nd].origin()), {nup, NMO});
+      CMatrix_ref haj_r(to_address(haj[nd].base()), {nup, NMO});
       ma::product(PsiT[2 * nd], H1C, haj_r);
-      CMatrix_ref hbj_r(to_address(haj[nd].origin()) + (nup * NMO), {ndown, NMO});
+      CMatrix_ref hbj_r(to_address(haj[nd].base()) + (nup * NMO), {ndown, NMO});
       if (ndown > 0)
         ma::product(PsiT[2 * nd + 1], H1C, hbj_r);
     }
     else
     {
-      CMatrix_ref haj_r(to_address(haj[nd].origin()), {nup, NMO});
+      CMatrix_ref haj_r(to_address(haj[nd].base()), {nup, NMO});
       ma::product(ComplexType(2.0), PsiT[nd], H1C, ComplexType(0.0), haj_r);
     }
   }
@@ -242,7 +242,7 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
             lik[i][k] = ComplexType(static_cast<RealType>(Likn[ik][nc]), 0.0);
         ma::product(PsiT[nspins * nd], lik, lak);
         for (int a = 0; a < nup; a++)
-          copy_n_cast(lak[a].origin(), NMO, to_address(Lank[nspins * nd][a][nc].origin()));
+          copy_n_cast(lak[a].base(), NMO, to_address(Lank[nspins * nd][a][nc].base()));
         if (ndet == 1)
           for (int a = 0, ak = 0; a < nup; a++)
             for (int k = 0; k < NMO; k++, ak++)
@@ -251,7 +251,7 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
         {
           ma::product(PsiT[2 * nd + 1], lik, lak.sliced(0, ndown));
           for (int a = 0; a < ndown; a++)
-            copy_n_cast(lak[a].origin(), NMO, to_address(Lank[2 * nd + 1][a][nc].origin()));
+            copy_n_cast(lak[a].base(), NMO, to_address(Lank[2 * nd + 1][a][nc].base()));
           if (ndet == 1)
             for (int a = 0, ak = nup * NMO; a < ndown; a++)
               for (int k = 0; k < NMO; k++, ak++)
@@ -264,10 +264,10 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
   if (distNode.root())
   {
     for (auto& v : Lank)
-      Qcomm_roots.all_reduce_in_place_n(to_address(v.origin()), v.num_elements(), std::plus<>());
+      Qcomm_roots.all_reduce_in_place_n(to_address(v.base()), v.num_elements(), std::plus<>());
     if (ndet == 1)
-      Qcomm_roots.all_reduce_in_place_n(to_address(Lakn.origin()), Lakn.num_elements(), std::plus<>());
-    std::fill_n(to_address(vn0.origin()), vn0.num_elements(), ComplexType(0.0));
+      Qcomm_roots.all_reduce_in_place_n(to_address(Lakn.base()), Lakn.num_elements(), std::plus<>());
+    std::fill_n(to_address(vn0.base()), vn0.num_elements(), ComplexType(0.0));
   }
   TG.Node().barrier();
 
@@ -278,16 +278,16 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
     if (iN > i0)
     {
       SpRMatrix v_({iN - i0, NMO});
-      SpRMatrix_ref Lijn(to_address(Likn.origin()), {NMO, NMO * local_ncv});
+      SpRMatrix_ref Lijn(to_address(Likn.base()), {NMO, NMO * local_ncv});
       ma::product(-0.5, Lijn.sliced(i0, iN), ma::T(Lijn), 0.0, v_);
-      copy_n_cast(v_.origin(), v_.num_elements(), to_address(vn0[i0].origin()));
+      copy_n_cast(v_.base(), v_.num_elements(), to_address(vn0[i0].base()));
     }
   }
   TG.Node().barrier();
 
   if (distNode.root())
   {
-    distNode_roots.all_reduce_in_place_n(to_address(vn0.origin()), vn0.num_elements(), std::plus<>());
+    distNode_roots.all_reduce_in_place_n(to_address(vn0.base()), vn0.num_elements(), std::plus<>());
     dump.pop();
     dump.close();
   }

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian_v2.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian_v2.cpp
@@ -139,7 +139,7 @@ HamiltonianOperations RealDenseHamiltonian_v2::getHamiltonianOperations(bool pur
         APP_ABORT("");
       }
     }
-    RMatrix_ref h1_(to_address(H1.origin()), H1.extensions());
+    RMatrix_ref h1_(to_address(H1.base()), H1.extents());
     if (!dump.readEntry(h1_, std::string("hcore")))
     {
       app_error() << " Error in RealDenseHamiltonian_v2::getHamiltonianOperations():"
@@ -151,7 +151,7 @@ HamiltonianOperations RealDenseHamiltonian_v2::getHamiltonianOperations(bool pur
   {
     // read L
     dump.push("DenseFactorized", false);
-    SpRMatrix_ref L(to_address(Likn.origin()), Likn.extensions());
+    SpRMatrix_ref L(to_address(Likn.base()), Likn.extents());
     hyperslab_proxy<SpRMatrix_ref, 2> hslab(L,
                                             std::array<size_t, 2>{static_cast<size_t>(NMO * NMO),
                                                                   static_cast<size_t>(global_ncvecs)},
@@ -196,7 +196,7 @@ HamiltonianOperations RealDenseHamiltonian_v2::getHamiltonianOperations(bool pur
 
   // for simplicity
   CMatrix H1C({NMO, NMO});
-  copy_n_cast(to_address(H1.origin()), NMO * NMO, H1C.origin());
+  copy_n_cast(to_address(H1.base()), NMO * NMO, H1C.base());
 
   int nt = 0;
   for (int nd = 0; nd < ndet; nd++)
@@ -206,15 +206,15 @@ HamiltonianOperations RealDenseHamiltonian_v2::getHamiltonianOperations(bool pur
       continue;
     if (type == COLLINEAR)
     {
-      CMatrix_ref haj_r(to_address(haj[nd].origin()), {nup, NMO});
+      CMatrix_ref haj_r(to_address(haj[nd].base()), {nup, NMO});
       ma::product(PsiT[2 * nd], H1C, haj_r);
-      CMatrix_ref hbj_r(to_address(haj[nd].origin()) + (nup * NMO), {ndown, NMO});
+      CMatrix_ref hbj_r(to_address(haj[nd].base()) + (nup * NMO), {ndown, NMO});
       if (ndown > 0)
         ma::product(PsiT[2 * nd + 1], H1C, hbj_r);
     }
     else
     {
-      CMatrix_ref haj_r(to_address(haj[nd].origin()), {nup, NMO});
+      CMatrix_ref haj_r(to_address(haj[nd].base()), {nup, NMO});
       ma::product(ComplexType(2.0), PsiT[nd], H1C, ComplexType(0.0), haj_r);
     }
   }
@@ -233,11 +233,11 @@ HamiltonianOperations RealDenseHamiltonian_v2::getHamiltonianOperations(bool pur
           for (int k = 0; k < NMO; k++, ik++)
             lik[i][k] = ComplexType(static_cast<RealType>(Likn[ik][nc]), 0.0);
         ma::product(PsiT[nspins * nd], lik, lak);
-        copy_n_cast(lak.origin(), nup * NMO, to_address(Lnak[nspins * nd][nc].origin()));
+        copy_n_cast(lak.base(), nup * NMO, to_address(Lnak[nspins * nd][nc].base()));
         if (type == COLLINEAR)
         {
           ma::product(PsiT[2 * nd + 1], lik, lak.sliced(0, ndown));
-          copy_n_cast(lak.origin(), ndown * NMO, to_address(Lnak[2 * nd + 1][nc].origin()));
+          copy_n_cast(lak.base(), ndown * NMO, to_address(Lnak[2 * nd + 1][nc].base()));
         }
       }
     }
@@ -246,8 +246,8 @@ HamiltonianOperations RealDenseHamiltonian_v2::getHamiltonianOperations(bool pur
   if (distNode.root())
   {
     for (auto& v : Lnak)
-      Qcomm_roots.all_reduce_in_place_n(to_address(v.origin()), v.num_elements(), std::plus<>());
-    std::fill_n(to_address(vn0.origin()), vn0.num_elements(), ComplexType(0.0));
+      Qcomm_roots.all_reduce_in_place_n(to_address(v.base()), v.num_elements(), std::plus<>());
+    std::fill_n(to_address(vn0.base()), vn0.num_elements(), ComplexType(0.0));
   }
   TG.Node().barrier();
 
@@ -258,16 +258,16 @@ HamiltonianOperations RealDenseHamiltonian_v2::getHamiltonianOperations(bool pur
     if (iN > i0)
     {
       SpRMatrix v_({iN - i0, NMO});
-      SpRMatrix_ref Lijn(to_address(Likn.origin()), {NMO, NMO * local_ncv});
+      SpRMatrix_ref Lijn(to_address(Likn.base()), {NMO, NMO * local_ncv});
       ma::product(-0.5, Lijn.sliced(i0, iN), ma::T(Lijn), 0.0, v_);
-      copy_n_cast(v_.origin(), v_.num_elements(), to_address(vn0[i0].origin()));
+      copy_n_cast(v_.base(), v_.num_elements(), to_address(vn0[i0].base()));
     }
   }
   TG.Node().barrier();
 
   if (distNode.root())
   {
-    distNode_roots.all_reduce_in_place_n(to_address(vn0.origin()), vn0.num_elements(), std::plus<>());
+    distNode_roots.all_reduce_in_place_n(to_address(vn0.base()), vn0.num_elements(), std::plus<>());
     dump.pop();
     dump.close();
   }

--- a/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
@@ -229,8 +229,8 @@ HamiltonianOperations THCHamiltonian::getHamiltonianOperations(bool pureSD,
     //         = -0.5 sum_u,v ma::conj(Piu(i,u)) W(u,v) Piu(l,u), where
     // W(u,v) = Muv(u,v) * sum_j Piu(j,u) ma::conj(Piu(j,v))
     ma::product(H(Piu__), Piu__({0, long(NMO)}, {long(c0), long(cN)}), Tuv);
-    auto itM = Muv.origin();
-    auto itT = Tuv.origin();
+    auto itM = Muv.base();
+    auto itT = Tuv.base();
     for (size_t i = 0; i < Muv.num_elements(); ++i, ++itT, ++itM)
       *(itT) = ma::conj(*itT) * (*itM);
 
@@ -240,10 +240,10 @@ HamiltonianOperations THCHamiltonian::getHamiltonianOperations(bool pureSD,
     ma::product(SPValueType(-0.5), T(T_), T(Piu__({0, long(NMO)}, {long(c0), long(cN)})), SPValueType(0.0), v0_);
 
     // reduce over Global
-    TG.Global().all_reduce_in_place_n(v0_.origin(), v0_.num_elements(), std::plus<>());
+    TG.Global().all_reduce_in_place_n(v0_.base(), v0_.num_elements(), std::plus<>());
     if (TG.Node().root())
     {
-      copy_n_cast(v0_.origin(), NMO * NMO, to_address(v0.origin()));
+      copy_n_cast(v0_.base(), NMO * NMO, to_address(v0.base()));
 #if defined(MIXED_PRECISION)
       // MAM: Since Muv gets large, might have problems with the check for hermicity below
       // fixing here
@@ -282,8 +282,8 @@ HamiltonianOperations THCHamiltonian::getHamiltonianOperations(bool pureSD,
     //         = -0.5 sum_u,v ma::conj(Piu(i,u)) W(u,v) Piu(l,v), where
     // W(u,v) = Muv(u,v) * sum_j Piu(j,u) ma::conj(Piu(j,v))
     ma::product(H(Piu), Piu({0, long(NMO)}, {long(c0), long(cN)}), Tuv);
-    auto itM = Muv.origin();
-    auto itT = Tuv.origin();
+    auto itM = Muv.base();
+    auto itT = Tuv.base();
     for (size_t i = 0; i < Muv.num_elements(); ++i, ++itT, ++itM)
       *(itT) = ma::conj(*itT) * (*itM);
 
@@ -293,10 +293,10 @@ HamiltonianOperations THCHamiltonian::getHamiltonianOperations(bool pureSD,
     ma::product(SPValueType(-0.5), T(T_), T(Piu({0, long(NMO)}, {long(c0), long(cN)})), SPValueType(0.0), v0_);
 
     // reduce over Global
-    TG.Global().all_reduce_in_place_n(v0_.origin(), v0_.num_elements(), std::plus<>());
+    TG.Global().all_reduce_in_place_n(v0_.base(), v0_.num_elements(), std::plus<>());
     if (TG.Node().root())
     {
-      copy_n_cast(v0_.origin(), NMO * NMO, to_address(v0.origin()));
+      copy_n_cast(v0_.base(), NMO * NMO, to_address(v0.base()));
 #if defined(MIXED_PRECISION)
       // MAM: Since Muv gets large, might have problems with the check for hermicity below
       // fixing here
@@ -360,13 +360,13 @@ HamiltonianOperations THCHamiltonian::getHamiltonianOperations(bool pureSD,
   if (TG.Node().root())
   {
     // dense one body hamiltonian
-    copy_n_cast((OneBodyHamiltonian::H1).origin(), NMO * NMO, to_address(H1_.origin()));
+    copy_n_cast((OneBodyHamiltonian::H1).base(), NMO * NMO, to_address(H1_.base()));
     int skp = ((type == COLLINEAR) ? 1 : 0);
     for (int n = 0, nd = 0; n < ndet; ++n, nd += (skp + 1))
     {
       check_wavefunction_consistency(type, &PsiT[nd], &PsiT[nd + skp], NMO, naea_, naeb_);
       auto hij_(rotateHij(type, &PsiT[nd], &PsiT[nd + skp], H1_));
-      std::copy_n(hij_.origin(), hij_.num_elements(), to_address(hij[n].origin()));
+      std::copy_n(hij_.base(), hij_.num_elements(), to_address(hij[n].base()));
     }
   }
   TG.Node().barrier();

--- a/src/AFQMC/Hamiltonians/generateHijkl.hpp
+++ b/src/AFQMC/Hamiltonians/generateHijkl.hpp
@@ -101,7 +101,7 @@ void generateHijkl(WALKER_TYPES walker_type,
       }
 #endif
     }
-  TG.Global().all_reduce_in_place_n(DiagHam.origin(), DiagHam.num_elements(), std::plus<>());
+  TG.Global().all_reduce_in_place_n(DiagHam.base(), DiagHam.num_elements(), std::plus<>());
 
   int occi, occj, occk, occl;
   if (reserve_to_fit_)

--- a/src/AFQMC/Hamiltonians/rotateHamiltonian.hpp
+++ b/src/AFQMC/Hamiltonians/rotateHamiltonian.hpp
@@ -99,7 +99,7 @@ inline boost::multi::array<ComplexType, 1> rotateHij(WALKER_TYPES walker_type,
   if (walker_type == CLOSED || walker_type == NONCOLLINEAR)
   {
     N.reextent(iextensions<1u>{NAEA * NMO});
-    boost::multi::array_ref<ComplexType, 2> N_(N.origin(), {NAEA, NMO});
+    boost::multi::array_ref<ComplexType, 2> N_(N.base(), {NAEA, NMO});
 
     ma::product(*Alpha, H1, N_);
     ma::scal(ComplexType(2.0), N);
@@ -110,8 +110,8 @@ inline boost::multi::array<ComplexType, 1> rotateHij(WALKER_TYPES walker_type,
     int NAEB = Beta->size(0);
 
     N.reextent(iextensions<1u>{(NAEA + NAEB) * NMO});
-    boost::multi::array_ref<ComplexType, 2> NA_(N.origin(), {NAEA, NMO});
-    boost::multi::array_ref<ComplexType, 2> NB_(N.origin() + NAEA * NMO, {NAEB, NMO});
+    boost::multi::array_ref<ComplexType, 2> NA_(N.base(), {NAEA, NMO});
+    boost::multi::array_ref<ComplexType, 2> NB_(N.base() + NAEA * NMO, {NAEB, NMO});
 
     ma::product(*Alpha, H1, NA_);
     ma::product(*Beta, H1, NB_);
@@ -269,14 +269,14 @@ inline void rotateHijkl(std::string& type,
 
   shmSpMatrix Qk({dummy_nrow, dummy_ncol}, shared_allocator<SPComplexType>{TG.Node()});
   if (coreid == 0)
-    std::fill_n(Qk.origin(), Qk.num_elements(), SPComplexType(0.0));
+    std::fill_n(Qk.base(), Qk.num_elements(), SPComplexType(0.0));
   dummy_nrow = nrow;
   dummy_ncol = ncol;
   if (sparseRl or nodeid >= ngrp)
     dummy_nrow = dummy_ncol = 0;
   shmSpMatrix Rl({dummy_ncol, dummy_nrow}, shared_allocator<SPComplexType>{TG.Node()});
   if (coreid == 0)
-    std::fill_n(Rl.origin(), Rl.num_elements(), SPComplexType(0.0));
+    std::fill_n(Rl.base(), Rl.num_elements(), SPComplexType(0.0));
 
   if (distribute_Ham)
   {
@@ -345,7 +345,7 @@ inline void rotateHijkl(std::string& type,
         int n0_, n1_, sz_ = Qk.size();
         std::tie(n0_, n1_) = FairDivideBoundary(coreid, sz_, ncores);
         if (n1_ - n0_ > 0)
-          ma::transpose(Qk.sliced(n0_, n1_), Rl(Rl.extension(), {n0_, n1_}));
+          ma::transpose(Qk.sliced(n0_, n1_), Rl(Rl.extent(), {n0_, n1_}));
       }
     }
 #endif
@@ -491,7 +491,7 @@ inline void rotateHijkl(std::string& type,
         int NEL0 = (k0 < NMO) ? NAEA : NAEB; // number of electrons in this spin block
         assert(nk > 0 && nk <= maxnk);       // just checking
 
-        boost::multi::array_ref<SPComplexType, 2> tQk(to_address(tQk_shmbuff.origin()), {nk * NEL0, nvec});
+        boost::multi::array_ref<SPComplexType, 2> tQk(to_address(tQk_shmbuff.base()), {nk * NEL0, nvec});
 
         Timer_.reset("T0");
         Timer_.start("T0");
@@ -535,9 +535,9 @@ inline void rotateHijkl(std::string& type,
           if (coreid == 0)
           {
             if (nn == comm.rank())
-              std::copy(Qk.origin() + bi * maxnk * NEL0 * nvec, Qk.origin() + (bi * maxnk + nk) * NEL0 * nvec,
-                        tQk.origin());
-            comm.broadcast_n(tQk.origin(), nk * NEL0 * nvec, nn);
+              std::copy(Qk.base() + bi * maxnk * NEL0 * nvec, Qk.base() + (bi * maxnk + nk) * NEL0 * nvec,
+                        tQk.base());
+            comm.broadcast_n(tQk.base(), nk * NEL0 * nvec, nn);
           }
           TG.node_barrier();
         }
@@ -545,7 +545,7 @@ inline void rotateHijkl(std::string& type,
         app_log() << " Loop: " << nn << "/" << comm.size() << " " << bi << "/" << nblk
                   << " communication: " << Timer_.total("T0") << " ";
 
-        boost::multi::array_ref<SPComplexType, 2> Ta(to_address(Ta_shmbuff.origin()), {nk * NEL0, nrow});
+        boost::multi::array_ref<SPComplexType, 2> Ta(to_address(Ta_shmbuff.base()), {nk * NEL0, nrow});
 
         Timer_.reset("T0");
         Timer_.start("T0");
@@ -616,7 +616,7 @@ inline void rotateHijkl(std::string& type,
       int NEL0 = (k0 < NMO) ? NAEA : NAEB; // number of electrons in this spin block
       assert(nk > 0 && nk <= maxnk);       // just checking
 
-      boost::multi::array_ref<SPComplexType, 2> tQk(to_address(tQk_shmbuff.origin()), {nk * NEL0, nvec});
+      boost::multi::array_ref<SPComplexType, 2> tQk(to_address(tQk_shmbuff.base()), {nk * NEL0, nvec});
 
       Timer_.reset("T0");
       Timer_.start("T0");
@@ -660,16 +660,16 @@ inline void rotateHijkl(std::string& type,
         if (coreid == 0)
         {
           if (nn == comm.rank())
-            std::copy(Qk.origin() + bi * maxnk * NEL0 * nvec, Qk.origin() + (bi * maxnk + nk) * NEL0 * nvec,
-                      tQk.origin());
-          comm.broadcast_n(tQk.origin(), nk * NEL0 * nvec, nn);
+            std::copy(Qk.base() + bi * maxnk * NEL0 * nvec, Qk.base() + (bi * maxnk + nk) * NEL0 * nvec,
+                      tQk.base());
+          comm.broadcast_n(tQk.base(), nk * NEL0 * nvec, nn);
         }
         TG.node_barrier();
       }
       app_log() << " Loop: " << nn << "/" << comm.size() << " " << bi << "/" << nblk
                 << " communication: " << Timer_.total("T0") << " ";
 
-      boost::multi::array_ref<SPComplexType, 2> Ta(to_address(Ta_shmbuff.origin()), {nk * NEL0, nrow});
+      boost::multi::array_ref<SPComplexType, 2> Ta(to_address(Ta_shmbuff.base()), {nk * NEL0, nrow});
 
       Timer_.reset("T0");
       Timer_.start("T0");
@@ -764,13 +764,13 @@ inline void rotateHijkl_single_node(std::string& type,
   int nx = (sparseQk ? 0 : 1);
   shmSpMatrix Qk({nx * NMO * NEL, nx * nvec}, shared_allocator<SPComplexType>{TG.Node()});
   if (coreid == 0)
-    std::fill_n(Qk.origin(), Qk.num_elements(), SPComplexType(0.0));
+    std::fill_n(Qk.base(), Qk.num_elements(), SPComplexType(0.0));
   nx = (sparseQk ? 1 : 0);
   SpCType_shm_csr_matrix SpQk(tp_ul_ul{nx * NMO * NEL, nx * nvec}, tp_ul_ul{0, 0}, 0, alloc);
 
   shmSpMatrix Rl({nvec, NMO * NEL}, shared_allocator<SPComplexType>{TG.Node()});
   if (coreid == 0)
-    std::fill_n(Rl.origin(), Rl.num_elements(), SPComplexType(0.0));
+    std::fill_n(Rl.base(), Rl.num_elements(), SPComplexType(0.0));
 
   {
     using std::get;
@@ -802,7 +802,7 @@ inline void rotateHijkl_single_node(std::string& type,
       int n0_, n1_, sz_ = get<0>(Qk.sizes());
       std::tie(n0_, n1_) = FairDivideBoundary(coreid, sz_, ncores);
       if (n1_ - n0_ > 0)
-        ma::transpose(Qk.sliced(n0_, n1_), Rl(Rl.extension(), {n0_, n1_}));
+        ma::transpose(Qk.sliced(n0_, n1_), Rl(Rl.extent(), {n0_, n1_}));
     }
 #endif
   }
@@ -844,30 +844,30 @@ inline void rotateHijkl_single_node(std::string& type,
       int kN = std::min(k0 + maxnk, NMO);
       int nk = kN - k0;
       { // alpha-alpha
-        boost::multi::array_ref<SPComplexType, 2> Ta(to_address(Ta_shmbuff.origin()), {nk * NAEA, NAEA * NMO});
+        boost::multi::array_ref<SPComplexType, 2> Ta(to_address(Ta_shmbuff.base()), {nk * NAEA, NAEA * NMO});
         if (type == "SD")
           count_Qk_x_Rl(walker_type, EJX, TG, sz_local, k0, kN, 0, NMO, NMO, NAEA, NAEB,
-                        SpQk[{size_t(k0 * NAEA), std::size_t(kN * NAEA)}], Rl(Rl.extension(), {0, NAEA * NMO}), Ta,
+                        SpQk[{size_t(k0 * NAEA), std::size_t(kN * NAEA)}], Rl(Rl.extent(), {0, NAEA * NMO}), Ta,
                         cut);
         else if (type == "DD")
         {
           count_Qk_x_Rl(walker_type, EJX, TG, sz_local, k0, kN, 0, NMO, NMO, NAEA, NAEB,
-                        Qk.sliced(size_t(k0 * NAEA), size_t(kN * NAEA)), Rl(Rl.extension(), {0, NAEA * NMO}), Ta, cut);
+                        Qk.sliced(size_t(k0 * NAEA), size_t(kN * NAEA)), Rl(Rl.extent(), {0, NAEA * NMO}), Ta, cut);
         }
       }
       TG.Node().barrier();
       if (walker_type == COLLINEAR)
       { // beta-beta
-        boost::multi::array_ref<SPComplexType, 2> Ta(to_address(Ta_shmbuff.origin()), {nk * NAEB, NAEB * NMO});
+        boost::multi::array_ref<SPComplexType, 2> Ta(to_address(Ta_shmbuff.base()), {nk * NAEB, NAEB * NMO});
         if (type == "SD")
           count_Qk_x_Rl(walker_type, EJX, TG, sz_local, k0 + NMO, kN + NMO, NMO, 2 * NMO, NMO, NAEA, NAEB,
                         SpQk[{size_t(NAEA * NMO + k0 * NAEB), std::size_t(NAEA * NMO + kN * NAEB)}],
-                        Rl(Rl.extension(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta, cut);
+                        Rl(Rl.extent(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta, cut);
         else if (type == "DD")
         {
           count_Qk_x_Rl(walker_type, EJX, TG, sz_local, k0 + NMO, kN + NMO, NMO, 2 * NMO, NMO, NAEA, NAEB,
                         Qk.sliced(NAEA * NMO + k0 * NAEB, NAEA * NMO + kN * NAEB),
-                        Rl(Rl.extension(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta, cut);
+                        Rl(Rl.extent(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta, cut);
         }
         TG.Node().barrier();
         if (addCoulomb)
@@ -875,12 +875,12 @@ inline void rotateHijkl_single_node(std::string& type,
           if (type == "SD")
             count_Qk_x_Rl(walker_type, EJX, TG, sz_local, k0, kN, NMO, 2 * NMO, NMO, NAEA, NAEB,
                           SpQk[{size_t(k0 * NAEA), std::size_t(kN * NAEA)}],
-                          Rl(Rl.extension(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta, cut);
+                          Rl(Rl.extent(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta, cut);
           else if (type == "DD")
           {
-            boost::multi::array_ref<SPComplexType, 2> Ta_(to_address(Ta_shmbuff.origin()), {nk * NAEA, NAEB * NMO});
+            boost::multi::array_ref<SPComplexType, 2> Ta_(to_address(Ta_shmbuff.base()), {nk * NAEA, NAEB * NMO});
             count_Qk_x_Rl(walker_type, EJX, TG, sz_local, k0, kN, NMO, 2 * NMO, NMO, NAEA, NAEB,
-                          Qk.sliced(k0 * NAEA, kN * NAEA), Rl(Rl.extension(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta_,
+                          Qk.sliced(k0 * NAEA, kN * NAEA), Rl(Rl.extent(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta_,
                           cut);
           }
         }
@@ -926,38 +926,38 @@ inline void rotateHijkl_single_node(std::string& type,
     int kN = std::min(k0 + maxnk, NMO);
     int nk = kN - k0;
     { // alpha-alpha
-      boost::multi::array_ref<SPComplexType, 2> Ta(to_address(Ta_shmbuff.origin()), {nk * NAEA, NAEA * NMO});
+      boost::multi::array_ref<SPComplexType, 2> Ta(to_address(Ta_shmbuff.base()), {nk * NAEA, NAEA * NMO});
       if (type == "SD")
         Qk_x_Rl(walker_type, EJX, TG, k0, kN, 0, NMO, NMO, NAEA, NAEB,
-                SpQk[{size_t(k0 * NAEA), std::size_t(kN * NAEA)}], Rl(Rl.extension(), {0, NAEA * NMO}), Ta, Vijkl,
+                SpQk[{size_t(k0 * NAEA), std::size_t(kN * NAEA)}], Rl(Rl.extent(), {0, NAEA * NMO}), Ta, Vijkl,
                 cut);
       else if (type == "DD")
         Qk_x_Rl(walker_type, EJX, TG, k0, kN, 0, NMO, NMO, NAEA, NAEB, Qk.sliced(size_t(k0 * NAEA), size_t(kN * NAEA)),
-                Rl(Rl.extension(), {0, NAEA * NMO}), Ta, Vijkl, cut);
+                Rl(Rl.extent(), {0, NAEA * NMO}), Ta, Vijkl, cut);
     }
     TG.Node().barrier();
     if (walker_type == COLLINEAR)
     { // beta-beta
-      boost::multi::array_ref<SPComplexType, 2> Ta(to_address(Ta_shmbuff.origin()), {nk * NAEB, NAEB * NMO});
+      boost::multi::array_ref<SPComplexType, 2> Ta(to_address(Ta_shmbuff.base()), {nk * NAEB, NAEB * NMO});
       if (type == "SD")
         Qk_x_Rl(walker_type, EJX, TG, k0 + NMO, kN + NMO, NMO, 2 * NMO, NMO, NAEA, NAEB,
                 SpQk[{size_t(NAEA * NMO + k0 * NAEB), std::size_t(NAEA * NMO + kN * NAEB)}],
-                Rl(Rl.extension(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta, Vijkl, cut);
+                Rl(Rl.extent(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta, Vijkl, cut);
       else if (type == "DD")
         Qk_x_Rl(walker_type, EJX, TG, k0 + NMO, kN + NMO, NMO, 2 * NMO, NMO, NAEA, NAEB,
                 Qk.sliced(NAEA * NMO + k0 * NAEB, NAEA * NMO + kN * NAEB),
-                Rl(Rl.extension(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta, Vijkl, cut);
+                Rl(Rl.extent(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta, Vijkl, cut);
       TG.Node().barrier();
       if (addCoulomb)
       { // alpha-beta
-        boost::multi::array_ref<SPComplexType, 2> Ta_(to_address(Ta_shmbuff.origin()), {nk * NAEA, NAEB * NMO});
+        boost::multi::array_ref<SPComplexType, 2> Ta_(to_address(Ta_shmbuff.base()), {nk * NAEA, NAEB * NMO});
         if (type == "SD")
           Qk_x_Rl(walker_type, EJX, TG, k0, kN, NMO, 2 * NMO, NMO, NAEA, NAEB,
                   SpQk[{size_t(k0 * NAEA), std::size_t(kN * NAEA)}],
-                  Rl(Rl.extension(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta, Vijkl, cut);
+                  Rl(Rl.extent(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta, Vijkl, cut);
         else if (type == "DD")
           Qk_x_Rl(walker_type, EJX, TG, k0, kN, NMO, 2 * NMO, NMO, NAEA, NAEB, Qk.sliced(k0 * NAEA, kN * NAEA),
-                  Rl(Rl.extension(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta_, Vijkl, cut);
+                  Rl(Rl.extent(), {NAEA * NMO, (NAEA + NAEB) * NMO}), Ta_, Vijkl, cut);
       }
       TG.Node().barrier();
     }

--- a/src/AFQMC/Hamiltonians/rotateHamiltonian_Helper2.hpp
+++ b/src/AFQMC/Hamiltonians/rotateHamiltonian_Helper2.hpp
@@ -77,7 +77,7 @@ inline void count_Qk_x_Rl(WALKER_TYPES walker_type,
   {
     // <a,b | k,l> = Ta(ka,lb) - Tb(la,kb)
     // Ta(ka,lb) = Q(k,a,:)*R(l,b,:)
-    ma::product(Qk, Rl(Rl.extension(0), {bl0, blN}), Ta(Ta.extension(0), {bl0, blN}));
+    ma::product(Qk, Rl(get<0>(Rl.extents()), {bl0, blN}), Ta(get<0>(Ta.extents()), {bl0, blN}));
     TG.node_barrier();
     for (int ka = ka0; ka < kaN; ka++)
     {                         // ka = local range index
@@ -109,7 +109,7 @@ inline void count_Qk_x_Rl(WALKER_TYPES walker_type,
       {
         // <a,b | k,l> = Ta(ka,lb) - Tb(la,kb)
         // Ta(ka,lb) = Q(k,a,:)*R(l,b,:)
-        ma::product(Qk, Rl(Rl.extension(0), {bl0, blN}), Ta(Ta.extension(0), {bl0, blN}));
+        ma::product(Qk, Rl(get<0>(Rl.extents()), {bl0, blN}), Ta(get<0>(Ta.extents()), {bl0, blN}));
         TG.node_barrier();
         for (int k = k0, ka = 0; k < kN; k++)
         {
@@ -135,7 +135,7 @@ inline void count_Qk_x_Rl(WALKER_TYPES walker_type,
       else if (std::abs(EJX) > 1e-8)
       {
         // <a,b | k,l> = Ta(ka,lb) = Q(k,a,:)*R(l,b,:)
-        ma::product(Qk, Rl(Rl.extension(0), {bl0, blN}), Ta(Ta.extension(0), {bl0, blN}));
+        ma::product(Qk, Rl(get<0>(Rl.extents()), {bl0, blN}), Ta(get<0>(Ta.extents()), {bl0, blN}));
         TG.node_barrier();
         for (int k = k0, ka = 0; k < kN; k++)
         {
@@ -158,7 +158,7 @@ inline void count_Qk_x_Rl(WALKER_TYPES walker_type,
       {
         // <a,b | k,l> = Ta(ka,lb) - Tb(la,kb)
         // Ta(ka,lb) = Q(k,a,:)*R(l,b,:)
-        ma::product(Qk, Rl(Rl.extension(0), {bl0, blN}), Ta(Ta.extension(0), {bl0, blN}));
+        ma::product(Qk, Rl(get<0>(Rl.extents()), {bl0, blN}), Ta(get<0>(Ta.extents()), {bl0, blN}));
         TG.node_barrier();
         for (int k = k0, ka = 0; k < kN; k++)
         {
@@ -239,7 +239,7 @@ inline void Qk_x_Rl(WALKER_TYPES walker_type,
   {
     // <a,b | k,l> = Ta(ka,lb) - Tb(la,kb)
     // Ta(ka,lb) = Q(k,a,:)*R(l,b,:)
-    ma::product(Qk, Rl(Rl.extension(0), {bl0, blN}), Ta(Ta.extension(0), {bl0, blN}));
+    ma::product(Qk, Rl(get<0>(Rl.extents()), {bl0, blN}), Ta(get<0>(Ta.extents()), {bl0, blN}));
     TG.node_barrier();
     for (int ka = ka0; ka < kaN; ka++)
     {                         // ka = local range index
@@ -279,7 +279,7 @@ inline void Qk_x_Rl(WALKER_TYPES walker_type,
       {
         // <a,b | k,l> = Ta(ka,lb) - Tb(la,kb)
         // Ta(ka,lb) = Q(k,a,:)*R(l,b,:)
-        ma::product(Qk, Rl(Rl.extension(0), {bl0, blN}), Ta(Ta.extension(0), {bl0, blN}));
+        ma::product(Qk, Rl(get<0>(Rl.extents()), {bl0, blN}), Ta(get<0>(Ta.extents()), {bl0, blN}));
         TG.node_barrier();
         for (int ka = ka0; ka < kaN; ka++)
         {                         // ka = local range index
@@ -312,7 +312,7 @@ inline void Qk_x_Rl(WALKER_TYPES walker_type,
       else if (std::abs(EJX) > 1e-8)
       {
         // <a,b | k,l> = Ta(ka,lb) = Q(k,a,:)*R(l,b,:)
-        ma::product(Qk, Rl(Rl.extension(0), {bl0, blN}), Ta(Ta.extension(0), {bl0, blN}));
+        ma::product(Qk, Rl(get<0>(Rl.extents()), {bl0, blN}), Ta(get<0>(Ta.extents()), {bl0, blN}));
         TG.node_barrier();
         for (int ka = ka0; ka < kaN; ka++)
         {                         // ka = local range index
@@ -338,7 +338,7 @@ inline void Qk_x_Rl(WALKER_TYPES walker_type,
       {
         // <a,b | k,l> = Ta(ka,lb) - Tb(la,kb)
         // Ta(ka,lb) = Q(k,a,:)*R(l,b,:)
-        ma::product(Qk, Rl(Rl.extension(0), {bl0, blN}), Ta(Ta.extension(0), {bl0, blN}));
+        ma::product(Qk, Rl(get<0>(Rl.extents()), {bl0, blN}), Ta(get<0>(Ta.extents()), {bl0, blN}));
         TG.node_barrier();
         for (int ka = ka0; ka < kaN; ka++)
         {                         // ka = local range index

--- a/src/AFQMC/Matrix/csr_matrix_construct.hpp
+++ b/src/AFQMC/Matrix/csr_matrix_construct.hpp
@@ -414,14 +414,14 @@ CSR construct_distributed_csr_matrix_from_distributed_containers(Container& Q,
   Timer.start("G0");
 
   boost::multi::array<long, 2> counts_per_core({nnodes_per_TG, ncores});
-  std::fill_n(counts_per_core.origin(), ncores * nnodes_per_TG, long(0));
+  std::fill_n(counts_per_core.base(), ncores * nnodes_per_TG, long(0));
   counts_per_core[node_number][coreid] = nterms_in_local_core;
-  eq_node_group.all_reduce_in_place_n(counts_per_core.origin(), ncores * nnodes_per_TG, std::plus<>());
+  eq_node_group.all_reduce_in_place_n(counts_per_core.base(), ncores * nnodes_per_TG, std::plus<>());
 
   // calculate how many terms each core is potentially sending
   // when algorithm works, make nplus a vector of pairs to save space, no need to store mostly zeros
   boost::multi::array<long, 2> nplus({nnodes_per_TG, ncores});
-  std::fill_n(nplus.origin(), ncores * nnodes_per_TG, long(0));
+  std::fill_n(nplus.base(), ncores * nnodes_per_TG, long(0));
   auto tgrank = eq_node_group.rank();
   // number of terms I'm sending
   long deltaN = 0;
@@ -450,7 +450,7 @@ CSR construct_distributed_csr_matrix_from_distributed_containers(Container& Q,
   for (int i = 0; i < nnodes_per_TG; i++)
   {
     long dn = (bounds[i + 1] - bounds[i]) -
-        std::accumulate(counts_per_core[i].origin(), counts_per_core[i].origin() + ncores, long(0));
+        std::accumulate(counts_per_core[i].base(), counts_per_core[i].base() + ncores, long(0));
     if (dn > 0)
       nminus[i] = long(dn);
   }

--- a/src/AFQMC/Matrix/ma_hdf5_readers.hpp
+++ b/src/AFQMC/Matrix/ma_hdf5_readers.hpp
@@ -79,7 +79,7 @@ inline void write_distributed_MA(MultiArray& A,
       // write local piece
       {
         using Mat_ref = boost::multi::array_ref<value_type, 2>;
-        Mat_ref A_(to_address(A.origin()), A.extensions());
+        Mat_ref A_(to_address(A.base()), A.extents());
         hyperslab_proxy<Mat_ref, 2> slab(A_, gdim, std::array<size_t, 2>{size_t(get<0>(A.sizes())), size_t(get<1>(A.sizes()))}, offset);
         dump.write(slab, name);
       }
@@ -89,7 +89,7 @@ inline void write_distributed_MA(MultiArray& A,
       {
         using Mat = boost::multi::array<value_type, 2>;
         Mat T({static_cast<typename Mat::size_type>(*(it + 2)), static_cast<typename Mat::size_type>(*(it + 3))});
-        TG.TG_Cores().receive_n(T.origin(), T.num_elements(), i, i);
+        TG.TG_Cores().receive_n(T.base(), T.num_elements(), i, i);
         hyperslab_proxy<Mat, 2> slab(T, gdim, std::array<size_t, 2>{*(it + 2), *(it + 3)},
                                      std::array<size_t, 2>{*(it), *(it + 1)});
         dump.write(slab, name);
@@ -105,7 +105,7 @@ inline void write_distributed_MA(MultiArray& A,
       ndim[4 * TG.TG_Cores().rank() + 2] = get<0>(A.sizes());
       ndim[4 * TG.TG_Cores().rank() + 3] = get<1>(A.sizes());
       TG.TG_Cores().all_reduce_in_place_n(ndim.begin(), ndim.size(), std::plus<>());
-      TG.TG_Cores().send_n(to_address(A.origin()), A.num_elements(), 0, TG.TG_Cores().rank());
+      TG.TG_Cores().send_n(to_address(A.base()), A.num_elements(), 0, TG.TG_Cores().rank());
     }
   }
   TG.Global().barrier();

--- a/src/AFQMC/Memory/CUDA/cuda_init.cpp
+++ b/src/AFQMC/Memory/CUDA/cuda_init.cpp
@@ -101,7 +101,7 @@ void CUDA_INIT(boost::mpi3::shared_communicator& node, unsigned long long int is
   /*
     device::cusparse_buffer = new boost::multi::array<std::complex<double>,1,
                                  device::device_allocator<std::complex<double>>>(
-                                 (typename boost::multi::layout_t<1u>::extensions_type{1},
+                                 (typename boost::multi::layout_t<1u>::extents_type{1},
                                  device::device_allocator<std::complex<double>>{}));
 */
 }

--- a/src/AFQMC/Memory/HIP/hip_init.cpp
+++ b/src/AFQMC/Memory/HIP/hip_init.cpp
@@ -106,7 +106,7 @@ void HIP_INIT(boost::mpi3::shared_communicator& node, unsigned long long int ise
   /*
     device::cusparse_buffer = new boost::multi::array<std::complex<double>,1,
                                  device::device_allocator<std::complex<double>>>(
-                                 (typename boost::multi::layout_t<1u>::extensions_type{1},
+                                 (typename boost::multi::layout_t<1u>::extents_type{1},
                                  device::device_allocator<std::complex<double>>{}));
 */
 }

--- a/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
+++ b/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
@@ -655,8 +655,8 @@ namespace boost
 namespace multi
 {
 template<typename T, typename Size, typename Q>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> fill_n(
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first,
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> fill_n(
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first,
     Size n,
     Q const& val)
 {
@@ -683,9 +683,9 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> fill_n(
 }
 
 template<typename T, typename Q>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> fill_n(
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> last,
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> fill_n(
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first,
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> last,
     Q const& val)
 {
   assert(stride(first) == stride(last));
@@ -694,9 +694,9 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> fill_n(
 
 
 template<class Alloc, typename T, typename Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_fill_n(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_fill_n(
     Alloc& a,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first,
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first,
     Size n,
     T const& val)
 {
@@ -723,10 +723,10 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized
 }
 
 template<class Alloc, typename T, typename Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_fill(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_fill(
     Alloc& a,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> last,
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first,
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> last,
     T const& val)
 {
   assert(stride(first) == stride(last));
@@ -734,9 +734,9 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized
 }
 
 template<class Alloc, typename T, typename Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_fill_n(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_fill_n(
     Alloc& a,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first,
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first,
     Size n,
     T const& val)
 {
@@ -744,10 +744,10 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uniniti
 }
 
 template<class Alloc, typename T, typename Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_fill(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_fill(
     Alloc& a,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> last,
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first,
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> last,
     T const& val)
 {
   assert(stride(first) == stride(last));
@@ -755,10 +755,10 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uniniti
 }
 
 template<class T, class Q1, class Q2, typename Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy_n(
-    multi::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> first,
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy_n(
+    multi::detail::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> first,
     Size n,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
@@ -780,10 +780,10 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy_n(
 }
 
 template<class T, class ForwardIt, typename Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy_n(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy_n(
     ForwardIt first,
     Size n,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
 {
   if (n == 0)
     return dest;
@@ -802,9 +802,9 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy_n(
 }
 
 template<class T, class Q1, class Q2, typename Size>
-multi::array_iterator<T, 1, T*> copy_n(multi::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> first,
+multi::detail::array_iterator<T, 1, T*> copy_n(multi::detail::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> first,
                                        Size n,
-                                       multi::array_iterator<T, 1, T*> dest)
+                                       multi::detail::array_iterator<T, 1, T*> dest)
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
@@ -821,10 +821,10 @@ multi::array_iterator<T, 1, T*> copy_n(multi::array_iterator<Q1, 1, shm::shm_ptr
 }
 
 template<class T, class Q1, class Q2>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy(
-    multi::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> first,
-    multi::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> last,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy(
+    multi::detail::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> first,
+    multi::detail::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> last,
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
@@ -833,19 +833,19 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy(
 }
 
 template<class T, class ForwardIt>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy(
     ForwardIt first,
     ForwardIt last,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
 {
   assert(stride(first) == stride(last));
   return copy_n(first, std::distance(first, last), dest);
 }
 
 template<class T, class Q1, class Q2>
-multi::array_iterator<T, 1, T*> copy(multi::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> first,
-                                     multi::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> last,
-                                     multi::array_iterator<T, 1, T*> dest)
+multi::detail::array_iterator<T, 1, T*> copy(multi::detail::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> first,
+                                     multi::detail::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> last,
+                                     multi::detail::array_iterator<T, 1, T*> dest)
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
@@ -854,11 +854,11 @@ multi::array_iterator<T, 1, T*> copy(multi::array_iterator<Q1, 1, shm::shm_ptr_w
 }
 
 template<class Alloc, class T, class Q, typename Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_copy_n(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_copy_n(
     Alloc& a,
-    multi::array_iterator<Q, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q>> first,
+    multi::detail::array_iterator<Q, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q>> first,
     Size n,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
 {
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
   if (n == 0)
@@ -886,53 +886,53 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized
 }
 
 template<class Alloc, class T, class Q, typename Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_copy_n(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_copy_n(
     Alloc& a,
-    multi::array_iterator<Q, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q>> first,
+    multi::detail::array_iterator<Q, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q>> first,
     Size n,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
 {
   return uninitialized_copy_n(a, first, n, dest);
 }
 
 
 template<class Alloc, class T, class ForwardIt, typename Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_copy_n(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_copy_n(
     Alloc& a,
     ForwardIt first,
     Size n,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
 {
   return copy_n(first, n, dest);
 }
 
 template<class Alloc, class T, class ForwardIt, typename Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_copy_n(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_copy_n(
     Alloc& a,
     ForwardIt first,
     Size n,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
 {
   return copy_n(first, n, dest);
 }
 
 template<class Alloc, class T, class ForwardIt>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_copy(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_copy(
     Alloc& a,
     ForwardIt first,
     ForwardIt last,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
 {
   assert(stride(first) == stride(last));
   return uninitialized_copy_n(a, first, std::distance(first, last), dest);
 }
 
 template<class Alloc, class T, class Q1, class Q2>
-multi::array_iterator<T, 1, T*> uninitialized_copy(
+multi::detail::array_iterator<T, 1, T*> uninitialized_copy(
     Alloc& a,
-    multi::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> first,
-    multi::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> last,
-    multi::array_iterator<T, 1, T*> dest)
+    multi::detail::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> first,
+    multi::detail::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> last,
+    multi::detail::array_iterator<T, 1, T*> dest)
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
@@ -957,30 +957,30 @@ multi::array_iterator<T, 1, T*> uninitialized_copy(
 }
 
 template<class Alloc, class T, class ForwardIt>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_copy(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_copy(
     Alloc& a,
     ForwardIt first,
     ForwardIt last,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest)
 {
   assert(stride(first) == stride(last));
   return uninitialized_copy_n(a, first, std::distance(first, last), dest);
 }
 
 template<class Alloc, class T, class Q1, class Q2>
-multi::array_iterator<T, 1, T*> alloc_uninitialized_copy(
+multi::detail::array_iterator<T, 1, T*> alloc_uninitialized_copy(
     Alloc& a,
-    multi::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> first,
-    multi::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> last,
-    multi::array_iterator<T, 1, T*> dest)
+    multi::detail::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> first,
+    multi::detail::array_iterator<Q1, 1, shm::shm_ptr_with_raw_ptr_dispatch<Q2>> last,
+    multi::detail::array_iterator<T, 1, T*> dest)
 {
   return uninitialized_copy(a, first, last, dest);
 }
 
 template<class Alloc, class T, class Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_default_construct_n(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_default_construct_n(
     Alloc& a,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> f,
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> f,
     Size n)
 {
   if (n == 0)
@@ -1006,27 +1006,27 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized
 }
 
 template<class Alloc, class T, class Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_value_construct_n(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized_value_construct_n(
     Alloc& a,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> f,
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> f,
     Size n)
 {
   return uninitialized_default_construct_n(a, f, n);
 }
 
 template<class Alloc, class T, class Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_default_construct_n(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_default_construct_n(
     Alloc& a,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> f,
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> f,
     Size n)
 {
   return uninitialized_default_construct_n(a, f, n);
 }
 
 template<class Alloc, class T, class Size>
-multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_value_construct_n(
+multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uninitialized_value_construct_n(
     Alloc& a,
-    multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> f,
+    multi::detail::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> f,
     Size n)
 {
   return uninitialized_default_construct_n(a, f, n);

--- a/src/AFQMC/Memory/device_pointers.hpp
+++ b/src/AFQMC/Memory/device_pointers.hpp
@@ -1012,8 +1012,8 @@ namespace multi
 // Can always call cudaMemcopy2D like you do in the blas backend
 
 template<typename T, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> fill_n(
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> fill_n(
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
     Size n,
     T const& val)
 {
@@ -1024,9 +1024,9 @@ multi::array_iterator<T, 1, device::device_pointer<T>> fill_n(
 }
 
 template<typename T, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> fill(
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
-    multi::array_iterator<T, 1, device::device_pointer<T>> last,
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> fill(
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> last,
     T const& val)
 {
   assert(stride(first) == stride(last));
@@ -1037,9 +1037,9 @@ multi::array_iterator<T, 1, device::device_pointer<T>> fill(
 }
 
 template<class Alloc, typename T, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_fill_n(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> uninitialized_fill_n(
     Alloc& a,
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
     Size n,
     T const& val)
 {
@@ -1050,10 +1050,10 @@ multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_fill_n(
 }
 
 template<class Alloc, typename T, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_fill(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> uninitialized_fill(
     Alloc& a,
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
-    multi::array_iterator<T, 1, device::device_pointer<T>> last,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> last,
     T const& val)
 {
   assert(stride(first) == stride(last));
@@ -1064,9 +1064,9 @@ multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_fill(
 }
 
 template<class Alloc, typename T, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_fill_n(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_fill_n(
     Alloc& a,
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
     Size n,
     T const& val)
 {
@@ -1077,10 +1077,10 @@ multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_fill_
 }
 
 template<class Alloc, typename T, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_fill(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_fill(
     Alloc& a,
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
-    multi::array_iterator<T, 1, device::device_pointer<T>> last,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> last,
     T const& val)
 {
   assert(stride(first) == stride(last));
@@ -1091,10 +1091,10 @@ multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_fill(
 }
 
 template<class T, class Q1, class Q2>
-multi::array_iterator<T, 1, device::device_pointer<T>> copy(
-    multi::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
-    multi::array_iterator<Q1, 1, device::device_pointer<Q2>> last,
-    multi::array_iterator<T, 1, device::device_pointer<T>> dest)
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> copy(
+    multi::detail::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
+    multi::detail::array_iterator<Q1, 1, device::device_pointer<Q2>> last,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> dest)
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
@@ -1107,9 +1107,9 @@ multi::array_iterator<T, 1, device::device_pointer<T>> copy(
 }
 
 template<class T, class ForwardIt>
-multi::array_iterator<T, 1, device::device_pointer<T>> copy(ForwardIt first,
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> copy(ForwardIt first,
                                                             ForwardIt last,
-                                                            multi::array_iterator<T, 1, device::device_pointer<T>> dest)
+                                                            multi::detail::array_iterator<T, 1, device::device_pointer<T>> dest)
 {
   assert(stride(first) == stride(last));
   if (std::distance(first, last) == 0)
@@ -1121,10 +1121,10 @@ multi::array_iterator<T, 1, device::device_pointer<T>> copy(ForwardIt first,
 }
 
 template<typename T, typename Q, typename QQ>
-multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy(
     T* first,
     T* last,
-    multi::array_iterator<Q, 1, device::device_pointer<QQ>> dest)
+    multi::detail::array_iterator<Q, 1, device::device_pointer<QQ>> dest)
 {
   static_assert(std::is_trivially_assignable<QQ&, T>{}, "!");
   assert(stride(first) == stride(last));
@@ -1137,8 +1137,8 @@ multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy(
 }
 
 template<class ForwardIt, class Q1, class Q2>
-ForwardIt copy(multi::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
-               multi::array_iterator<Q1, 1, device::device_pointer<Q2>> last,
+ForwardIt copy(multi::detail::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
+               multi::detail::array_iterator<Q1, 1, device::device_pointer<Q2>> last,
                ForwardIt dest)
 {
   using T = typename std::decay<typename ForwardIt::value_type>::type;
@@ -1154,10 +1154,10 @@ ForwardIt copy(multi::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
 }
 
 template<class T, class Q1, class Q2, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> copy_n(
-    multi::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> copy_n(
+    multi::detail::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
     Size N,
-    multi::array_iterator<T, 1, device::device_pointer<T>> dest)
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> dest)
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
@@ -1169,10 +1169,10 @@ multi::array_iterator<T, 1, device::device_pointer<T>> copy_n(
 }
 
 template<class T, class ForwardIt, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> copy_n(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> copy_n(
     ForwardIt first,
     Size n,
-    multi::array_iterator<T, 1, device::device_pointer<T>> dest)
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> dest)
 {
   if (n == 0)
     return dest;
@@ -1183,7 +1183,7 @@ multi::array_iterator<T, 1, device::device_pointer<T>> copy_n(
 }
 
 template<class ForwardIt, class Q1, class Q2, typename Size>
-ForwardIt copy_n(multi::array_iterator<Q1, 1, device::device_pointer<Q2>> first, Size N, ForwardIt dest)
+ForwardIt copy_n(multi::detail::array_iterator<Q1, 1, device::device_pointer<Q2>> first, Size N, ForwardIt dest)
 {
   using T = typename std::decay<typename ForwardIt::value_type>::type;
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
@@ -1197,10 +1197,10 @@ ForwardIt copy_n(multi::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
 }
 
 template<class Q, class QQ, class T, class TT>
-multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy(
-    multi::array_iterator<Q, 1, device::device_pointer<QQ>> first,
-    multi::array_iterator<Q, 1, device::device_pointer<QQ>> last,
-    multi::array_iterator<T, 1, device::device_pointer<TT>> dest)
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy(
+    multi::detail::array_iterator<Q, 1, device::device_pointer<QQ>> first,
+    multi::detail::array_iterator<Q, 1, device::device_pointer<QQ>> last,
+    multi::detail::array_iterator<T, 1, device::device_pointer<TT>> dest)
 {
   static_assert(std::is_trivially_assignable<TT&, QQ&>{}, "!");
   assert(stride(first) == stride(last));
@@ -1213,11 +1213,11 @@ multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy(
 }
 
 template<class Alloc, class T, class ForwardIt>
-multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_copy(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_copy(
     Alloc& a,
     ForwardIt first,
     ForwardIt last,
-    multi::array_iterator<T, 1, device::device_pointer<T>> dest)
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> dest)
 {
   assert(stride(first) == stride(last));
   if (std::distance(first, last) == 0)
@@ -1229,11 +1229,11 @@ multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_copy(
 }
 
 template<class Alloc, class Q, class QQ, class T, class TT>
-multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_copy(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_copy(
     Alloc& a,
-    multi::array_iterator<Q, 1, device::device_pointer<QQ>> first,
-    multi::array_iterator<Q, 1, device::device_pointer<QQ>> last,
-    multi::array_iterator<T, 1, device::device_pointer<TT>> dest)
+    multi::detail::array_iterator<Q, 1, device::device_pointer<QQ>> first,
+    multi::detail::array_iterator<Q, 1, device::device_pointer<QQ>> last,
+    multi::detail::array_iterator<T, 1, device::device_pointer<TT>> dest)
 {
   static_assert(std::is_trivially_assignable<TT&, QQ&>{}, "!");
   assert(stride(first) == stride(last));
@@ -1247,11 +1247,11 @@ multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_copy(
 
 /*
 template<class Alloc, class T, class Q>
-multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy( 
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy( 
                          Alloc &a,
-                         multi::array_iterator<Q, 1, device::device_pointer<Q>> first,
-                         multi::array_iterator<Q, 1, device::device_pointer<Q>> last,
-                         multi::array_iterator<T, 1, device::device_pointer<T>> dest ){
+                         multi::detail::array_iterator<Q, 1, device::device_pointer<Q>> first,
+                         multi::detail::array_iterator<Q, 1, device::device_pointer<Q>> last,
+                         multi::detail::array_iterator<T, 1, device::device_pointer<T>> dest ){
   static_assert(std::is_same<typename std::decay<Q>::type,T>::value,"Wrong dispatch.\n");
   assert( stride(first) == stride(last) );
   if(std::distance(first,last) == 0 ) return dest;
@@ -1263,11 +1263,11 @@ multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy(
 }
 
 template<class Alloc, class T, class Q>
-multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy(
                          Alloc &a,
-                         multi::array_iterator<Q, 1, boost::mpi3::intranode::array_ptr<Q>> first,
-                         multi::array_iterator<Q, 1, boost::mpi3::intranode::array_ptr<Q>> last,
-                         multi::array_iterator<T, 1, device::device_pointer<T>> dest ){
+                         multi::detail::array_iterator<Q, 1, boost::mpi3::intranode::array_ptr<Q>> first,
+                         multi::detail::array_iterator<Q, 1, boost::mpi3::intranode::array_ptr<Q>> last,
+                         multi::detail::array_iterator<T, 1, device::device_pointer<T>> dest ){
   static_assert(std::is_same<typename std::decay<Q>::type,T>::value,"Wrong dispatch.\n");
   assert( stride(first) == stride(last) );
   if(std::distance(first,last) == 0 ) return dest;
@@ -1279,11 +1279,11 @@ multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy(
 }
 
 template<class Alloc, class T, class Q1, class Q2>
-multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy(
                          Alloc &a,
-                         multi::array_iterator<Q1, 1, Q2*> first,
-                         multi::array_iterator<Q1, 1, Q2*> last,
-                         multi::array_iterator<T, 1, device::device_pointer<T>> dest ){
+                         multi::detail::array_iterator<Q1, 1, Q2*> first,
+                         multi::detail::array_iterator<Q1, 1, Q2*> last,
+                         multi::detail::array_iterator<T, 1, device::device_pointer<T>> dest ){
   static_assert(std::is_same<typename std::decay<Q1>::type,T>::value,"Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type,T>::value,"Wrong dispatch.\n");
   assert( stride(first) == stride(last) );
@@ -1297,10 +1297,10 @@ multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy(
 */
 
 template<class Alloc, class T, class Q1, class Q2>
-multi::array_iterator<T, 1, T*> uninitialized_copy(Alloc& a,
-                                                   multi::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
-                                                   multi::array_iterator<Q1, 1, device::device_pointer<Q2>> last,
-                                                   multi::array_iterator<T, 1, T*> dest)
+multi::detail::array_iterator<T, 1, T*> uninitialized_copy(Alloc& a,
+                                                   multi::detail::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
+                                                   multi::detail::array_iterator<Q1, 1, device::device_pointer<Q2>> last,
+                                                   multi::detail::array_iterator<T, 1, T*> dest)
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
@@ -1314,10 +1314,10 @@ multi::array_iterator<T, 1, T*> uninitialized_copy(Alloc& a,
 }
 
 template<class Alloc, class T, class Q1, class Q2>
-multi::array_iterator<T, 1, T*> alloc_uninitialized_copy(Alloc& a,
-                                                         multi::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
-                                                         multi::array_iterator<Q1, 1, device::device_pointer<Q2>> last,
-                                                         multi::array_iterator<T, 1, T*> dest)
+multi::detail::array_iterator<T, 1, T*> alloc_uninitialized_copy(Alloc& a,
+                                                         multi::detail::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
+                                                         multi::detail::array_iterator<Q1, 1, device::device_pointer<Q2>> last,
+                                                         multi::detail::array_iterator<T, 1, T*> dest)
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
@@ -1332,11 +1332,11 @@ multi::array_iterator<T, 1, T*> alloc_uninitialized_copy(Alloc& a,
 
 /*
 template<class Alloc, class T, class Q, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy_n( 
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy_n( 
                            Alloc &a,
-                           multi::array_iterator<Q, 1, device::device_pointer<Q>> first,
+                           multi::detail::array_iterator<Q, 1, device::device_pointer<Q>> first,
                            Size N,
-                           multi::array_iterator<T, 1, device::device_pointer<T>> dest ){
+                           multi::detail::array_iterator<T, 1, device::device_pointer<T>> dest ){
   static_assert(std::is_same<typename std::decay<Q>::type,T>::value,"Wrong dispatch.\n");
   if(N==0) return dest;
   if(cudaSuccess != cudaMemcpy2D(to_address(base(dest)),sizeof(T)*stride(dest),
@@ -1348,10 +1348,10 @@ multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy_n(
 */
 
 template<class Alloc, class T, class Q1, class Q2, typename Size>
-multi::array_iterator<T, 1, T*> uninitialized_copy_n(Alloc& a,
-                                                     multi::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
+multi::detail::array_iterator<T, 1, T*> uninitialized_copy_n(Alloc& a,
+                                                     multi::detail::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
                                                      Size n,
-                                                     multi::array_iterator<T, 1, T*> dest)
+                                                     multi::detail::array_iterator<T, 1, T*> dest)
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
@@ -1364,11 +1364,11 @@ multi::array_iterator<T, 1, T*> uninitialized_copy_n(Alloc& a,
 }
 
 template<class Alloc, class T, class ForwardIt, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy_n(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy_n(
     Alloc& a,
     ForwardIt first,
     Size n,
-    multi::array_iterator<T, 1, device::device_pointer<T>> dest)
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> dest)
 {
   if (n == 0)
     return dest;
@@ -1379,47 +1379,47 @@ multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_copy_n(
 }
 
 template<class Alloc, typename T, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_default_construct_n(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> uninitialized_default_construct_n(
     Alloc& a,
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
     Size n)
 {
   return uninitialized_fill_n(first, n, T());
 }
 
 template<class Alloc, typename T>
-multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_default_construct(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> uninitialized_default_construct(
     Alloc& a,
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
-    multi::array_iterator<T, 1, device::device_pointer<T>> last)
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> last)
 {
   return uninitialized_fill_n(a, first, std::distance(first, last), T());
 }
 
 template<class Alloc, typename T, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_value_construct_n(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> uninitialized_value_construct_n(
     Alloc& a,
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
     Size n)
 {
   return uninitialized_fill_n(first, n, T());
 }
 
 template<class Alloc, typename T>
-multi::array_iterator<T, 1, device::device_pointer<T>> uninitialized_value_construct(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> uninitialized_value_construct(
     Alloc& a,
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
-    multi::array_iterator<T, 1, device::device_pointer<T>> last)
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> last)
 {
   return uninitialized_fill_n(a, first, std::distance(first, last), T());
 }
 
 template<class Alloc, class T, class Q1, class Q2, typename Size>
-multi::array_iterator<T, 1, T*> alloc_uninitialized_copy_n(
+multi::detail::array_iterator<T, 1, T*> alloc_uninitialized_copy_n(
     Alloc& a,
-    multi::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
+    multi::detail::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
     Size n,
-    multi::array_iterator<T, 1, T*> dest)
+    multi::detail::array_iterator<T, 1, T*> dest)
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
@@ -1432,11 +1432,11 @@ multi::array_iterator<T, 1, T*> alloc_uninitialized_copy_n(
 }
 
 template<class Alloc, class T, class ForwardIt, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_copy_n(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_copy_n(
     Alloc& a,
     ForwardIt first,
     Size n,
-    multi::array_iterator<T, 1, device::device_pointer<T>> dest)
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> dest)
 {
   if (n == 0)
     return dest;
@@ -1447,11 +1447,11 @@ multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_copy_
 }
 
 template<class Alloc, class T, class Q1, class Q2, typename Size>
-multi::array_iterator<T, 1, T*> alloc_uninitialized_move_n(
+multi::detail::array_iterator<T, 1, T*> alloc_uninitialized_move_n(
     Alloc& a,
-    multi::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
+    multi::detail::array_iterator<Q1, 1, device::device_pointer<Q2>> first,
     Size n,
-    multi::array_iterator<T, 1, T*> dest)
+    multi::detail::array_iterator<T, 1, T*> dest)
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
@@ -1464,11 +1464,11 @@ multi::array_iterator<T, 1, T*> alloc_uninitialized_move_n(
 }
 
 template<class Alloc, class T, class ForwardIt, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_move_n(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_move_n(
     Alloc& a,
     ForwardIt first,
     Size n,
-    multi::array_iterator<T, 1, device::device_pointer<T>> dest)
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> dest)
 {
   if (n == 0)
     return dest;
@@ -1479,37 +1479,37 @@ multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_move_
 }
 
 template<class Alloc, typename T, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_default_construct_n(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_default_construct_n(
     Alloc& a,
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
     Size n)
 {
   return uninitialized_fill_n(first, n, T());
 }
 
 template<class Alloc, typename T>
-multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_default_construct(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_default_construct(
     Alloc& a,
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
-    multi::array_iterator<T, 1, device::device_pointer<T>> last)
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> last)
 {
   return uninitialized_fill_n(a, first, std::distance(first, last), T());
 }
 
 template<class Alloc, typename T, typename Size>
-multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_value_construct_n(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_value_construct_n(
     Alloc& a,
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
     Size n)
 {
   return uninitialized_fill_n(first, n, T());
 }
 
 template<class Alloc, typename T>
-multi::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_value_construct(
+multi::detail::array_iterator<T, 1, device::device_pointer<T>> alloc_uninitialized_value_construct(
     Alloc& a,
-    multi::array_iterator<T, 1, device::device_pointer<T>> first,
-    multi::array_iterator<T, 1, device::device_pointer<T>> last)
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> first,
+    multi::detail::array_iterator<T, 1, device::device_pointer<T>> last)
 {
   return uninitialized_fill_n(a, first, std::distance(first, last), T());
 }

--- a/src/AFQMC/Numerics/csr_blas.hpp
+++ b/src/AFQMC/Numerics/csr_blas.hpp
@@ -14,6 +14,15 @@
 #ifndef CSR_BLAS_HPP
 #define CSR_BLAS_HPP
 
+// multi::array_ref::origin() is deprecated in favor of .base(), but .base() (const&) miscomputes
+// element_const_ptr when ElementPtr's pointee type differs from T (as with the real/complex
+// reinterpret views used throughout this file for BLAS calls) in boost-multi 0.91.1. Keep .origin()
+// here and suppress the warning until that library issue is fixed.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <utility> //std::enable_if
 #include <cassert>
 #include <iostream>
@@ -406,4 +415,8 @@ MultiArray2D transpose(csr_matrix&& A, MultiArray2D&& AT)
 
 } // namespace shm
 } // namespace csr
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
 #endif

--- a/src/AFQMC/Numerics/detail/CUDA/sparse_cuda_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/sparse_cuda_gpu_ptr.hpp
@@ -158,12 +158,12 @@ void csrmm(const char transa,
     {
       cusparse_buffer = new boost::multi::array<
           std::complex<double>, 1,
-          device::device_allocator<std::complex<double>>>(typename boost::multi::layout_t<1u>::extensions_type{M * M},
+          device::device_allocator<std::complex<double>>>(typename boost::multi::layout_t<1u>::extents_type{M * M},
                                                           device::device_allocator<std::complex<double>>{});
     }
     else if (cusparse_buffer->num_elements() < M * N)
-      cusparse_buffer->reextent(typename boost::multi::layout_t<1u>::extensions_type{M * N});
-    device_pointer<T> C_(cusparse_buffer->origin().pointer_cast<T>());
+      cusparse_buffer->reextent(typename boost::multi::layout_t<1u>::extents_type{M * N});
+    device_pointer<T> C_(cusparse_buffer->base().pointer_cast<T>());
 
     // if beta != 0, transpose C into C_
     if (std::abs(beta) > 1e-12)
@@ -195,15 +195,15 @@ void csrmm(const char transa,
     {
       cusparse_buffer = new boost::multi::array<
           std::complex<double>, 1,
-          device::device_allocator<std::complex<double>>>(typename boost::multi::layout_t<1u>::extensions_type{(M + K) *
+          device::device_allocator<std::complex<double>>>(typename boost::multi::layout_t<1u>::extents_type{(M + K) *
                                                                                                                N},
                                                           device::device_allocator<std::complex<double>>{});
     }
     else if (cusparse_buffer->num_elements() < (M + K) * N)
-      cusparse_buffer->reextent(typename boost::multi::layout_t<1u>::extensions_type{(M + K) * N});
+      cusparse_buffer->reextent(typename boost::multi::layout_t<1u>::extents_type{(M + K) * N});
     // A is MxK
     // B should be MxN
-    device_pointer<T> B_(cusparse_buffer->origin().pointer_cast<T>());
+    device_pointer<T> B_(cusparse_buffer->base().pointer_cast<T>());
     // C should be KxN
     device_pointer<T> C_(B_ + M * N);
 

--- a/src/AFQMC/Numerics/detail/HIP/sparse_hip_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/HIP/sparse_hip_gpu_ptr.hpp
@@ -97,12 +97,12 @@ void csrmm(const char transa,
     {
       hipsparse_buffer = new boost::multi::array<
           std::complex<double>, 1,
-          device::device_allocator<std::complex<double>>>(typename boost::multi::layout_t<1u>::extensions_type{M * M},
+          device::device_allocator<std::complex<double>>>(typename boost::multi::layout_t<1u>::extents_type{M * M},
                                                           device::device_allocator<std::complex<double>>{});
     }
     else if (hipsparse_buffer->num_elements() < M * N)
-      hipsparse_buffer->reextent(typename boost::multi::layout_t<1u>::extensions_type{M * N});
-    device_pointer<T> C_(hipsparse_buffer->origin().pointer_cast<T>());
+      hipsparse_buffer->reextent(typename boost::multi::layout_t<1u>::extents_type{M * N});
+    device_pointer<T> C_(hipsparse_buffer->base().pointer_cast<T>());
 
     // if beta != 0, transpose C into C_
     if (std::abs(beta) > 1e-12)
@@ -143,15 +143,15 @@ void csrmm(const char transa,
     {
       hipsparse_buffer = new boost::multi::array<
           std::complex<double>, 1,
-          device::device_allocator<std::complex<double>>>(typename boost::multi::layout_t<1u>::extensions_type{(M + K) *
+          device::device_allocator<std::complex<double>>>(typename boost::multi::layout_t<1u>::extents_type{(M + K) *
                                                                                                                N},
                                                           device::device_allocator<std::complex<double>>{});
     }
     else if (hipsparse_buffer->num_elements() < (M + K) * N)
-      hipsparse_buffer->reextent(typename boost::multi::layout_t<1u>::extensions_type{(M + K) * N});
+      hipsparse_buffer->reextent(typename boost::multi::layout_t<1u>::extents_type{(M + K) * N});
     // A is MxK
     // B should be MxN
-    device_pointer<T> B_(hipsparse_buffer->origin().pointer_cast<T>());
+    device_pointer<T> B_(hipsparse_buffer->base().pointer_cast<T>());
     // C should be KxN
     device_pointer<T> C_(B_ + M * N);
 

--- a/src/AFQMC/Numerics/ma_blas.hpp
+++ b/src/AFQMC/Numerics/ma_blas.hpp
@@ -18,6 +18,15 @@
 #ifndef MA_BLAS_HPP
 #define MA_BLAS_HPP
 
+// multi::array_ref::origin() is deprecated in favor of .base(), but .base() (const&) miscomputes
+// element_const_ptr when ElementPtr's pointee type differs from T (as with the real/complex
+// reinterpret views used throughout this file for BLAS calls) in boost-multi 0.91.1. Keep .origin()
+// here and suppress the warning until that library issue is fixed.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include "AFQMC/Numerics/detail/blas.hpp"
 #include <utility> //std::enable_if
 #include <cassert>
@@ -423,5 +432,9 @@ MultiArray2DC&& geam(T alpha, MultiArray2DA const& a, MultiArray2DC&& c)
 }
 
 } // namespace ma
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/src/AFQMC/Numerics/ma_blas_extensions.hpp
+++ b/src/AFQMC/Numerics/ma_blas_extensions.hpp
@@ -18,6 +18,15 @@
 #ifndef MA_BLAS_EXTENSIONS_HPP
 #define MA_BLAS_EXTENSIONS_HPP
 
+// multi::array_ref::origin() is deprecated in favor of .base(), but .base() (const&) miscomputes
+// element_const_ptr when ElementPtr's pointee type differs from T (as with the real/complex
+// reinterpret views used throughout this file for BLAS calls) in boost-multi 0.91.1. Keep .origin()
+// here and suppress the warning until that library issue is fixed.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include "AFQMC/Numerics/detail/blas.hpp"
 #include <utility> //std::enable_if
 #include <cassert>
@@ -634,5 +643,9 @@ void Matrix2MA(char TA, MA const& A, MultiArray2D& M, Vector const& occups)
 }
 
 } // namespace ma
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/src/AFQMC/Numerics/ma_lapack.hpp
+++ b/src/AFQMC/Numerics/ma_lapack.hpp
@@ -18,6 +18,15 @@
 #ifndef MA_LAPACK_HPP
 #define MA_LAPACK_HPP
 
+// multi::array_ref::origin() is deprecated in favor of .base(), but .base() (const&) miscomputes
+// element_const_ptr when ElementPtr's pointee type differs from T (as with the real/complex
+// reinterpret views used throughout this file for BLAS calls) in boost-multi 0.91.1. Keep .origin()
+// here and suppress the warning until that library issue is fixed.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include "AFQMC/Utilities/type_conversion.hpp"
 #include "AFQMC/Numerics/detail/lapack.hpp"
 #include "multi/array_ref.hpp"
@@ -260,7 +269,7 @@ std::pair<MultiArray1D, MultiArray2D> symEig(MultiArray2D const& A)
   using eigSys     = std::pair<MultiArray1D, MultiArray2D>;
   using Type       = typename MultiArray2D::element;
   using RealType   = typename qmcplusplus::afqmc::remove_complex<Type>::value_type;
-  using extensions = typename boost::multi::layout_t<1u>::extensions_type;
+  using extensions = typename boost::multi::layout_t<1u>::extents_type;
 
   using std::get;
   assert(A.size() == get<1>(A.sizes()));
@@ -335,7 +344,7 @@ std::pair<MultiArray1D, MultiArray2D> symEigSelect(MultiArray2DA& A, int neig)
   using TypeA  = typename MultiArray2DA::element;
   static_assert(std::is_same<Type, TypeA>::value, "Wrong types.");
   using RealType   = typename qmcplusplus::afqmc::remove_complex<Type>::value_type;
-  using extensions = typename boost::multi::layout_t<1u>::extensions_type;
+  using extensions = typename boost::multi::layout_t<1u>::extents_type;
 
   using std::get;
   assert(get<0>(A.sizes()) == get<1>(A.sizes()));
@@ -415,7 +424,7 @@ std::pair<MultiArray1D, MultiArray2D> genEigSelect(MultiArray2DA& A, MultiArray2
   static_assert(std::is_same<Type, TypeA>::value, "Wrong types.");
   static_assert(std::is_same<TypeA, TypeB>::value, "Wrong types.");
   using RealType   = typename qmcplusplus::afqmc::remove_complex<Type>::value_type;
-  using extensions = typename boost::multi::layout_t<1u>::extensions_type;
+  using extensions = typename boost::multi::layout_t<1u>::extents_type;
 
   using std::get;
   assert(get<0>(A.sizes()) == get<1>(A.sizes()));
@@ -475,5 +484,9 @@ std::pair<MultiArray1D, MultiArray2D> genEigSelect(MultiArray2DA& A, MultiArray2
 }
 
 } // namespace ma
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/src/AFQMC/Numerics/ma_operations.hpp
+++ b/src/AFQMC/Numerics/ma_operations.hpp
@@ -18,6 +18,15 @@
 #ifndef MA_OPERATIONS_HPP
 #define MA_OPERATIONS_HPP
 
+// multi::array_ref::origin() is deprecated in favor of .base(), but .base() (const&) miscomputes
+// element_const_ptr when ElementPtr's pointee type differs from T (as with the real/complex
+// reinterpret views used throughout this file for BLAS calls) in boost-multi 0.91.1. Keep .origin()
+// here and suppress the warning until that library issue is fixed.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include "ma_blas.hpp"
 #include "ma_lapack.hpp"
 #include "AFQMC/Numerics/detail/sparse.hpp"
@@ -591,7 +600,7 @@ T invert(MultiArray2D&& m, T LogOverlapFactor)
   using element         = typename std::decay<MultiArray2D>::type::element;
   using allocator_type  = typename std::decay<MultiArray2D>::type::allocator_type;
   using iallocator_type = typename allocator_type::template rebind<int>::other;
-  using extensions      = typename boost::multi::layout_t<1u>::extensions_type;
+  using extensions      = typename boost::multi::layout_t<1u>::extents_type;
   using qmcplusplus::afqmc::fill2D;
   auto bufferSize(invert_optimal_workspace_size(std::forward<MultiArray2D>(m)));
   boost::multi::array<element, 1, allocator_type> WORK(extensions{bufferSize}, m.get_allocator());
@@ -890,6 +899,10 @@ int main()
 
   cout << "test ended" << std::endl;
 }
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
 #endif
 
 #endif

--- a/src/AFQMC/Numerics/shm_tests/test_shm_gemm.cpp
+++ b/src/AFQMC/Numerics/shm_tests/test_shm_gemm.cpp
@@ -36,6 +36,7 @@ using namespace afqmc;
 
 void timing_shm_blas(int c)
 {
+  using std::get;
   using Type         = double;
   using communicator = boost::mpi3::communicator;
   using shm_Alloc    = shared_allocator<Type>;
@@ -83,14 +84,14 @@ void timing_shm_blas(int c)
       std::tie(c0, cN) = FairDivideBoundary(mycol, n, nc);
 
 
-      ma::product(A.sliced(r0, rN), B(B.extension(0), {c0, cN}), C({r0, rN}, {c0, cN}));
+      ma::product(A.sliced(r0, rN), B(get<0>(B.extents()), {c0, cN}), C({r0, rN}, {c0, cN}));
 
       Timer.reset("Gen");
       node.barrier();
       Timer.start("Gen");
       for (int t = 0; t < ntimes; t++)
       {
-        ma::product(A.sliced(r0, rN), B(B.extension(0), {c0, cN}), C({r0, rN}, {c0, cN}));
+        ma::product(A.sliced(r0, rN), B(get<0>(B.extents()), {c0, cN}), C({r0, rN}, {c0, cN}));
         node.barrier();
       }
       Timer.stop("Gen");

--- a/src/AFQMC/Numerics/tensor_operations.hpp
+++ b/src/AFQMC/Numerics/tensor_operations.hpp
@@ -15,6 +15,15 @@
 #ifndef AFQMC_NUMERICS_HELPERS_TENSOR_TRANSPOSITION_HPP
 #define AFQMC_NUMERICS_HELPERS_TENSOR_TRANSPOSITION_HPP
 
+// multi::array_ref::origin() is deprecated in favor of .base(), but .base() (const&) miscomputes
+// element_const_ptr when ElementPtr's pointee type differs from T (as with the real/complex
+// reinterpret views used throughout this file for BLAS calls) in boost-multi 0.91.1. Keep .origin()
+// here and suppress the warning until that library issue is fixed.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <cassert>
 #include "AFQMC/Numerics/detail/utilities.hpp"
 #if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
@@ -367,6 +376,10 @@ void transpose_wabn_to_wban(int nwalk, int na, int nb, int nchol, device_pointer
 }
 
 } // namespace device
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
 #endif
 
 #endif

--- a/src/AFQMC/Numerics/tests/test_batched_operations.cpp
+++ b/src/AFQMC/Numerics/tests/test_batched_operations.cpp
@@ -86,11 +86,11 @@ TEST_CASE("Tab_to_Kl", "[Numerics][batched_operations]")
   std::vector<ComplexType> buffer(nwalk * nel * nel * nchol);
   create_data(buffer, ComplexType(1.0));
   Tensor4D<ComplexType> Twban({nwalk, nel, nel, nchol}, alloc);
-  copy_n(buffer.data(), buffer.size(), Twban.origin());
+  copy_n(buffer.data(), buffer.size(), Twban.base());
   Tensor2D<ComplexType> Kl({nwalk, nchol}, 0.0, alloc);
   using ma::Tab_to_Kl;
-  Tab_to_Kl(nwalk, nel, nchol, Twban.origin(), Kl.origin());
-  array_ref<ComplexType, 1, pointer<ComplexType>> Kl_(Kl.origin(), iextensions<1u>{nwalk * nchol});
+  Tab_to_Kl(nwalk, nel, nchol, Twban.base(), Kl.base());
+  array_ref<ComplexType, 1, pointer<ComplexType>> Kl_(Kl.base(), iextensions<1u>{nwalk * nchol});
   array<ComplexType, 1, Alloc<ComplexType>> ref = {84.0,  87.0,  90.0,  93.0,  96.0,  99.0,  102.0,
                                                    273.0, 276.0, 279.0, 282.0, 285.0, 288.0, 291.0,
                                                    462.0, 465.0, 468.0, 471.0, 474.0, 477.0, 480.0};
@@ -109,17 +109,17 @@ TEST_CASE("batched_Tab_to_Klr", "[batched_operations]")
   int ncholQ0            = 2;
   std::vector<int> kdiag = {0, 1, 2, 3};
   Tensor1D<int> dev_kdiag(iextensions<1u>{nbatch}, alloc);
-  copy_n(kdiag.data(), kdiag.size(), dev_kdiag.origin());
+  copy_n(kdiag.data(), kdiag.size(), dev_kdiag.base());
   std::vector<ComplexType> buffer(2 * nbatch * nwalk * nel * nel * nchol_max);
   create_data(buffer, ComplexType(1.0));
   Tensor5D<ComplexType> Tab({2 * nbatch, nwalk, nel, nel, nchol_max}, alloc);
-  copy_n(buffer.data(), buffer.size(), Tab.origin());
+  copy_n(buffer.data(), buffer.size(), Tab.base());
   Tensor2D<ComplexType> Kl({nwalk, 2 * nchol}, 0.0, alloc);
   Tensor2D<ComplexType> Kr({nwalk, 2 * nchol}, 0.0, alloc);
   using ma::batched_Tab_to_Klr;
-  batched_Tab_to_Klr(nbatch, nwalk, nel, nchol_max, nchol, ncholQ, ncholQ0, dev_kdiag.origin(), Tab.origin(),
-                     Kl.origin(), Kr.origin());
-  copy_n(Kr.origin(), Kr.num_elements(), buffer.data());
+  batched_Tab_to_Klr(nbatch, nwalk, nel, nchol_max, nchol, ncholQ, ncholQ0, dev_kdiag.base(), Tab.base(),
+                     Kl.base(), Kr.base());
+  copy_n(Kr.base(), Kr.num_elements(), buffer.data());
   //std::cout << std::setprecision(16) << Kl[2][3] << " " << Kl[1][4] << " " << Kr[1][3] << " " << Kr[0][1] << std::endl;
   CHECK(real(buffer[2 * nchol + 3]) == Approx(2262));
 }
@@ -136,11 +136,11 @@ TEST_CASE("Tanb_to_Kl", "[batched_operations]")
   std::vector<ComplexType> buffer(nwalk * nel * nel * nchol);
   create_data(buffer, ComplexType(1.0));
   Tensor4D<ComplexType> Twanb({nwalk, nel, nchol, nel}, alloc);
-  copy_n(buffer.data(), buffer.size(), Twanb.origin());
+  copy_n(buffer.data(), buffer.size(), Twanb.base());
   Tensor2D<ComplexType> Kl({nwalk, nchol}, 0.0, alloc);
   using ma::Tanb_to_Kl;
-  Tanb_to_Kl(nwalk, nel, nchol, nchol, Twanb.origin(), Kl.origin());
-  array_ref<ComplexType, 1, pointer<ComplexType>> Kl_(Kl.origin(), iextensions<1u>{nwalk * nchol});
+  Tanb_to_Kl(nwalk, nel, nchol, nchol, Twanb.base(), Kl.base());
+  array_ref<ComplexType, 1, pointer<ComplexType>> Kl_(Kl.base(), iextensions<1u>{nwalk * nchol});
   //std::cout << "{";
   //for (auto i : Kl_)
   //std::cout << "ComplexType(" << real(i) << ")," << std::endl;
@@ -167,13 +167,13 @@ TEST_CASE("batched_dot_wabn_wban", "[Numerics][batched_operations]")
   create_data(buffer, ComplexType(1e4));
   Tensor5D<ComplexType> Twabn({2 * nbatch, nwalk, nocc, nocc, nchol}, alloc);
   Tensor1D<ComplexType> scal({nbatch}, 1.0, alloc);
-  copy_n(buffer.data(), buffer.size(), Twabn.origin());
+  copy_n(buffer.data(), buffer.size(), Twabn.base());
   std::vector<pointer<ComplexType>> Aarray;
   array<ComplexType, 1, Alloc<ComplexType>> out(iextensions<1u>{nwalk}, alloc);
   array<ComplexType, 1, Alloc<ComplexType>> ref = {ComplexType(1693.073254599684), ComplexType(1930.853888599637),
                                                    ComplexType(2189.312510839587)};
   using ma::batched_dot_wabn_wban;
-  batched_dot_wabn_wban(nbatch, nwalk, nocc, nchol, scal.origin(), Twabn.origin(), to_address(out.data()), 1);
+  batched_dot_wabn_wban(nbatch, nwalk, nocc, nchol, scal.base(), Twabn.base(), to_address(out.data()), 1);
   //std::cout << std::setprecision(16) << "this: " <<  out[0] << " " << out[1] << " " << out[2] << std::endl;
   verify_approx(ref, out);
 }
@@ -191,13 +191,13 @@ TEST_CASE("batched_dot_wanb_wbna", "[Numerics][batched_operations]")
   create_data(buffer, ComplexType(1e4));
   Tensor5D<ComplexType> Twabn({2 * nbatch, nwalk, nocc, nchol, nocc}, alloc);
   Tensor1D<ComplexType> scal({nbatch}, 1.0, alloc);
-  copy_n(buffer.data(), buffer.size(), Twabn.origin());
+  copy_n(buffer.data(), buffer.size(), Twabn.base());
   std::vector<pointer<ComplexType>> Aarray;
   array<ComplexType, 1, Alloc<ComplexType>> out(iextensions<1u>{nwalk}, alloc);
   array<ComplexType, 1, Alloc<ComplexType>> ref = {ComplexType(1692.867783879684), ComplexType(1930.648417879638),
                                                    ComplexType(2189.107040119586)};
   using ma::batched_dot_wanb_wbna;
-  batched_dot_wanb_wbna(nbatch, nwalk, nocc, nchol, scal.origin(), Twabn.origin(), to_address(out.data()), 1);
+  batched_dot_wanb_wbna(nbatch, nwalk, nocc, nchol, scal.base(), Twabn.base(), to_address(out.data()), 1);
   //std::cout << std::setprecision(16) << "this: " <<  out[0] << " " << out[1] << " " << out[2] << std::endl;
   verify_approx(ref, out);
 }
@@ -212,10 +212,10 @@ TEST_CASE("dot_wabn", "[Numerics][batched_operations]")
   std::vector<ComplexType> buffer(nwalk * nocc * nocc * nchol);
   create_data(buffer, ComplexType(100));
   Tensor4D<ComplexType> Twabn({nwalk, nocc, nocc, nchol}, alloc);
-  copy_n(buffer.data(), buffer.size(), Twabn.origin());
+  copy_n(buffer.data(), buffer.size(), Twabn.base());
   array<ComplexType, 1, Alloc<ComplexType>> out(iextensions<1u>{nwalk}, alloc);
   using ma::dot_wabn;
-  dot_wabn(nwalk, nocc, nchol, ComplexType(1.0), Twabn.origin(), to_address(out.origin()), 1);
+  dot_wabn(nwalk, nocc, nchol, ComplexType(1.0), Twabn.base(), to_address(out.base()), 1);
   array<ComplexType, 1, Alloc<ComplexType>> ref = {ComplexType(7045.35), ComplexType(58699.7), ComplexType(162049.0)};
   verify_approx(out, ref);
 }
@@ -230,11 +230,11 @@ TEST_CASE("dot_wanb", "[Numerics][batched_operations]")
   // T = numpy.arange(nw*nocc*nocc*nchol).reshape(nw,nocc,nchol,nocc) / 100.0
   create_data(buffer, ComplexType(100));
   Tensor4D<ComplexType> Twanb({nwalk, nocc, nchol, nocc}, alloc);
-  copy_n(buffer.data(), buffer.size(), Twanb.origin());
+  copy_n(buffer.data(), buffer.size(), Twanb.base());
   array<ComplexType, 1, Alloc<ComplexType>> out(iextensions<1u>{nwalk}, 0.0, alloc);
   using ma::dot_wanb;
   // out = numpy.einsum('wanb,wbna->w', Twanb, Twanb)
-  dot_wanb(nwalk, nocc, nchol, ComplexType(1.0), Twanb.origin(), to_address(out.origin()), 1);
+  dot_wanb(nwalk, nocc, nchol, ComplexType(1.0), Twanb.base(), to_address(out.base()), 1);
   array<ComplexType, 1, Alloc<ComplexType>> ref = {ComplexType(6531.67), ComplexType(58186.1), ComplexType(161535)};
   verify_approx(out, ref);
 }
@@ -251,7 +251,7 @@ TEST_CASE("Auwn_Bun_Cuw", "[Numerics][batched_operations]")
   ComplexType alpha = 0.5;
   // C = alpha * numpy.einsum('uwn,un->uw', A, B)
   using ma::Auwn_Bun_Cuw;
-  Auwn_Bun_Cuw(nu, nw, nn, alpha, A.origin(), B.origin(), C.origin());
+  Auwn_Bun_Cuw(nu, nw, nn, alpha, A.base(), B.base(), C.base());
   Tensor2D<ComplexType> ref({nu, nw}, 4.0, alloc);
   verify_approx(C, ref);
 }
@@ -271,7 +271,7 @@ TEST_CASE("Awiu_Biu_Cuw", "[Numerics][batched_operations]")
   using ma::Awiu_Biu_Cuw;
 
   using std::get;
-  Awiu_Biu_Cuw(nu, nw, nn, alpha, A.origin(), B.origin(), get<1>(B.sizes()), C.origin(), get<1>(C.sizes()));
+  Awiu_Biu_Cuw(nu, nw, nn, alpha, A.base(), B.base(), get<1>(B.sizes()), C.base(), get<1>(C.sizes()));
   Tensor2D<ComplexType> ref({nu, nw}, 4.0, alloc);
   ref[1][0] = 3.0;
   ref[1][1] = 3.0;
@@ -291,7 +291,7 @@ TEST_CASE("Aijk_Bkj_Cik", "[Numerics][batched_operations]")
   // C = alpha * numpy.einsum('wnu,nu->uw', A, B)
   using ma::Aijk_Bkj_Cik;
   using std::get;
-  Aijk_Bkj_Cik(ni, nj, nk, A.origin(), get<1>(A.sizes()), A.stride(), B.origin(), B.stride(), C.origin(), C.stride());
+  Aijk_Bkj_Cik(ni, nj, nk, A.base(), get<1>(A.sizes()), A.stride(), B.base(), B.stride(), C.base(), C.stride());
   Tensor2D<ComplexType> ref({ni, nk}, 4.0, alloc);
   ref[0][0] = 2.0;
   ref[1][0] = 2.0;
@@ -309,7 +309,7 @@ TEST_CASE("viwj_vwij", "[Numerics][batched_operations]")
   Tensor3D<ComplexType> B({ni, nw, nj}, 0.0, alloc);
   std::vector<ComplexType> buffer(ni * nj * nw);
   create_data(buffer, ComplexType(1.0));
-  copy_n(buffer.data(), buffer.size(), B.origin());
+  copy_n(buffer.data(), buffer.size(), B.base());
   using ma::viwj_vwij;
   //viwj_vwij(nw, ni, 0, nj, B.data(), A.data());
   //std::cout << A[0][1][1] << " " << A[1][2][1] << std::endl;
@@ -327,7 +327,7 @@ TEST_CASE("element_wise_Aij_Bjk_Ckij", "[Numerics][batched_operations]")
     Tensor2D<ComplexType> B({nj, nk}, 2.0, alloc);
     Tensor3D<ComplexType> C({nk, ni, nj}, 0.0, alloc);
     using std::get;
-    element_wise_Aij_Bjk_Ckij('N', ni, nj, nk, A.origin(), A.stride(), B.origin(), B.stride(), C.origin(), get<1>(C.sizes()),
+    element_wise_Aij_Bjk_Ckij('N', ni, nj, nk, A.base(), A.stride(), B.base(), B.stride(), C.base(), get<1>(C.sizes()),
                               get<2>(C.sizes()));
     Tensor3D<ComplexType> ref({nk, ni, nj}, 6.0, alloc);
     verify_approx(C, ref);
@@ -338,7 +338,7 @@ TEST_CASE("element_wise_Aij_Bjk_Ckij", "[Numerics][batched_operations]")
     Tensor3D<ComplexType> C({nk, ni, nj}, 0.0, alloc);
 
     using std::get;
-    element_wise_Aij_Bjk_Ckij('C', ni, nj, nk, A.origin(), A.stride(), B.origin(), B.stride(), C.origin(), get<1>(C.sizes()),
+    element_wise_Aij_Bjk_Ckij('C', ni, nj, nk, A.base(), A.stride(), B.base(), B.stride(), C.base(), get<1>(C.sizes()),
                               get<2>(C.sizes()));
     Tensor3D<ComplexType> ref({nk, ni, nj}, ComplexType(-6.0, 3.0), alloc);
     verify_approx(C, ref);
@@ -359,7 +359,7 @@ void test_Aij_Bjk_Ckji()
   Tensor3D<T2> C({nk, nj, ni}, 0.0, alloc_b);
 
   using std::get;
-  element_wise_Aij_Bjk_Ckji(ni, nj, nk, A.origin(), A.stride(), B.origin(), B.stride(), C.origin(), get<2>(C.sizes()),
+  element_wise_Aij_Bjk_Ckji(ni, nj, nk, A.base(), A.stride(), B.base(), B.stride(), C.base(), get<2>(C.sizes()),
                             C.stride());
   Tensor3D<T2> ref({nk, nj, ni}, T2(-3.0, -6.0), alloc_b);
   verify_approx(C, ref);
@@ -384,7 +384,7 @@ TEST_CASE("inplace_product", "[Numerics][batched_operations]")
   Tensor2D<double> B({ni, nj}, 2.0, dalloc);
   using ma::inplace_product;
   using std::get;
-  inplace_product(nb, ni, nj, B.origin(), get<1>(B.sizes()), A.origin(), get<2>(A.sizes()));
+  inplace_product(nb, ni, nj, B.base(), get<1>(B.sizes()), A.base(), get<2>(A.sizes()));
   Tensor3D<ComplexType> ref({nb, ni, nj}, ComplexType(2.0, -6.0), alloc);
   verify_approx(A, ref);
 }
@@ -400,9 +400,9 @@ TEST_CASE("inplace_product", "[Numerics][batched_operations]")
 //std::vector<int> packed_dims = {7,7,7,7,7,7,7,7};
 //Tensor1D<ComplexType> Buff;
 //Buff = std::move(Tensor1D<ComplexType>(iextensions<1u>{2*nrows*ncols+nbatch}, alloc));
-//Tensor2D_ref<ComplexType> A(make_device_ptr(Buff.origin()), {nrows,ncols});
-//Tensor2D_ref<ComplexType> B(make_device_ptr(Buff.origin()+nrows*ncols), {nrows,ncols});
-//Tensor1D_ref<ComplexType> C(make_device_ptr(Buff.origin()+2*nrows*ncols), iextensions<1u>{nbatch});
+//Tensor2D_ref<ComplexType> A(make_device_ptr(Buff.base()), {nrows,ncols});
+//Tensor2D_ref<ComplexType> B(make_device_ptr(Buff.base()+nrows*ncols), {nrows,ncols});
+//Tensor1D_ref<ComplexType> C(make_device_ptr(Buff.base()+2*nrows*ncols), iextensions<1u>{nbatch});
 
 ////Tensor2D<ComplexType> A({nrows, ncols}, alloc);
 ////Tensor2D<ComplexType> B({ncols, nrows}, alloc);
@@ -411,11 +411,11 @@ TEST_CASE("inplace_product", "[Numerics][batched_operations]")
 ////std::vector<pointer<ComplexType>> y(nbatch);
 //std::vector<ComplexType> buffer(nrows*ncols);
 //create_data(buffer, ComplexType(1.0));
-//copy_n(buffer.data(), buffer.size(), A.origin());
-//copy_n(buffer.data(), buffer.size(), B.origin());
+//copy_n(buffer.data(), buffer.size(), A.base());
+//copy_n(buffer.data(), buffer.size(), B.base());
 //for (int i=0; i < nbatch; i++) {
-//Aarray.emplace_back(ma::pointer_dispatch(A.origin()));
-//Barray.emplace_back(ma::pointer_dispatch(B.origin()));
+//Aarray.emplace_back(ma::pointer_dispatch(A.base()));
+//Barray.emplace_back(ma::pointer_dispatch(B.base()));
 //}
 //using ma::batched_ab_ba;
 //batched_ab_ba(packed_dims.data(), A.data(), ncols, B.data(), nrows,
@@ -437,10 +437,10 @@ TEST_CASE("vbias_from_v1", "[Numerics][batched_operations]")
   Tensor3D<ComplexType> v1({2 * nkpts, nchol_max, nwalk}, ComplexType(1.0, -0.007), alloc);
   Tensor2D<ComplexType> vbias({2 * nchol_tot, nwalk}, 0.0, alloc);
   using ma::vbias_from_v1;
-  vbias_from_v1(nwalk, nkpts, nchol_max, qmap.origin(), kminus.origin(), nchol_pq.origin(), q2vbias.origin(),
-                ComplexType(0.05), v1.origin(), to_address(vbias.origin()));
+  vbias_from_v1(nwalk, nkpts, nchol_max, qmap.base(), kminus.base(), nchol_pq.base(), q2vbias.base(),
+                ComplexType(0.05), v1.base(), to_address(vbias.base()));
   array<ComplexType, 2> vbias_host({2 * nchol_tot, nwalk}, 0.0);
-  copy_n(vbias.origin(), vbias.num_elements(), vbias_host.origin());
+  copy_n(vbias.base(), vbias.num_elements(), vbias_host.base());
   // Captured from stdout
   CHECK(real(vbias_host[0][0]) == Approx(0.1));
   CHECK(imag(vbias_host[10][0]) == Approx(-0.0007));

--- a/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
@@ -342,9 +342,9 @@ void test_dense_mat_vec_device(Allocator& alloc)
     array<T, 1, Allocator> X(iextensions<1u>(x.size()), alloc);
     array<T, 1, Allocator> Y(iextensions<1u>(y.size()), alloc);
 
-    copy_n(m.data(), m.size(), M.origin());
+    copy_n(m.data(), m.size(), M.base());
     REQUIRE(M.num_elements() == m.size());
-    copy_n(x.data(), x.size(), X.origin());
+    copy_n(x.data(), x.size(), X.base());
     REQUIRE(X.num_elements() == x.size());
     REQUIRE(Y.num_elements() == y.size());
 
@@ -366,9 +366,9 @@ void test_dense_mat_vec_device(Allocator& alloc)
     array<T, 1, Allocator> X(iextensions<1u>(x.size()), alloc);
     array<T, 1, Allocator> Y(iextensions<1u>(y.size()), alloc);
 
-    copy_n(m.data(), m.size(), M.origin());
+    copy_n(m.data(), m.size(), M.base());
     REQUIRE(M.num_elements() == m.size());
-    copy_n(x.data(), x.size(), X.origin());
+    copy_n(x.data(), x.size(), X.base());
     REQUIRE(X.num_elements() == x.size());
     REQUIRE(Y.num_elements() == y.size());
 
@@ -388,9 +388,9 @@ void test_dense_mat_vec_device(Allocator& alloc)
     array<T, 1, Allocator> X(iextensions<1u>(x.size()), alloc);
     array<T, 1, Allocator> Y(iextensions<1u>(y.size()), alloc);
 
-    copy_n(m.data(), m.size(), M.origin());
+    copy_n(m.data(), m.size(), M.base());
     REQUIRE(M.num_elements() == m.size());
-    copy_n(x.data(), x.size(), X.origin());
+    copy_n(x.data(), x.size(), X.base());
     REQUIRE(X.num_elements() == x.size());
     REQUIRE(Y.num_elements() == y.size());
 
@@ -407,11 +407,11 @@ void test_dense_mat_vec_device(Allocator& alloc)
     vector<T> y = {4., 5., 6.};
 
     array<T, 2, Allocator> M({3, 4}, alloc);
-    copy_n(m.data(), m.size(), M.origin());
+    copy_n(m.data(), m.size(), M.base());
     REQUIRE(M.num_elements() == m.size());
 
     array<T, 1, Allocator> X(iextensions<1u>(x.size()), alloc);
-    copy_n(x.data(), x.size(), X.origin());
+    copy_n(x.data(), x.size(), X.base());
     REQUIRE(X.num_elements() == x.size());
 
     array<T, 1, Allocator> Y(iextensions<1u>(y.size()), alloc);
@@ -433,7 +433,7 @@ void test_dense_mat_mul_device(Allocator& alloc)
   {
     vector<T> m = {1., 2., 1., 2., 5., 8., 1., 8., 9.};
     array<T, 2, Allocator> M({3, 3}, alloc);
-    copy_n(m.data(), m.size(), M.origin());
+    copy_n(m.data(), m.size(), M.base());
     REQUIRE(M.num_elements() == m.size());
     //  REQUIRE( ma::is_hermitian(M) );
   }
@@ -442,10 +442,10 @@ void test_dense_mat_mul_device(Allocator& alloc)
   {
     vector<T> m = {1., 2., 1., 2., 5., 8., 1., 8., 9.};
     array<T, 2, Allocator> M({3, 3}, alloc);
-    copy_n(m.data(), m.size(), M.origin());
+    copy_n(m.data(), m.size(), M.base());
     REQUIRE(M.num_elements() == m.size());
 
-    array_ref<T, 2, typename Allocator::pointer> Mref(M.origin(), M.extensions());
+    array_ref<T, 2, typename Allocator::pointer> Mref(M.base(), M.extents());
     // not yet implemented in GPU
     //    REQUIRE( ma::is_hermitian(Mref) );
   }
@@ -456,11 +456,11 @@ void test_dense_mat_mul_device(Allocator& alloc)
     vector<T> b = {6., 2., 8., 9., 5., 5., 1., 7., 9.};
 
     array<T, 2, Allocator> A({3, 3}, alloc);
-    copy_n(a.data(), a.size(), A.origin());
+    copy_n(a.data(), a.size(), A.base());
     REQUIRE(A.num_elements() == a.size());
 
     array<T, 2, Allocator> B({3, 3}, alloc);
-    copy_n(b.data(), b.size(), B.origin());
+    copy_n(b.data(), b.size(), B.base());
     REQUIRE(B.num_elements() == b.size());
 
     array<T, 2, Allocator> D({3, 3}, alloc);
@@ -506,11 +506,11 @@ void test_dense_mat_mul_device(Allocator& alloc)
     vector<T> id = {1., 0., 0., 0., 1., 0., 0., 0., 1.};
 
     array<T, 2, Allocator> A({3, 3}, alloc);
-    copy_n(a.data(), a.size(), A.origin());
+    copy_n(a.data(), a.size(), A.base());
     REQUIRE(A.num_elements() == a.size());
 
     array<T, 2, Allocator> B({3, 3}, alloc);
-    copy_n(a.data(), a.size(), B.origin());
+    copy_n(a.data(), a.size(), B.base());
     REQUIRE(B.num_elements() == a.size());
 
     array<T, 2, Allocator> I({3, 3}, alloc);
@@ -527,7 +527,7 @@ void test_dense_mat_mul_device(Allocator& alloc)
     vector<T> a  = {9., 24., 30., 45., 4., 10., 12., 12.};
     vector<T> at = {9., 4., 24., 10., 30., 12., 45., 12.};
     array<T, 2, Allocator> A({2, 4}, alloc);
-    copy_n(a.data(), a.size(), A.origin());
+    copy_n(a.data(), a.size(), A.base());
     REQUIRE(A.num_elements() == a.size());
 
     array<T, 2, Allocator> B({4, 2}, alloc);
@@ -548,7 +548,7 @@ void test_dense_gerf_gqr_device(Allocator& alloc)
     vector<T> id = {1., 0., 0., 0., 1., 0., 0., 0., 1.};
 
     array<T, 2, Allocator> A({3, 3}, alloc);
-    copy_n(a.data(), a.size(), A.origin());
+    copy_n(a.data(), a.size(), A.base());
     REQUIRE(A.num_elements() == a.size());
 
     array<T, 2, Allocator> Id({3, 3}, alloc);
@@ -571,7 +571,7 @@ void test_dense_gerf_gqr_device(Allocator& alloc)
     vector<T> id = {1., 0., 0., 0., 1., 0., 0., 0., 1.};
 
     array<T, 2, Allocator> A({3, 4}, alloc);
-    copy_n(a.data(), a.size(), A.origin());
+    copy_n(a.data(), a.size(), A.base());
     REQUIRE(A.num_elements() == a.size());
 
     array<T, 2, Allocator> Id({3, 3}, alloc);
@@ -599,8 +599,8 @@ void test_dense_gerf_gqr_strided_device(Allocator& alloc)
     vector<T> id = {1., 0., 0., 0., 1., 0., 0., 0., 1.};
 
     array<T, 3, Allocator> A({2, 3, 4}, alloc);
-    copy_n(a.data(), a.size(), A[0].origin());
-    copy_n(a.data(), a.size(), A[1].origin());
+    copy_n(a.data(), a.size(), A[0].base());
+    copy_n(a.data(), a.size(), A[1].base());
     REQUIRE(A.num_elements() == 2 * a.size());
 
     auto sz = std::max(ma::geqrf_optimal_workspace_size(A[0]), ma::gqr_optimal_workspace_size(A[0]));
@@ -610,8 +610,8 @@ void test_dense_gerf_gqr_strided_device(Allocator& alloc)
     array<int, 1, IAllocator> info(iextensions<1u>{2}, IAllocator{alloc});
     array<T, 2, Allocator> TAU({2, 4}, alloc);
 
-    geqrfStrided(4, 3, A.origin(), 4, 12, TAU.origin(), 4, info.origin(), 2);
-    gqrStrided(4, 3, 3, A.origin(), 4, 12, TAU.origin(), 4, WORK.origin(), sz, info.origin(), 2);
+    geqrfStrided(4, 3, A.base(), 4, 12, TAU.base(), 4, info.base(), 2);
+    gqrStrided(4, 3, 3, A.base(), 4, 12, TAU.base(), 4, WORK.base(), sz, info.base(), 2);
     for (int i = 0; i < 2; i++)
     {
       ma::product(A[i], ma::H(A[i]), Id);
@@ -640,9 +640,9 @@ void test_dense_batched_gemm(Allocator& alloc)
     std::vector<pointer> C_array;
     for (int i = 0; i < nbatch; i++)
     {
-      A_array.emplace_back(a.origin());
-      B_array.emplace_back(b.origin());
-      C_array.emplace_back(c[i].origin());
+      A_array.emplace_back(a.base());
+      B_array.emplace_back(b.base());
+      C_array.emplace_back(c[i].base());
     }
     using ma::gemmBatched;
     gemmBatched('N', 'N', 3, 3, 3, alpha, A_array.data(), 3, B_array.data(), 3, beta, C_array.data(), 3, nbatch);
@@ -667,9 +667,9 @@ void test_dense_geqrf_getri_batched_device(Allocator& alloc)
   std::vector<pointer> A_array, Ai_array;
   for (int i = 0; i < 2; i++)
   {
-    copy_n(a.data(), a.size(), A[i].origin());
-    A_array.emplace_back(A[i].origin());
-    Ai_array.emplace_back(Ai[i].origin());
+    copy_n(a.data(), a.size(), A[i].base());
+    A_array.emplace_back(A[i].base());
+    Ai_array.emplace_back(Ai[i].base());
   }
 
   array<T, 1, Allocator> WORK(iextensions<1u>{9}, alloc);
@@ -683,21 +683,21 @@ void test_dense_geqrf_getri_batched_device(Allocator& alloc)
   //SECTION("getrf_batched")
   {
     using ma::getrfBatched;
-    getrfBatched(3, A_array.data(), 4, ma::pointer_dispatch(piv.origin()), ma::pointer_dispatch(info.origin()), 2);
-    copy_n(a2.data(), a2.size(), B.origin());
+    getrfBatched(3, A_array.data(), 4, ma::pointer_dispatch(piv.base()), ma::pointer_dispatch(info.base()), 2);
+    copy_n(a2.data(), a2.size(), B.base());
     using ma::getrf;
-    getrf(3, 3, ma::pointer_dispatch(B.origin()), 3, ma::pointer_dispatch(spiv.data()), status,
+    getrf(3, 3, ma::pointer_dispatch(B.base()), 3, ma::pointer_dispatch(spiv.data()), status,
           ma::pointer_dispatch(WORK.data()));
   }
   //SECTION("getri_batched")
   {
     using ma::getriBatched;
-    getriBatched(3, A_array.data(), 4, ma::pointer_dispatch(piv.origin()), Ai_array.data(), 3,
-                 ma::pointer_dispatch(info.origin()), 2);
+    getriBatched(3, A_array.data(), 4, ma::pointer_dispatch(piv.base()), Ai_array.data(), 3,
+                 ma::pointer_dispatch(info.base()), 2);
     //SECTION("getri")
     {
-      getri(3, ma::pointer_dispatch(B.origin()), 3, ma::pointer_dispatch(piv.origin()),
-            ma::pointer_dispatch(WORK.origin()), 9, status);
+      getri(3, ma::pointer_dispatch(B.base()), 3, ma::pointer_dispatch(piv.base()),
+            ma::pointer_dispatch(WORK.base()), 9, status);
       for (int i = 0; i < 2; i++)
       {
         verify_approx(Ai[i], B);
@@ -707,8 +707,8 @@ void test_dense_geqrf_getri_batched_device(Allocator& alloc)
   //SECTION("mat_inv")
   {
     using std::copy_n;
-    copy_n(B.origin(), B.num_elements(), Bi.origin());
-    copy_n(a2.data(), a2.size(), B.origin());
+    copy_n(B.base(), B.num_elements(), Bi.base());
+    copy_n(a2.data(), a2.size(), B.base());
     array<T, 2, Allocator> out({3, 3}, 0.0, alloc);
     // note transpose to account for fortran ordering
     array_ref<T, 2> Id2(id.data(), {3, 3});
@@ -719,7 +719,7 @@ void test_dense_geqrf_getri_batched_device(Allocator& alloc)
   {
     for (int i = 0; i < 2; i++)
     {
-      copy_n(a.data(), a.size(), A[i].origin());
+      copy_n(a.data(), a.size(), A[i].base());
       array<T, 2, Allocator> out({3, 3}, alloc);
       ma::product(ma::H(A[i]({0, 3}, {0, 3})), ma::H(Ai[i]), out);
       array_ref<T, 2> Id2(id.data(), {3, 3});

--- a/src/AFQMC/Numerics/tests/test_determinant.cpp
+++ b/src/AFQMC/Numerics/tests/test_determinant.cpp
@@ -71,7 +71,7 @@ TEST_CASE("determinant_from_getrf", "[Numerics][determinant]")
   double detx         = 0.06317052169675352;
   using ma::determinant_from_getrf;
   using std::get;
-  double ovlp = determinant_from_getrf(get<0>(x.sizes()), lu.origin(), get<1>(lu.sizes()), pivot.origin(), log_factor);
+  double ovlp = determinant_from_getrf(get<0>(x.sizes()), lu.base(), get<1>(lu.sizes()), pivot.base(), log_factor);
   CHECK(ovlp == Approx(detx));
 }
 
@@ -90,15 +90,15 @@ TEST_CASE("strided_determinant_from_getrf", "[Numerics][determinant]")
   Tensor3D<double> lus({3, 3, 3}, 0.0, alloc);
   using std::copy_n;
   for (int i = 0; i < 3; i++)
-    copy_n(lu.origin(), lu.num_elements(), lus[i].origin());
+    copy_n(lu.base(), lu.num_elements(), lus[i].base());
   Tensor2D<int> pivot    = {{1, 1, 2}, {1, 1, 2}, {1, 1, 2}};
   Tensor1D<double> ovlps = {0, 0, 0};
   double log_factor      = 0.0;
   double detx            = 0.06317052169675352;
   using ma::strided_determinant_from_getrf;
   using std::get;
-  strided_determinant_from_getrf(get<0>(x.sizes()), lus.origin(), get<1>(lu.sizes()), lu.num_elements(), pivot.origin(), get<1>(pivot.sizes()),
-                                 log_factor, to_address(ovlps.origin()), get<0>(lus.sizes()));
+  strided_determinant_from_getrf(get<0>(x.sizes()), lus.base(), get<1>(lu.sizes()), lu.num_elements(), pivot.base(), get<1>(pivot.sizes()),
+                                 log_factor, to_address(ovlps.base()), get<0>(lus.sizes()));
   CHECK(ovlps[0] == Approx(detx));
   CHECK(ovlps[1] == Approx(detx));
   CHECK(ovlps[2] == Approx(detx));
@@ -119,15 +119,15 @@ TEST_CASE("batched_determinant_from_getrf", "[Numerics][determinant]")
   std::vector<pointer<double>> lu_array;
   using std::copy_n;
   for (int i = 0; i < 3; i++)
-    lu_array.emplace_back(lu.origin());
+    lu_array.emplace_back(lu.base());
   Tensor2D<int> pivot    = {{1, 1, 2}, {1, 1, 2}, {1, 1, 2}};
   Tensor1D<double> ovlps = {0, 0, 0};
   double log_factor      = 0.0;
   double detx            = 0.06317052169675352;
   using ma::batched_determinant_from_getrf;
   using std::get;
-  batched_determinant_from_getrf(get<0>(x.sizes()), lu_array.data(), get<1>(lu.sizes()), pivot.origin(), get<1>(pivot.sizes()), log_factor,
-                                 to_address(ovlps.origin()), lu_array.size());
+  batched_determinant_from_getrf(get<0>(x.sizes()), lu_array.data(), get<1>(lu.sizes()), pivot.base(), get<1>(pivot.sizes()), log_factor,
+                                 to_address(ovlps.base()), lu_array.size());
   CHECK(ovlps[0] == Approx(detx));
   CHECK(ovlps[1] == Approx(detx));
   CHECK(ovlps[2] == Approx(detx));
@@ -148,15 +148,15 @@ TEST_CASE("batched_determinant_from_getrf_complex", "[Numerics][determinant]")
   std::vector<pointer<std::complex<double>>> lu_array;
   using std::copy_n;
   for (int i = 0; i < 3; i++)
-    lu_array.emplace_back(lu.origin());
+    lu_array.emplace_back(lu.base());
   Tensor2D<int> pivot                  = {{1, 1, 2}, {1, 1, 2}, {1, 1, 2}};
   Tensor1D<std::complex<double>> ovlps = {0, 0, 0};
   std::complex<double> log_factor      = 0.0;
   std::complex<double> detx            = 0.06317052169675352;
   using ma::batched_determinant_from_getrf;
   using std::get;
-  batched_determinant_from_getrf(get<0>(x.sizes()), lu_array.data(), get<1>(lu.sizes()), pivot.origin(), get<1>(pivot.sizes()), log_factor,
-                                 to_address(ovlps.origin()), lu_array.size());
+  batched_determinant_from_getrf(get<0>(x.sizes()), lu_array.data(), get<1>(lu.sizes()), pivot.base(), get<1>(pivot.sizes()), log_factor,
+                                 to_address(ovlps.base()), lu_array.size());
   CHECK(ovlps[0] == ComplexApprox(detx));
   CHECK(ovlps[1] == ComplexApprox(detx));
   CHECK(ovlps[2] == ComplexApprox(detx));

--- a/src/AFQMC/Numerics/tests/test_ma_blas_extensions.cpp
+++ b/src/AFQMC/Numerics/tests/test_ma_blas_extensions.cpp
@@ -91,7 +91,7 @@ TEST_CASE("adotpby", "[Numerics][ma_blas_extensions]")
       b[i] = 0.1;
     }
     using ma::adotpby;
-    adotpby(alpha, a, b, beta, y.origin());
+    adotpby(alpha, a, b, beta, y.base());
     CHECK(y[0] == Approx(0.5 * a.size() * 0.01));
   }
   SECTION("complex")
@@ -109,7 +109,7 @@ TEST_CASE("adotpby", "[Numerics][ma_blas_extensions]")
       b[i] = ComplexType(0.1, -0.1);
     }
     using ma::adotpby;
-    adotpby(alpha, a, b, beta, y.origin());
+    adotpby(alpha, a, b, beta, y.base());
     copy_n(y.data(), y.size(), y_cpu.data());
     CHECK(std::real(y_cpu[0]) == Approx(a.size() * 0.01));
     CHECK(std::imag(y_cpu[0]) == Approx(0.00));
@@ -188,7 +188,7 @@ TEST_CASE("sum2D", "[Numerics][ma_blas_extensions]")
   std::vector<double> buffer(3 * 3);
   Tensor2D<double> y({3, 3}, alloc);
   create_data(buffer, 1.0);
-  copy_n(buffer.data(), buffer.size(), y.origin());
+  copy_n(buffer.data(), buffer.size(), y.base());
   using ma::sum;
   double res = sum(y);
   CHECK(res == Approx(36.0));
@@ -200,7 +200,7 @@ TEST_CASE("sum3D", "[Numerics][ma_blas_extensions]")
   std::vector<double> buffer(3 * 3 * 3);
   Tensor3D<double> y({3, 3, 3}, alloc);
   create_data(buffer, 1.0);
-  copy_n(buffer.data(), buffer.size(), y.origin());
+  copy_n(buffer.data(), buffer.size(), y.base());
   using ma::sum;
   double res = sum(y);
   CHECK(res == Approx(351.0));
@@ -212,7 +212,7 @@ TEST_CASE("sum4D", "[Numerics][ma_blas_extensions]")
   std::vector<double> buffer(3 * 3 * 3 * 3);
   Tensor4D<double> y({3, 3, 3, 3}, alloc);
   create_data(buffer, 1.0);
-  copy_n(buffer.data(), buffer.size(), y.origin());
+  copy_n(buffer.data(), buffer.size(), y.base());
   using ma::sum;
   double res = sum(y);
   CHECK(res == Approx(3240.0));
@@ -234,7 +234,7 @@ TEST_CASE("set_identity2D", "[Numerics][ma_blas_extensions]")
   Alloc<double> alloc{};
   std::vector<double> buffer(3 * 3);
   Tensor2D<double> y({3, 3}, alloc);
-  copy_n(buffer.data(), buffer.size(), y.origin());
+  copy_n(buffer.data(), buffer.size(), y.base());
   using ma::set_identity;
   set_identity(y);
   CHECK(y[0][0] == Approx(1.0));
@@ -247,7 +247,7 @@ TEST_CASE("set_identity3D", "[Numerics][ma_blas_extensions]")
   Alloc<double> alloc{};
   std::vector<double> buffer(3 * 3 * 3);
   Tensor3D<double> y({3, 3, 3}, alloc);
-  copy_n(buffer.data(), buffer.size(), y.origin());
+  copy_n(buffer.data(), buffer.size(), y.base());
   using ma::set_identity;
   set_identity(y);
   CHECK(y[0][0][0] == Approx(1.0));
@@ -260,7 +260,7 @@ TEST_CASE("fill2D", "[Numerics][ma_blas_extensions]")
   Alloc<double> alloc{};
   std::vector<double> buffer(2 * 2);
   Tensor2D<double> y({2, 2}, alloc);
-  copy_n(buffer.data(), buffer.size(), y.origin());
+  copy_n(buffer.data(), buffer.size(), y.base());
   using ma::fill;
   fill(y, 2.0);
   Tensor2D<double> ref = {{2.0, 2.0}, {2.0, 2.0}};

--- a/src/AFQMC/Numerics/tests/test_misc_kernels.cpp
+++ b/src/AFQMC/Numerics/tests/test_misc_kernels.cpp
@@ -69,11 +69,11 @@ TEST_CASE("axpyBatched", "[Numerics][misc_kernels]")
   using std::get;
   for (int i = 0; i < get<0>(x.sizes()); i++)
   {
-    x_batched.emplace_back(x[i].origin());
-    y_batched.emplace_back(y[i].origin());
+    x_batched.emplace_back(x[i].base());
+    y_batched.emplace_back(y[i].base());
   }
   using ma::axpyBatched;
-  axpyBatched(get<1>(x.sizes()), to_address(a.origin()), x_batched.data(), 1, y_batched.data(), 1, x_batched.size());
+  axpyBatched(get<1>(x.sizes()), to_address(a.base()), x_batched.data(), 1, y_batched.data(), 1, x_batched.size());
   // 1 + 2 = 3.
   Tensor2D<std::complex<double>> ref({3, 4}, 3.0, alloc);
   verify_approx(y, ref);
@@ -97,8 +97,8 @@ TEST_CASE("construct_X", "[Numerics][misc_kernels]")
   Tensor2D<std::complex<double>> mf({nsteps, nwalk}, 2.0, alloc);
   Tensor3D<std::complex<double>> x({ncv, nsteps, nwalk}, 0.1, alloc);
   using kernels::construct_X;
-  construct_X(ncv, nsteps, nwalk, fp, sqrtdt, vbound, to_address(vmf.origin()), to_address(vbias.origin()),
-              to_address(hws.origin()), to_address(mf.origin()), to_address(x.origin()));
+  construct_X(ncv, nsteps, nwalk, fp, sqrtdt, vbound, to_address(vmf.base()), to_address(vbias.base()),
+              to_address(hws.base()), to_address(mf.base()), to_address(x.base()));
   // captured from stdout.
   std::complex<double> ref_val = std::complex<double>(0.102, 0.08);
   Tensor3D<std::complex<double>> ref({ncv, nsteps, nwalk}, ref_val, alloc);
@@ -117,7 +117,7 @@ TEST_CASE("batchedDot", "[Numerics][misc_kernels]")
   std::complex<double> alpha(2.0);
   std::complex<double> beta(-1.0);
   using kernels::batchedDot;
-  batchedDot(dim, dim, alpha, to_address(A.origin()), dim, to_address(B.origin()), dim, beta, to_address(y.origin()),
+  batchedDot(dim, dim, alpha, to_address(A.base()), dim, to_address(B.base()), dim, beta, to_address(y.base()),
              1);
   // from numpy.
   std::complex<double> ref_val(-1.2, -1.0);

--- a/src/AFQMC/Numerics/tests/test_sparse_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_sparse_numerics.cpp
@@ -66,7 +66,7 @@ void test_sparse_matrix_mult(Allocator const& alloc = {})
     vector<double> b = {1., 2., 1., 5., 2., 5., 8., 7., 1., 8., 9., 9., 4., 1., 2., 3.};
     array<double, 2, Allocator> B({4, 4}, alloc);
     using std::copy_n;
-    copy_n(b.data(), b.size(), B.origin());
+    copy_n(b.data(), b.size(), B.base());
     REQUIRE(B.num_elements() == b.size());
 
     array<double, 2, Allocator> C({4, 4}, 0.0, alloc);
@@ -93,7 +93,7 @@ void test_sparse_matrix_mult(Allocator const& alloc = {})
     vector<double> b = {1., 2., 1., 4.};
     array<double, 1, Allocator> B(iextensions<1u>{4}, alloc);
     using std::copy_n;
-    copy_n(b.data(), b.size(), B.origin());
+    copy_n(b.data(), b.size(), B.base());
     REQUIRE(B.num_elements() == b.size());
 
     array<double, 1, Allocator> C(iextensions<1u>{4}, alloc);
@@ -125,7 +125,7 @@ void test_sparse_matrix_mult(Allocator const& alloc = {})
     vector<double> b = {1., 2., 1., 5., 2., 5., 8., 7., 1., 8., 9., 9., 4., 1., 2., 3.};
     array<double, 2, Allocator> B({4, 4}, alloc);
     using std::copy_n;
-    copy_n(b.data(), b.size(), B.origin());
+    copy_n(b.data(), b.size(), B.base());
     REQUIRE(B.num_elements() == b.size());
 
     array<double, 2, Allocator> C({4, 4}, alloc);
@@ -151,7 +151,7 @@ void test_sparse_matrix_mult(Allocator const& alloc = {})
     vector<double> b = {1., 2., 1., 4.};
     array<double, 1, Allocator> B(iextensions<1u>{4}, alloc);
     using std::copy_n;
-    copy_n(b.data(), b.size(), B.origin());
+    copy_n(b.data(), b.size(), B.base());
     REQUIRE(B.num_elements() == b.size());
 
     array<double, 1, Allocator> C(iextensions<1u>{4}, alloc);

--- a/src/AFQMC/Numerics/tests/test_tensor_operations.cpp
+++ b/src/AFQMC/Numerics/tests/test_tensor_operations.cpp
@@ -87,12 +87,12 @@ TEST_CASE("KaKjw_to_KKwaj", "[Numerics][tensor_operations]")
   Tensor1D<int> nel_pk  = {occ_k, occ_k, occ_k};
   Tensor1D<int> nmo_pk0 = {0, nmo_k, 2 * nmo_k};
   Tensor1D<int> nel_pk0 = {0, occ_k, 2 * occ_k};
-  copy_n(buffer.data(), buffer.size(), KaKjw.origin());
+  copy_n(buffer.data(), buffer.size(), KaKjw.base());
   // KaKjw = numpy.arange(nk*na*nk*nj*nw).reshape((nk,na,nk,nj,nw))
   // KKwaj = numpy.transpose(KaKjw, (0,2,1,3,4))
   using ma::KaKjw_to_KKwaj;
-  KaKjw_to_KKwaj(nwalk, nk, 1, nmo_k, nk * nmo_k, occ_k, nmo_pk.origin(), nmo_pk0.origin(), nel_pk.origin(),
-                 nel_pk0.origin(), KaKjw.origin(), KKwaj.origin());
+  KaKjw_to_KKwaj(nwalk, nk, 1, nmo_k, nk * nmo_k, occ_k, nmo_pk.base(), nmo_pk0.base(), nel_pk.base(),
+                 nel_pk0.base(), KaKjw.base(), KKwaj.base());
   // Reference values from python
   CHECK(KKwaj[1][2][3][4][4] == Approx(1473.0));
   CHECK(KKwaj[2][1][3][4][4] == Approx(2173.0));
@@ -116,10 +116,10 @@ TEST_CASE("KaKjw_to_QKwaj", "[Numerics][tensor_operations]")
   Tensor1D<int> nel_pk0 = {0, occ_k, 2 * occ_k, 3 * occ_k};
   // From 221 k-point grid
   Tensor2D<int> qk_to_k2 = {{0, 1, 2, 3}, {1, 0, 3, 2}, {2, 3, 0, 1}, {3, 2, 1, 0}};
-  copy_n(buffer.data(), buffer.size(), KaKjw.origin());
+  copy_n(buffer.data(), buffer.size(), KaKjw.base());
   using ma::KaKjw_to_QKajw;
-  KaKjw_to_QKajw(nwalk, nk, 1, nmo_k, nk * nmo_k, occ_k, nmo_pk.origin(), nmo_pk0.origin(), nel_pk.origin(),
-                 nel_pk0.origin(), qk_to_k2.origin(), KaKjw.origin(), QKajw.origin());
+  KaKjw_to_QKajw(nwalk, nk, 1, nmo_k, nk * nmo_k, occ_k, nmo_pk.base(), nmo_pk0.base(), nel_pk.base(),
+                 nel_pk0.base(), qk_to_k2.base(), KaKjw.base(), QKajw.base());
   // Just captured from output.
   CHECK(QKajw[1][2][3][4][4] == Approx(1904.0));
   CHECK(QKajw[2][1][3][4][4] == Approx(1264.0));
@@ -153,44 +153,44 @@ TEST_CASE("term_by_term_matrix_vector", "[Numerics][tensor_operations]")
   Tensor1D<ComplexType> x(iextensions<1u>{ncol}, alloc);
   std::vector<ComplexType> buffer(nrow * ncol);
   create_data(buffer, ComplexType(1.0));
-  copy_n(buffer.data(), buffer.size(), A.origin());
-  copy_n(buffer.data(), x.size(), x.origin());
+  copy_n(buffer.data(), buffer.size(), A.base());
+  copy_n(buffer.data(), x.size(), x.base());
   using ma::term_by_term_matrix_vector;
   Tensor2D<ComplexType> ref = {{0, 1, 2}, {4, 5, 6}, {8, 9, 10}};
-  term_by_term_matrix_vector(ma::TOp_PLUS, 0, nrow, ncol, A.origin(), ncol, x.origin(), 1);
+  term_by_term_matrix_vector(ma::TOp_PLUS, 0, nrow, ncol, A.base(), ncol, x.base(), 1);
   verify_approx(ref, A);
-  copy_n(buffer.data(), buffer.size(), A.origin());
-  term_by_term_matrix_vector(ma::TOp_PLUS, 1, nrow, ncol, A.origin(), ncol, x.origin(), 1);
+  copy_n(buffer.data(), buffer.size(), A.base());
+  term_by_term_matrix_vector(ma::TOp_PLUS, 1, nrow, ncol, A.base(), ncol, x.base(), 1);
   // MAM: operator asignment from initializer lists is not working on Multi
   //      on some compilers( nvcc, intel19 )
   //      It does work on construction, so a temporary fix
   ref = Tensor2D<ComplexType>{{0, 2, 4}, {3, 5, 7}, {6, 8, 10}};
   verify_approx(ref, A);
-  copy_n(buffer.data(), buffer.size(), A.origin());
-  term_by_term_matrix_vector(ma::TOp_MINUS, 0, nrow, ncol, A.origin(), ncol, x.origin(), 1);
+  copy_n(buffer.data(), buffer.size(), A.base());
+  term_by_term_matrix_vector(ma::TOp_MINUS, 0, nrow, ncol, A.base(), ncol, x.base(), 1);
   ref = Tensor2D<ComplexType>{{0, 1, 2}, {2, 3, 4}, {4, 5, 6}};
   verify_approx(ref, A);
-  copy_n(buffer.data(), buffer.size(), A.origin());
-  term_by_term_matrix_vector(ma::TOp_MINUS, 1, nrow, ncol, A.origin(), ncol, x.origin(), 1);
+  copy_n(buffer.data(), buffer.size(), A.base());
+  term_by_term_matrix_vector(ma::TOp_MINUS, 1, nrow, ncol, A.base(), ncol, x.base(), 1);
   ref = Tensor2D<ComplexType>{{0, 0, 0}, {3, 3, 3}, {6, 6, 6}};
   verify_approx(ref, A);
-  copy_n(buffer.data(), buffer.size(), A.origin());
-  term_by_term_matrix_vector(ma::TOp_MUL, 0, nrow, ncol, A.origin(), ncol, x.origin(), 1);
+  copy_n(buffer.data(), buffer.size(), A.base());
+  term_by_term_matrix_vector(ma::TOp_MUL, 0, nrow, ncol, A.base(), ncol, x.base(), 1);
   ref = Tensor2D<ComplexType>{{0, 0, 0}, {3, 4, 5}, {12, 14, 16}};
   verify_approx(ref, A);
-  copy_n(buffer.data(), buffer.size(), A.origin());
-  term_by_term_matrix_vector(ma::TOp_MUL, 1, nrow, ncol, A.origin(), ncol, x.origin(), 1);
+  copy_n(buffer.data(), buffer.size(), A.base());
+  term_by_term_matrix_vector(ma::TOp_MUL, 1, nrow, ncol, A.base(), ncol, x.base(), 1);
   ref = Tensor2D<ComplexType>{{0, 1, 4}, {0, 4, 10}, {0, 7, 16}};
   verify_approx(ref, A);
   // Avoid dividing by zero
-  copy_n(buffer.data() + 1, x.size(), x.origin());
-  copy_n(buffer.data(), buffer.size(), A.origin());
-  term_by_term_matrix_vector(ma::TOp_DIV, 0, nrow, ncol, A.origin(), ncol, x.origin(), 1);
+  copy_n(buffer.data() + 1, x.size(), x.base());
+  copy_n(buffer.data(), buffer.size(), A.base());
+  term_by_term_matrix_vector(ma::TOp_DIV, 0, nrow, ncol, A.base(), ncol, x.base(), 1);
   ref = Tensor2D<ComplexType>{{0, 1, 2}, {1.5, 2.0, 2.5}, {2, 2.333333333333, 2.666666666667}};
   verify_approx(ref, A);
-  copy_n(buffer.data() + 1, x.size(), x.origin());
-  copy_n(buffer.data(), buffer.size(), A.origin());
-  term_by_term_matrix_vector(ma::TOp_DIV, 1, nrow, ncol, A.origin(), ncol, x.origin(), 1);
+  copy_n(buffer.data() + 1, x.size(), x.base());
+  copy_n(buffer.data(), buffer.size(), A.base());
+  term_by_term_matrix_vector(ma::TOp_DIV, 1, nrow, ncol, A.base(), ncol, x.base(), 1);
   ref = Tensor2D<ComplexType>{{0.0, 0.5, 0.666666666667}, {3.0, 2.0, 1.666666666667}, {6.0, 3.5, 2.666666666667}};
   verify_approx(ref, A);
 }
@@ -206,12 +206,12 @@ TEST_CASE("transpose_wabn_to_wban", "[Numerics][tensor_operations]")
   create_data(buffer, ComplexType(1.0));
   Tensor4D<ComplexType> Twabn({nwalk, na, nb, nchol}, alloc);
   Tensor4D<ComplexType> Twban({nwalk, na, nb, nchol}, 0.0, alloc);
-  copy_n(buffer.data(), buffer.size(), Twabn.origin());
+  copy_n(buffer.data(), buffer.size(), Twabn.base());
   // Twabn = numpy.arange(nw*na*nb*nc).reshape((nw,na,nb,nc))
   // Twban = numpy.transpose(Twabn, (0,2,1,3))
   using ma::transpose_wabn_to_wban;
-  transpose_wabn_to_wban(nwalk, na, nb, nchol, Twabn.origin(), Twban.origin());
-  Tensor1D_ref<ComplexType> chunk(Twban.origin() + 10, iextensions<1u>{10});
+  transpose_wabn_to_wban(nwalk, na, nb, nchol, Twabn.base(), Twban.base());
+  Tensor1D_ref<ComplexType> chunk(Twban.base() + 10, iextensions<1u>{10});
   // From Twban.copy().ravel()[10:20].
   Tensor1D<ComplexType> ref = {10, 55, 56, 57, 58, 59, 60, 61, 62, 63};
   verify_approx(chunk, ref);
@@ -233,11 +233,11 @@ TEST_CASE("vKKwij_tovwKiKj", "[Numerics][tensor_operations]")
   Tensor3D<ComplexType> vKK({nk, nk, nwalk * nmo_k * nmo_k}, 0.0, alloc);
   std::vector<ComplexType> buffer(nk * nk * nwalk * nmo_k * nmo_k, 0.0);
   create_data(buffer, ComplexType(1.0));
-  copy_n(buffer.data(), buffer.size(), vKK.origin());
+  copy_n(buffer.data(), buffer.size(), vKK.base());
   using ma::vKKwij_to_vwKiKj;
-  vKKwij_to_vwKiKj(nwalk, nk, nmo_k, nk * nmo_k, KKTransID.origin(), nmo_pk.origin(), nmo_pk0.origin(), vKK.origin(),
-                   vKiKj.origin());
-  copy_n(vKiKj.origin(), vKiKj.num_elements(), buffer.data());
+  vKKwij_to_vwKiKj(nwalk, nk, nmo_k, nk * nmo_k, KKTransID.base(), nmo_pk.base(), nmo_pk0.base(), vKK.base(),
+                   vKiKj.base());
+  copy_n(vKiKj.base(), vKiKj.num_elements(), buffer.data());
   // Just captured from output.
   CHECK(real(buffer[17]) == Approx(507.0));
   CHECK(real(buffer[0]) == Approx(0.0));

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.cpp
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.cpp
@@ -216,41 +216,41 @@ void AFQMCBasePropagator::assemble_X(size_t nsteps, size_t nwalk, RealType sqrtd
     int i0,iN;
     std::tie(i0,iN) = FairDivideBoundary(TG.TG_local().rank(),int(X.num_elements()),
                                          TG.TG_local().size());  
-    sampleGaussianFields_n(make_device_ptr(X.origin())+i0,iN-i0,*rng);
+    sampleGaussianFields_n(make_device_ptr(X.base())+i0,iN-i0,*rng);
   }
 
   // construct X
-  fill_n(make_device_ptr(HWs.origin()),HWs.num_elements(),ComplexType(0));  
-  fill_n(make_device_ptr(MF.origin()),MF.num_elements(),ComplexType(0));  
+  fill_n(make_device_ptr(HWs.base()),HWs.num_elements(),ComplexType(0));  
+  fill_n(make_device_ptr(MF.base()),MF.num_elements(),ComplexType(0));  
 
 // leaving compiler switch until I decide how to do this better
 // basically hide this decision somewhere based on the value of pointer!!!
 #ifdef ENABLE_CUDA
   kernels::construct_X(nCV,nsteps,nwalk,free_projection,sqrtdt,vbias_bound,
-                       to_address(vMF.origin()),
-                       to_address(vbias.origin()),
-                       to_address(HWs.origin()),
-                       to_address(MF.origin()),
-                       to_address(X.origin())
+                       to_address(vMF.base()),
+                       to_address(vbias.base()),
+                       to_address(HWs.base()),
+                       to_address(MF.base()),
+                       to_address(X.base())
                       );
 #else
-  boost::multi::array_ref<ComplexType,3> X3D(to_address(X.origin()),
+  boost::multi::array_ref<ComplexType,3> X3D(to_address(X.base()),
                         {long(X.size(0)),long(nsteps),long(nwalk)});
   int m0,mN;
   std::tie(m0,mN) = FairDivideBoundary(TG.TG_local().rank(),nCV,TG.TG_local().size());   
   TG.local_barrier();
   for(int m=m0; m<mN; ++m) { 
     auto X_m = X3D[m];
-    auto vb_ = to_address(vbias[m].origin());
+    auto vb_ = to_address(vbias[m].base());
     auto vmf_t = sqrtdt*apply_bound_vbias(vMF[m],1.0);
     auto vmf_ = sqrtdt*vMF[m];
     // apply bounds to vbias
     for(int iw=0; iw<nwalk; iw++) 
       vb_[iw] = apply_bound_vbias(vb_[iw],sqrtdt);
     for(int ni=0; ni<nsteps; ni++) {
-      auto X_ = X3D[m][ni].origin();
-      auto hws_ = to_address(HWs[ni].origin());
-      auto mf_ = to_address(MF[ni].origin());
+      auto X_ = X3D[m][ni].base();
+      auto hws_ = to_address(HWs[ni].base());
+      auto mf_ = to_address(MF[ni].base());
       for(int iw=0; iw<nwalk; iw++) {
         // No force bias term when doing free projection.
         ComplexType vdiff = free_projection?ComplexType(0.0, 0.0):(im*(vb_[iw]-vmf_t));

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -76,7 +76,7 @@ protected:
   using stdCMatrix_ref   = boost::multi::array_ref<ComplexType, 2>;
   using stdSPCMatrix_ref = boost::multi::array_ref<SPComplexType, 2>;
   using stdC3Tensor_ref  = boost::multi::array_ref<ComplexType, 3>;
-  using CMatrix_ptr      = boost::multi::array_ptr<ComplexType, 2, pointer>;
+  using CMatrix_ptr      = boost::multi::detail::array_ptr<ComplexType, 2, pointer>;
 
   using mpi3CVector   = boost::multi::array<ComplexType, 1, shared_allocator<ComplexType>>;
   using mpi3SPCVector = boost::multi::array<SPComplexType, 1, shared_allocator<SPComplexType>>;

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.icc
@@ -96,14 +96,14 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
       std::tie(Gak0, GakN) = FairDivideBoundary(TG.getLocalTGRank(), int(G.num_elements()), TG.getNCoresPerTG());
       StaticMatrix Gc(G_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
       wfn.MixedDensityMatrix_for_vbias(wset, Gc);
-      copy_n_cast(make_device_ptr(Gc.origin()) + Gak0, GakN - Gak0, make_device_ptr(G.origin()) + Gak0);
+      copy_n_cast(make_device_ptr(Gc.base()) + Gak0, GakN - Gak0, make_device_ptr(G.base()) + Gak0);
     }
     TG.local_barrier();
 #else
     wfn.MixedDensityMatrix_for_vbias(wset, G);
 #endif
     AFQMCTimers[G_for_vbias_timer].get().stop();
-    //std::cout<<" G: " <<ma::dot(G(G.extension(0),0),G(G.extension(0),0)) <<std::endl;
+    //std::cout<<" G: " <<ma::dot(G(get<0>(G.extents()),0),G(get<0>(G.extents()),0)) <<std::endl;
 
     StaticSPMatrix vbias({long(localnCV), long(nwalk)},
                          buffer_manager.get_generator().template get_allocator<SPComplexType>());
@@ -111,7 +111,7 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     AFQMCTimers[vbias_timer].get().start();
     if (free_projection)
     {
-      fill_n(vbias.origin(), localnCV * nwalk, SPComplexType(0.0, 0.0));
+      fill_n(vbias.base(), localnCV * nwalk, SPComplexType(0.0, 0.0));
     }
     else
     {
@@ -127,8 +127,8 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     assemble_X(nsteps, nwalk, sqrtdt, X, vbias, MFfactor, hybrid_weight);
     if (TG.TG_local().size() > 1)
     {
-      TG.TG_local().all_reduce_in_place_n(to_address(MFfactor.origin()), MFfactor.num_elements(), std::plus<>());
-      TG.TG_local().all_reduce_in_place_n(to_address(hybrid_weight.origin()), hybrid_weight.num_elements(),
+      TG.TG_local().all_reduce_in_place_n(to_address(MFfactor.base()), MFfactor.num_elements(), std::plus<>());
+      TG.TG_local().all_reduce_in_place_n(to_address(hybrid_weight.base()), hybrid_weight.num_elements(),
                                           std::plus<>());
     }
     AFQMCTimers[assemble_X_timer].get().stop();
@@ -143,7 +143,7 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
           auto&& V(*wset.getFields(bp_step));
           if (nsteps == 1)
           {
-            copy_n(X[cv0].origin(), nwalk * (cvN - cv0), V[cv0].origin());
+            copy_n(X[cv0].base(), nwalk * (cvN - cv0), V[cv0].base());
             ma::scal(SPComplexType(sqrtdt), V.sliced(cv0, cvN));
           }
           else
@@ -162,11 +162,11 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     AFQMCTimers[vHS_timer].get().start();
 #if defined(MIXED_PRECISION)
     // is this clever or dirsty? seems to work well and saves memory!
-    SPCMatrix_ref vsp(sp_pointer(make_device_ptr(vHS.origin())), vhs_ext);
+    SPCMatrix_ref vsp(sp_pointer(make_device_ptr(vHS.base())), vhs_ext);
     wfn.vHS(X, vsp, sqrtdt);
     TG.local_barrier();
     if (TG.TG_local().root())
-      inplace_cast<SPComplexType, ComplexType>(vsp.origin(), vsp.num_elements());
+      inplace_cast<SPComplexType, ComplexType>(vsp.base(), vsp.num_elements());
     TG.local_barrier();
 #else
     wfn.vHS(X, vHS, sqrtdt);
@@ -175,7 +175,7 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     //std::cout<<" Pg vHS: " <<TG.Global().rank() <<" " <<ma::sum(vHS) <<"\n" <<std::endl;
   }
 
-  C3Tensor_ref vHS3D(make_device_ptr(vHS.origin()), vhs3d_ext);
+  C3Tensor_ref vHS3D(make_device_ptr(vHS.base()), vhs3d_ext);
 
   int nx = 1;
   if (walker_type == COLLINEAR)
@@ -278,7 +278,7 @@ void AFQMCBasePropagator::BackPropagate(int nbpsteps, int nStabalize, WlkSet& ws
   StaticMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
   StaticSPMatrix X({long(globalnCV), long(nwalk)},
                    buffer_manager.get_generator().template get_allocator<SPComplexType>());
-  C3Tensor_ref vHS3D(make_device_ptr(vHS.origin()), vhs3d_ext);
+  C3Tensor_ref vHS3D(make_device_ptr(vHS.base()), vhs3d_ext);
 
   using std::get;
 
@@ -306,7 +306,7 @@ void AFQMCBasePropagator::BackPropagate(int nbpsteps, int nStabalize, WlkSet& ws
 
   assert(get<0>(detR.sizes()) == nwalk);
   assert(get<1>(detR.sizes()) == nrefs * nx);
-  std::fill_n(detR.origin(), detR.num_elements(), ComplexType(1.0, 0.0));
+  std::fill_n(detR.base(), detR.num_elements(), ComplexType(1.0, 0.0));
 
   // from now on, individual work on each walker/step
   const int ntasks_per_core     = int(nx * nwalk) / TG.getNCoresPerTG();
@@ -326,28 +326,28 @@ void AFQMCBasePropagator::BackPropagate(int nbpsteps, int nStabalize, WlkSet& ws
   // 0. copy SlaterMatrix to SlaterMatrixAux
   for (int i = 0; i < nwalk; i++)
   {
-    copy_n((*wset[i].SlaterMatrix(Alpha)).origin() + r0, rN - r0, (*wset[i].SlaterMatrixAux(Alpha)).origin() + r0);
+    copy_n((*wset[i].SlaterMatrix(Alpha)).base() + r0, rN - r0, (*wset[i].SlaterMatrixAux(Alpha)).base() + r0);
     // optimize for the single reference case
     if (nrefs == 1)
-      copy_n(Refs[i][0].origin() + r0, rN - r0, make_device_ptr((*wset[i].SlaterMatrix(Alpha)).origin()) + r0);
+      copy_n(Refs[i][0].base() + r0, rN - r0, make_device_ptr((*wset[i].SlaterMatrix(Alpha)).base()) + r0);
   }
   TG.TG_local().barrier();
 
   for (int ni = nbpsteps - 1; ni >= 0; --ni)
   {
     // 1. Get X(nCV,nwalk) from wset
-    copy_n(Fields[ni][cv0].origin(), nwalk * (cvN - cv0), make_device_ptr(X[cv0].origin()));
+    copy_n(Fields[ni][cv0].base(), nwalk * (cvN - cv0), make_device_ptr(X[cv0].base()));
     TG.TG_local().barrier();
 
     // 2. Calculate vHS(M*M,nwalk)/vHS(nwalk,M*M)
     //  X has been scaled by sqrtdt to avoid needing it here
 #if defined(MIXED_PRECISION)
     // is this clever or dirsty? seems to work well and saves memory!
-    SPCMatrix_ref vsp(sp_pointer(make_device_ptr(vHS.origin())), vhs_ext);
+    SPCMatrix_ref vsp(sp_pointer(make_device_ptr(vHS.base())), vhs_ext);
     wfn.vHS(X, vsp);
     TG.local_barrier();
     if (TG.TG_local().root())
-      inplace_cast<SPComplexType, ComplexType>(vsp.origin(), vsp.num_elements());
+      inplace_cast<SPComplexType, ComplexType>(vsp.base(), vsp.num_elements());
     TG.local_barrier();
 #else
     wfn.vHS(X, vHS);
@@ -359,7 +359,7 @@ void AFQMCBasePropagator::BackPropagate(int nbpsteps, int nStabalize, WlkSet& ws
       // 3. copy reference to SlaterMatrix
       if (nrefs > 1)
         for (int i = 0; i < nwalk; i++)
-          copy_n(Refs[i][nr].origin() + r0, rN - r0, make_device_ptr((*wset[i].SlaterMatrix(Alpha)).origin()) + r0);
+          copy_n(Refs[i][nr].base() + r0, rN - r0, make_device_ptr((*wset[i].SlaterMatrix(Alpha)).base()) + r0);
       TG.TG_local().barrier();
 
       // 4. Propagate walkers
@@ -376,16 +376,16 @@ void AFQMCBasePropagator::BackPropagate(int nbpsteps, int nStabalize, WlkSet& ws
         if (nbatched_qr != 0)
         {
           if (walker_type != COLLINEAR)
-            Orthogonalize_batched(wset, detR(detR.extension(0), {nr, nr + 1}));
+            Orthogonalize_batched(wset, detR(get<0>(detR.extents()), {nr, nr + 1}));
           else
-            Orthogonalize_batched(wset, detR(detR.extension(0), {2 * nr, 2 * nr + 2}));
+            Orthogonalize_batched(wset, detR(get<0>(detR.extents()), {2 * nr, 2 * nr + 2}));
         }
         else
         {
           if (walker_type != COLLINEAR)
-            Orthogonalize_shared(wset, detR(detR.extension(0), {nr, nr + 1}));
+            Orthogonalize_shared(wset, detR(get<0>(detR.extents()), {nr, nr + 1}));
           else
-            Orthogonalize_shared(wset, detR(detR.extension(0), {2 * nr, 2 * nr + 2}));
+            Orthogonalize_shared(wset, detR(get<0>(detR.extents()), {2 * nr, 2 * nr + 2}));
         }
       }
       TG.TG_local().barrier();
@@ -393,7 +393,7 @@ void AFQMCBasePropagator::BackPropagate(int nbpsteps, int nStabalize, WlkSet& ws
       // 5. copy reference to back
       if (nrefs > 1)
         for (int i = 0; i < nwalk; i++)
-          copy_n(make_device_ptr((*wset[i].SlaterMatrix(Alpha)).origin()) + r0, rN - r0, Refs[i][nr].origin() + r0);
+          copy_n(make_device_ptr((*wset[i].SlaterMatrix(Alpha)).base()) + r0, rN - r0, Refs[i][nr].base() + r0);
       TG.TG_local().barrier();
     }
   }
@@ -402,8 +402,8 @@ void AFQMCBasePropagator::BackPropagate(int nbpsteps, int nStabalize, WlkSet& ws
   for (int i = 0; i < nwalk; i++)
   {
     if (nrefs == 1)
-      copy_n((*wset[i].SlaterMatrix(Alpha)).origin() + r0, rN - r0, Refs[i][0].origin() + r0);
-    copy_n((*wset[i].SlaterMatrixAux(Alpha)).origin() + r0, rN - r0, (*wset[i].SlaterMatrix(Alpha)).origin() + r0);
+      copy_n((*wset[i].SlaterMatrix(Alpha)).base() + r0, rN - r0, Refs[i][0].base() + r0);
+    copy_n((*wset[i].SlaterMatrixAux(Alpha)).base() + r0, rN - r0, (*wset[i].SlaterMatrix(Alpha)).base() + r0);
   }
   TG.TG_local().barrier();
 }
@@ -485,7 +485,7 @@ void AFQMCBasePropagator::apply_propagators(char TA,
         int nt = ni * nwalk + tk / 2;
         if (oldw != tk / 2)
         {
-          local_vHS = vHS3D(local_vHS.extension(0), local_vHS.extension(1), nt);
+          local_vHS = vHS3D(get<0>(local_vHS.extents()), get<1>(local_vHS.extents()), nt);
           oldw      = tk / 2;
         }
         if (tk % 2 == 0)
@@ -497,7 +497,7 @@ void AFQMCBasePropagator::apply_propagators(char TA,
       {
         int tk    = (ntasks_total_serial + last_task_index);
         int nt    = ni * nwalk + tk / 2;
-        local_vHS = vHS3D(local_vHS.extension(0), local_vHS.extension(1), nt);
+        local_vHS = vHS3D(get<0>(local_vHS.extents()), get<1>(local_vHS.extents()), nt);
         if (tk % 2 == 0)
           SDetOp->Propagate(*wset[tk / 2].SlaterMatrix(Alpha), P1[0], local_vHS, local_group_comm, order, TA);
         else
@@ -510,7 +510,7 @@ void AFQMCBasePropagator::apply_propagators(char TA,
       for (int tk = tk0; tk < tkN; ++tk)
       {
         int nt    = ni * nwalk + tk;
-        local_vHS = vHS3D(local_vHS.extension(0), local_vHS.extension(1), nt);
+        local_vHS = vHS3D(get<0>(local_vHS.extents()), get<1>(local_vHS.extents()), nt);
         //std::cout<<" pp: " <<tk <<" " <<ma::sum(local_vHS) <<"\n" <<std::endl;
         SDetOp->Propagate(*wset[tk].SlaterMatrix(Alpha), P1[0], local_vHS, order, TA, noncol);
       }
@@ -518,7 +518,7 @@ void AFQMCBasePropagator::apply_propagators(char TA,
       {
         int iw    = ntasks_total_serial + last_task_index;
         int nt    = ni * nwalk + iw;
-        local_vHS = vHS3D(local_vHS.extension(0), local_vHS.extension(1), nt);
+        local_vHS = vHS3D(get<0>(local_vHS.extents()), get<1>(local_vHS.extents()), nt);
         SDetOp->Propagate(*wset[iw].SlaterMatrix(Alpha), P1[0], local_vHS, local_group_comm, order, TA, noncol);
       }
     }
@@ -572,13 +572,13 @@ void AFQMCBasePropagator::apply_propagators_batched(char TA, WSet& wset, int ni,
       local_vHS = CMatrix({nbatch, NMO * NMO});
     // vHS3D[M][M][nstep*nwalk]: need temporary buffer in this case
     int N2 = get<0>(vHS3D.sizes()) * get<1>(vHS3D.sizes());
-    CMatrix_ref vHS2D(vHS3D.origin(), {N2, get<2>(vHS3D.sizes())});
-    C3Tensor_ref local3D(local_vHS.origin(), {nbatch, NMO, NMO});
+    CMatrix_ref vHS2D(vHS3D.base(), {N2, get<2>(vHS3D.sizes())});
+    C3Tensor_ref local3D(local_vHS.base(), {nbatch, NMO, NMO});
     int nt = ni * nwalk;
     for (int iw = 0; iw < nwalk; iw += nbatch, nt += nbatch)
     {
       int nb = std::min(nbatch, nwalk - iw);
-      ma::transpose(vHS2D(vHS2D.extension(0), {nt, nt + nb}), local_vHS.sliced(0, nb));
+      ma::transpose(vHS2D(get<0>(vHS2D.extents()), {nt, nt + nb}), local_vHS.sliced(0, nb));
       Ai.clear();
       for (int ni = 0; ni < nb; ni++)
         Ai.emplace_back(wset[iw + ni].SlaterMatrix(Alpha));
@@ -663,9 +663,9 @@ void AFQMCBasePropagator::Orthogonalize_batched(WlkSet& wset, CMat&& detR)
       Ai.clear();
       for (int ni = 0; ni < nb; ni++)
         Ai.emplace_back(wset[iw + ni].SlaterMatrix(Alpha));
-      SDetOp->BatchedOrthogonalize(Ai, LogOverlapFactor, local_vHS.origin());
+      SDetOp->BatchedOrthogonalize(Ai, LogOverlapFactor, local_vHS.base());
       // GPU trickery,to make sure detR_ is in CPU, since detR is in CPU
-      copy_n(local_vHS.origin(), nb, detR_.origin());
+      copy_n(local_vHS.base(), nb, detR_.base());
       for (int ni = 0; ni < nb; ni++)
         detR[iw + ni][0] *= detR_[ni];
     }
@@ -679,16 +679,16 @@ void AFQMCBasePropagator::Orthogonalize_batched(WlkSet& wset, CMat&& detR)
       Ai.clear();
       for (int ni = 0; ni < nb; ni++)
         Ai.emplace_back(wset[iw + ni].SlaterMatrix(Alpha));
-      SDetOp->BatchedOrthogonalize(Ai, LogOverlapFactor, local_vHS.origin());
-      copy_n(local_vHS.origin(), nb, detR_.origin());
+      SDetOp->BatchedOrthogonalize(Ai, LogOverlapFactor, local_vHS.base());
+      copy_n(local_vHS.base(), nb, detR_.base());
       for (int ni = 0; ni < nb; ni++)
         detR[iw + ni][0] *= detR_[ni];
       // Beta
       Ai.clear();
       for (int ni = 0; ni < nb; ni++)
         Ai.emplace_back(wset[iw + ni].SlaterMatrix(Beta));
-      SDetOp->BatchedOrthogonalize(Ai, LogOverlapFactor, local_vHS.origin());
-      copy_n(local_vHS.origin(), nb, detR_.origin());
+      SDetOp->BatchedOrthogonalize(Ai, LogOverlapFactor, local_vHS.base());
+      copy_n(local_vHS.base(), nb, detR_.base());
       for (int ni = 0; ni < nb; ni++)
         detR[iw + ni][1] *= detR_[ni];
     }
@@ -724,29 +724,29 @@ void AFQMCBasePropagator::assemble_X(size_t nsteps,
   {
     int i0, iN;
     std::tie(i0, iN) = FairDivideBoundary(TG.TG_local().rank(), int(X.num_elements()), TG.TG_local().size());
-    sampleGaussianFields_n(make_device_ptr(X.origin()) + i0, iN - i0, rng);
+    sampleGaussianFields_n(make_device_ptr(X.base()) + i0, iN - i0, rng);
   }
 
   // construct X
-  fill_n(make_device_ptr(HWs.origin()), HWs.num_elements(), ComplexType(0));
-  fill_n(make_device_ptr(MF.origin()), MF.num_elements(), ComplexType(0));
+  fill_n(make_device_ptr(HWs.base()), HWs.num_elements(), ComplexType(0));
+  fill_n(make_device_ptr(MF.base()), MF.num_elements(), ComplexType(0));
 
 // leaving compiler switch until I decide how to do this better
 // basically hide this decision somewhere based on the value of pointer!!!
 // TODO: Move this
 #if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
-  kernels::construct_X(nCV, nsteps, nwalk, free_projection, sqrtdt, vbias_bound, to_address(vMF.origin()),
-                       to_address(vbias.origin()), to_address(HWs.origin()), to_address(MF.origin()),
-                       to_address(X.origin()));
+  kernels::construct_X(nCV, nsteps, nwalk, free_projection, sqrtdt, vbias_bound, to_address(vMF.base()),
+                       to_address(vbias.base()), to_address(HWs.base()), to_address(MF.base()),
+                       to_address(X.base()));
 #else
-  boost::multi::array_ref<XType, 3> X3D(to_address(X.origin()), {long(X.size()), long(nsteps), long(nwalk)});
+  boost::multi::array_ref<XType, 3> X3D(to_address(X.base()), {long(X.size()), long(nsteps), long(nwalk)});
   int m0, mN;
   std::tie(m0, mN) = FairDivideBoundary(TG.TG_local().rank(), nCV, TG.TG_local().size());
   TG.local_barrier();
   for (int m = m0; m < mN; ++m)
   {
     auto X_m = X3D[m];
-    auto vb_ = to_address(vbias[m].origin());
+    auto vb_ = to_address(vbias[m].base());
     auto vmf_t = sqrtdt * apply_bound_vbias(vMF[m], 1.0);
     auto vmf_ = sqrtdt * vMF[m];
     // apply bounds to vbias
@@ -754,9 +754,9 @@ void AFQMCBasePropagator::assemble_X(size_t nsteps,
       vb_[iw] = apply_bound_vbias(vb_[iw], sqrtdt);
     for (int ni = 0; ni < nsteps; ni++)
     {
-      auto X_ = X3D[m][ni].origin();
-      auto hws_ = to_address(HWs[ni].origin());
-      auto mf_ = to_address(MF[ni].origin());
+      auto X_ = X3D[m][ni].base();
+      auto hws_ = to_address(HWs[ni].base());
+      auto mf_ = to_address(MF[ni].base());
       for (int iw = 0; iw < nwalk; iw++)
       {
         // No force bias term when doing free projection.

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagator.icc
@@ -85,7 +85,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
   AFQMCTimers[setup_timer].get().stop();
 
   StaticMatrix vHS_buff(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
-  SPCMatrix_ref vHS(sp_pointer(make_device_ptr(vHS_buff.origin())), vhs_ext);
+  SPCMatrix_ref vHS(sp_pointer(make_device_ptr(vHS_buff.base())), vhs_ext);
   {
     StaticSPMatrix G(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
@@ -98,7 +98,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
       StaticMatrix Gc(G_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
       wfn.MixedDensityMatrix_for_vbias(wset, Gc);
       TG.local_barrier();
-      copy_n_cast(make_device_ptr(Gc.origin()) + Gak0, GakN - Gak0, make_device_ptr(G.origin()) + Gak0);
+      copy_n_cast(make_device_ptr(Gc.base()) + Gak0, GakN - Gak0, make_device_ptr(G.base()) + Gak0);
     }
     TG.local_barrier();
 #else
@@ -129,7 +129,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
     {
       int i0, iN;
       std::tie(i0, iN) = FairDivideBoundary(TG.TG_local().rank(), int(RNG.num_elements()), TG.TG_local().size());
-      sampleGaussianFields_n(make_device_ptr(RNG.origin()) + i0, iN - i0, rng);
+      sampleGaussianFields_n(make_device_ptr(RNG.base()) + i0, iN - i0, rng);
     }
 
     for (int k = 0; k < nnodes; ++k)
@@ -141,13 +141,13 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
         int i0, iN, Gak0, GakN;
         std::tie(i0, iN)     = FairDivideBoundary(TG.TG_local().rank(), int(RNG.num_elements()), TG.TG_local().size());
         std::tie(Gak0, GakN) = FairDivideBoundary(TG.TG_local().rank(), int(G.num_elements()), TG.TG_local().size());
-        copy_n(make_device_ptr(RNG.origin()) + i0, iN - i0, make_device_ptr(X.origin()) + i0);
+        copy_n(make_device_ptr(RNG.base()) + i0, iN - i0, make_device_ptr(X.base()) + i0);
         // can I do this in a way I don't need the barrier???
-        copy_n(make_device_ptr(G.origin()) + Gak0, GakN - Gak0, make_device_ptr(Gwork.origin()) + Gak0);
+        copy_n(make_device_ptr(G.base()) + Gak0, GakN - Gak0, make_device_ptr(Gwork.base()) + Gak0);
         TG.local_barrier();
       }
-      core_comm.broadcast_n(to_address(Gwork.origin()) + G0, GN - G0, k);
-      core_comm.broadcast_n(to_address(X.origin()) + X0, XN - X0, k);
+      core_comm.broadcast_n(to_address(Gwork.base()) + G0, GN - G0, k);
+      core_comm.broadcast_n(to_address(X.base()) + X0, XN - X0, k);
       TG.local_barrier();
       AFQMCTimers[vHS_comm_overhead_timer].get().stop();
 
@@ -159,7 +159,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
 
       // all_reduce vbias
       AFQMCTimers[vHS_comm_overhead_timer].get().start();
-      core_comm.all_reduce_in_place_n(to_address(vbias.origin()) + vb0, vbN - vb0, std::plus<>());
+      core_comm.all_reduce_in_place_n(to_address(vbias.base()) + vb0, vbN - vb0, std::plus<>());
       TG.local_barrier();
       AFQMCTimers[vHS_comm_overhead_timer].get().stop();
 
@@ -167,10 +167,10 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
       assemble_X(nsteps, nwalk, sqrtdt, X, vbias, MFfactor[1], hybrid_weight[1], false);
       if (k == node_number)
       {
-        TG.TG_local().all_reduce_n(to_address(MFfactor[1].origin()), MFfactor[1].num_elements(),
-                                   to_address(MFfactor[0].origin()), std::plus<>());
-        TG.TG_local().all_reduce_n(to_address(hybrid_weight[1].origin()), hybrid_weight[1].num_elements(),
-                                   to_address(hybrid_weight[0].origin()), std::plus<>());
+        TG.TG_local().all_reduce_n(to_address(MFfactor[1].base()), MFfactor[1].num_elements(),
+                                   to_address(MFfactor[0].base()), std::plus<>());
+        TG.TG_local().all_reduce_n(to_address(hybrid_weight[1].base()), hybrid_weight[1].num_elements(),
+                                   to_address(hybrid_weight[0].base()), std::plus<>());
       }
 
       // 4c. Calculate vHS(M*M,nsteps,nwalk)
@@ -180,7 +180,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
       AFQMCTimers[vHS_timer].get().stop();
 
       AFQMCTimers[vHS_comm_overhead_timer].get().start();
-      core_comm.reduce_n(to_address(vHSwork.origin()) + vak0, vakN - vak0, to_address(vHS.origin()) + vak0,
+      core_comm.reduce_n(to_address(vHSwork.base()) + vak0, vakN - vak0, to_address(vHS.base()) + vak0,
                          std::plus<>(), k);
       TG.local_barrier();
       AFQMCTimers[vHS_comm_overhead_timer].get().stop();
@@ -192,10 +192,10 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
   TG.local_barrier();
   using qmcplusplus::afqmc::inplace_cast;
   if (TG.TG_local().root())
-    inplace_cast<SPComplexType, ComplexType>(vHS.origin(), vHS.num_elements());
+    inplace_cast<SPComplexType, ComplexType>(vHS.base(), vHS.num_elements());
   TG.local_barrier();
 #endif
-  C3Tensor_ref vHS3D(make_device_ptr(vHS_buff.origin()), vhs3d_ext);
+  C3Tensor_ref vHS3D(make_device_ptr(vHS_buff.base()), vhs3d_ext);
 
   // From here on is similar to Shared
   int nx = 1;

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
@@ -89,7 +89,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
   TG.local_barrier();
 
   StaticMatrix vrecv_buff(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
-  SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.origin())), vhs_ext);
+  SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.base())), vhs_ext);
 
   { // using scope to control lifetime of StaticArrays, avoiding unnecessary buffer space
 
@@ -107,7 +107,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       std::tie(Gak0, GakN) = FairDivideBoundary(TG.getLocalTGRank(), int(Gwork.num_elements()), TG.getNCoresPerTG());
       StaticMatrix Gc(G_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
       wfn.MixedDensityMatrix_for_vbias(wset, Gc);
-      copy_n_cast(make_device_ptr(Gc.origin()) + Gak0, GakN - Gak0, make_device_ptr(Gwork.origin()) + Gak0);
+      copy_n_cast(make_device_ptr(Gc.base()) + Gak0, GakN - Gak0, make_device_ptr(Gwork.base()) + Gak0);
     }
     TG.local_barrier();
 #else
@@ -123,7 +123,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
                      buffer_manager.get_generator().template get_allocator<SPComplexType>());
 #if defined(MIXED_PRECISION)
     // in MIXED_PRECISION, use second half of vrecv_buff for vsend
-    SPCMatrix_ref vsend(sp_pointer(make_device_ptr(vrecv_buff.origin())) + vrecv_buff.num_elements(), vhs_ext);
+    SPCMatrix_ref vsend(sp_pointer(make_device_ptr(vrecv_buff.base())) + vrecv_buff.num_elements(), vhs_ext);
 #else
     StaticSPMatrix vsend(vhs_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 #endif
@@ -134,16 +134,16 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     int Gak0, GakN;
     std::tie(Gak0, GakN) = FairDivideBoundary(TG.getLocalTGRank(), int(Gwork.num_elements()), TG.getNCoresPerTG());
     std::tie(vak0, vakN) = FairDivideBoundary(TG.getLocalTGRank(), int(vHS.num_elements()), TG.getNCoresPerTG());
-    MPI_Send_init(to_address(Gwork.origin()) + Gak0, (GakN - Gak0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(),
+    MPI_Send_init(to_address(Gwork.base()) + Gak0, (GakN - Gak0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(),
                   3456, TG.TG().get(), &req_Gsend);
-    MPI_Recv_init(to_address(Grecv.origin()) + Gak0, (GakN - Gak0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(),
+    MPI_Recv_init(to_address(Grecv.base()) + Gak0, (GakN - Gak0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(),
                   3456, TG.TG().get(), &req_Grecv);
-    MPI_Send_init(to_address(vsend.origin()) + vak0, (vakN - vak0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(),
+    MPI_Send_init(to_address(vsend.base()) + vak0, (vakN - vak0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(),
                   5678, TG.TG().get(), &req_vsend);
-    MPI_Recv_init(to_address(vrecv.origin()) + vak0, (vakN - vak0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(),
+    MPI_Recv_init(to_address(vrecv.base()) + vak0, (vakN - vak0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(),
                   5678, TG.TG().get(), &req_vrecv);
 
-    fill_n(make_device_ptr(vsend.origin()) + vak0, (vakN - vak0), zero);
+    fill_n(make_device_ptr(vsend.base()) + vak0, (vakN - vak0), zero);
 
     // are we back propagating?
     int bp_step = wset.getBPPos(), bp_max = wset.NumBackProp();
@@ -156,11 +156,11 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       {
         bpX     = mpi3SPCVector(iextensions<1u>(m_), shared_allocator<SPComplexType>{TG.TG_local()});
         if (TG.TG_local().root())
-          fill_n(bpX.origin(), bpX.num_elements(), SPComplexType(0.0));
+          fill_n(bpX.base(), bpX.num_elements(), SPComplexType(0.0));
       }
     }
-    stdSPCMatrix_ref Xsend(to_address(bpX.origin()), {long(globalnCV * xx), nwalk * nsteps});
-    stdSPCMatrix_ref Xrecv(Xsend.origin() + Xsend.num_elements(), {long(globalnCV * xx), nwalk * nsteps});
+    stdSPCMatrix_ref Xsend(to_address(bpX.base()), {long(globalnCV * xx), nwalk * nsteps});
+    stdSPCMatrix_ref Xrecv(Xsend.base() + Xsend.num_elements(), {long(globalnCV * xx), nwalk * nsteps});
     int Xg0, XgN;
     std::tie(Xg0, XgN) = FairDivideBoundary(TG.getLocalTGRank(), globalnCV * nwalk * nsteps, TG.getNCoresPerTG());
     int Xl0, XlN;
@@ -170,9 +170,9 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
 
     if (bp_step >= 0 && bp_step < bp_max)
     {
-      MPI_Send_init(Xsend.origin() + Xg0, (XgN - Xg0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(), 3456, TG.TG().get(),
+      MPI_Send_init(Xsend.base() + Xg0, (XgN - Xg0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(), 3456, TG.TG().get(),
                     &req_X2send);
-      MPI_Recv_init(Xrecv.origin() + Xg0, (XgN - Xg0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(), 3456, TG.TG().get(),
+      MPI_Recv_init(Xrecv.base() + Xg0, (XgN - Xg0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(), 3456, TG.TG().get(),
                     &req_X2recv);
     }
 
@@ -189,7 +189,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       {
         MPI_Wait(&req_Grecv, &st);
         MPI_Wait(&req_Gsend, &st); // need to wait for Gsend in order to overwrite Gwork
-        copy_n(make_device_ptr(Grecv.origin()) + Gak0, GakN - Gak0, make_device_ptr(Gwork.origin()) + Gak0);
+        copy_n(make_device_ptr(Grecv.base()) + Gak0, GakN - Gak0, make_device_ptr(Gwork.base()) + Gak0);
         TG.local_barrier();
       }
 
@@ -211,9 +211,9 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       AFQMCTimers[assemble_X_timer].get().start();
       int q = (node_number + k) % nnodes;
       assemble_X(nsteps, nwalk, sqrtdt, X, vbias, MFfactor, hybrid_weight);
-      copy_n(make_device_ptr(MFfactor.origin()), MFfactor.num_elements(), make_device_ptr(globalMFfactor[q].origin()));
-      copy_n(make_device_ptr(hybrid_weight.origin()), hybrid_weight.num_elements(),
-             make_device_ptr(globalhybrid_weight[q].origin()));
+      copy_n(make_device_ptr(MFfactor.base()), MFfactor.num_elements(), make_device_ptr(globalMFfactor[q].base()));
+      copy_n(make_device_ptr(hybrid_weight.base()), hybrid_weight.num_elements(),
+             make_device_ptr(globalhybrid_weight[q].base()));
       TG.local_barrier();
       AFQMCTimers[assemble_X_timer].get().stop();
       if (bp_step >= 0 && bp_step < bp_max)
@@ -223,11 +223,11 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
         {
           MPI_Wait(&req_X2recv, &st);
           MPI_Wait(&req_X2send, &st);
-          copy_n(Xrecv.origin() + Xg0, XgN - Xg0, Xsend.origin() + Xg0);
+          copy_n(Xrecv.base() + Xg0, XgN - Xg0, Xsend.base() + Xg0);
           TG.local_barrier();
         }
         // accumulate
-        copy_n(make_device_ptr(X[cv0].origin()), nwalk * nsteps * (cvN - cv0), Xsend[global_origin + cv0].origin());
+        copy_n(make_device_ptr(X[cv0].base()), nwalk * nsteps * (cvN - cv0), Xsend[global_origin + cv0].base());
         TG.local_barrier();
         // start X communication
         MPI_Start(&req_X2send);
@@ -246,11 +246,11 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       {
         MPI_Wait(&req_vrecv, &st);
         MPI_Wait(&req_vsend, &st);
-        copy_n(make_device_ptr(vrecv.origin()) + vak0, vakN - vak0, make_device_ptr(vsend.origin()) + vak0);
+        copy_n(make_device_ptr(vrecv.base()) + vak0, vakN - vak0, make_device_ptr(vsend.base()) + vak0);
       }
 
       // 6. add local contribution to vsend
-      axpy(vakN - vak0, one, make_device_ptr(vHS.origin()) + vak0, 1, make_device_ptr(vsend.origin()) + vak0, 1);
+      axpy(vakN - vak0, one, make_device_ptr(vHS.base()) + vak0, 1, make_device_ptr(vsend.base()) + vak0, 1);
 
       // 7. start v communication
       MPI_Start(&req_vsend);
@@ -286,7 +286,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
           auto&& V(*wset.getFields(bp_step));
           if (nsteps == 1)
           {
-            copy_n(Xrecv[cvg0].origin(), nwalk * (cvgN - cvg0), V[cvg0].origin());
+            copy_n(Xrecv[cvg0].base(), nwalk * (cvgN - cvg0), V[cvg0].base());
             ma::scal(SPComplexType(sqrtdt), V.sliced(cvg0, cvgN));
           }
           else
@@ -302,16 +302,16 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     // reduce MF and HWs
     if (TG.TG().size() > 1)
     {
-      TG.TG().all_reduce_in_place_n(to_address(globalMFfactor.origin()), globalMFfactor.num_elements(), std::plus<>());
-      TG.TG().all_reduce_in_place_n(to_address(globalhybrid_weight.origin()), globalhybrid_weight.num_elements(),
+      TG.TG().all_reduce_in_place_n(to_address(globalMFfactor.base()), globalMFfactor.num_elements(), std::plus<>());
+      TG.TG().all_reduce_in_place_n(to_address(globalhybrid_weight.base()), globalhybrid_weight.num_elements(),
                                     std::plus<>());
     }
 
     // copy from global to local array
-    copy_n(make_device_ptr(globalMFfactor[node_number].origin()), MFfactor.num_elements(),
-           make_device_ptr(MFfactor.origin()));
-    copy_n(make_device_ptr(globalhybrid_weight[node_number].origin()), hybrid_weight.num_elements(),
-           make_device_ptr(hybrid_weight.origin()));
+    copy_n(make_device_ptr(globalMFfactor[node_number].base()), MFfactor.num_elements(),
+           make_device_ptr(MFfactor.base()));
+    copy_n(make_device_ptr(globalhybrid_weight[node_number].base()), hybrid_weight.num_elements(),
+           make_device_ptr(hybrid_weight.base()));
 
     TG.local_barrier();
     AFQMCTimers[vHS_comm_overhead_timer].get().stop();
@@ -322,10 +322,10 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
   TG.local_barrier();
   using qmcplusplus::afqmc::inplace_cast;
   if (TG.TG_local().root())
-    inplace_cast<SPComplexType, ComplexType>(vrecv.origin(), vrecv.num_elements());
+    inplace_cast<SPComplexType, ComplexType>(vrecv.base(), vrecv.num_elements());
   TG.local_barrier();
 #endif
-  C3Tensor_ref vHS3D(make_device_ptr(vrecv_buff.origin()), vhs3d_ext);
+  C3Tensor_ref vHS3D(make_device_ptr(vrecv_buff.base()), vhs3d_ext);
 
   // From here on is similar to Shared
   int nx = 1;
@@ -459,8 +459,8 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
   TG.local_barrier();
 
   StaticMatrix vrecv_buff(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
-  C3Tensor_ref vHS3D(make_device_ptr(vrecv_buff.origin()), vhs3d_ext);
-  SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.origin())), vhs_ext);
+  C3Tensor_ref vHS3D(make_device_ptr(vrecv_buff.base()), vhs3d_ext);
+  SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.base())), vhs_ext);
 
   // scope controlling lifetime of temporary arrays
   {
@@ -479,7 +479,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     {
       StaticMatrix Gstore_(G_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
       wfn.MixedDensityMatrix_for_vbias(wset, Gstore_);
-      copy_n_cast(make_device_ptr(Gstore_.origin()) + Gak0, GakN - Gak0, make_device_ptr(Gstore.origin()) + Gak0);
+      copy_n_cast(make_device_ptr(Gstore_.base()) + Gak0, GakN - Gak0, make_device_ptr(Gstore.base()) + Gak0);
     }
 #else
     wfn.MixedDensityMatrix_for_vbias(wset, Gstore);
@@ -494,7 +494,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
                      buffer_manager.get_generator().template get_allocator<SPComplexType>());
 // reusing second half of vrecv buffer reinterpreted as a SPComplex Array
 #if defined(MIXED_PRECISION)
-    SPCMatrix_ref vHS(sp_pointer(make_device_ptr(vrecv_buff.origin())) + vrecv_buff.num_elements(), vhs_ext);
+    SPCMatrix_ref vHS(sp_pointer(make_device_ptr(vrecv_buff.base())) + vrecv_buff.num_elements(), vhs_ext);
 #else
     StaticMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
 #endif
@@ -514,10 +514,10 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
       {
         bpX     = mpi3SPCVector(iextensions<1u>(m_), shared_allocator<SPComplexType>{TG.TG_local()});
         if (TG.TG_local().root())
-          fill_n(bpX.origin(), bpX.num_elements(), SPComplexType(0.0));
+          fill_n(bpX.base(), bpX.num_elements(), SPComplexType(0.0));
       }
     }
-    stdSPCMatrix_ref Xrecv(to_address(bpX.origin()), {long(globalnCV * xx), nwalk * nsteps});
+    stdSPCMatrix_ref Xrecv(to_address(bpX.base()), {long(globalnCV * xx), nwalk * nsteps});
     int Xg0, XgN;
     std::tie(Xg0, XgN) = FairDivideBoundary(TG.getLocalTGRank(), globalnCV * nwalk * nsteps, TG.getNCoresPerTG());
     int Xl0, XlN;
@@ -552,22 +552,22 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
       // 2. bcast G
       AFQMCTimers[vHS_comm_overhead_timer].get().start();
       if (k == node_number)
-        copy_n(make_device_ptr(Gstore.origin()) + Gak0, GakN - Gak0, make_device_ptr(Gwork.origin()) + Gak0);
+        copy_n(make_device_ptr(Gstore.base()) + Gak0, GakN - Gak0, make_device_ptr(Gwork.base()) + Gak0);
 #ifdef BUILD_AFQMC_WITH_NCCL
 #ifdef ENABLE_CUDA
 #if defined(MIXED_PRECISION)
       NCCLCHECK(
-          ncclBcast(to_address(Gwork.origin() + Gak0), 2 * (GakN - Gak0), ncclFloat, k, TG.ncclTG(), TG.ncclStream()));
+          ncclBcast(to_address(Gwork.base() + Gak0), 2 * (GakN - Gak0), ncclFloat, k, TG.ncclTG(), TG.ncclStream()));
 #else
       NCCLCHECK(
-          ncclBcast(to_address(Gwork.origin() + Gak0), 2 * (GakN - Gak0), ncclDouble, k, TG.ncclTG(), TG.ncclStream()));
+          ncclBcast(to_address(Gwork.base() + Gak0), 2 * (GakN - Gak0), ncclDouble, k, TG.ncclTG(), TG.ncclStream()));
 #endif
       qmc_cuda::cuda_check(cudaStreamSynchronize(TG.ncclStream()), "cudaStreamSynchronize(s)");
 #else
 #error "BUILD_AFQMC_WITH_NCCL only with ENABLE_CUDA"
 #endif
 #else
-      TG.TG_Cores().broadcast_n(to_address(Gwork.origin()) + Gak0, GakN - Gak0, k);
+      TG.TG_Cores().broadcast_n(to_address(Gwork.base()) + Gak0, GakN - Gak0, k);
 #endif
       TG.local_barrier();
       AFQMCTimers[vHS_comm_overhead_timer].get().stop();
@@ -581,20 +581,20 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
       // 3b. Assemble X(nCV,nsteps,nwalk)
       AFQMCTimers[assemble_X_timer].get().start();
       assemble_X(nsteps, nwalk, sqrtdt, X, vbias, MFfactor, hybrid_weight);
-      copy_n(make_device_ptr(MFfactor.origin()), MFfactor.num_elements(), make_device_ptr(globalMFfactor[k].origin()));
-      copy_n(make_device_ptr(hybrid_weight.origin()), hybrid_weight.num_elements(),
-             make_device_ptr(globalhybrid_weight[k].origin()));
+      copy_n(make_device_ptr(MFfactor.base()), MFfactor.num_elements(), make_device_ptr(globalMFfactor[k].base()));
+      copy_n(make_device_ptr(hybrid_weight.base()), hybrid_weight.num_elements(),
+             make_device_ptr(globalhybrid_weight[k].base()));
       TG.local_barrier();
       AFQMCTimers[assemble_X_timer].get().stop();
       if (bp_step >= 0 && bp_step < bp_max)
       {
         APP_ABORT("Finish");
         // accumulate
-        //copy_n(X[cv0].origin(),nwalk*nsteps*(cvN-cv0),Xsend[global_origin+cv0].origin());
+        //copy_n(X[cv0].base(),nwalk*nsteps*(cvN-cv0),Xsend[global_origin+cv0].base());
         // how do I know if these change???
         // possible if 2 execute blocks use different ncores
         // maybe store last ncores and change if this number changes!!!
-        TG.TG().gatherv_n(to_address(X[cv0].origin()), nwalk * nsteps * (cvN - cv0), to_address(Xrecv.origin()),
+        TG.TG().gatherv_n(to_address(X[cv0].base()), nwalk * nsteps * (cvN - cv0), to_address(Xrecv.base()),
                           bpx_counts.begin(), bpx_displ.begin(), k * ncores);
         TG.local_barrier();
       }
@@ -610,10 +610,10 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
 #ifdef BUILD_AFQMC_WITH_NCCL
 #ifdef ENABLE_CUDA
 #if defined(MIXED_PRECISION)
-      NCCLCHECK(ncclReduce((const void*)to_address(vHS.origin() + vak0), (void*)to_address(vrecv.origin() + vak0),
+      NCCLCHECK(ncclReduce((const void*)to_address(vHS.base() + vak0), (void*)to_address(vrecv.base() + vak0),
                            2 * (vakN - vak0), ncclFloat, ncclSum, k, TG.ncclTG(), TG.ncclStream()));
 #else
-      NCCLCHECK(ncclReduce((const void*)to_address(vHS.origin() + vak0), (void*)to_address(vrecv.origin() + vak0),
+      NCCLCHECK(ncclReduce((const void*)to_address(vHS.base() + vak0), (void*)to_address(vrecv.base() + vak0),
                            2 * (vakN - vak0), ncclDouble, ncclSum, k, TG.ncclTG(), TG.ncclStream()));
 #endif
       qmc_cuda::cuda_check(cudaStreamSynchronize(TG.ncclStream()), "cudaStreamSynchronize(s)");
@@ -621,7 +621,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
 #error "BUILD_AFQMC_WITH_NCCL only with ENABLE_CUDA"
 #endif
 #else
-      TG.TG_Cores().reduce_n(to_address(vHS.origin()) + vak0, vakN - vak0, to_address(vrecv.origin()) + vak0,
+      TG.TG_Cores().reduce_n(to_address(vHS.base()) + vak0, vakN - vak0, to_address(vrecv.base()) + vak0,
                              std::plus<>(), k);
 #endif
 
@@ -644,7 +644,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
           auto&& V(*wset.getFields(bp_step));
           if (nsteps == 1)
           {
-            copy_n(Xrecv[cvg0].origin(), nwalk * (cvgN - cvg0), V[cvg0].origin());
+            copy_n(Xrecv[cvg0].base(), nwalk * (cvgN - cvg0), V[cvg0].base());
             ma::scal(sqrtdt, V.sliced(cvg0, cvgN));
           }
           else
@@ -662,29 +662,29 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     {
 #ifdef BUILD_AFQMC_WITH_NCCL
 #ifdef ENABLE_CUDA
-      NCCLCHECK(ncclAllReduce((const void*)to_address(globalMFfactor.origin()),
-                              (void*)to_address(globalMFfactor.origin()), 2 * globalMFfactor.num_elements(), ncclDouble,
+      NCCLCHECK(ncclAllReduce((const void*)to_address(globalMFfactor.base()),
+                              (void*)to_address(globalMFfactor.base()), 2 * globalMFfactor.num_elements(), ncclDouble,
                               ncclSum, TG.ncclTG(), TG.ncclStream()));
-      NCCLCHECK(ncclAllReduce((const void*)to_address(globalhybrid_weight.origin()),
-                              (void*)to_address(globalhybrid_weight.origin()), 2 * globalhybrid_weight.num_elements(),
+      NCCLCHECK(ncclAllReduce((const void*)to_address(globalhybrid_weight.base()),
+                              (void*)to_address(globalhybrid_weight.base()), 2 * globalhybrid_weight.num_elements(),
                               ncclDouble, ncclSum, TG.ncclTG(), TG.ncclStream()));
       qmc_cuda::cuda_check(cudaStreamSynchronize(TG.ncclStream()), "cudaStreamSynchronize(s)");
 #else
 #error "BUILD_AFQMC_WITH_NCCL only with ENABLE_CUDA"
 #endif
 #else
-      TG.TG().all_reduce_in_place_n(to_address(globalMFfactor.origin()), globalMFfactor.num_elements(), std::plus<>());
-      TG.TG().all_reduce_in_place_n(to_address(globalhybrid_weight.origin()), globalhybrid_weight.num_elements(),
+      TG.TG().all_reduce_in_place_n(to_address(globalMFfactor.base()), globalMFfactor.num_elements(), std::plus<>());
+      TG.TG().all_reduce_in_place_n(to_address(globalhybrid_weight.base()), globalhybrid_weight.num_elements(),
                                     std::plus<>());
 #endif
     }
     TG.local_barrier();
 
     // copy from global to local array
-    copy_n(make_device_ptr(globalMFfactor[node_number].origin()), MFfactor.num_elements(),
-           make_device_ptr(MFfactor.origin()));
-    copy_n(make_device_ptr(globalhybrid_weight[node_number].origin()), hybrid_weight.num_elements(),
-           make_device_ptr(hybrid_weight.origin()));
+    copy_n(make_device_ptr(globalMFfactor[node_number].base()), MFfactor.num_elements(),
+           make_device_ptr(MFfactor.base()));
+    copy_n(make_device_ptr(globalhybrid_weight[node_number].base()), hybrid_weight.num_elements(),
+           make_device_ptr(hybrid_weight.base()));
 
     AFQMCTimers[vHS_comm_overhead_timer].get().stop();
   } // scope controlling lifetime of temporary arrays
@@ -693,7 +693,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
   TG.local_barrier();
   using qmcplusplus::afqmc::inplace_cast;
   if (TG.TG_local().root())
-    inplace_cast<SPComplexType, ComplexType>(make_device_ptr(vrecv.origin()), vrecv.num_elements());
+    inplace_cast<SPComplexType, ComplexType>(make_device_ptr(vrecv.base()), vrecv.num_elements());
   TG.local_barrier();
 #endif
 
@@ -809,9 +809,9 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
   StaticSPMatrix Xrecv({long(globalnCV), long(nwalk)},
                        buffer_manager.get_generator().template get_allocator<SPComplexType>());
   StaticMatrix vrecv_buff(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
-  SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.origin())), vhs_ext);
+  SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.base())), vhs_ext);
 #if defined(MIXED_PRECISION)
-  SPCMatrix_ref vsend(sp_pointer(make_device_ptr(vrecv_buff.origin())) + vrecv_buff.num_elements(), vhs_ext);
+  SPCMatrix_ref vsend(sp_pointer(make_device_ptr(vrecv_buff.base())) + vrecv_buff.num_elements(), vhs_ext);
 #else
   StaticSPMatrix vsend(vhs_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 #endif
@@ -822,13 +822,13 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
   int X0, XN;
   std::tie(X0, XN)     = FairDivideBoundary(TG.getLocalTGRank(), int(Xsend.num_elements()), TG.getNCoresPerTG());
   std::tie(vak0, vakN) = FairDivideBoundary(TG.getLocalTGRank(), int(vHS.num_elements()), TG.getNCoresPerTG());
-  MPI_Send_init(to_address(Xsend.origin()) + X0, (XN - X0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(), 2345,
+  MPI_Send_init(to_address(Xsend.base()) + X0, (XN - X0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(), 2345,
                 TG.TG().get(), &req_Xsend);
-  MPI_Recv_init(to_address(Xrecv.origin()) + X0, (XN - X0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(), 2345,
+  MPI_Recv_init(to_address(Xrecv.base()) + X0, (XN - X0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(), 2345,
                 TG.TG().get(), &req_Xrecv);
-  MPI_Send_init(to_address(vsend.origin()) + vak0, (vakN - vak0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(),
+  MPI_Send_init(to_address(vsend.base()) + vak0, (vakN - vak0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(),
                 6789, TG.TG().get(), &req_bpvsend);
-  MPI_Recv_init(to_address(vrecv.origin()) + vak0, (vakN - vak0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(),
+  MPI_Recv_init(to_address(vrecv.base()) + vak0, (vakN - vak0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(),
                 6789, TG.TG().get(), &req_bpvrecv);
   TG.local_barrier();
 
@@ -860,7 +860,7 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
 
   assert(get<0>(detR.sizes()) == nwalk);
   assert(get<1>(detR.sizes()) == nrefs * nx);
-  std::fill_n(detR.origin(), detR.num_elements(), SPComplexType(1.0, 0.0));
+  std::fill_n(detR.base(), detR.num_elements(), SPComplexType(1.0, 0.0));
 
   // from now on, individual work on each walker/step
   const int ntasks_per_core     = int(nx * nwalk) / TG.getNCoresPerTG();
@@ -880,20 +880,20 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
   // 0. copy SlaterMatrix to SlaterMatrixAux
   for (int i = 0; i < nwalk; i++)
   {
-    copy_n((*wset[i].SlaterMatrix(Alpha)).origin() + r0, rN - r0, (*wset[i].SlaterMatrixAux(Alpha)).origin() + r0);
+    copy_n((*wset[i].SlaterMatrix(Alpha)).base() + r0, rN - r0, (*wset[i].SlaterMatrixAux(Alpha)).base() + r0);
     // optimize for the single reference case
     if (nrefs == 1)
-      copy_n(Refs[i][0].origin() + r0, rN - r0, (*wset[i].SlaterMatrix(Alpha)).origin() + r0);
+      copy_n(Refs[i][0].base() + r0, rN - r0, (*wset[i].SlaterMatrix(Alpha)).base() + r0);
   }
   TG.TG_local().barrier();
 
   for (int ni = nbpsteps - 1; ni >= 0; --ni)
   {
     // 1. Get X(nCV,nwalk) from wset
-    fill_n(make_device_ptr(vsend.origin()) + vak0, (vakN - vak0), zero);
-    copy_n(Fields[ni].origin() + X0, (XN - X0), make_device_ptr(Xsend.origin()) + X0);
+    fill_n(make_device_ptr(vsend.base()) + vak0, (vakN - vak0), zero);
+    copy_n(Fields[ni].base() + X0, (XN - X0), make_device_ptr(Xsend.base()) + X0);
     TG.TG_local().barrier();
-    copy_n(make_device_ptr(Xsend[global_origin + cv0].origin()), nwalk * (cvN - cv0), make_device_ptr(X[cv0].origin()));
+    copy_n(make_device_ptr(Xsend[global_origin + cv0].base()), nwalk * (cvN - cv0), make_device_ptr(X[cv0].base()));
     TG.TG_local().barrier();
     // 2. Calculate vHS(M*M,nwalk)/vHS(nwalk,M*M) using distributed algorithm
     for (int k = 0; k < nnodes; ++k)
@@ -903,10 +903,10 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
       {
         MPI_Wait(&req_Xrecv, &st);
         MPI_Wait(&req_Xsend, &st); // need to wait for Gsend in order to overwrite Gwork
-        copy_n(make_device_ptr(Xrecv.origin()) + X0, XN - X0, make_device_ptr(Xsend.origin()) + X0);
+        copy_n(make_device_ptr(Xrecv.base()) + X0, XN - X0, make_device_ptr(Xsend.base()) + X0);
         TG.local_barrier();
-        copy_n(make_device_ptr(Xsend[global_origin + cv0].origin()), nwalk * (cvN - cv0),
-               make_device_ptr(X[cv0].origin()));
+        copy_n(make_device_ptr(Xsend[global_origin + cv0].base()), nwalk * (cvN - cv0),
+               make_device_ptr(X[cv0].base()));
         TG.local_barrier();
       }
 
@@ -918,7 +918,7 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
       }
 
       // 2.3 Calculate vHS
-      //std::cout<<" k, X: " <<TG.Global().rank() <<" " <<k <<" " <<ma::dot(X(X.extension(0),0),X(X.extension(0),0)) <<"\n\n" <<std::endl;
+      //std::cout<<" k, X: " <<TG.Global().rank() <<" " <<k <<" " <<ma::dot(X(get<0>(X.extents()),0),X(get<0>(X.extents()),0)) <<"\n\n" <<std::endl;
       wfn.vHS(X, vHS);
       //std::cout<<" k, vHS: " <<TG.Global().rank() <<" " <<k <<" " <<ma::dot(vHS[0],vHS[0]) <<"\n\n" <<std::endl;
 
@@ -927,13 +927,13 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
       {
         MPI_Wait(&req_bpvrecv, &st);
         MPI_Wait(&req_bpvsend, &st);
-        copy_n(make_device_ptr(vrecv.origin()) + vak0, vakN - vak0, make_device_ptr(vsend.origin()) + vak0);
+        copy_n(make_device_ptr(vrecv.base()) + vak0, vakN - vak0, make_device_ptr(vsend.base()) + vak0);
       }
       TG.local_barrier();
 
       // 2.5 add local contribution to vsend
       using ma::axpy;
-      axpy(vakN - vak0, one, make_device_ptr(vHS.origin()) + vak0, 1, make_device_ptr(vsend.origin()) + vak0, 1);
+      axpy(vakN - vak0, one, make_device_ptr(vHS.base()) + vak0, 1, make_device_ptr(vsend.base()) + vak0, 1);
       //std::cout<<" k vsend: " <<TG.Global().rank() <<" " <<k <<" " <<ma::dot(vsend[0],vsend[0]) <<"\n\n" <<std::endl;
 
       // 2.6 start v communication
@@ -950,17 +950,17 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
 #if defined(MIXED_PRECISION)
     TG.local_barrier();
     if (TG.TG_local().root())
-      inplace_cast<SPComplexType, ComplexType>(vrecv.origin(), vrecv.num_elements());
+      inplace_cast<SPComplexType, ComplexType>(vrecv.base(), vrecv.num_elements());
     TG.local_barrier();
 #endif
-    C3Tensor_ref vHS3D(make_device_ptr(vrecv_buff.origin()), vhs3d_ext);
+    C3Tensor_ref vHS3D(make_device_ptr(vrecv_buff.base()), vhs3d_ext);
 
     for (int nr = 0; nr < nrefs; ++nr)
     {
       // 3. copy reference to SlaterMatrix
       if (nrefs > 1)
         for (int i = 0; i < nwalk; i++)
-          copy_n(Refs[i][nr].origin() + r0, rN - r0, (*wset[i].SlaterMatrix(Alpha)).origin() + r0);
+          copy_n(Refs[i][nr].base() + r0, rN - r0, (*wset[i].SlaterMatrix(Alpha)).base() + r0);
       TG.TG_local().barrier();
 
       // 4. Propagate walkers
@@ -977,23 +977,23 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
         if (nbatched_qr != 0)
         {
           if (walker_type != COLLINEAR)
-            Orthogonalize_batched(wset, detR(detR.extension(0), {nr, nr + 1}));
+            Orthogonalize_batched(wset, detR(get<0>(detR.extents()), {nr, nr + 1}));
           else
-            Orthogonalize_batched(wset, detR(detR.extension(0), {2 * nr, 2 * nr + 2}));
+            Orthogonalize_batched(wset, detR(get<0>(detR.extents()), {2 * nr, 2 * nr + 2}));
         }
         else
         {
           if (walker_type != COLLINEAR)
-            Orthogonalize_shared(wset, detR(detR.extension(0), {nr, nr + 1}));
+            Orthogonalize_shared(wset, detR(get<0>(detR.extents()), {nr, nr + 1}));
           else
-            Orthogonalize_shared(wset, detR(detR.extension(0), {2 * nr, 2 * nr + 2}));
+            Orthogonalize_shared(wset, detR(get<0>(detR.extents()), {2 * nr, 2 * nr + 2}));
         }
       }
 
       // 5. copy reference to back
       if (nrefs > 1)
         for (int i = 0; i < nwalk; i++)
-          copy_n((*wset[i].SlaterMatrix(Alpha)).origin() + r0, rN - r0, Refs[i][nr].origin() + r0);
+          copy_n((*wset[i].SlaterMatrix(Alpha)).base() + r0, rN - r0, Refs[i][nr].base() + r0);
       TG.TG_local().barrier();
     }
   }
@@ -1002,8 +1002,8 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
   for (int i = 0; i < nwalk; i++)
   {
     if (nrefs == 1)
-      copy_n((*wset[i].SlaterMatrix(Alpha)).origin() + r0, rN - r0, Refs[i][0].origin() + r0);
-    copy_n((*wset[i].SlaterMatrixAux(Alpha)).origin() + r0, rN - r0, (*wset[i].SlaterMatrix(Alpha)).origin() + r0);
+      copy_n((*wset[i].SlaterMatrix(Alpha)).base() + r0, rN - r0, Refs[i][0].base() + r0);
+    copy_n((*wset[i].SlaterMatrixAux(Alpha)).base() + r0, rN - r0, (*wset[i].SlaterMatrix(Alpha)).base() + r0);
   }
   MPI_Request_free(&req_Xrecv);
   MPI_Request_free(&req_Xsend);

--- a/src/AFQMC/Propagators/PropagatorFactory.cpp
+++ b/src/AFQMC/Propagators/PropagatorFactory.cpp
@@ -69,7 +69,7 @@ Propagator PropagatorFactory::buildAFQMCPropagator(TaskGroup_& TG,
   // buld mean field expectation value of the Cholesky matrix
   CVector vMF(iextensions<1u>{wfn.local_number_of_cholesky_vectors()}, allocator{});
   using std::fill_n;
-  fill_n(vMF.origin(), vMF.num_elements(), ComplexType(0));
+  fill_n(vMF.base(), vMF.num_elements(), ComplexType(0));
   if (substractMF)
   {
     wfn.vMF(vMF);
@@ -77,14 +77,14 @@ Propagator PropagatorFactory::buildAFQMCPropagator(TaskGroup_& TG,
     if (not wfn.distribution_over_cholesky_vectors())
     {
       if (not TG.TG_local().root())
-        fill_n(vMF.origin(), vMF.num_elements(), ComplexType(0));
-      TG.TG().all_reduce_in_place_n(to_address(vMF.origin()), vMF.num_elements(), std::plus<>());
+        fill_n(vMF.base(), vMF.num_elements(), ComplexType(0));
+      TG.TG().all_reduce_in_place_n(to_address(vMF.base()), vMF.num_elements(), std::plus<>());
     }
   }
 
-  boost::multi::array<ComplexType, 1> vMF_(vMF.extensions());
+  boost::multi::array<ComplexType, 1> vMF_(vMF.extents());
   using std::copy_n;
-  copy_n(vMF.origin(), vMF.num_elements(), vMF_.origin());
+  copy_n(vMF.base(), vMF.num_elements(), vMF_.base());
   RealType vmax = 0, v_ = 0;
   for (int i = 0; i < vMF_.size(); i++)
     v_ = std::max(v_, std::abs(vMF_[i]));

--- a/src/AFQMC/Propagators/WalkerSetUpdate.hpp
+++ b/src/AFQMC/Propagators/WalkerSetUpdate.hpp
@@ -50,9 +50,9 @@ void free_projection_walker_update(Wlk&& w,
   w.getProperty(PSEUDO_ELOC_, work[2]);
   w.getProperty(OVLP, work[3]);
   using std::copy_n;
-  copy_n(overlap.origin(), nwalk, work[4].origin());
-  copy_n(MFfactor.origin(), nwalk, work[5].origin());
-  copy_n(hybrid_weight.origin(), nwalk, work[6].origin());
+  copy_n(overlap.base(), nwalk, work[4].base());
+  copy_n(MFfactor.base(), nwalk, work[5].base());
+  copy_n(hybrid_weight.base(), nwalk, work[6].base());
 
   for (int i = 0; i < nwalk; i++)
   {
@@ -99,9 +99,9 @@ void hybrid_walker_update(Wlk&& w,
   w.getProperty(PSEUDO_ELOC_, work[1]);
   w.getProperty(OVLP, work[2]);
   using std::copy_n;
-  copy_n(overlap.origin(), nwalk, work[4].origin());
-  copy_n(MFfactor.origin(), nwalk, work[5].origin());
-  copy_n(hybrid_weight.origin(), nwalk, work[6].origin());
+  copy_n(overlap.base(), nwalk, work[4].base());
+  copy_n(MFfactor.base(), nwalk, work[5].base());
+  copy_n(hybrid_weight.base(), nwalk, work[6].base());
 
   for (int i = 0; i < nwalk; i++)
   {
@@ -164,9 +164,9 @@ void hybrid_walker_update(Wlk&& w,
   {
     auto&& WFac((*w.getWeightFactors())[w.getHistoryPos()]);
     using std::copy_n;
-    copy_n(work[3].origin(), nwalk, WFac.origin());
+    copy_n(work[3].base(), nwalk, WFac.base());
     auto&& WHis((*w.getWeightHistory())[w.getHistoryPos()]);
-    copy_n(work[0].origin(), nwalk, WHis.origin());
+    copy_n(work[0].base(), nwalk, WHis.base());
   }
 }
 
@@ -198,8 +198,8 @@ void local_energy_walker_update(Wlk&& w,
   w.getProperty(EXX_, work[4]);
   w.getProperty(EJ_, work[5]);
   using std::copy_n;
-  copy_n(overlap.origin(), nwalk, work[7].origin());
-  copy_n(MFfactor.origin(), nwalk, work[8].origin());
+  copy_n(overlap.base(), nwalk, work[7].base());
+  copy_n(MFfactor.base(), nwalk, work[8].base());
   ma::copy(energies({0, nwalk}, 0), work[9]);
   ma::copy(energies({0, nwalk}, 1), work[10]);
   ma::copy(energies({0, nwalk}, 2), work[11]);
@@ -250,9 +250,9 @@ void local_energy_walker_update(Wlk&& w,
   {
     auto&& WFac((*w.getWeightFactors())[w.getHistoryPos()]);
     using std::copy_n;
-    copy_n(work[6].origin(), nwalk, WFac.origin());
+    copy_n(work[6].base(), nwalk, WFac.base());
     auto&& WHis((*w.getWeightHistory())[w.getHistoryPos()]);
-    copy_n(work[0].origin(), nwalk, WHis.origin());
+    copy_n(work[0].base(), nwalk, WHis.base());
   }
 }
 

--- a/src/AFQMC/Propagators/generate1BodyPropagator.hpp
+++ b/src/AFQMC/Propagators/generate1BodyPropagator.hpp
@@ -53,11 +53,11 @@ P_Type generate1BodyPropagator(TaskGroup_& TG,
   if (TG.TG_local().root())
   {
     boost::multi::array<ComplexType, 2> v({NMO, NMO});
-    fill_n(v.origin(), v.num_elements(), ComplexType(0));
+    fill_n(v.base(), v.num_elements(), ComplexType(0));
 
     // running on host regardless
-    boost::multi::array<ComplexType, 2> h1_(H1.extensions());
-    std::copy_n(to_address(H1.origin()), H1.num_elements(), h1_.origin());
+    boost::multi::array<ComplexType, 2> h1_(H1.extents());
+    std::copy_n(to_address(H1.base()), H1.num_elements(), h1_.base());
 
     for (int i = 0; i < NMO; i++)
       ma::axpy(-0.5 * dt, h1_[i], v[i]);
@@ -96,13 +96,13 @@ P_Type generate1BodyPropagator(TaskGroup_& TG,
   if (TG.TG_local().root())
   {
     //      boost::multi::array<ComplexType,2> v({NMO,NMO});
-    //      fill_n(v.origin(),v.num_elements(),ComplexType(0));
+    //      fill_n(v.base(),v.num_elements(),ComplexType(0));
 
     // running on host regardless
     boost::multi::array<ComplexType, 2> h1_(H1);
     //boost::multi::array<ComplexType,2> h1ext_(H1ext);
     boost::multi::array<ComplexType, 2> h1ext_({NMO, NMO});
-    //copy_n(H1ext.origin(),NMO*NMO,h1ext_.origin());
+    //copy_n(H1ext.base(),NMO*NMO,h1ext_.base());
     h1ext_ = H1ext;
 
 

--- a/src/AFQMC/Propagators/store/AFQMCDistributedPropagatorDistCV.icc
+++ b/src/AFQMC/Propagators/store/AFQMCDistributedPropagatorDistCV.icc
@@ -83,7 +83,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       buffer = std::move(sharedCVector(iextensions<1u>{memory_needs}, aux_alloc_));
     }
     memory_report();
-    fill_n(buffer.origin(), buffer.num_elements(), ComplexType(0.0));
+    fill_n(buffer.base(), buffer.num_elements(), ComplexType(0.0));
   }
 
   memory_needs       = nwalk * (2 * Gsize + 2 * NMO * NMO * nsteps);
@@ -102,46 +102,46 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
 #endif
     }
     memory_report();
-    fill_n(comm_buffer.origin(), comm_buffer.num_elements(), ComplexType(0.0));
+    fill_n(comm_buffer.base(), comm_buffer.num_elements(), ComplexType(0.0));
     new_shm_space = true;
   }
 
   // convert array to a basic_array<element,1,pointer>. This generates a view of buffer
   // with type basic_array<ComplexType,1,pointer> which eliminates the need to cast origin()
   //auto mem_pool(boost::multi::static_array_cast<ComplexType, pointer>(buffer));
-  CVector_ref mem_pool(make_device_ptr(buffer.origin()), buffer.extensions());
-  stdCVector_ref comm_mem_pool(static_cast<ComplexType*>(comm_buffer.origin()), comm_buffer.extensions());
+  CVector_ref mem_pool(make_device_ptr(buffer.base()), buffer.extents());
+  stdCVector_ref comm_mem_pool(static_cast<ComplexType*>(comm_buffer.base()), comm_buffer.extents());
 
   size_t displ = 0;
   // Mixed Density Matrix for walkers at original configuration
-  CMatrix_ref Gwork(mem_pool.origin() + displ, {G_nr, G_nc});
+  CMatrix_ref Gwork(mem_pool.base() + displ, {G_nr, G_nc});
   displ += G_nr * G_nc;
   // vias potential for walkers at original configuration
-  CMatrix_ref vbias(mem_pool.origin() + displ, {long(localnCV), nwalk});
+  CMatrix_ref vbias(mem_pool.base() + displ, {long(localnCV), nwalk});
   displ += localnCV * nwalk;
   // right hand side matrix in calculation of HS potential for all steps: ~ sigma + (vbias-vMF)
   // The same vbias is used in all steps
-  CMatrix_ref X(mem_pool.origin() + displ, {long(localnCV), nwalk * nsteps});
+  CMatrix_ref X(mem_pool.base() + displ, {long(localnCV), nwalk * nsteps});
   displ += localnCV * nwalk * nsteps;
   // HS potential for all steps.
-  CMatrix_ref vHS(mem_pool.origin() + displ, {vhs_nr, vhs_nc});
+  CMatrix_ref vHS(mem_pool.base() + displ, {vhs_nr, vhs_nc});
   displ += vhs_nr * vhs_nc;
   // second view of vHS matrix for use in propagation step
-  C3Tensor_ref vHS3D(vHS.origin(), {vhs3d_n1, vhs3d_n2, vhs3d_n3});
+  C3Tensor_ref vHS3D(vHS.base(), {vhs3d_n1, vhs3d_n2, vhs3d_n3});
 
   // setup communication buffers
   displ = 0;
   // Mixed Density Matrix for walkers at original configuration
-  stdCMatrix_ref Gsend(comm_mem_pool.origin() + displ, {G_nr, G_nc});
+  stdCMatrix_ref Gsend(comm_mem_pool.base() + displ, {G_nr, G_nc});
   displ += G_nr * G_nc;
   // Mixed Density Matrix used for communication
-  stdCMatrix_ref Grecv(comm_mem_pool.origin() + displ, {G_nr, G_nc});
+  stdCMatrix_ref Grecv(comm_mem_pool.base() + displ, {G_nr, G_nc});
   displ += G_nr * G_nc;
   // HS potential for communication
-  stdCMatrix_ref vsend(comm_mem_pool.origin() + displ, {vhs_nr, vhs_nc});
+  stdCMatrix_ref vsend(comm_mem_pool.base() + displ, {vhs_nr, vhs_nc});
   displ += vhs_nr * vhs_nc;
   // HS potential for communication
-  stdCMatrix_ref vrecv(comm_mem_pool.origin() + displ, {vhs_nr, vhs_nc});
+  stdCMatrix_ref vrecv(comm_mem_pool.base() + displ, {vhs_nr, vhs_nc});
 
   // partition G and v for communications: all cores communicate a piece of the matrix
   int vak0, vakN;
@@ -159,13 +159,13 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       MPI_Request_free(&req_vrecv);
     if (req_vsend != MPI_REQUEST_NULL)
       MPI_Request_free(&req_vsend);
-    MPI_Send_init(to_address(Gsend.origin()) + Gak0, (GakN - Gak0) * sizeof(ComplexType), MPI_CHAR, TG.prev_core(),
+    MPI_Send_init(to_address(Gsend.base()) + Gak0, (GakN - Gak0) * sizeof(ComplexType), MPI_CHAR, TG.prev_core(),
                   3456, &TG.TG(), &req_Gsend);
-    MPI_Recv_init(to_address(Grecv.origin()) + Gak0, (GakN - Gak0) * sizeof(ComplexType), MPI_CHAR, TG.next_core(),
+    MPI_Recv_init(to_address(Grecv.base()) + Gak0, (GakN - Gak0) * sizeof(ComplexType), MPI_CHAR, TG.next_core(),
                   3456, &TG.TG(), &req_Grecv);
-    MPI_Send_init(to_address(vsend.origin()) + vak0, (vakN - vak0) * sizeof(ComplexType), MPI_CHAR, TG.prev_core(),
+    MPI_Send_init(to_address(vsend.base()) + vak0, (vakN - vak0) * sizeof(ComplexType), MPI_CHAR, TG.prev_core(),
                   5678, &TG.TG(), &req_vsend);
-    MPI_Recv_init(to_address(vrecv.origin()) + vak0, (vakN - vak0) * sizeof(ComplexType), MPI_CHAR, TG.next_core(),
+    MPI_Recv_init(to_address(vrecv.base()) + vak0, (vakN - vak0) * sizeof(ComplexType), MPI_CHAR, TG.next_core(),
                   5678, &TG.TG(), &req_vrecv);
   }
 
@@ -188,7 +188,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     P1          = std::move(generate1BodyPropagator<P1shm>(TG, 1e-8, dt, H1));
   }
 
-  fill_n(vsend.origin() + vak0, (vakN - vak0), zero);
+  fill_n(vsend.base() + vak0, (vakN - vak0), zero);
 
   TG.local_barrier();
   AFQMCTimers[setup_timer].get().stop();
@@ -211,7 +211,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       MPI_Wait(&req_Grecv, &st);
       MPI_Wait(&req_Gsend, &st); // need to wait for Gsend in order to overwrite Gsend
       ma::copy(Grecv.sliced(Gak0, GakN), Gsend.sliced(Gak0, GakN));
-      copy_n(Grecv.origin() + Gak0, GakN - Gak0, Gwork.origin() + Gak0);
+      copy_n(Grecv.base() + Gak0, GakN - Gak0, Gwork.base() + Gak0);
       TG.local_barrier();
     }
 
@@ -231,8 +231,8 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
 
     // 4b. Assemble X(nCV,nsteps,nwalk)
     int q = (node_number + k) % nnodes;
-    CMatrix_ref mf_(MFfactor[q * nsteps].origin(), {long(nsteps), long(nwalk)});
-    CMatrix_ref hw_(hybrid_weight[q * nsteps].origin(), {long(nsteps), long(nwalk)});
+    CMatrix_ref mf_(MFfactor[q * nsteps].base(), {long(nsteps), long(nwalk)});
+    CMatrix_ref hw_(hybrid_weight[q * nsteps].base(), {long(nsteps), long(nwalk)});
     assemble_X(nsteps, nwalk, sqrtdt, X, vbias, mf_, hw_);
 
     // 4c. Calculate vHS(M*M,nsteps,nwalk)
@@ -247,17 +247,17 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     {
       MPI_Wait(&req_vrecv, &st);
       MPI_Wait(&req_vsend, &st);
-      copy_n(vrecv.origin() + vak0, vakN - vak0, vsend.origin() + vak0);
+      copy_n(vrecv.base() + vak0, vakN - vak0, vsend.base() + vak0);
     }
 
     // 6. add local contribution to vsend
     using ma::axpy;
 #ifdef ENABLE_CUDA
-    copy_n(vHS.origin() + vak0, vakN - vak0,
-           vrecv.origin() + vak0); // using vrecv as temporary space, since it is free now
-    axpy(vakN - vak0, one, vrecv.origin() + vak0, 1, vsend.origin() + vak0, 1);
+    copy_n(vHS.base() + vak0, vakN - vak0,
+           vrecv.base() + vak0); // using vrecv as temporary space, since it is free now
+    axpy(vakN - vak0, one, vrecv.base() + vak0, 1, vsend.base() + vak0, 1);
 #else
-    axpy(vakN - vak0, one, vHS.origin() + vak0, 1, vsend.origin() + vak0, 1);
+    axpy(vakN - vak0, one, vHS.base() + vak0, 1, vsend.base() + vak0, 1);
 #endif
 
     // 7. start v communication
@@ -271,14 +271,14 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
   AFQMCTimers[vHS_comm_overhead_timer].get().start();
   MPI_Wait(&req_vrecv, &st);
   MPI_Wait(&req_vsend, &st);
-  copy_n(vrecv.origin() + vak0, vakN - vak0, vHS.origin() + vak0);
+  copy_n(vrecv.base() + vak0, vakN - vak0, vHS.base() + vak0);
   TG.local_barrier();
 
   // reduce MF and HWs
   if (TG.TG().size() > 1)
   {
-    TG.TG().all_reduce_in_place_n(to_address(MFfactor.origin()), MFfactor.num_elements(), std::plus<>());
-    TG.TG().all_reduce_in_place_n(to_address(hybrid_weight.origin()), hybrid_weight.num_elements(), std::plus<>());
+    TG.TG().all_reduce_in_place_n(to_address(MFfactor.base()), MFfactor.num_elements(), std::plus<>());
+    TG.TG().all_reduce_in_place_n(to_address(hybrid_weight.base()), hybrid_weight.num_elements(), std::plus<>());
   }
   TG.local_barrier();
   AFQMCTimers[vHS_comm_overhead_timer].get().stop();

--- a/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
+++ b/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
@@ -137,7 +137,7 @@ void propg_fac_shared(boost::mpi3::communicator& world)
     REQUIRE(get<1>(initial_guess.sizes()) == NPOL * NMO);
     REQUIRE(get<2>(initial_guess.sizes()) == NAEA);
     wset.resize(nwalk, initial_guess[0], initial_guess[0]);
-    //                         initial_guess[1](XXX.extension(0),{0,NAEB}));
+    //                         initial_guess[1](get<0>(XXX.extents()),{0,NAEB}));
 
     const char* propg_xml_block = R"(<Propagator name="prop0"></Propagator>)";
     Libxml2Document doc4;

--- a/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_base.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_base.hpp
@@ -307,10 +307,10 @@ public:
     ma::geqrf(AT, TAU, WORK);
     using ma::determinant_from_geqrf;
     using ma::scale_columns;
-    T res = determinant_from_geqrf(get<0>(AT.sizes()), AT.origin(), AT.stride(), scl.origin(), LogOverlapFactor);
+    T res = determinant_from_geqrf(get<0>(AT.sizes()), AT.base(), AT.stride(), scl.base(), LogOverlapFactor);
     ma::gqr(AT, TAU, WORK);
     ma::transpose(AT, A);
-    scale_columns(get<0>(A.sizes()), get<1>(A.sizes()), A.origin(), A.stride(), scl.origin());
+    scale_columns(get<0>(A.sizes()), get<1>(A.sizes()), A.base(), A.stride(), scl.base());
 #else
     int NMO = A.size();
     TVector TAU(iextensions<1u>{NMO}, buffer_manager.get_generator().template get_allocator<T>());

--- a/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_serial.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_serial.hpp
@@ -192,10 +192,10 @@ public:
     if (noncollinear)
     {
       // treat 2 polarizations as separate elements in the batch
-      using TTensor_ref = boost::multi::array_ref<T, 3, decltype(TMN.origin())>;
-      TTensor_ref TMN_(TMN.origin(), {npol * nbatch, M, NAEA});
-      TTensor_ref T1_(T1.origin(), {npol * nbatch, M, NAEA});
-      TTensor_ref T2_(T2.origin(), {npol * nbatch, M, NAEA});
+      using TTensor_ref = boost::multi::array_ref<T, 3, decltype(TMN.base())>;
+      TTensor_ref TMN_(TMN.base(), {npol * nbatch, M, NAEA});
+      TTensor_ref T1_(T1.base(), {npol * nbatch, M, NAEA});
+      TTensor_ref T2_(T2.base(), {npol * nbatch, M, NAEA});
       SlaterDeterminantOperations::batched::apply_expM_noncollinear(V, TMN_, T1_, T2_, order, TA);
     }
     else
@@ -343,17 +343,17 @@ public:
     for (int i = 0; i < nbatch; i++)
       ma::transpose(*Ai[i], AT[i]);
     // careful, expects fortran order
-    geqrfStrided(NMO, NAEA, AT.origin(), NMO, NMO * NAEA, T_.origin(), NMO, IWORK.origin(), nbatch);
+    geqrfStrided(NMO, NAEA, AT.base(), NMO, NMO * NAEA, T_.base(), NMO, IWORK.base(), nbatch);
     using ma::determinant_from_geqrf;
     using ma::scale_columns;
     for (int i = 0; i < nbatch; i++)
-      *(detR + i) = determinant_from_geqrf(NAEA, AT[i].origin(), NMO, scl[i].origin(), LogOverlapFactor);
-    gqrStrided(NMO, NAEA, NAEA, AT.origin(), NMO, NMO * NAEA, T_.origin(), NMO, WORK.origin(), sz, IWORK.origin(),
+      *(detR + i) = determinant_from_geqrf(NAEA, AT[i].base(), NMO, scl[i].base(), LogOverlapFactor);
+    gqrStrided(NMO, NAEA, NAEA, AT.base(), NMO, NMO * NAEA, T_.base(), NMO, WORK.base(), sz, IWORK.base(),
                nbatch);
     for (int i = 0; i < nbatch; i++)
     {
       ma::transpose(AT[i], *Ai[i]);
-      scale_columns(NMO, NAEA, (*Ai[i]).origin(), (*Ai[i]).stride(), scl[i].origin());
+      scale_columns(NMO, NAEA, (*Ai[i]).base(), (*Ai[i]).stride(), scl[i].base());
     }
 #else
     int nw = Ai.size();
@@ -382,17 +382,17 @@ public:
     for (int i = 0; i < nbatch; i++)
       ma::transpose(*Ai[i], AT[i]);
     // careful, expects fortran order
-    geqrfStrided(NMO, NAEA, AT.origin(), NMO, NMO * NAEA, T_.origin(), NMO, IWORK.origin(), nbatch);
+    geqrfStrided(NMO, NAEA, AT.base(), NMO, NMO * NAEA, T_.base(), NMO, IWORK.base(), nbatch);
     using ma::determinant_from_geqrf;
     using ma::scale_columns;
     for (int i = 0; i < nbatch; i++)
-      determinant_from_geqrf(NAEA, AT[i].origin(), NMO, scl[i].origin());
-    gqrStrided(NMO, NAEA, NAEA, AT.origin(), NMO, NMO * NAEA, T_.origin(), NMO, WORK.origin(), sz, IWORK.origin(),
+      determinant_from_geqrf(NAEA, AT[i].base(), NMO, scl[i].base());
+    gqrStrided(NMO, NAEA, NAEA, AT.base(), NMO, NMO * NAEA, T_.base(), NMO, WORK.base(), sz, IWORK.base(),
                nbatch);
     for (int i = 0; i < nbatch; i++)
     {
       ma::transpose(AT[i], *Ai[i]);
-      scale_columns(NMO, NAEA, (*Ai[i]).origin(), (*Ai[i]).stride(), scl[i].origin());
+      scale_columns(NMO, NAEA, (*Ai[i]).base(), (*Ai[i]).stride(), scl[i].base());
     }
 #else
     int nw = Ai.size();

--- a/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_shared.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_shared.hpp
@@ -80,8 +80,8 @@ public:
     int NAEA = (herm ? get<0>(hermA.sizes()) : get<1>(hermA.sizes()));
     set_shm_buffer(comm, NAEA * (NAEA + NMO));
     assert(SM_TMats->num_elements() >= NAEA * (NAEA + NMO));
-    boost::multi::array_ref<T, 2> TNN(to_address(SM_TMats->origin()), {NAEA, NAEA});
-    boost::multi::array_ref<T, 2> TNM(to_address(SM_TMats->origin()) + NAEA * NAEA, {NAEA, NMO});
+    boost::multi::array_ref<T, 2> TNN(to_address(SM_TMats->base()), {NAEA, NAEA});
+    boost::multi::array_ref<T, 2> TNM(to_address(SM_TMats->base()) + NAEA * NAEA, {NAEA, NMO});
     TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
     IVector IWORK(iextensions<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::shm::MixedDensityMatrix<T>(hermA, B, std::forward<MatC>(C), LogOverlapFactor,
@@ -110,11 +110,11 @@ public:
     set_shm_buffer(comm, NEL * (NEL + Nact + NMO));
     assert(SM_TMats->num_elements() >= NEL * (NEL + Nact + NMO));
     size_t cnt = 0;
-    boost::multi::array_ref<T, 2> TNN(to_address(SM_TMats->origin()), {NEL, NEL});
+    boost::multi::array_ref<T, 2> TNN(to_address(SM_TMats->base()), {NEL, NEL});
     cnt += TNN.num_elements();
-    boost::multi::array_ref<T, 2> TAB(to_address(SM_TMats->origin()) + cnt, {Nact, NEL});
+    boost::multi::array_ref<T, 2> TAB(to_address(SM_TMats->base()) + cnt, {Nact, NEL});
     cnt += TAB.num_elements();
-    boost::multi::array_ref<T, 2> TNM(to_address(SM_TMats->origin()) + cnt, {NEL, NMO});
+    boost::multi::array_ref<T, 2> TNM(to_address(SM_TMats->base()) + cnt, {NEL, NMO});
     TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
     IVector IWORK(iextensions<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::shm::MixedDensityMatrixForWoodbury<T>(hermA, B, std::forward<MatC>(C),
@@ -130,8 +130,8 @@ public:
     int NAEA = (herm ? get<0>(hermA.sizes()) : get<1>(hermA.sizes()));
     set_shm_buffer(comm, 2 * NAEA * NAEA);
     assert(SM_TMats->num_elements() >= 2 * NAEA * NAEA);
-    boost::multi::array_ref<T, 2> TNN(to_address(SM_TMats->origin()), {NAEA, NAEA});
-    boost::multi::array_ref<T, 2> TNN2(to_address(SM_TMats->origin()) + NAEA * NAEA, {NAEA, NAEA});
+    boost::multi::array_ref<T, 2> TNN(to_address(SM_TMats->base()), {NAEA, NAEA});
+    boost::multi::array_ref<T, 2> TNN2(to_address(SM_TMats->base()) + NAEA * NAEA, {NAEA, NAEA});
     IVector IWORK(iextensions<1u>{NAEA + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::shm::Overlap<T>(hermA, B, LogOverlapFactor, TNN, IWORK, TNN2.elements(), comm, herm);
   }
@@ -153,8 +153,8 @@ public:
     assert(get<1>(QQ0.sizes()) == NEL);
     set_shm_buffer(comm, NEL * (Nact + NEL));
     assert(SM_TMats->num_elements() >= NEL * (Nact + NEL));
-    boost::multi::array_ref<T, 2> TNN(to_address(SM_TMats->origin()), {NEL, NEL});
-    boost::multi::array_ref<T, 2> TMN(to_address(SM_TMats->origin()) + NEL * NEL, {Nact, NEL});
+    boost::multi::array_ref<T, 2> TNN(to_address(SM_TMats->base()), {NEL, NEL});
+    boost::multi::array_ref<T, 2> TMN(to_address(SM_TMats->base()) + NEL * NEL, {Nact, NEL});
     TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
     IVector IWORK(iextensions<1u>{Nact + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::shm::OverlapForWoodbury<T>(hermA, B, LogOverlapFactor, std::forward<MatC>(QQ0),
@@ -183,9 +183,9 @@ public:
     assert(get<1>(V.sizes()) == M);
     set_shm_buffer(comm, NAEA * (NMO + 2 * M));
     assert(SM_TMats->num_elements() >= NAEA * (NMO + 2 * M));
-    boost::multi::array_ref<T, 2> T0(to_address(SM_TMats->origin()), {NMO, NAEA});
-    boost::multi::array_ref<T, 2> T1(to_address(T0.origin()) + T0.num_elements(), {M, NAEA});
-    boost::multi::array_ref<T, 2> T2(to_address(T1.origin()) + T1.num_elements(), {M, NAEA});
+    boost::multi::array_ref<T, 2> T0(to_address(SM_TMats->base()), {NMO, NAEA});
+    boost::multi::array_ref<T, 2> T1(to_address(T0.base()) + T0.num_elements(), {M, NAEA});
+    boost::multi::array_ref<T, 2> T2(to_address(T1.base()) + T1.num_elements(), {M, NAEA});
     using ma::H;
     using ma::T;
     if (comm.root())

--- a/src/AFQMC/SlaterDeterminantOperations/apply_expM.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/apply_expM.hpp
@@ -113,9 +113,9 @@ inline void apply_expM(const MatA& V, MatB&& S, MatC& T1, MatC& T2, communicator
   {
     const ComplexType fact = im * static_cast<ComplexType>(1.0 / static_cast<double>(n));
     if (TA == 'H' || TA == 'h')
-      ma::product(fact, ma::H(V(V.extension(0), {M0, Mn})), *pT1, zero, (*pT2).sliced(M0, Mn));
+      ma::product(fact, ma::H(V(get<0>(V.extents()), {M0, Mn})), *pT1, zero, (*pT2).sliced(M0, Mn));
     else if (TA == 'T' || TA == 't')
-      ma::product(fact, ma::T(V(V.extension(0), {M0, Mn})), *pT1, zero, (*pT2).sliced(M0, Mn));
+      ma::product(fact, ma::T(V(get<0>(V.extents()), {M0, Mn})), *pT1, zero, (*pT2).sliced(M0, Mn));
     else
       ma::product(fact, V.sliced(M0, Mn), *pT1, zero, (*pT2).sliced(M0, Mn));
     // overload += ???
@@ -174,7 +174,7 @@ inline void apply_expM(const MatA& V, MatB&& S, MatC& T1, MatC& T2, int order = 
   // getting around issue in multi, fix later
   //T1 = S;
   using std::copy_n;
-  copy_n(S.origin(), S.num_elements(), T1.origin());
+  copy_n(S.base(), S.num_elements(), T1.base());
   for (int n = 1; n <= order; n++)
   {
     ComplexType fact = im * static_cast<ComplexType>(1.0 / static_cast<double>(n));
@@ -186,7 +186,7 @@ inline void apply_expM(const MatA& V, MatB&& S, MatC& T1, MatC& T2, int order = 
       ma::productStridedBatched(fact, V, *pT1, zero, *pT2);
     //ma::add(ComplexType(1.0),*pT2,ComplexType(1.0),S,S);
     using ma::axpy;
-    axpy(S.num_elements(), ComplexType(1.0), (*pT2).origin(), 1, S.origin(), 1);
+    axpy(S.num_elements(), ComplexType(1.0), (*pT2).base(), 1, S.base(), 1);
     std::swap(pT1, pT2);
   }
 }
@@ -248,13 +248,13 @@ inline void apply_expM_noncollinear(const MatA& V, MatB&& S, MatC& T1, MatC& T2,
   T2i.reserve(T2.size());
   for (int i = 0; i < V.size(); i++)
   {
-    Vi.emplace_back(ma::pointer_dispatch(V[i].origin()));
-    Vi.emplace_back(ma::pointer_dispatch(V[i].origin()));
+    Vi.emplace_back(ma::pointer_dispatch(V[i].base()));
+    Vi.emplace_back(ma::pointer_dispatch(V[i].base()));
   }
   for (int i = 0; i < T1.size(); i++)
-    T1i.emplace_back(ma::pointer_dispatch(T1[i].origin()));
+    T1i.emplace_back(ma::pointer_dispatch(T1[i].base()));
   for (int i = 0; i < T2.size(); i++)
-    T2i.emplace_back(ma::pointer_dispatch(T2[i].origin()));
+    T2i.emplace_back(ma::pointer_dispatch(T2[i].base()));
 
   auto pT1i(std::addressof(T1i));
   auto pT2i(std::addressof(T2i));
@@ -262,7 +262,7 @@ inline void apply_expM_noncollinear(const MatA& V, MatB&& S, MatC& T1, MatC& T2,
   // getting around issue in multi, fix later
   //T1 = S;
   using std::copy_n;
-  copy_n(S.origin(), S.num_elements(), T1.origin());
+  copy_n(S.base(), S.num_elements(), T1.base());
   for (int n = 1; n <= order; n++)
   {
     ComplexType fact = im * static_cast<ComplexType>(1.0 / static_cast<double>(n));
@@ -271,7 +271,7 @@ inline void apply_expM_noncollinear(const MatA& V, MatB&& S, MatC& T1, MatC& T2,
     gemmBatched('N', TA, M, N, K, fact, pT1i->data(), get<1>((*pT1).strides()), Vi.data(), ldv, zero, pT2i->data(),
                 get<1>((*pT2).strides()), nbatch);
     using ma::axpy;
-    axpy(S.num_elements(), ComplexType(1.0), (*pT2).origin(), 1, S.origin(), 1);
+    axpy(S.num_elements(), ComplexType(1.0), (*pT2).base(), 1, S.base(), 1);
     std::swap(pT1, pT2);
     std::swap(pT1i, pT2i);
   }

--- a/src/AFQMC/SlaterDeterminantOperations/mixed_density_matrix.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/mixed_density_matrix.hpp
@@ -185,7 +185,7 @@ Tp MixedDensityMatrixForWoodbury(const MatA& hermA,
 
   // TNN = TAB[ref,:]
   for (int i = 0; i < NEL; i++)
-    std::copy_n(to_address(TAB[*(ref + i)].origin()), NEL, to_address(TNN[i].origin()));
+    std::copy_n(to_address(TAB[*(ref + i)].base()), NEL, to_address(TNN[i].base()));
 
   // TNN = TNN^(-1)
   Tp ovlp = ma::invert(std::forward<Mat1>(TNN), IWORK, WORK, LogOverlapFactor);
@@ -266,7 +266,7 @@ Tp MixedDensityMatrixFromConfiguration(const MatA& hermA,
 
   // TNN = TAB[ref,:]
   for (int i = 0; i < NEL; i++)
-    std::copy_n(to_address(TAB[*(ref + i)].origin()), NEL, to_address(TNN[i].origin()));
+    std::copy_n(to_address(TAB[*(ref + i)].base()), NEL, to_address(TNN[i].base()));
 
   // TNN = TNN^(-1)
   Tp ovlp = ma::invert(std::forward<Mat1>(TNN), IWORK, WORK, LogOverlapFactor);
@@ -426,19 +426,19 @@ Tp MixedDensityMatrix_noHerm_wSVD(const MatA& A,
 
   // keep a copy of U in UA temporarily
   using std::copy_n;
-  copy_n(U.origin(), U.num_elements(), UA.origin());
+  copy_n(U.base(), U.num_elements(), UA.base());
 
   // get determinant, since you can't get the phase trivially from SVD
   Tp ovlp = ma::determinant(U, IWORK, WORK, LogOverlapFactor);
   //  ma::geqrf(U,VT[0],WORK);
-  //  determinant_from_geqrf(N,U.origin(),U.stride(),VT[1].origin(),LogOverlapFactor,ovlp);
+  //  determinant_from_geqrf(N,U.base(),U.stride(),VT[1].base(),LogOverlapFactor,ovlp);
   //  if you want the correct phase of the determinant
   //  ma::gqr(U,S.sliced(0,N),WORK);
   //  ComplexType ovQ = ma::determinant(U,IWORK,WORK,0.0);
   //  *ovlp *= ovQ;
 
   // restore U
-  copy_n(UA.origin(), U.num_elements(), U.origin());
+  copy_n(UA.base(), U.num_elements(), U.base());
 
   // H(A)*B = AtB = U * S * VT
   // inv(H(A)*B) = inv(AtB) = H(VT) * inv(S) * H(U)
@@ -463,8 +463,8 @@ Tp MixedDensityMatrix_noHerm_wSVD(const MatA& A,
 
 
     // VT = VT * inv(S), which works since S is diagonal and real
-    term_by_term_matrix_vector(ma::TOp_DIV, 0, get<0>(VT.sizes()), get<1>(VT.sizes()), ma::pointer_dispatch(VT.origin()), VT.stride(),
-                               ma::pointer_dispatch(S.origin()), 1);
+    term_by_term_matrix_vector(ma::TOp_DIV, 0, get<0>(VT.sizes()), get<1>(VT.sizes()), ma::pointer_dispatch(VT.base()), VT.stride(),
+                               ma::pointer_dispatch(S.base()), 1);
 
     // BV = H(VT) * H(U)
     ma::product(H(VT), H(U), BV.sliced(0, N));
@@ -483,8 +483,8 @@ Tp MixedDensityMatrix_noHerm_wSVD(const MatA& A,
     ma::product(B, H(VT), BV);
 
     // BV = BV * inv(S), which works since S is diagonal and real
-    term_by_term_matrix_vector(ma::TOp_DIV, 1, get<0>(BV.sizes()), get<1>(BV.sizes()), ma::pointer_dispatch(BV.origin()), BV.stride(),
-                               ma::pointer_dispatch(S.origin()), 1);
+    term_by_term_matrix_vector(ma::TOp_DIV, 1, get<0>(BV.sizes()), get<1>(BV.sizes()), ma::pointer_dispatch(BV.base()), BV.stride(),
+                               ma::pointer_dispatch(S.base()), 1);
 
     // UA = H(U) * H(A)
     ma::product(H(U), H(A), UA);
@@ -574,7 +574,7 @@ Tp OverlapForWoodbury(const MatA& hermA,
 
   // TNN = TMN[ref,:]
   for (int i = 0; i < NEL; i++)
-    std::copy_n(to_address(TMN[*(ref + i)].origin()), NEL, to_address(TNN[i].origin()));
+    std::copy_n(to_address(TMN[*(ref + i)].base()), NEL, to_address(TNN[i].base()));
 
   // TNN -> inv(TNN)
   Tp ovlp = ma::invert(std::forward<MatD>(TNN), IWORK, WORK, LogOverlapFactor);
@@ -688,9 +688,9 @@ Tp MixedDensityMatrix(const MatA& hermA,
   if (N0 != Nn)
   {
     if (herm)
-      ma::product(hermA, B(B.extension(0), {N0, Nn}), T1(T1.extension(0), {N0, Nn}));
+      ma::product(hermA, B(get<0>(B.extents()), {N0, Nn}), T1(get<0>(T1.extents()), {N0, Nn}));
     else
-      ma::product(H(hermA), B(B.extension(0), {N0, Nn}), T1(T1.extension(0), {N0, Nn}));
+      ma::product(H(hermA), B(get<0>(B.extents()), {N0, Nn}), T1(get<0>(T1.extents()), {N0, Nn}));
   }
 
   comm.barrier();
@@ -718,7 +718,7 @@ Tp MixedDensityMatrix(const MatA& hermA,
     //            T(B),
     //            C.sliced(N0,Nn));
     if (N0 != Nn)
-      ma::product(T(T1(T1.extension(0), {N0, Nn})), T(B), C.sliced(N0, Nn));
+      ma::product(T(T1(get<0>(T1.extents()), {N0, Nn})), T(B), C.sliced(N0, Nn));
   }
   else
   {
@@ -730,7 +730,7 @@ Tp MixedDensityMatrix(const MatA& hermA,
       //            T2.sliced(N0,Nn));
 
       if (N0 != Nn)
-        ma::product(ComplexType(1.0), T(T1(T1.extension(0), {N0, Nn})), T(B), ComplexType(0.0), T2.sliced(N0, Nn));
+        ma::product(ComplexType(1.0), T(T1(get<0>(T1.extents()), {N0, Nn})), T(B), ComplexType(0.0), T2.sliced(N0, Nn));
 
       comm.barrier();
 
@@ -739,7 +739,7 @@ Tp MixedDensityMatrix(const MatA& hermA,
 
       // C = conj(A) * T2
       if (N0 != Nn)
-        ma::product(T(hermA), T2(T2.extension(0), {N0, Nn}), C(C.extension(0), {N0, Nn}));
+        ma::product(T(hermA), T2(get<0>(T2.extents()), {N0, Nn}), C(get<0>(C.extents()), {N0, Nn}));
     }
     else
     {
@@ -755,7 +755,7 @@ Tp MixedDensityMatrix(const MatA& hermA,
 
       // C = T( B * T2) = T(T2) * T(B)
       if (N0 != Nn)
-        ma::product(T(T2(T2.extension(0), {N0, Nn})), T(B), C.sliced(N0, Nn));
+        ma::product(T(T2(get<0>(T2.extents()), {N0, Nn})), T(B), C.sliced(N0, Nn));
     }
   }
   comm.barrier();
@@ -804,9 +804,9 @@ Tp Overlap(const MatA& hermA,
   if (N0 != Nn)
   {
     if (herm)
-      ma::product(hermA, B(B.extension(0), {N0, Nn}), T1(T1.extension(0), {N0, Nn}));
+      ma::product(hermA, B(get<0>(B.extents()), {N0, Nn}), T1(get<0>(T1.extents()), {N0, Nn}));
     else
-      ma::product(H(hermA), B(B.extension(0), {N0, Nn}), T1(T1.extension(0), {N0, Nn}));
+      ma::product(H(hermA), B(get<0>(B.extents()), {N0, Nn}), T1(get<0>(T1.extents()), {N0, Nn}));
   }
 
   comm.barrier();
@@ -859,12 +859,12 @@ Tp OverlapForWoodbury(const MatA& hermA,
   Tp ovlp;
   // T(B)*conj(A)
   if (N0 != Nn)
-    ma::product(hermA, B(B.extension(0), {N0, Nn}), TMN(TMN.extension(0), {N0, Nn}));
+    ma::product(hermA, B(get<0>(B.extents()), {N0, Nn}), TMN(get<0>(TMN.extents()), {N0, Nn}));
   comm.barrier();
   if (comm.rank() == 0)
   {
     for (int i = 0; i < NEL; i++)
-      std::copy_n(to_address(TMN[*(ref + i)].origin()), NEL, to_address(TNN[i].origin()));
+      std::copy_n(to_address(TMN[*(ref + i)].base()), NEL, to_address(TNN[i].base()));
     ovlp = ma::invert(std::forward<MatD>(TNN), IWORK, WORK, LogOverlapFactor);
   }
   comm.broadcast_n(&ovlp, 1, 0);
@@ -874,7 +874,7 @@ Tp OverlapForWoodbury(const MatA& hermA,
   std::tie(M0, Mn) = FairDivideBoundary(comm.rank(), sz, comm.size());
 
   // QQ0 = TMN * inv(TNN)
-  ma::product(TMN.sliced(M0, Mn), TNN, QQ0({M0, Mn}, QQ0.extension(1))); //.sliced(M0,Mn));
+  ma::product(TMN.sliced(M0, Mn), TNN, QQ0({M0, Mn}, get<1>(QQ0.extents()))); //.sliced(M0,Mn));
                                                                          //QQ0.sliced(M0,Mn));
   comm.barrier();
   return ovlp;
@@ -938,11 +938,11 @@ Tp MixedDensityMatrixForWoodbury(const MatA& hermA,
   // TAB = herm(A)*B
   if (N0 != Nn)
   {
-    ma::product(hermA, B(B.extension(0), {N0, Nn}), TAB(TAB.extension(0), {N0, Nn}));
+    ma::product(hermA, B(get<0>(B.extents()), {N0, Nn}), TAB(get<0>(TAB.extents()), {N0, Nn}));
 
     // TNN = TAB[ref,:]
     for (int i = 0; i < NEL; i++)
-      std::copy_n(to_address(TAB[*(ref + i)].origin()) + N0, Nn - N0, to_address(TNN[i].origin()) + N0);
+      std::copy_n(to_address(TAB[*(ref + i)].base()) + N0, Nn - N0, to_address(TNN[i].base()) + N0);
   }
 
   comm.barrier();
@@ -958,26 +958,26 @@ Tp MixedDensityMatrixForWoodbury(const MatA& hermA,
 
   // QQ0 = TAB * inv(TNN)
   if (P0 != Pn)
-    ma::product(TAB.sliced(P0, Pn), TNN, QQ0({P0, Pn}, QQ0.extension(1)));
+    ma::product(TAB.sliced(P0, Pn), TNN, QQ0({P0, Pn}, get<1>(QQ0.extents())));
   //QQ0.sliced(P0,Pn));
   if (compact)
   {
     // C = T(TNN) * T(B)
     if (N0 != Nn)
-      ma::product(T(TNN(TNN.extension(0), {N0, Nn})), T(B), C({N0, Nn}, C.extension(1)));
+      ma::product(T(TNN(get<0>(TNN.extents()), {N0, Nn})), T(B), C({N0, Nn}, get<1>(C.extents())));
   }
   else
   {
     // TNM = T(TNN) * T(B)
     if (N0 != Nn)
-      ma::product(T(TNN(TNN.extension(0), {N0, Nn})), T(B), TNM.sliced(N0, Nn));
+      ma::product(T(TNN(get<0>(TNN.extents()), {N0, Nn})), T(B), TNM.sliced(N0, Nn));
 
     int sz           = get<1>(TNM.sizes());
     std::tie(N0, Nn) = FairDivideBoundary(comm.rank(), sz, comm.size());
     comm.barrier();
 
     // C = conj(A) * TNM
-    ma::product(T(hermA), TNM(TNM.extension(0), {N0, Nn}), C(C.extension(0), {N0, Nn}));
+    ma::product(T(hermA), TNM(get<0>(TNM.extents()), {N0, Nn}), C(get<0>(C.extents()), {N0, Nn}));
   }
 
   comm.barrier();
@@ -1056,9 +1056,9 @@ void MixedDensityMatrix(std::vector<MatA>& hermA,
   //  TNNi.reserve(nbatch);
   for (int i = 0; i < nbatch; i++)
   {
-    NNarray.emplace_back(TNN3D[i].origin());
-    Carray.emplace_back(C[i].origin());
-    Warray.emplace_back((*Bi[i]).origin());
+    NNarray.emplace_back(TNN3D[i].base());
+    Carray.emplace_back(C[i].base());
+    Warray.emplace_back((*Bi[i]).base());
     Ci.emplace_back(&C[i]);
     //    TNNi.emplace_back(TNN3D[i]);
   }
@@ -1076,16 +1076,16 @@ void MixedDensityMatrix(std::vector<MatA>& hermA,
     ma::BatchedProduct('C', 'N', hermA, Bi, Ct);
 
   // Invert Ct into TNN3D
-  getrfBatched(NEL, Carray.data(), ldC, ma::pointer_dispatch(IWORK.origin()),
-               ma::pointer_dispatch(IWORK.origin()) + nbatch * NEL, nbatch);
+  getrfBatched(NEL, Carray.data(), ldC, ma::pointer_dispatch(IWORK.base()),
+               ma::pointer_dispatch(IWORK.base()) + nbatch * NEL, nbatch);
 
   using ma::strided_determinant_from_getrf;
   strided_determinant_from_getrf(NEL, ma::pointer_dispatch(Carray[0]), ldC, C.stride(),
-                                 ma::pointer_dispatch(IWORK.origin()), NEL, LogOverlapFactor, to_address(ovlp.origin()),
+                                 ma::pointer_dispatch(IWORK.base()), NEL, LogOverlapFactor, to_address(ovlp.base()),
                                  nbatch);
 
-  getriBatched(NEL, Carray.data(), ldC, ma::pointer_dispatch(IWORK.origin()), NNarray.data(), ldN,
-               ma::pointer_dispatch(IWORK.origin()) + nbatch * NEL, nbatch);
+  getriBatched(NEL, Carray.data(), ldC, ma::pointer_dispatch(IWORK.base()), NNarray.data(), ldN,
+               ma::pointer_dispatch(IWORK.base()) + nbatch * NEL, nbatch);
 
 
   if (compact)
@@ -1104,7 +1104,7 @@ void MixedDensityMatrix(std::vector<MatA>& hermA,
       TNMi.reserve(nbatch);
       for (int i = 0; i < nbatch; i++)
       {
-        NMarray.emplace_back(TNM3D[i].origin());
+        NMarray.emplace_back(TNM3D[i].base());
         TNMi.emplace_back(&TNM3D[i]);
       }
 
@@ -1132,7 +1132,7 @@ void MixedDensityMatrix(std::vector<MatA>& hermA,
       std::vector<pointer> NMarray;
       NMarray.reserve(nbatch);
       for (int i = 0; i < nbatch; i++)
-        NMarray.emplace_back(TNM3D[i].origin());
+        NMarray.emplace_back(TNM3D[i].base());
 
       // T2 = T(T1) * T(B)
       // C = T( B * T2) = T(T2) * T(B)
@@ -1212,10 +1212,10 @@ void DensityMatrices(std::vector<MatA> const& Left,
   {
     assert((*Right[i]).stride() == ldR);
     assert((*Left[i]).stride() == ldL);
-    NNarray.emplace_back(TNN3D[i].origin());
-    Garray.emplace_back((*G[i]).origin());
-    Rarray.emplace_back((*Right[i]).origin());
-    Larray.emplace_back((*Left[i]).origin());
+    NNarray.emplace_back(TNN3D[i].base());
+    Garray.emplace_back((*G[i]).base());
+    Rarray.emplace_back((*Right[i]).base());
+    Larray.emplace_back((*Left[i]).base());
   }
 
   // T(conj(A))*B
@@ -1228,14 +1228,14 @@ void DensityMatrices(std::vector<MatA> const& Left,
 
   // T1 = T1^(-1)
   // Invert
-  getrfBatched(NEL, Garray.data(), NEL, ma::pointer_dispatch(IWORK.origin()),
-               ma::pointer_dispatch(IWORK.origin()) + nbatch * NEL, nbatch);
+  getrfBatched(NEL, Garray.data(), NEL, ma::pointer_dispatch(IWORK.base()),
+               ma::pointer_dispatch(IWORK.base()) + nbatch * NEL, nbatch);
 
-  batched_determinant_from_getrf(NEL, Garray.data(), NEL, IWORK.origin(), NEL, LogOverlapFactor,
-                                 to_address(ovlp.origin()), nbatch);
+  batched_determinant_from_getrf(NEL, Garray.data(), NEL, IWORK.base(), NEL, LogOverlapFactor,
+                                 to_address(ovlp.base()), nbatch);
 
-  getriBatched(NEL, Garray.data(), NEL, ma::pointer_dispatch(IWORK.origin()), ma::pointer_dispatch(NNarray.data()), ldN,
-               ma::pointer_dispatch(IWORK.origin()) + nbatch * NEL, nbatch);
+  getriBatched(NEL, Garray.data(), NEL, ma::pointer_dispatch(IWORK.base()), ma::pointer_dispatch(NNarray.data()), ldN,
+               ma::pointer_dispatch(IWORK.base()) + nbatch * NEL, nbatch);
 
   if (compact)
   {
@@ -1250,7 +1250,7 @@ void DensityMatrices(std::vector<MatA> const& Left,
     std::vector<pointer> NMarray;
     NMarray.reserve(nbatch);
     for (int i = 0; i < nbatch; i++)
-      NMarray.emplace_back(TNM3D[i].origin());
+      NMarray.emplace_back(TNM3D[i].base());
 
     if (herm)
     {
@@ -1322,8 +1322,8 @@ void Overlap(std::vector<MatA>& hermA,
   Ci.reserve(nbatch);
   for (int i = 0; i < nbatch; i++)
   {
-    NNarray.emplace_back(TNN3D[i].origin());
-    Warray.emplace_back((*Bi[i]).origin());
+    NNarray.emplace_back(TNN3D[i].base());
+    Warray.emplace_back((*Bi[i]).base());
     Ci.emplace_back(&TNN3D[i]);
   }
 
@@ -1339,11 +1339,11 @@ void Overlap(std::vector<MatA>& hermA,
 
   // T1 = T1^(-1)
   // Invert
-  getrfBatched(NEL, NNarray.data(), ldN, IWORK.origin(), IWORK.origin() + nbatch * NEL, nbatch);
+  getrfBatched(NEL, NNarray.data(), ldN, IWORK.base(), IWORK.base() + nbatch * NEL, nbatch);
 
   using ma::strided_determinant_from_getrf;
-  strided_determinant_from_getrf(NEL, NNarray[0], ldN, TNN3D.stride(), IWORK.origin(), NEL, LogOverlapFactor,
-                                 to_address(ovlp.origin()), nbatch);
+  strided_determinant_from_getrf(NEL, NNarray[0], ldN, TNN3D.stride(), IWORK.base(), NEL, LogOverlapFactor,
+                                 to_address(ovlp.base()), nbatch);
 }
 
 

--- a/src/AFQMC/SlaterDeterminantOperations/rotate.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/rotate.hpp
@@ -132,7 +132,7 @@ void halfRotateCholeskyMatrix(WALKER_TYPES type,
           continue;
         if (cnt >= ak1)
           break;
-        std::fill_n(vec.origin(), vec.size(), SPComplexType(0, 0));
+        std::fill_n(vec.base(), vec.size(), SPComplexType(0, 0));
         auto Aa = (*Alpha)[a];
         for (int ip = 0; ip < Aa.num_non_zero_elements(); ++ip)
         {
@@ -170,7 +170,7 @@ void halfRotateCholeskyMatrix(WALKER_TYPES type,
             continue;
           if (cnt >= ak1)
             break;
-          std::fill_n(vec.origin(), vec.size(), SPComplexType(0, 0));
+          std::fill_n(vec.base(), vec.size(), SPComplexType(0, 0));
           auto Aa = (*Beta)[a];
           for (int ip = 0; ip < Aa.num_non_zero_elements(); ++ip)
           {
@@ -210,7 +210,7 @@ void halfRotateCholeskyMatrix(WALKER_TYPES type,
         continue;
       if (cnt >= ak1)
         break;
-      std::fill_n(vec.origin(), vec.size(), SPComplexType(0, 0));
+      std::fill_n(vec.base(), vec.size(), SPComplexType(0, 0));
       auto Aa = (*Alpha)[a];
       for (int ip = 0; ip < Aa.num_non_zero_elements(); ++ip)
       {
@@ -248,7 +248,7 @@ void halfRotateCholeskyMatrix(WALKER_TYPES type,
           continue;
         if (cnt >= ak1)
           break;
-        std::fill_n(vec.origin(), vec.size(), SPComplexType(0, 0));
+        std::fill_n(vec.base(), vec.size(), SPComplexType(0, 0));
         auto Aa = (*Beta)[a];
         for (int ip = 0; ip < Aa.num_non_zero_elements(); ++ip)
         {
@@ -334,7 +334,7 @@ SpCType_shm_csr_matrix halfRotateCholeskyMatrixForBias(WALKER_TYPES type,
         continue;
       if (cnt >= ak1)
         break;
-      std::fill_n(vec.origin(), vec.size(), SPComplexType(0, 0));
+      std::fill_n(vec.base(), vec.size(), SPComplexType(0, 0));
       auto Aa = (*Alpha)[a];
       for (int ip = 0; ip < Aa.num_non_zero_elements(); ++ip)
       {
@@ -361,7 +361,7 @@ SpCType_shm_csr_matrix halfRotateCholeskyMatrixForBias(WALKER_TYPES type,
           continue;
         if (cnt >= ak1)
           break;
-        std::fill_n(vec.origin(), vec.size(), SPComplexType(0, 0));
+        std::fill_n(vec.base(), vec.size(), SPComplexType(0, 0));
         auto Aa = (*Beta)[a];
         for (int ip = 0; ip < Aa.num_non_zero_elements(); ++ip)
         {
@@ -392,7 +392,7 @@ SpCType_shm_csr_matrix halfRotateCholeskyMatrixForBias(WALKER_TYPES type,
         continue;
       if (cnt >= ak1)
         break;
-      std::fill_n(vec.origin(), vec.size(), SPComplexType(0, 0));
+      std::fill_n(vec.base(), vec.size(), SPComplexType(0, 0));
       auto Aa = (*Alpha)[a];
       for (int ip = 0; ip < Aa.num_non_zero_elements(); ++ip)
       {
@@ -418,7 +418,7 @@ SpCType_shm_csr_matrix halfRotateCholeskyMatrixForBias(WALKER_TYPES type,
           continue;
         if (cnt >= ak1)
           break;
-        std::fill_n(vec.origin(), vec.size(), SPComplexType(0, 0));
+        std::fill_n(vec.base(), vec.size(), SPComplexType(0, 0));
         auto Aa = (*Beta)[a];
         for (int ip = 0; ip < Aa.num_non_zero_elements(); ++ip)
         {
@@ -529,7 +529,7 @@ void halfRotateCholeskyMatrix(WALKER_TYPES type,
         break;
       if (transpose)
       {
-        auto vec = Q(Q.extension(0), cnt);
+        auto vec = Q(get<0>(Q.extents()), cnt);
         for (auto& v : vec)
           v = SPComplexType(0, 0);
         auto Aa = (*Alpha)[a];
@@ -576,7 +576,7 @@ void halfRotateCholeskyMatrix(WALKER_TYPES type,
           break;
         if (transpose)
         {
-          auto vec = Q(Q.extension(0), cnt);
+          auto vec = Q(get<0>(Q.extents()), cnt);
           for (auto& v : vec)
             v = SPComplexType(0, 0);
           auto Aa = (*Beta)[a];
@@ -648,15 +648,15 @@ void getLank(MultiArray2DA&& Aai,
 
   using elementA = typename std::decay<MultiArray2DA>::type::element;
   using element  = typename std::decay<MultiArray3DC>::type::element;
-  boost::multi::array_ref<elementA, 2> Aas_i(to_address(Aai.origin()), {na * npol, ni});
-  boost::multi::array_ref<element, 2> Li_kn(to_address(Likn.origin()), {ni, nk * nchol});
-  boost::multi::array_ref<element, 2> Las_kn(to_address(Lank.origin()), {na * npol, nk * nchol});
+  boost::multi::array_ref<elementA, 2> Aas_i(to_address(Aai.base()), {na * npol, ni});
+  boost::multi::array_ref<element, 2> Li_kn(to_address(Likn.base()), {ni, nk * nchol});
+  boost::multi::array_ref<element, 2> Las_kn(to_address(Lank.base()), {na * npol, nk * nchol});
 
   ma::product(Aas_i, Li_kn, Las_kn);
   for (int a = 0; a < na; a++)
   {
-    boost::multi::array_ref<element, 2> Lskn(to_address(Lank[a].origin()), {npol * nk, nchol});
-    boost::multi::array_ref<element, 2> Lnsk(to_address(Lank[a].origin()), {nchol, npol * nk});
+    boost::multi::array_ref<element, 2> Lskn(to_address(Lank[a].base()), {npol * nk, nchol});
+    boost::multi::array_ref<element, 2> Lnsk(to_address(Lank[a].base()), {nchol, npol * nk});
     buff({0, npol * nk}, {0, nchol}) = Lskn;
     ma::transpose(buff({0, npol * nk}, {0, nchol}), Lnsk);
   }
@@ -696,8 +696,8 @@ void getLank_from_Lkin(MultiArray2DA&& Aai,
 
   using Type     = typename std::decay<MultiArray3DC>::type::element;
   using elementA = typename std::decay<MultiArray2DA>::type::element;
-  boost::multi::array_ref<elementA, 2> Aas_i(to_address(Aai.origin()), {na * npol, ni});
-  boost::multi::array_ref<Type, 2> bnas(to_address(buff.origin()), {nchol, na * npol});
+  boost::multi::array_ref<elementA, 2> Aas_i(to_address(Aai.base()), {na * npol, ni});
+  boost::multi::array_ref<Type, 2> bnas(to_address(buff.base()), {nchol, na * npol});
   // Lank[a][n][k] = sum_i Aai[a][i] conj(Lkin[k][i][n])
   // Lank[as][n][k] = sum_i Aai[as][i] conj(Lkin[k][i][n])
   for (int k = 0; k < nk; k++)
@@ -749,9 +749,9 @@ void getLakn_Lank(MultiArray2DA&& Aai,
   using elmB = typename std::decay<MultiArray3DB>::type::element;
   using elmC = typename std::decay<MultiArray3DC>::type::element;
 
-  boost::multi::array_ref<elmA, 2> Aas_i(to_address(Aai.origin()), {na * npol, ni});
-  boost::multi::array_ref<elmB, 2, decltype(Likn.origin())> Li_kn(Likn.origin(), {ni, nmo * nchol});
-  boost::multi::array_ref<elmC, 2, decltype(Lakn.origin())> Las_kn(Lakn.origin(), {na * npol, nmo * nchol});
+  boost::multi::array_ref<elmA, 2> Aas_i(to_address(Aai.base()), {na * npol, ni});
+  boost::multi::array_ref<elmB, 2, decltype(Likn.base())> Li_kn(Likn.base(), {ni, nmo * nchol});
+  boost::multi::array_ref<elmC, 2, decltype(Lakn.base())> Las_kn(Lakn.base(), {na * npol, nmo * nchol});
 
   ma::product(Aas_i, Li_kn, Las_kn);
   for (int a = 0; a < na; a++)
@@ -795,8 +795,8 @@ void getLakn_Lank_from_Lkin(MultiArray2DA&& Aai,
   using elm2 = typename std::decay<MultiArray2D>::type::element;
   using elmA = typename std::decay<MultiArray2DA>::type::element;
 
-  boost::multi::array_ref<elmA, 2> Aas_i(to_address(Aai.origin()), {na * npol, ni});
-  boost::multi::array_ref<elm2, 2, ptr2> bnas(buff.origin(), {nchol, na * npol});
+  boost::multi::array_ref<elmA, 2> Aas_i(to_address(Aai.base()), {na * npol, ni});
+  boost::multi::array_ref<elm2, 2, ptr2> bnas(buff.base(), {nchol, na * npol});
   // Lakn[a][sk][n] = sum_i Aai[as][i] conj(Lkin[k][i][n])
   for (int k = 0; k < nmo; k++)
   {

--- a/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
+++ b/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
@@ -120,8 +120,8 @@ TEST_CASE("SDetOps_double_serial", "[sdet_ops]")
   CHECK(SDet.Overlap(Aref,Bref) == Approx(ov));
 
   // Test array_view
-  CHECK(SDet.Overlap(A(A.extension(0),A.extension(1)),B) == Approx(ov));
-  CHECK(SDet.Overlap(A,B(B.extension(0),B.extension(1))) == Approx(ov));
+  CHECK(SDet.Overlap(A(get<0>(A.extents()),get<1>(A.extents())),B) == Approx(ov));
+  CHECK(SDet.Overlap(A,B(get<0>(B.extents()),get<1>(B.extents()))) == Approx(ov));
 
   array A_ = A({0,2},{0,3});
   array B_ = B({0,3},{0,2});
@@ -265,8 +265,8 @@ TEST_CASE("SDetOps_double_mpi3", "[sdet_ops]")
   CHECK(SDet.Overlap(Aref,Bref,node) == Approx(ov));
 
   // Test array_view
-  CHECK(SDet.Overlap(A(A.extension(0),A.extension(1)),B,node) == Approx(ov));
-  CHECK(SDet.Overlap(A,B(B.extension(0),B.extension(1)),node) == Approx(ov));
+  CHECK(SDet.Overlap(A(get<0>(A.extents()),get<1>(A.extents())),B,node) == Approx(ov));
+  CHECK(SDet.Overlap(A,B(get<0>(B.extents()),get<1>(B.extents())),node) == Approx(ov));
 
   array A_ = A({0,2},{0,3});
   array B_ = B({0,3},{0,2});
@@ -311,8 +311,8 @@ TEST_CASE("SDetOps_double_mpi3", "[sdet_ops]")
   boost::multi::array<Type,1,shared_allocator<Type>> SMbuff(iextensions<1u>{NMO*(NMO+NEL)},
                                                             shared_allocator<Type>{node});  
 
-  array_ref G(to_address(SMbuff.origin()),{NMO,NMO});
-  array_ref Gc(to_address(SMbuff.origin())+NMO*NMO,{NEL,NMO});
+  array_ref G(to_address(SMbuff.base()),{NMO,NMO});
+  array_ref Gc(to_address(SMbuff.base())+NMO*NMO,{NEL,NMO});
 
   ov_=SDet.MixedDensityMatrix(A,B,G,node,false); check(G,g_ref);
   ov_=SDet.MixedDensityMatrix(Aref,B,G,node,false); check(G,g_ref);
@@ -353,8 +353,8 @@ TEST_CASE("SDetOps_double_mpi3", "[sdet_ops]")
   boost::multi::array<Type,1,shared_allocator<Type>> SMbuff2(iextensions<1u>{NMO*(NMO+NEL)},
                                                             shared_allocator<Type>{node_});
 
-  array_ref G2(to_address(SMbuff2.origin()),{NMO,NMO});
-  array_ref Gc2(to_address(SMbuff2.origin())+NMO*NMO,{NEL,NMO});
+  array_ref G2(to_address(SMbuff2.base()),{NMO,NMO});
+  array_ref Gc2(to_address(SMbuff2.base())+NMO*NMO,{NEL,NMO});
 
   // switch comm
   ov_=SDet.MixedDensityMatrix(A,B,G2,node_,false); check(G2,g_ref);
@@ -383,7 +383,7 @@ void SDetOps_complex_serial(Allocator alloc, BufferManager b)
   using vector    = std::vector<Type>;
   using array     = boost::multi::array<Type, 2, Allocator>;
   using array_ref = boost::multi::array_ref<Type, 2, typename Allocator::pointer>;
-  using array_ptr = boost::multi::array_ptr<Type, 2, typename Allocator::pointer>;
+  using array_ptr = boost::multi::detail::array_ptr<Type, 2, typename Allocator::pointer>;
   using namespace std::complex_literals;
 
   const Type ov  = -7.62332599999999 + 22.20453200000000i;
@@ -398,12 +398,12 @@ void SDetOps_complex_serial(Allocator alloc, BufferManager b)
                 0.60000 + 0.90000i, 1.10000 + 0.50000i, 0.30000 + 0.60000i, 0.90000 + 0.70000i};
 
   array A({NEL, NMO}, alloc);
-  copy_n(m_a.data(), m_a.size(), A.origin());
+  copy_n(m_a.data(), m_a.size(), A.base());
   array B({NMO, NEL}, alloc);
-  copy_n(m_b.data(), m_b.size(), B.origin());
+  copy_n(m_b.data(), m_b.size(), B.base());
 
-  array_ref Aref(A.origin(), {NEL, NMO});
-  array_ref Bref(B.origin(), {NMO, NEL});
+  array_ref Aref(A.base(), {NEL, NMO});
+  array_ref Bref(B.base(), {NMO, NEL});
 
   SlaterDetOperations SDet(SlaterDetOperations_serial<Type, BufferManager>(NMO, NEL, b));
 
@@ -425,9 +425,9 @@ void SDetOps_complex_serial(Allocator alloc, BufferManager b)
   //SECTION("array_view")
   {
     Type ov_;
-    ov_ = SDet.Overlap(A(A.extension(0), A.extension(1)), B, 0.0);
+    ov_ = SDet.Overlap(A(get<0>(A.extents()), get<1>(A.extents())), B, 0.0);
     myCHECK(ov_, ov);
-    ov_ = SDet.Overlap(A, B(B.extension(0), B.extension(1)), 0.0);
+    ov_ = SDet.Overlap(A, B(get<0>(B.extents()), get<1>(B.extents())), 0.0);
     myCHECK(ov_, ov);
   }
 
@@ -680,9 +680,9 @@ TEST_CASE("SDetOps_complex_mpi3", "[sdet_ops]")
   myCHECK(ov_, ov);
 
   // Test array_view
-  ov_ = SDet.Overlap(A(A.extension(0), A.extension(1)), B, 0.0, node);
+  ov_ = SDet.Overlap(A(get<0>(A.extents()), get<1>(A.extents())), B, 0.0, node);
   myCHECK(ov_, ov);
-  ov_ = SDet.Overlap(A, B(B.extension(0), B.extension(1)), 0.0, node);
+  ov_ = SDet.Overlap(A, B(get<0>(B.extents()), get<1>(B.extents())), 0.0, node);
   myCHECK(ov_, ov);
 
   array A_ = A({0, 2}, {0, 3});
@@ -740,8 +740,8 @@ TEST_CASE("SDetOps_complex_mpi3", "[sdet_ops]")
   boost::multi::array<Type, 1, shared_allocator<Type>> SMbuff(iextensions<1u>{NMO * (NMO + NEL)},
                                                               shared_allocator<Type>{node});
 
-  array_ref G(to_address(SMbuff.origin()), {NMO, NMO});
-  array_ref Gc(to_address(SMbuff.origin()) + NMO * NMO, {NEL, NMO});
+  array_ref G(to_address(SMbuff.base()), {NMO, NMO});
+  array_ref Gc(to_address(SMbuff.base()) + NMO * NMO, {NEL, NMO});
 
   ov_ = SDet.MixedDensityMatrix(A, B, G, 0.0, node, false);
   check(G, g_ref);
@@ -778,8 +778,8 @@ TEST_CASE("SDetOps_complex_mpi3", "[sdet_ops]")
   boost::multi::array<Type, 1, shared_allocator<Type>> SMbuff2(iextensions<1u>{NMO * (NMO + NEL)},
                                                                shared_allocator<Type>{node_});
 
-  array_ref G2(to_address(SMbuff2.origin()), {NMO, NMO});
-  array_ref Gc2(to_address(SMbuff2.origin()) + NMO * NMO, {NEL, NMO});
+  array_ref G2(to_address(SMbuff2.base()), {NMO, NMO});
+  array_ref Gc2(to_address(SMbuff2.base()) + NMO * NMO, {NEL, NMO});
 
   // switch comm
   ov_ = SDet.MixedDensityMatrix(A, B, G2, 0.0, node_, false);
@@ -854,9 +854,9 @@ TEST_CASE("SDetOps_complex_csr", "[sdet_ops]")
   myCHECK(ov_, ov);
 
   // Test array_view
-  ov_ = SDet.Overlap(Acsr, B(B.extension(0), B.extension(1)), 0.0, node);
+  ov_ = SDet.Overlap(Acsr, B(get<0>(B.extents()), get<1>(B.extents())), 0.0, node);
   myCHECK(ov_, ov);
-  ov_ = SDet.Overlap(Acsr, B(B.extension(0), B.extension(1)), 0.0);
+  ov_ = SDet.Overlap(Acsr, B(get<0>(B.extents()), get<1>(B.extents())), 0.0);
   myCHECK(ov_, ov);
 
   shared_communicator node_ = node.split(node.rank() % 2, node.rank());
@@ -908,8 +908,8 @@ TEST_CASE("SDetOps_complex_csr", "[sdet_ops]")
   boost::multi::array<Type, 1, shared_allocator<Type>> SMbuff(iextensions<1u>{NMO * (NMO + NEL)},
                                                               shared_allocator<Type>{node});
 
-  array_ref G(to_address(SMbuff.origin()), {NMO, NMO});
-  array_ref Gc(to_address(SMbuff.origin()) + NMO * NMO, {NEL, NMO});
+  array_ref G(to_address(SMbuff.base()), {NMO, NMO});
+  array_ref Gc(to_address(SMbuff.base()) + NMO * NMO, {NEL, NMO});
 
   ov_ = SDet.MixedDensityMatrix(Acsr, B, G, 0.0, node, false);
   check(G, g_ref);
@@ -934,8 +934,8 @@ TEST_CASE("SDetOps_complex_csr", "[sdet_ops]")
   boost::multi::array<Type, 1, shared_allocator<Type>> SMbuff2(iextensions<1u>{NMO * (NMO + NEL)},
                                                                shared_allocator<Type>{node_});
 
-  array_ref G2(to_address(SMbuff2.origin()), {NMO, NMO});
-  array_ref Gc2(to_address(SMbuff2.origin()) + NMO * NMO, {NEL, NMO});
+  array_ref G2(to_address(SMbuff2.base()), {NMO, NMO});
+  array_ref Gc2(to_address(SMbuff2.base()) + NMO * NMO, {NEL, NMO});
 
   // switch comm
 

--- a/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
+++ b/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
@@ -385,6 +385,7 @@ void SDetOps_complex_serial(Allocator alloc, BufferManager b)
   using array_ref = boost::multi::array_ref<Type, 2, typename Allocator::pointer>;
   using array_ptr = boost::multi::detail::array_ptr<Type, 2, typename Allocator::pointer>;
   using namespace std::complex_literals;
+  using std::get;
 
   const Type ov  = -7.62332599999999 + 22.20453200000000i;
   const Type ov2 = -10.37150000000000 - 7.15750000000000i;

--- a/src/AFQMC/Utilities/hdf5_consistency_helper.hpp
+++ b/src/AFQMC/Utilities/hdf5_consistency_helper.hpp
@@ -103,7 +103,7 @@ bool readComplexOrReal(hdf_archive& dump, std::string name, boost::multi::array<
     // Real integrals.
     boost::multi::array<RealType, 2> out_real({shape[0], shape[1]});
     dump.readEntry(out_real, name);
-    std::copy_n(out_real.origin(), out_real.num_elements(), out.origin());
+    std::copy_n(out_real.base(), out_real.num_elements(), out.base());
     return true;
   }
   else

--- a/src/AFQMC/Utilities/kp_utilities.hpp
+++ b/src/AFQMC/Utilities/kp_utilities.hpp
@@ -32,7 +32,7 @@ bool get_nocc_per_kp(Vector const& nmo_per_kp, CSR const& PsiT, Array&& nocc_per
   assert(M % npol == 0);
   assert(nocc_per_kp.size() == nkpts);
 
-  std::fill_n(to_address(nocc_per_kp.origin()), nkpts, 0);
+  std::fill_n(to_address(nocc_per_kp.base()), nkpts, 0);
   std::vector<int> bounds(npol * nkpts + 1);
   bounds[0] = 0;
   for (int k = 0; k < npol * nkpts; k++)
@@ -43,7 +43,7 @@ bool get_nocc_per_kp(Vector const& nmo_per_kp, CSR const& PsiT, Array&& nocc_per
     auto nt = PsiT.num_non_zero_elements(i);
     if (nt == 0)
     {
-      std::fill_n(to_address(nocc_per_kp.origin()), nkpts, 0);
+      std::fill_n(to_address(nocc_per_kp.base()), nkpts, 0);
       return false;
     }
     auto col = PsiT.non_zero_indices2_data(i);
@@ -56,7 +56,7 @@ bool get_nocc_per_kp(Vector const& nmo_per_kp, CSR const& PsiT, Array&& nocc_per
     assert(pol_ == 0 || pol_ == 1);
     if (Q_ < Q)
     {
-      std::fill_n(to_address(nocc_per_kp.origin()), nkpts, 0);
+      std::fill_n(to_address(nocc_per_kp.base()), nkpts, 0);
       return false;
     }
     Q = Q_;
@@ -65,7 +65,7 @@ bool get_nocc_per_kp(Vector const& nmo_per_kp, CSR const& PsiT, Array&& nocc_per
       if ((*col < bounds[Q] || *col >= bounds[Q + 1]) &&
           (*col < bounds[(npol - 1) * nkpts + Q] || *col >= bounds[(npol - 1) * nkpts + Q + 1]))
       {
-        std::fill_n(to_address(nocc_per_kp.origin()), nkpts, 0);
+        std::fill_n(to_address(nocc_per_kp.base()), nkpts, 0);
         return false;
       }
     }
@@ -115,7 +115,7 @@ Array get_PsiK(Vector const& nmo_per_kp, CSR const& PsiT, int K, bool noncolin =
   using element = typename std::decay<Array>::type::element;
   Array A({nel, npol * nmo_per_kp[K]});
   using std::fill_n;
-  fill_n(A.origin(), A.num_elements(), element(0));
+  fill_n(A.base(), A.num_elements(), element(0));
   nel = 0;
   for (int i = 0; i < N; i++)
   {
@@ -222,18 +222,18 @@ bool check_cholesky_symmetry(T1 const& LQKikn,
         int nj = nmo_per_kp[KJ];
         int nk = nmo_per_kp[KK];
         int nl = nmo_per_kp[KL];
-        boost::multi::array_ref<ComplexType, 2, const ComplexType*> LKI(std::addressof(*LQKikn[Q][KI].origin()),
+        boost::multi::array_ref<ComplexType, 2, const ComplexType*> LKI(std::addressof(*LQKikn[Q][KI].base()),
                                                                         {ni * nk, nchol_per_kp[Q]});
-        boost::multi::array_ref<ComplexType, 2, const ComplexType*> LKL(std::addressof(*LQKikn[Q][KL].origin()),
+        boost::multi::array_ref<ComplexType, 2, const ComplexType*> LKL(std::addressof(*LQKikn[Q][KL].base()),
                                                                         {nl * nj, nchol_per_kp[Q]});
-        boost::multi::array_ref<ComplexType, 2> IJKL(std::addressof(*IJKL_.origin()), {ni * nk, nl * nj});
-        boost::multi::array_ref<ComplexType, 4> IJKL_4D(std::addressof(*IJKL_.origin()), {ni, nk, nl, nj});
+        boost::multi::array_ref<ComplexType, 2> IJKL(std::addressof(*IJKL_.base()), {ni * nk, nl * nj});
+        boost::multi::array_ref<ComplexType, 4> IJKL_4D(std::addressof(*IJKL_.base()), {ni, nk, nl, nj});
         ma::product(LKI, ma::H(LKL), IJKL);
 
-        boost::multi::array_ref<ComplexType, 2, const ComplexType*> LKJ(std::addressof(*LQKikn[Q][KJ].origin()),
+        boost::multi::array_ref<ComplexType, 2, const ComplexType*> LKJ(std::addressof(*LQKikn[Q][KJ].base()),
                                                                         {nj * nl, nchol_per_kp[Q]});
-        boost::multi::array_ref<ComplexType, 2> IJKL2(std::addressof(*IJKL2_.origin()), {ni * nk, nj * nl});
-        boost::multi::array_ref<ComplexType, 4> IJKL2_4D(std::addressof(*IJKL2_.origin()), {ni, nk, nj, nl});
+        boost::multi::array_ref<ComplexType, 2> IJKL2(std::addressof(*IJKL2_.base()), {ni * nk, nj * nl});
+        boost::multi::array_ref<ComplexType, 4> IJKL2_4D(std::addressof(*IJKL2_.base()), {ni, nk, nj, nl});
         ma::product(LKI, ma::T(LKJ), IJKL2);
         double mx(0.0);
         for (int i = 0; i < ni; i++)

--- a/src/AFQMC/Utilities/readWfn.cpp
+++ b/src/AFQMC/Utilities/readWfn.cpp
@@ -270,6 +270,7 @@ void read_general_wavefunction(std::ifstream& in,
                                std::vector<PsiT_Matrix>& PsiT,
                                std::vector<ComplexType>& ci)
 {
+  using std::get;
   in.clear();
   in.seekg(0, std::ios::beg);
 
@@ -348,7 +349,7 @@ void read_general_wavefunction(std::ifstream& in,
         {
           PsiT.emplace_back(csr::shm::construct_csr_matrix_single_input<PsiT_Matrix>(OrbMat, 1e-8, 'H', comm));
           PsiT.emplace_back(
-              csr::shm::construct_csr_matrix_single_input<PsiT_Matrix>(OrbMat(OrbMat.extension(0), {0, NAEB}), 1e-8,
+              csr::shm::construct_csr_matrix_single_input<PsiT_Matrix>(OrbMat(get<0>(OrbMat.extents()), {0, NAEB}), 1e-8,
                                                                        'H', comm));
         }
         else if (walker_type == NONCOLLINEAR)
@@ -357,7 +358,7 @@ void read_general_wavefunction(std::ifstream& in,
           /*
           boost::multi::array<ComplexType,2> Mat({2*NMO,NAEA+NAEB});
           if(comm.rank()==0) {
-            std::fill_n(Mat.origin(),2*NMO*(NAEA+NAEB),ComplexType(0.0));
+            std::fill_n(Mat.base(),2*NMO*(NAEA+NAEB),ComplexType(0.0));
             Mat({0,NMO},{0,NAEA}) = OrbMat;
             Mat({NMO,2*NMO},{NAEA,NAEA+NAEB}) = OrbMat({0,NMO},{0,NAEB});
           }  
@@ -384,9 +385,9 @@ void read_general_wavefunction(std::ifstream& in,
 
         PsiT.emplace_back(csr::shm::construct_csr_matrix_single_input<PsiT_Matrix>(OrbMat, 1e-8, 'H', comm));
         if (comm.rank() == 0)
-          read_mat(in, OrbMat(OrbMat.extension(0), {0, NAEB}), Cstyle, fullMOMat, NMO, NAEB);
+          read_mat(in, OrbMat(get<0>(OrbMat.extents()), {0, NAEB}), Cstyle, fullMOMat, NMO, NAEB);
         PsiT.emplace_back(
-            csr::shm::construct_csr_matrix_single_input<PsiT_Matrix>(OrbMat(OrbMat.extension(0), {0, NAEB}), 1e-8, 'H',
+            csr::shm::construct_csr_matrix_single_input<PsiT_Matrix>(OrbMat(get<0>(OrbMat.extents()), {0, NAEB}), 1e-8, 'H',
                                                                      comm));
       }
     }

--- a/src/AFQMC/Utilities/type_conversion.hpp
+++ b/src/AFQMC/Utilities/type_conversion.hpp
@@ -173,9 +173,9 @@ void emplace_back_array_ref(VType& V, MType&& M, bool device=true) {
   assert(M.stride() == M.size(1));
   assert(get<1>(M.strides()) == 1);
   if(device) {  
-    V.emplace_back(make_device_ptr(M.origin()),iextensions<2u>{M.size(0),M.size(1)});
+    V.emplace_back(make_device_ptr(M.base()),iextensions<2u>{M.size(0),M.size(1)});
   } else {
-    V.emplace_back(to_address(M.origin()),iextensions<2u>{M.size(0),M.size(1)});
+    V.emplace_back(to_address(M.base()),iextensions<2u>{M.size(0),M.size(1)});
   }
 } 
 */

--- a/src/AFQMC/Walkers/WalkerControl.hpp
+++ b/src/AFQMC/Walkers/WalkerControl.hpp
@@ -89,7 +89,7 @@ inline int swapWalkersSimple(WlkBucket& wset,
   {
     if (plus[ic] == MyContext)
     {
-      comm.send_n(Wexcess[nsend].origin(), Wexcess[nsend].size(), minus[ic], plus[ic] + 999);
+      comm.send_n(Wexcess[nsend].base(), Wexcess[nsend].size(), minus[ic], plus[ic] + 999);
       ++nsend;
     }
     if (minus[ic] == MyContext)
@@ -165,7 +165,7 @@ inline int swapWalkersAsync(WlkBucket& wset,
       }
       else
       {
-        requests.emplace_back(comm.isend(Wexcess[nsend].origin(), Wexcess[nsend].origin() + countSend * get<1>(Wexcess.sizes()),
+        requests.emplace_back(comm.isend(Wexcess[nsend].base(), Wexcess[nsend].base() + countSend * get<1>(Wexcess.sizes()),
                                          minus[ic], plus[ic] + 1999));
         nsend += countSend;
         countSend = 1;

--- a/src/AFQMC/Walkers/WalkerIO.hpp
+++ b/src/AFQMC/Walkers/WalkerIO.hpp
@@ -444,7 +444,7 @@ bool dumpToHDF5(WalkerSet& wset, hdf_archive& dump)
         }
       }
 
-      TG.TG_heads().gatherv_n(SendBuff.origin(), SendBuff.num_elements(), RecvBuff.origin(), counts.data(),
+      TG.TG_heads().gatherv_n(SendBuff.base(), SendBuff.num_elements(), RecvBuff.base(), counts.data(),
                               displ.data(), 0);
       nsent += nw_to_send;
 

--- a/src/AFQMC/Walkers/WalkerSetBase.h
+++ b/src/AFQMC/Walkers/WalkerSetBase.h
@@ -70,8 +70,8 @@ protected:
   using BPCMatrix_ref = boost::multi::array_ref<bp_element, 2, bp_pointer>;
   using BPCTensor_ref = boost::multi::array_ref<bp_element, 3, bp_pointer>;
 
-  using stdCMatrix_ptr = boost::multi::array_ptr<bp_element, 2>;
-  using stdCTensor_ptr = boost::multi::array_ptr<bp_element, 3>;
+  using stdCMatrix_ptr = boost::multi::detail::array_ptr<bp_element, 2>;
+  using stdCTensor_ptr = boost::multi::detail::array_ptr<bp_element, 3>;
 
 public:
   // contiguous_walker = true means that all the data of a walker is continguous in memory
@@ -262,7 +262,7 @@ public:
         while (pos < n)
         {
           using std::fill_n;
-          fill_n(W[pos].origin(), W[pos].size(), ComplexType(0, 0));
+          fill_n(W[pos].base(), W[pos].size(), ComplexType(0, 0));
           reference w0(W[pos], data_displ, wlk_desc);
           //w0.SlaterMatrix(Alpha) = A;
           auto&& SM_(*w0.SlaterMatrix(Alpha));
@@ -338,7 +338,7 @@ public:
     {
       bp_buffer.reextent({bp_walker_size, get<0>(walker_buffer.sizes())});
       using std::fill_n;
-      fill_n(bp_buffer.origin() + data_displ[WEIGHT_FAC] * get<1>(bp_buffer.sizes()),
+      fill_n(bp_buffer.base() + data_displ[WEIGHT_FAC] * get<1>(bp_buffer.sizes()),
              wlk_desc[6] * get<1>(bp_buffer.sizes()), bp_element(1.0));
     }
     if (nbp > 0 && (data_displ[SMN] < 0 || data_displ[SM_AUX] < 0))
@@ -349,7 +349,7 @@ public:
       data_displ[SM_AUX] = walker_size;
       walker_size += nrow * ncol;
       CMatrix wb({get<0>(walker_buffer.sizes()), walker_size}, walker_buffer.get_allocator());
-      ma::copy(walker_buffer, wb(get<0>(wb.extensions()), {0, sz}));
+      ma::copy(walker_buffer, wb(get<0>(wb.extents()), {0, sz}));
       walker_buffer = std::move(wb);
     }
   }
@@ -412,7 +412,7 @@ public:
     {
       W[tot_num_walkers] = M[i].sliced(0, walker_size);
       if (wlk_desc[3] > 0)
-        BPW(get<0>(BPW.extensions()), tot_num_walkers) = M[i].sliced(walker_size, walker_size + bp_walker_size);
+        BPW(get<0>(BPW.extents()), tot_num_walkers) = M[i].sliced(walker_size, walker_size + bp_walker_size);
       tot_num_walkers++;
     }
   }
@@ -447,7 +447,7 @@ public:
     {
       M[i].sliced(0, walker_size) = W[tot_num_walkers - 1];
       if (wlk_desc[3] > 0)
-        M[i].sliced(walker_size, walker_size + bp_walker_size) = BPW(BPW.extension(0), tot_num_walkers - 1);
+        M[i].sliced(walker_size, walker_size + bp_walker_size) = BPW(get<0>(BPW.extents()), tot_num_walkers - 1);
       tot_num_walkers--;
     }
   }
@@ -511,7 +511,7 @@ public:
         std::swap(*kill, *keep);
         W[std::distance(itbegin, kill)] = W[tot_num_walkers - 1];
         if (wlk_desc[3] > 0)
-          BPW(get<0>(BPW.extensions()), std::distance(itbegin, kill)) = BPW(get<0>(BPW.extensions()), tot_num_walkers - 1);
+          BPW(get<0>(BPW.extents()), std::distance(itbegin, kill)) = BPW(get<0>(BPW.extents()), tot_num_walkers - 1);
         --tot_num_walkers;
         --keep;
       }
@@ -545,9 +545,9 @@ public:
         //walker_buffer[pos][data_displ[WEIGHT]] = ComplexType(itbegin->first,0.0);
         // need synthetic references to make this easier!!!
         using std::fill_n;
-        fill_n(W[pos].origin() + data_displ[WEIGHT], 1, ComplexType(itbegin->first, 0.0));
+        fill_n(W[pos].base() + data_displ[WEIGHT], 1, ComplexType(itbegin->first, 0.0));
         if (wlk_desc[6] > 0 && his_pos >= 0 && his_pos < wlk_desc[6])
-          fill_n(BPW[data_displ[WEIGHT_HISTORY] + his_pos].origin() + pos, 1, ComplexType(itbegin->first, 0.0));
+          fill_n(BPW[data_displ[WEIGHT_HISTORY] + his_pos].base() + pos, 1, ComplexType(itbegin->first, 0.0));
       }
       else
       {
@@ -557,21 +557,21 @@ public:
         //walker_buffer[pos][data_displ[WEIGHT]] = ComplexType(itbegin->first,0.0);
         // need synthetic references to make this easier!!!
         using std::fill_n;
-        fill_n(W[pos].origin() + data_displ[WEIGHT], 1, ComplexType(itbegin->first, 0.0));
+        fill_n(W[pos].base() + data_displ[WEIGHT], 1, ComplexType(itbegin->first, 0.0));
         if (wlk_desc[6] > 0 && his_pos >= 0 && his_pos < wlk_desc[6])
-          fill_n(BPW[data_displ[WEIGHT_HISTORY] + his_pos].origin() + pos, 1, ComplexType(itbegin->first, 0.0));
+          fill_n(BPW[data_displ[WEIGHT_HISTORY] + his_pos].base() + pos, 1, ComplexType(itbegin->first, 0.0));
         for (int i = 0; i < n; i++)
         {
           W[tot_num_walkers] = W[pos];
           if (wlk_desc[3] > 0)
-            BPW(get<0>(BPW.extensions()), tot_num_walkers) = BPW(get<0>(BPW.extensions()), pos);
+            BPW(get<0>(BPW.extents()), tot_num_walkers) = BPW(get<0>(BPW.extents()), pos);
           tot_num_walkers++;
         }
         for (int i = 0, in = itbegin->second - 1 - n; i < in; i++, cnt++)
         {
           M[cnt].sliced(0, walker_size) = W[pos];
           if (wlk_desc[3] > 0)
-            M[cnt].sliced(walker_size, walker_size + bp_walker_size) = BPW(get<0>(BPW.extensions()), pos);
+            M[cnt].sliced(walker_size, walker_size + bp_walker_size) = BPW(get<0>(BPW.extents()), pos);
         }
       }
     }
@@ -643,7 +643,7 @@ public:
     assert(get<1>(walker_buffer.sizes()) == walker_size);
     auto W(boost::multi::static_array_cast<element, pointer>(walker_buffer));
     using std::copy_n;
-    copy_n(W[n].origin(), walkerSizeIO(), x.origin());
+    copy_n(W[n].base(), walkerSizeIO(), x.base());
   }
 
   template<class Vec>
@@ -655,7 +655,7 @@ public:
     assert(get<1>(walker_buffer.sizes()) == walker_size);
     auto W(boost::multi::static_array_cast<element, pointer>(walker_buffer));
     using std::copy_n;
-    copy_n(x.origin(), walkerSizeIO(), W[n].origin());
+    copy_n(x.base(), walkerSizeIO(), W[n].base());
   }
 
   template<class TVec>
@@ -696,12 +696,12 @@ public:
       APP_ABORT(" Error: index out of bounds in getFields. \n");
 
     int skip = (data_displ[FIELDS] + ip * wlk_desc[4]) * get<1>(bp_buffer.sizes());
-    return stdCMatrix_ptr(to_address(bp_buffer.origin()) + skip, {wlk_desc[4], get<1>(bp_buffer.sizes())});
+    return stdCMatrix_ptr(to_address(bp_buffer.base()) + skip, {wlk_desc[4], get<1>(bp_buffer.sizes())});
   }
 
   stdCTensor_ptr getFields()
   {
-    return stdCTensor_ptr(to_address(bp_buffer.origin()) + data_displ[FIELDS] * get<1>(bp_buffer.sizes()),
+    return stdCTensor_ptr(to_address(bp_buffer.base()) + data_displ[FIELDS] * get<1>(bp_buffer.sizes()),
                           {wlk_desc[3], wlk_desc[4], get<1>(bp_buffer.sizes())});
   }
 
@@ -713,7 +713,7 @@ public:
     if (V.stride() == get<1>(V.sizes()))
     {
       using std::copy_n;
-      copy_n(V.origin(), F.num_elements(), F.origin());
+      copy_n(V.base(), F.num_elements(), F.base());
     }
     else
       F = V;
@@ -721,13 +721,13 @@ public:
 
   stdCMatrix_ptr getWeightFactors()
   {
-    return stdCMatrix_ptr(to_address(bp_buffer.origin()) + data_displ[WEIGHT_FAC] * get<1>(bp_buffer.sizes()),
+    return stdCMatrix_ptr(to_address(bp_buffer.base()) + data_displ[WEIGHT_FAC] * get<1>(bp_buffer.sizes()),
                           {wlk_desc[6], get<1>(bp_buffer.sizes())});
   }
 
   stdCMatrix_ptr getWeightHistory()
   {
-    return stdCMatrix_ptr(to_address(bp_buffer.origin()) + data_displ[WEIGHT_HISTORY] * get<1>(bp_buffer.sizes()),
+    return stdCMatrix_ptr(to_address(bp_buffer.base()) + data_displ[WEIGHT_HISTORY] * get<1>(bp_buffer.sizes()),
                           {wlk_desc[6], get<1>(bp_buffer.sizes())});
   }
 

--- a/src/AFQMC/Walkers/WalkerSetBase.icc
+++ b/src/AFQMC/Walkers/WalkerSetBase.icc
@@ -224,7 +224,7 @@ void WalkerSetBase<Alloc, Ptr>::reserve(int n)
   {
     bp_buffer.reextent({bp_walker_size, n});
     using std::fill_n;
-    fill_n(bp_buffer.origin(), bp_buffer.num_elements(), bp_element(0));
+    fill_n(bp_buffer.base(), bp_buffer.num_elements(), bp_element(0));
   }
 }
 

--- a/src/AFQMC/Walkers/Walkers.hpp
+++ b/src/AFQMC/Walkers/Walkers.hpp
@@ -32,11 +32,11 @@ struct walker
 public:
   using pointer = Ptr;
   using element = typename std::pointer_traits<pointer>::element_type;
-  using SMType  = boost::multi::array_ptr<element, 2, pointer>;
+  using SMType  = boost::multi::detail::array_ptr<element, 2, pointer>;
 
   template<class ma>
   walker(ma&& a, const wlk_indices& i_, const wlk_descriptor& d_)
-      : w_(a.origin(), iextensions<1u>{a.size()}), indx(i_), desc(d_)
+      : w_(a.base(), iextensions<1u>{a.size()}), indx(i_), desc(d_)
   {
     static_assert(std::decay<ma>::type::dimensionality == 1, "Wrong dimensionality");
   }
@@ -44,9 +44,9 @@ public:
   ~walker() {}
 
   /*
-      walker(walker&& other): w_(other.w_.origin(), iextensions<1u>{other.w_.size()}), 
+      walker(walker&& other): w_(other.w_.base(), iextensions<1u>{other.w_.size()}), 
                               indx(other.indx),desc(other.desc)  {} 
-      walker(walker const& other): w_(other.w_.origin(),iextensions<1u>{other.w_.size()}), 
+      walker(walker const& other): w_(other.w_.base(),iextensions<1u>{other.w_.size()}), 
                               indx(other.indx),desc(other.desc)  {} 
 */
   // no copy/move assignment
@@ -55,7 +55,7 @@ public:
   walker& operator=(walker&& other) = delete;
   walker& operator=(walker const& other) = delete;
 
-  pointer base() { return (*w_).origin(); }
+  pointer base() { return (*w_).base(); }
   int size() const { return (*w_).size(0); }
   SMType SlaterMatrix(SpinTypes s)
   {
@@ -102,11 +102,11 @@ public:
   }
 
 private:
-  boost::multi::array_ptr<element, 1, pointer> w_;
+  boost::multi::detail::array_ptr<element, 1, pointer> w_;
   const wlk_indices& indx;
   const wlk_descriptor& desc;
 
-  pointer getw_(int P) const { return (*w_).origin() + indx[P]; }
+  pointer getw_(int P) const { return (*w_).base() + indx[P]; }
 };
 
 template<class Ptr>
@@ -117,22 +117,22 @@ struct walker_iterator
 public:
   template<class WBuff>
   walker_iterator(int k, WBuff&& w_, const wlk_indices& i_, const wlk_descriptor& d_)
-      : pos(k), W(w_.origin(), w_.extensions()), indx(&i_), desc(&d_)
+      : pos(k), W(w_.base(), w_.extents()), indx(&i_), desc(&d_)
   {}
 
   using pointer         = Ptr;
   using element         = typename std::pointer_traits<pointer>::element_type;
-  using Wlk_Buff        = boost::multi::array_ptr<element, 2, Ptr>;
+  using Wlk_Buff        = boost::multi::detail::array_ptr<element, 2, Ptr>;
   using difference_type = std::ptrdiff_t;
   using reference       = walker<Ptr>;
 
   /*
     walker_iterator(walker_iterator const& it):
-        pos(it.pos),W(it.W.origin(),it.W.extensions()),indx(it.indx),desc(it.desc)
+        pos(it.pos),W(it.W.base(),it.W.extents()),indx(it.indx),desc(it.desc)
     {}
 
     walker_iterator(walker_iterator && it):
-        pos(it.pos),W(it.W.origin(),it.W.extensions()),indx(it.indx),desc(it.desc)
+        pos(it.pos),W(it.W.base(),it.W.extents()),indx(it.indx),desc(it.desc)
     {}
 */
 

--- a/src/AFQMC/Wavefunctions/NOMSD.hpp
+++ b/src/AFQMC/Wavefunctions/NOMSD.hpp
@@ -69,7 +69,7 @@ class NOMSD : public AFQMCInfo
   using CTensor      = boost::multi::array<ComplexType, 3, Allocator>;
   using CVector_ref  = boost::multi::array_ref<ComplexType, 1, pointer>;
   using CMatrix_ref  = boost::multi::array_ref<ComplexType, 2, pointer>;
-  using CMatrix_ptr  = boost::multi::array_ptr<ComplexType, 2, pointer>;
+  using CMatrix_ptr  = boost::multi::detail::array_ptr<ComplexType, 2, pointer>;
   using CMatrix_cref = boost::multi::array_ref<const ComplexType, 2, const_pointer>;
   using CTensor_ref  = boost::multi::array_ref<ComplexType, 3, pointer>;
   using CTensor_cref = boost::multi::array_ref<const ComplexType, 3, const_pointer>;
@@ -311,9 +311,9 @@ public:
     if (TG.getLocalTGRank() == 0)
     {
       wset.setProperty(OVLP, ovlp);
-      wset.setProperty(E1_, eloc(eloc.extension(), 0));
-      wset.setProperty(EXX_, eloc(eloc.extension(), 1));
-      wset.setProperty(EJ_, eloc(eloc.extension(), 2));
+      wset.setProperty(E1_, eloc(eloc.extent(), 0));
+      wset.setProperty(EXX_, eloc(eloc.extent(), 1));
+      wset.setProperty(EJ_, eloc(eloc.extent(), 2));
     }
     TG.local_barrier();
   }
@@ -523,7 +523,7 @@ public:
         {
           for (int i = 0; i < ndet; ++i)
           {
-            boost::multi::array_ref<ComplexType, 2> A_(to_address(RefOrbMats[i].origin()), {nrow, ncol});
+            boost::multi::array_ref<ComplexType, 2> A_(to_address(RefOrbMats[i].base()), {nrow, ncol});
             ma::Matrix2MAREF('H', OrbMats[i], A_);
           }
         }
@@ -531,9 +531,9 @@ public:
         {
           for (int i = 0; i < ndet; ++i)
           {
-            boost::multi::array_ref<ComplexType, 2> A_(to_address(RefOrbMats[i].origin()), {NMO, NAEA});
+            boost::multi::array_ref<ComplexType, 2> A_(to_address(RefOrbMats[i].base()), {NMO, NAEA});
             ma::Matrix2MAREF('H', OrbMats[2 * i], A_);
-            boost::multi::array_ref<ComplexType, 2> B_(A_.origin() + A_.num_elements(), {NMO, NAEB});
+            boost::multi::array_ref<ComplexType, 2> B_(A_.base() + A_.num_elements(), {NMO, NAEB});
             ma::Matrix2MAREF('H', OrbMats[2 * i + 1], B_);
           }
         }
@@ -549,7 +549,7 @@ public:
     int n0, n1;
     std::tie(n0, n1) = FairDivideBoundary(TG.getLocalTGRank(), int(get<1>(A.sizes())), TG.getNCoresPerTG());
     for (int i = 0; i < ndet; i++)
-      copy_n(RefOrbMats_[i].origin() + n0, n1 - n0, A_[i].origin() + n0);
+      copy_n(RefOrbMats_[i].base() + n0, n1 - n0, A_[i].base() + n0);
     TG.TG_local().barrier();
   }
 

--- a/src/AFQMC/Wavefunctions/NOMSD.icc
+++ b/src/AFQMC/Wavefunctions/NOMSD.icc
@@ -58,8 +58,8 @@ void NOMSD<devPsiT>::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
 
   // temporary runtime check for incompatible memory spaces
   {
-    auto dev_ptr(make_device_ptr(E.origin()));
-    auto dev_ptr_(make_device_ptr(Ov.origin()));
+    auto dev_ptr(make_device_ptr(E.base()));
+    auto dev_ptr_(make_device_ptr(Ov.base()));
   }
 
   ComplexType zero(0.0);
@@ -70,27 +70,27 @@ void NOMSD<devPsiT>::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
     std::swap(nr, nc);
   StaticSHMVector shmbuff(iextensions<1u>{(Gsize + 1) * nwalk},
                           shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
-  CMatrix_ref G(make_device_ptr(shmbuff.origin()), {nr, nc});
-  CVector_ref ov_(G.origin() + G.num_elements(), iextensions<1u>{nwalk});
+  CMatrix_ref G(make_device_ptr(shmbuff.base()), {nr, nc});
+  CVector_ref ov_(G.base() + G.num_elements(), iextensions<1u>{nwalk});
   StaticMatrix eloc2({nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
 
   using std::fill_n;
-  fill_n(Ov.origin(), nwalk, zero);
-  fill_n(E.origin(), 3 * nwalk, zero);
+  fill_n(Ov.base(), nwalk, zero);
+  fill_n(E.base(), 3 * nwalk, zero);
 
   for (int nd = 0, nref = 0; nd < ci.size(); nd++, nref += nspins)
   {
     DensityMatrix(wset, OrbMats[nref], OrbMats[nref + nspins - 1], G, ov_, true, true, transposed_G_for_E_);
     ma::axpy(ma::conj(ci[nd]), ov_, Ov);
     HamOp.energy(eloc2, G, nd, TG.TG_local().root());
-    //TG.TG_local().all_reduce_in_place_n(eloc2.origin(),3*nwalk,std::plus<>());
+    //TG.TG_local().all_reduce_in_place_n(eloc2.base(),3*nwalk,std::plus<>());
     for (int i = 0; i < nwalk; ++i)
       for (int k = 0; k < 3; ++k)
         E[i][k] += ma::conj(ci[nd]) * ov_[i] * eloc2[i][k];
   }
 
   if (TG.TG_local().size() > 1)
-    TG.TG_local().all_reduce_in_place_n(to_address(E.origin()), 3 * nwalk, std::plus<>());
+    TG.TG_local().all_reduce_in_place_n(to_address(E.base()), 3 * nwalk, std::plus<>());
   for (int i = 0; i < nwalk; ++i)
     for (int k = 0; k < 3; k++)
       E[i][k] /= Ov[i];
@@ -116,8 +116,8 @@ void NOMSD<devPsiT>::Energy_distributed_singleDet(const WlkSet& wset, Mat&& E, T
   using std::fill_n;
   // temporary runtime check for incompatible memory spaces
   {
-    auto dev_ptr(make_device_ptr(E.origin()));
-    auto dev_ptr_(make_device_ptr(Ov.origin()));
+    auto dev_ptr(make_device_ptr(E.base()));
+    auto dev_ptr_(make_device_ptr(Ov.base()));
   }
   assert(ci.size() == 1);
   const int node_number = TG.getLocalGroupNumber();
@@ -144,21 +144,21 @@ void NOMSD<devPsiT>::Energy_distributed_singleDet(const WlkSet& wset, Mat&& E, T
   int nr = Gsize, nc = nwalk;
   if (transposed_G_for_E_)
     std::swap(nr, nc);
-  CMatrix_ref Gwork(make_device_ptr(shmbuff.origin()), {nr, nc});
-  CMatrix_ref Grecv(Gwork.origin() + Gwork.num_elements(), {nr, nc});
-  CVector_ref overlaps(Grecv.origin() + Grecv.num_elements(), iextensions<1u>{nwalk});
+  CMatrix_ref Gwork(make_device_ptr(shmbuff.base()), {nr, nc});
+  CMatrix_ref Grecv(Gwork.base() + Gwork.num_elements(), {nr, nc});
+  CVector_ref overlaps(Grecv.base() + Grecv.num_elements(), iextensions<1u>{nwalk});
   StaticMatrix eloc2({ngroups * nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
   int nak0, nak1;
   std::tie(nak0, nak1) = FairDivideBoundary(TG.getLocalTGRank(), Gsize * nwalk, TG.getNCoresPerTG());
 
   // use mpi3 when ready
   MPI_Request req_Gsend, req_Grecv;
-  MPI_Send_init(to_address(Gwork.origin()) + nak0, (nak1 - nak0) * sizeof(ComplexType), MPI_CHAR, TG.prev_core(), 1234,
+  MPI_Send_init(to_address(Gwork.base()) + nak0, (nak1 - nak0) * sizeof(ComplexType), MPI_CHAR, TG.prev_core(), 1234,
                 TG.TG().get(), &req_Gsend);
-  MPI_Recv_init(to_address(Grecv.origin()) + nak0, (nak1 - nak0) * sizeof(ComplexType), MPI_CHAR, TG.next_core(), 1234,
+  MPI_Recv_init(to_address(Grecv.base()) + nak0, (nak1 - nak0) * sizeof(ComplexType), MPI_CHAR, TG.next_core(), 1234,
                 TG.TG().get(), &req_Grecv);
 
-  fill_n(eloc2.origin(), 3 * ngroups * nwalk, ComplexType(0.0));
+  fill_n(eloc2.base(), 3 * ngroups * nwalk, ComplexType(0.0));
   TG.local_barrier();
 
   MPI_Status st;
@@ -175,7 +175,7 @@ void NOMSD<devPsiT>::Energy_distributed_singleDet(const WlkSet& wset, Mat&& E, T
     {
       MPI_Wait(&req_Grecv, &st);
       MPI_Wait(&req_Gsend, &st); // need to wait for Gsend in order to overwrite Gwork
-      copy_n(Grecv.origin() + nak0, (nak1 - nak0), Gwork.origin() + nak0);
+      copy_n(Grecv.base() + nak0, (nak1 - nak0), Gwork.base() + nak0);
       TG.local_barrier();
     }
 
@@ -191,10 +191,10 @@ void NOMSD<devPsiT>::Energy_distributed_singleDet(const WlkSet& wset, Mat&& E, T
     TG.local_barrier();
   }
   if (TG.TG().size() > 1)
-    TG.TG().all_reduce_in_place_n(to_address(eloc2.origin()), 3 * ngroups * nwalk, std::plus<>());
+    TG.TG().all_reduce_in_place_n(to_address(eloc2.base()), 3 * ngroups * nwalk, std::plus<>());
   TG.local_barrier();
-  copy_n(eloc2[node_number * nwalk].origin(), 3 * nwalk, E.origin());
-  copy_n(overlaps.origin(), nwalk, Ov.origin());
+  copy_n(eloc2[node_number * nwalk].base(), 3 * nwalk, E.base());
+  copy_n(overlaps.base(), nwalk, Ov.base());
   MPI_Request_free(&req_Grecv);
   MPI_Request_free(&req_Gsend);
   TG.local_barrier();
@@ -222,8 +222,8 @@ void NOMSD<devPsiT>::Energy_distributed_multiDet(const WlkSet& wset, Mat&& E, TV
   using std::fill_n;
   // temporary runtime check for incompatible memory spaces
   {
-    auto dev_ptr(make_device_ptr(E.origin()));
-    auto dev_ptr_(make_device_ptr(Ov.origin()));
+    auto dev_ptr(make_device_ptr(E.base()));
+    auto dev_ptr_(make_device_ptr(Ov.base()));
   }
   assert(ci.size() > 1);
   const int node_number = TG.getLocalGroupNumber();
@@ -250,10 +250,10 @@ void NOMSD<devPsiT>::Energy_distributed_multiDet(const WlkSet& wset, Mat&& E, TV
   int nr = Gsize, nc = nwalk;
   if (transposed_G_for_E_)
     std::swap(nr, nc);
-  CMatrix_ref SMwork(make_device_ptr(shmbuff.origin()), {nwalk, Gsize});
-  CMatrix_ref SMrecv(SMwork.origin() + SMwork.num_elements(), {nwalk, Gsize});
-  CMatrix_ref Gwork(SMrecv.origin() + SMrecv.num_elements(), {nr, nc});
-  CVector_ref overlaps(Gwork.origin() + Gwork.num_elements(), iextensions<1u>{nwalk});
+  CMatrix_ref SMwork(make_device_ptr(shmbuff.base()), {nwalk, Gsize});
+  CMatrix_ref SMrecv(SMwork.base() + SMwork.num_elements(), {nwalk, Gsize});
+  CMatrix_ref Gwork(SMrecv.base() + SMrecv.num_elements(), {nr, nc});
+  CVector_ref overlaps(Gwork.base() + Gwork.num_elements(), iextensions<1u>{nwalk});
   // used for temporary storage in ndet loop for local calculation
   StaticMatrix eloc2({nnodes * nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
   StaticMatrix eloc3({nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
@@ -264,22 +264,22 @@ void NOMSD<devPsiT>::Energy_distributed_multiDet(const WlkSet& wset, Mat&& E, TV
 
   MPI_Request req_SMsend, req_SMrecv;
   // use mpi3 when ready
-  MPI_Send_init(to_address(SMwork.origin()) + nak0, (nak1 - nak0) * sizeof(ComplexType), MPI_CHAR, TG.prev_core(), 2345,
+  MPI_Send_init(to_address(SMwork.base()) + nak0, (nak1 - nak0) * sizeof(ComplexType), MPI_CHAR, TG.prev_core(), 2345,
                 TG.TG().get(), &req_SMsend);
-  MPI_Recv_init(to_address(SMrecv.origin()) + nak0, (nak1 - nak0) * sizeof(ComplexType), MPI_CHAR, TG.next_core(), 2345,
+  MPI_Recv_init(to_address(SMrecv.base()) + nak0, (nak1 - nak0) * sizeof(ComplexType), MPI_CHAR, TG.next_core(), 2345,
                 TG.TG().get(), &req_SMrecv);
 
-  fill_n(eloc2.origin(), 3 * nnodes * nwalk, ComplexType(0.0));
-  fill_n(Ov.origin(), nwalk, ComplexType(0));
+  fill_n(eloc2.base(), 3 * nnodes * nwalk, ComplexType(0.0));
+  fill_n(Ov.base(), nwalk, ComplexType(0));
   if (TG.TG_local().root())
-    fill_n(overlaps.origin(), nwalk, ComplexType(0));
+    fill_n(overlaps.base(), nwalk, ComplexType(0));
 
   MPI_Status st;
 
   // copy SM from wset. Assumes that SM data is contiguous in memory (Alpha+Beta)
   for (int i = 0; i < nwalk; i++)
     if (i % TG.TG_local().size() == TG.TG_local().rank())
-      copy_n((*wset[i].SlaterMatrix(Alpha)).origin(), Gsize, SMwork[i].origin());
+      copy_n((*wset[i].SlaterMatrix(Alpha)).base(), Gsize, SMwork[i].base());
   TG.local_barrier();
 
   for (int k = 0; k < nnodes; k++)
@@ -289,7 +289,7 @@ void NOMSD<devPsiT>::Energy_distributed_multiDet(const WlkSet& wset, Mat&& E, TV
     {
       MPI_Wait(&req_SMrecv, &st);
       MPI_Wait(&req_SMsend, &st); // need to wait for Gsend in order to overwrite Gwork
-      copy_n(SMrecv.origin() + nak0, (nak1 - nak0), SMwork.origin() + nak0);
+      copy_n(SMrecv.base() + nak0, (nak1 - nak0), SMwork.base() + nak0);
       TG.local_barrier();
     }
 
@@ -316,7 +316,7 @@ void NOMSD<devPsiT>::Energy_distributed_multiDet(const WlkSet& wset, Mat&& E, TV
     TG.local_barrier();
   }
   if (TG.TG().size() > 1)
-    TG.TG().all_reduce_in_place_n(to_address(eloc2.origin()), 3 * nnodes * nwalk, std::plus<>());
+    TG.TG().all_reduce_in_place_n(to_address(eloc2.base()), 3 * nnodes * nwalk, std::plus<>());
   TG.local_barrier();
   auto elocal = eloc2.sliced(node_number * nwalk, (node_number + 1) * nwalk);
   for (int i = 0; i < nwalk; i++)
@@ -357,11 +357,11 @@ void NOMSD<devPsiT>::MixedDensityMatrix_for_E_from_SM(const MatSM& SM,
 
   if (transposed_G_for_E_)
   {
-    assert((G.extensions() == boost::multi::extensions_t<2>{nw, static_cast<boost::multi::size_t>(dm_size(false))}));
+    assert((G.extents() == boost::multi::extensions_t<2>{nw, static_cast<boost::multi::size_t>(dm_size(false))}));
   }
   else
   {
-    assert((G.extensions() == boost::multi::extensions_t<2>{static_cast<boost::multi::size_t>(dm_size(false)), nw}));
+    assert((G.extents() == boost::multi::extensions_t<2>{static_cast<boost::multi::size_t>(dm_size(false)), nw}));
   }
   assert(Ov.size() >= nw);
 
@@ -369,17 +369,17 @@ void NOMSD<devPsiT>::MixedDensityMatrix_for_E_from_SM(const MatSM& SM,
   assert(get<1>(SM.sizes()) == Gsize);
   // to force synchronization before modifying structures in SHM
   TG.local_barrier();
-  fill_n(Ov.origin(), nw, 0);
-  fill_n(G.origin(), G.num_elements(), ComplexType(0.0));
+  fill_n(Ov.base(), nw, 0);
+  fill_n(G.base(), G.num_elements(), ComplexType(0.0));
   TG.local_barrier();
   if (walker_type != COLLINEAR)
   {
     auto Gdims = dm_dims(false, Alpha);
     StaticMatrix G2D_({Gdims.first, Gdims.second},
                       buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref G1D_(G2D_.origin(), iextensions<1u>{Gsize});
+    CVector_ref G1D_(G2D_.base(), iextensions<1u>{Gsize});
     // notice interchange of dimensions
-    CTensor_cref A(SM.origin(), {nw, Gdims.second, Gdims.first});
+    CTensor_cref A(SM.base(), {nw, Gdims.second, Gdims.first});
 
     for (int iw = 0; iw < nw; ++iw)
     {
@@ -391,22 +391,22 @@ void NOMSD<devPsiT>::MixedDensityMatrix_for_E_from_SM(const MatSM& SM,
       if (transposed_G_for_E_)
         G[iw] = G1D_;
       else
-        G(G.extension(), iw) = G1D_;
+        G(G.extent(), iw) = G1D_;
     }
   }
   else
   {
     // store overlaps locally to be able to split alpha/beta pairs
     StaticVector ovlp2(iextensions<1u>{2 * nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
-    fill_n(ovlp2.origin(), 2 * nw, ComplexType(0.0));
+    fill_n(ovlp2.base(), 2 * nw, ComplexType(0.0));
     auto GAdims = dm_dims(false, Alpha);
     auto GBdims = dm_dims(false, Beta);
     StaticMatrix GA2D_({GAdims.first, GAdims.second},
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
     // can reuse space!!!
-    CMatrix_ref GB2D_(GA2D_.origin(), {GBdims.first, GBdims.second});
-    CVector_ref GA1D_(GA2D_.origin(), iextensions<1u>{GA2D_.num_elements()});
-    CVector_ref GB1D_(GB2D_.origin(), iextensions<1u>{GB2D_.num_elements()});
+    CMatrix_ref GB2D_(GA2D_.base(), {GBdims.first, GBdims.second});
+    CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GA2D_.num_elements()});
+    CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GB2D_.num_elements()});
 
     for (int iw = 0; iw < 2 * nw; ++iw)
     {
@@ -416,7 +416,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_for_E_from_SM(const MatSM& SM,
       if (iw % 2 == 0)
       {
         // notice interchange of dimensions
-        CMatrix_cref M(SM[iw / 2].origin(), {GAdims.second, GAdims.first});
+        CMatrix_cref M(SM[iw / 2].base(), {GAdims.second, GAdims.first});
         ovlp2[iw] = SDetOp.MixedDensityMatrix(OrbMats[2 * nd], M, GA2D_, LogOverlapFactor, true);
         if (transposed_G_for_E_)
           G[iw / 2].sliced(0, GAdims.first * GAdims.second) = GA1D_;
@@ -426,7 +426,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_for_E_from_SM(const MatSM& SM,
       else
       {
         // notice interchange of dimensions
-        CMatrix_cref M(SM[iw / 2].origin() + GAdims.first * GAdims.second, {GBdims.second, GBdims.first});
+        CMatrix_cref M(SM[iw / 2].base() + GAdims.first * GAdims.second, {GBdims.second, GBdims.first});
         ovlp2[iw] = SDetOp.MixedDensityMatrix(OrbMats[2 * nd + 1], M, GB2D_, LogOverlapFactor, true);
         if (transposed_G_for_E_)
           G[iw / 2].sliced(GAdims.first * GAdims.second, G[iw / 2].size()) = GB1D_;
@@ -437,7 +437,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_for_E_from_SM(const MatSM& SM,
     // CHECK: I don't need all_reduce here, but the current version of mpi3
     //        fails if I use reduce_in_place_n
     if (TG.TG_local().size() > 1)
-      TG.TG_local().all_reduce_in_place_n(to_address(ovlp2.origin()), 2 * nw, std::plus<>());
+      TG.TG_local().all_reduce_in_place_n(to_address(ovlp2.base()), 2 * nw, std::plus<>());
     if (TG.TG_local().root())
       for (int iw = 0; iw < nw; ++iw)
         Ov[iw] = ovlp2[2 * iw] * ovlp2[2 * iw + 1];
@@ -466,20 +466,20 @@ void NOMSD<devPsiT>::DensityMatrix_shared(const WlkSet& wset,
   assert(Ov.stride() == 1);
   if (transposed)
   {
-    assert((G.extensions() ==
+    assert((G.extents() ==
             boost::multi::extensions_t<2>{wset.size(), static_cast<boost::multi::size_t>(dm_size(not compact))}));
   }
   else
   {
-    assert((G.extensions() ==
+    assert((G.extents() ==
             boost::multi::extensions_t<2>{static_cast<boost::multi::size_t>(dm_size(not compact)), wset.size()}));
   }
   const int nw = wset.size();
   assert(Ov.size() >= nw);
   // to force synchronization before modifying structures in SHM
   TG.local_barrier();
-  fill_n(Ov.origin(), Ov.num_elements(), 0);
-  fill_n(G.origin(), G.num_elements(), ComplexType(0.0));
+  fill_n(Ov.base(), Ov.num_elements(), 0);
+  fill_n(G.base(), G.num_elements(), ComplexType(0.0));
   TG.local_barrier();
   double LogOverlapFactor(wset.getLogOverlapFactor());
   auto Gsize = dm_size(not compact);
@@ -501,7 +501,7 @@ void NOMSD<devPsiT>::DensityMatrix_shared(const WlkSet& wset,
     auto Gdims = dm_dims(not compact, Alpha);
     StaticMatrix G2D_({Gdims.first, Gdims.second},
                       buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref G1D_(G2D_.origin(), iextensions<1u>{G2D_.num_elements()});
+    CVector_ref G1D_(G2D_.base(), iextensions<1u>{G2D_.num_elements()});
 
     for (int iw = 0; iw < nw; ++iw)
     {
@@ -516,7 +516,7 @@ void NOMSD<devPsiT>::DensityMatrix_shared(const WlkSet& wset,
       }
       else
       {
-        G(G.extension(), iw) = G1D_;
+        G(G.extent(), iw) = G1D_;
       }
     }
   }
@@ -543,14 +543,14 @@ void NOMSD<devPsiT>::DensityMatrix_shared(const WlkSet& wset,
              get<0>(RefB.sizes()) == dm_dims(false, Beta).second);
     }
     StaticVector ovlp2(iextensions<1u>{2 * nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
-    fill_n(ovlp2.origin(), 2 * nw, ComplexType(0.0));
+    fill_n(ovlp2.base(), 2 * nw, ComplexType(0.0));
     auto GAdims = dm_dims(not compact, Alpha);
     auto GBdims = dm_dims(not compact, Beta);
     StaticMatrix GA2D_({GAdims.first, GAdims.second},
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CMatrix_ref GB2D_(GA2D_.origin(), {GBdims.first, GBdims.second});
-    CVector_ref GA1D_(GA2D_.origin(), iextensions<1u>{GA2D_.num_elements()});
-    CVector_ref GB1D_(GB2D_.origin(), iextensions<1u>{GB2D_.num_elements()});
+    CMatrix_ref GB2D_(GA2D_.base(), {GBdims.first, GBdims.second});
+    CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GA2D_.num_elements()});
+    CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GB2D_.num_elements()});
 
     for (int iw = 0; iw < 2 * nw; ++iw)
     {
@@ -577,7 +577,7 @@ void NOMSD<devPsiT>::DensityMatrix_shared(const WlkSet& wset,
       }
     }
     if (TG.TG_local().size() > 1)
-      TG.TG_local().all_reduce_in_place_n(to_address(ovlp2.origin()), 2 * nw, std::plus<>());
+      TG.TG_local().all_reduce_in_place_n(to_address(ovlp2.base()), 2 * nw, std::plus<>());
     if (TG.TG_local().root())
       for (int iw = 0; iw < nw; ++iw)
         Ov[iw] = ovlp2[2 * iw] * ovlp2[2 * iw + 1];
@@ -602,8 +602,8 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
   using std::fill_n;
   // temporary runtime check for incompatible memory spaces
   {
-    auto dev_ptr_(make_device_ptr(Ov.origin()));
-    auto dev_ptr(make_device_ptr(G.origin()));
+    auto dev_ptr_(make_device_ptr(Ov.base()));
+    auto dev_ptr(make_device_ptr(G.base()));
   }
 
   using std::get;
@@ -612,12 +612,12 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
 
   if (transposed)
   {
-    assert((G.extensions() ==
+    assert((G.extents() ==
             boost::multi::extensions_t<2>{wset.size(), static_cast<boost::multi::size_t>(dm_size(not compact))}));
   }
   else
   {
-    assert((G.extensions() ==
+    assert((G.extents() ==
             boost::multi::extensions_t<2>{static_cast<boost::multi::size_t>(dm_size(not compact)), wset.size()}));
   }
 
@@ -626,11 +626,11 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
   assert(Ov.size() >= nw);
   // to force synchronization before modifying structures in SHM
   TG.local_barrier();
-  fill_n(Ov.origin(), nw, 0);
-  fill_n(G.origin(), G.num_elements(), ComplexType(0.0));
+  fill_n(Ov.base(), nw, 0);
+  fill_n(G.base(), G.num_elements(), ComplexType(0.0));
   StaticVector ovlp2(iextensions<1u>{2 * nbatch__},
                      buffer_manager.get_generator().template get_allocator<ComplexType>());
-  fill_n(ovlp2.origin(), ovlp2.num_elements(), ComplexType(0.0));
+  fill_n(ovlp2.base(), ovlp2.num_elements(), ComplexType(0.0));
 
   using std::get;
   if (get<1>(G.sizes()) != G.stride())
@@ -664,7 +664,7 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
     }
     Static3Tensor G3D_({nbatch__, GAdims.first, GAdims.second},
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CMatrix_ref G2D_(G3D_.origin(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
+    CMatrix_ref G2D_(G3D_.base(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
 
     for (int iw = 0; iw < nw; iw += nbatch__)
     {
@@ -677,7 +677,7 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
         Oia.emplace_back(&RefA);
       SDetOp.BatchedMixedDensityMatrix(Oia, Ai, G3D_.sliced(0, nb), LogOverlapFactor, ovlp2.sliced(0, nb), compact,
                                        herm);
-      copy_n(ovlp2.origin(), nb, hvec.origin());
+      copy_n(ovlp2.base(), nb, hvec.base());
       for (int ib = 0; ib < nb; ++ib)
       {
         ComplexType ov(hvec[ib]);
@@ -689,7 +689,7 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
         }
         else
         {
-          ma::copy(G2D_[ib], G(G.extension(0), iw + ib));
+          ma::copy(G2D_[ib], G(get<0>(G.extents()), iw + ib));
         }
         Ov[iw + ib] = ov;
       }
@@ -721,9 +721,9 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
     auto GBdims = dm_dims(not compact, Beta);
     Static3Tensor GA3D_({nbatch__, GAdims.first, GAdims.second},
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CMatrix_ref GA2D_(GA3D_.origin(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
-    CTensor_ref GB3D_(GA3D_.origin(), {nbatch__, GBdims.first, GBdims.second});
-    CMatrix_ref GB2D_(GB3D_.origin(), iextensions<2u>{nbatch__, GBdims.first * GBdims.second});
+    CMatrix_ref GA2D_(GA3D_.base(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
+    CTensor_ref GB3D_(GA3D_.base(), {nbatch__, GBdims.first, GBdims.second});
+    CMatrix_ref GB2D_(GB3D_.base(), iextensions<2u>{nbatch__, GBdims.first * GBdims.second});
 
     for (int iw = 0; iw < nw; iw += nbatch__)
     {
@@ -815,8 +815,8 @@ void NOMSD<devPsiT>::DensityMatrix_batched(std::vector<MatA>& Left,
   using std::fill_n;
   // temporary runtime check for incompatible memory spaces
   {
-    auto dev_ptr_(make_device_ptr(Ov.origin()));
-    auto dev_ptr(make_device_ptr((*G[0]).origin()));
+    auto dev_ptr_(make_device_ptr(Ov.base()));
+    auto dev_ptr(make_device_ptr((*G[0]).base()));
   }
   const int nw = Left.size();
   assert(Right.size() == nw);
@@ -831,7 +831,7 @@ void NOMSD<devPsiT>::DensityMatrix_batched(std::vector<MatA>& Left,
   Ri.reserve(nbatch__);
   Gi.reserve(nbatch__);
   StaticVector ovlp2(iextensions<1u>{nbatch__}, buffer_manager.get_generator().template get_allocator<ComplexType>());
-  fill_n(ovlp2.origin(), ovlp2.num_elements(), ComplexType(0.0));
+  fill_n(ovlp2.base(), ovlp2.num_elements(), ComplexType(0.0));
 
   for (int iw = 0; iw < nw; iw += nbatch__)
   {
@@ -869,8 +869,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
   using std::fill_n;
   // temporary runtime check for incompatible memory spaces
   {
-    auto dev_ptr_(make_device_ptr(Ov.origin()));
-    auto dev_ptr(make_device_ptr(G.origin()));
+    auto dev_ptr_(make_device_ptr(Ov.base()));
+    auto dev_ptr(make_device_ptr(G.base()));
   }
 
   using std::get;
@@ -878,25 +878,25 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
   assert(Ov.stride() == 1);
   if (transpose)
   {
-    assert((G.extensions() ==
+    assert((G.extents() ==
             boost::multi::extensions_t<2>{wset.size(), static_cast<boost::multi::size_t>(dm_size(not compact))}));
   }
   else
   {
-    assert((G.extensions() ==
+    assert((G.extents() ==
             boost::multi::extensions_t<2>{static_cast<boost::multi::size_t>(dm_size(not compact)), wset.size()}));
   }
   const int nw   = wset.size();
   const int ndet = ci.size();
   double LogOverlapFactor(wset.getLogOverlapFactor());
   assert(Ov.size() >= nw);
-  fill_n(Ov.origin(), nw, 0);
+  fill_n(Ov.base(), nw, 0);
   // need strided fill_n????
   if (get<1>(G.sizes()) != G.stride())
   {
     APP_ABORT(" Error: FIX FIX FIX need strided fill_n\n");
   }
-  fill_n(G.origin(), G.num_elements(), ComplexType(0.0));
+  fill_n(G.base(), G.num_elements(), ComplexType(0.0));
   TG.local_barrier();
   auto Gsize    = dm_size(not compact);
   auto wlk_dims = wset.walker_dims();
@@ -905,7 +905,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
     auto Gdims = dm_dims(not compact, Alpha);
     StaticMatrix G2D_({Gdims.first, Gdims.second},
                       buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref G1D_(G2D_.origin(), iextensions<1u>{G2D_.num_elements()});
+    CVector_ref G1D_(G2D_.base(), iextensions<1u>{G2D_.num_elements()});
 
     const int ntasks_percore      = (nw * ndet) / TG.getNCoresPerTG();
     const int ntasks_total_serial = ntasks_percore * TG.getNCoresPerTG();
@@ -935,7 +935,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
       else
       {
         std::lock_guard<shared_mutex> guard(*mutex);
-        ma::axpy(ov, G1D_, G(G.extension(0), iw));
+        ma::axpy(ov, G1D_, G(get<0>(G.extents()), iw));
       }
       Ov[iw] += ov;
     }
@@ -966,8 +966,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
       if (last_task_index < 0 || last_task_index > nextra)
         APP_ABORT("Error: Problems in NOMSD<devPsiT>::Overlap(WSet,Ov)");
       {
-        boost::multi::array_ref<ComplexType, 2> G2D_2(to_address(shmbuff_for_G->origin()), {Gdims.first, Gdims.second});
-        boost::multi::array_ref<ComplexType, 1> G1D_2(to_address(shmbuff_for_G->origin()), iextensions<1u>{Gsize});
+        boost::multi::array_ref<ComplexType, 2> G2D_2(to_address(shmbuff_for_G->base()), {Gdims.first, Gdims.second});
+        boost::multi::array_ref<ComplexType, 1> G1D_2(to_address(shmbuff_for_G->base()), iextensions<1u>{Gsize});
         int iw         = (last_task_index + ntasks_total_serial) / ndet;
         int nd         = (last_task_index + ntasks_total_serial) % ndet;
         ComplexType ov = SDetOp.MixedDensityMatrix(OrbMats[nd], *wset[iw].SlaterMatrix(Alpha), G2D_2, LogOverlapFactor,
@@ -986,7 +986,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
           else
           {
             std::lock_guard<shared_mutex> guard(*mutex);
-            ma::axpy(ov, G1D_2, G(G.extension(0), iw));
+            ma::axpy(ov, G1D_2, G(get<0>(G.extents()), iw));
           }
           Ov[iw] += ov;
         }
@@ -1001,8 +1001,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
     StaticMatrix GB2D_({GBdims.first, GBdims.second},
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref GA1D_(GA2D_.origin(), iextensions<1u>{GA2D_.num_elements()});
-    CVector_ref GB1D_(GB2D_.origin(), iextensions<1u>{GB2D_.num_elements()});
+    CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GA2D_.num_elements()});
+    CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GB2D_.num_elements()});
 
     const int ntasks_percore      = (nw * ndet) / TG.getNCoresPerTG();
     const int ntasks_total_serial = ntasks_percore * TG.getNCoresPerTG();
@@ -1065,14 +1065,14 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
       if (last_task_index < 0 || last_task_index > nextra)
         APP_ABORT("Error: Problems in NOMSD<devPsiT>::Overlap(WSet,Ov)");
       {
-        boost::multi::array_ref<ComplexType, 2> GA2D_2(to_address(shmbuff_for_G->origin()),
+        boost::multi::array_ref<ComplexType, 2> GA2D_2(to_address(shmbuff_for_G->base()),
                                                        {GAdims.first, GAdims.second});
-        boost::multi::array_ref<ComplexType, 2> GB2D_2(to_address(shmbuff_for_G->origin()) +
+        boost::multi::array_ref<ComplexType, 2> GB2D_2(to_address(shmbuff_for_G->base()) +
                                                            GAdims.first * GAdims.second,
                                                        {GBdims.first, GBdims.second});
-        boost::multi::array_ref<ComplexType, 1> GA1D_2(to_address(shmbuff_for_G->origin()),
+        boost::multi::array_ref<ComplexType, 1> GA1D_2(to_address(shmbuff_for_G->base()),
                                                        iextensions<1u>{GAdims.first * GAdims.second});
-        boost::multi::array_ref<ComplexType, 1> GB1D_2(to_address(shmbuff_for_G->origin()) +
+        boost::multi::array_ref<ComplexType, 1> GB1D_2(to_address(shmbuff_for_G->base()) +
                                                            GAdims.first * GAdims.second,
                                                        iextensions<1u>{GBdims.first * GBdims.second});
         int task       = (last_task_index + ntasks_total_serial);
@@ -1104,7 +1104,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
   }
   // normalize G
   if (TG.TG_local().size() > 1)
-    TG.TG_local().all_reduce_in_place_n(to_address(Ov.origin()), nw, std::plus<>());
+    TG.TG_local().all_reduce_in_place_n(to_address(Ov.base()), nw, std::plus<>());
   if (transpose)
   {
     for (size_t iw = 0; iw < G.size(); ++iw)
@@ -1122,8 +1122,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
     int ik0, ikN;
     std::tie(ik0, ikN) = FairDivideBoundary(TG.TG_local().rank(), int(G.size()), TG.TG_local().size());
     using ma::term_by_term_matrix_vector;
-    term_by_term_matrix_vector(ma::TOp_DIV, 1, ikN - ik0, get<1>(G.sizes()), make_device_ptr(G[ik0].origin()),
-                               G.stride(), make_device_ptr(Ov.origin()), Ov.stride());
+    term_by_term_matrix_vector(ma::TOp_DIV, 1, ikN - ik0, get<1>(G.sizes()), make_device_ptr(G[ik0].base()),
+                               G.stride(), make_device_ptr(Ov.base()), Ov.stride());
   }
   TG.local_barrier();
 }
@@ -1139,8 +1139,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
   using std::fill_n;
   // temporary runtime check for incompatible memory spaces
   {
-    auto dev_ptr_(make_device_ptr(Ov.origin()));
-    auto dev_ptr(make_device_ptr(G.origin()));
+    auto dev_ptr_(make_device_ptr(Ov.base()));
+    auto dev_ptr(make_device_ptr(G.base()));
   }
 
   using std::get;
@@ -1148,12 +1148,12 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
   assert(Ov.stride() == 1);
   if (transpose)
   {
-    assert((G.extensions() ==
+    assert((G.extents() ==
             boost::multi::extensions_t<2>{wset.size(), static_cast<boost::multi::size_t>(dm_size(not compact))}));
   }
   else
   {
-    assert((G.extensions() ==
+    assert((G.extents() ==
             boost::multi::extensions_t<2>{static_cast<boost::multi::size_t>(dm_size(not compact)), wset.size()}));
   }
   const int nw   = wset.size();
@@ -1162,10 +1162,10 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
   // do batches of determinants to simplify code
   double LogOverlapFactor(wset.getLogOverlapFactor());
   assert(Ov.size() >= nw);
-  fill_n(Ov.origin(), nw, 0);
+  fill_n(Ov.base(), nw, 0);
   StaticVector ovlp2(iextensions<1u>{2 * nbatch__},
                      buffer_manager.get_generator().template get_allocator<ComplexType>());
-  fill_n(ovlp2.origin(), ovlp2.num_elements(), ComplexType(0.0));
+  fill_n(ovlp2.base(), ovlp2.num_elements(), ComplexType(0.0));
   // need strided fill_n????
 
   using std::get;
@@ -1173,10 +1173,10 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
   {
     APP_ABORT(" Error: FIX FIX FIX need strided fill_n\n");
   }
-  fill_n(G.origin(), G.num_elements(), ComplexType(0.0));
+  fill_n(G.base(), G.num_elements(), ComplexType(0.0));
   stdCVector hvec(iextensions<1u>{2 * nbatch__});
   stdCVector Ovl(iextensions<1u>{nw});
-  fill_n(Ovl.origin(), nw, ComplexType(0.0));
+  fill_n(Ovl.base(), nw, ComplexType(0.0));
   TG.local_barrier();
   auto Gsize = dm_size(not compact);
   std::vector<CMatrix_ptr> Ai;
@@ -1189,7 +1189,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
     auto GAdims = dm_dims(not compact, Alpha);
     Static3Tensor G3D_({nbatch__, GAdims.first, GAdims.second},
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CMatrix_ref G2D_(G3D_.origin(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
+    CMatrix_ref G2D_(G3D_.base(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
     std::vector<pointer> Gx;
     std::vector<pointer> Gy;
     Gx.reserve(nbatch__);
@@ -1208,7 +1208,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
       for (int ni = 0; ni < nb; ni++)
         Oi.emplace_back(&OrbMats[(b0 + ni) / nw]);
       SDetOp.BatchedMixedDensityMatrix(Oi, Ai, G3D_.sliced(0, nb), LogOverlapFactor, ovlp2.sliced(0, nb), compact);
-      copy_n(ovlp2.origin(), nb, hvec.origin());
+      copy_n(ovlp2.base(), nb, hvec.base());
       Gx.clear();
       Gy.clear();
       for (int ib = 0; ib < nb; ++ib)
@@ -1218,11 +1218,11 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
         if (walker_type == CLOSED)
           hvec[ib] *= hvec[ib];
         hvec[ib] *= ma::conj(ci[idet]);
-        Gx.emplace_back(G2D_[ib].origin());
+        Gx.emplace_back(G2D_[ib].base());
         if (transpose)
-          Gy.emplace_back(G[iw].origin());
+          Gy.emplace_back(G[iw].base());
         else
-          Gy.emplace_back(G.origin() + iw);
+          Gy.emplace_back(G.base() + iw);
         Ovl[iw] += hvec[ib];
       }
       using ma::sumGwBatched;
@@ -1240,8 +1240,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
     Static3Tensor GB3D_({nbatch__, GBdims.first, GBdims.second},
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CMatrix_ref GA2D_(GA3D_.origin(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
-    CMatrix_ref GB2D_(GB3D_.origin(), iextensions<2u>{nbatch__, GBdims.first * GBdims.second});
+    CMatrix_ref GA2D_(GA3D_.base(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
+    CMatrix_ref GB2D_(GB3D_.base(), iextensions<2u>{nbatch__, GBdims.first * GBdims.second});
     std::vector<pointer> Gxa;
     std::vector<pointer> Gya;
     std::vector<pointer> Gxb;
@@ -1272,7 +1272,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
         Oi.emplace_back(&OrbMats[2 * ((b0 + ni) / nw) + 1]);
       SDetOp.BatchedMixedDensityMatrix(Oi, Ai, GB3D_.sliced(0, nb), LogOverlapFactor, ovlp2.sliced(nb, 2 * nb),
                                        compact);
-      copy_n(ovlp2.origin(), 2 * nb, hvec.origin());
+      copy_n(ovlp2.base(), 2 * nb, hvec.base());
       Gxa.clear();
       Gya.clear();
       Gxb.clear();
@@ -1282,17 +1282,17 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
         int idet = (b0 + ib) / nw;
         int iw   = (b0 + ib) % nw;
         hvec[ib] *= hvec[nb + ib] * ma::conj(ci[idet]);
-        Gxa.emplace_back(GA2D_[ib].origin());
-        Gxb.emplace_back(GB2D_[ib].origin());
+        Gxa.emplace_back(GA2D_[ib].base());
+        Gxb.emplace_back(GB2D_[ib].base());
         if (transpose)
         {
-          Gya.emplace_back(G[iw].origin());
-          Gyb.emplace_back(G[iw].origin() + GAdims.first * GAdims.second);
+          Gya.emplace_back(G[iw].base());
+          Gyb.emplace_back(G[iw].base() + GAdims.first * GAdims.second);
         }
         else
         {
-          Gya.emplace_back(G.origin() + iw);
-          Gyb.emplace_back(G[GAdims.first * GAdims.second].origin() + iw);
+          Gya.emplace_back(G.base() + iw);
+          Gyb.emplace_back(G[GAdims.first * GAdims.second].base() + iw);
         }
         Ovl[iw] += hvec[ib];
       }
@@ -1309,7 +1309,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
       }
     }
   }
-  copy_n(Ovl.origin(), nw, Ov.origin());
+  copy_n(Ovl.base(), nw, Ov.base());
 
   using std::get;
   // normalize G
@@ -1324,8 +1324,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
   else
   {
     using ma::term_by_term_matrix_vector;
-    term_by_term_matrix_vector(ma::TOp_DIV, 1, G.size(), get<1>(G.sizes()), make_device_ptr(G.origin()),
-                               G.stride(), make_device_ptr(Ov.origin()), Ov.stride());
+    term_by_term_matrix_vector(ma::TOp_DIV, 1, G.size(), get<1>(G.sizes()), make_device_ptr(G.base()),
+                               G.stride(), make_device_ptr(Ov.base()), Ov.stride());
   }
   TG.local_barrier();
 }
@@ -1341,7 +1341,7 @@ void NOMSD<devPsiT>::Overlap_batched(const WlkSet& wset, TVec&& Ov)
   using std::fill_n;
   // temporary runtime check for incompatible memory spaces
   {
-    auto dev_ptr_(make_device_ptr(Ov.origin()));
+    auto dev_ptr_(make_device_ptr(Ov.base()));
   }
 
   // since the memory usage is low, all walkers are always done together
@@ -1350,12 +1350,12 @@ void NOMSD<devPsiT>::Overlap_batched(const WlkSet& wset, TVec&& Ov)
   const int ndet = ci.size();
   double LogOverlapFactor(wset.getLogOverlapFactor());
   assert(Ov.size() >= nw);
-  fill_n(Ov.origin(), nw, 0);
+  fill_n(Ov.base(), nw, 0);
   StaticVector ovlp2(iextensions<1u>{2 * ndet * nw},
                      buffer_manager.get_generator().template get_allocator<ComplexType>());
-  fill_n(ovlp2.origin(), ovlp2.num_elements(), ComplexType(0.0));
+  fill_n(ovlp2.base(), ovlp2.num_elements(), ComplexType(0.0));
   stdCVector hvec(iextensions<1u>{(2 * ndet + 1) * nw});
-  fill_n(hvec.origin(), hvec.num_elements(), ComplexType(0.0));
+  fill_n(hvec.base(), hvec.num_elements(), ComplexType(0.0));
   int i0(2 * nw * ndet);
   TG.local_barrier();
   std::vector<CMatrix_ptr> Ai;
@@ -1375,7 +1375,7 @@ void NOMSD<devPsiT>::Overlap_batched(const WlkSet& wset, TVec&& Ov)
         Oi.emplace_back(&OrbMats[idet]);
     }
     SDetOp.BatchedOverlap(Oi, Ai, LogOverlapFactor, ovlp2.sliced(0, ndet * nw));
-    copy_n(ovlp2.origin(), nw * ndet, hvec.origin());
+    copy_n(ovlp2.base(), nw * ndet, hvec.base());
     for (int idet = 0, idb = 0; idet < ndet; ++idet)
     {
       for (int ib = 0; ib < nw; ++ib, ++idb)
@@ -1405,14 +1405,14 @@ void NOMSD<devPsiT>::Overlap_batched(const WlkSet& wset, TVec&& Ov)
         Oi.emplace_back(&OrbMats[2 * idet + 1]);
     }
     SDetOp.BatchedOverlap(Oi, Ai, LogOverlapFactor, ovlp2.sliced(ndet * nw, 2 * ndet * nw));
-    copy_n(ovlp2.origin(), 2 * nw * ndet, hvec.origin());
+    copy_n(ovlp2.base(), 2 * nw * ndet, hvec.base());
     for (int idet = 0, idb = 0, idb2 = nw * ndet; idet < ndet; ++idet)
     {
       for (int ib = 0; ib < nw; ++ib, ++idb, ++idb2)
         hvec[i0 + ib] += ma::conj(ci[idet]) * hvec[idb] * hvec[idb2];
     }
   }
-  copy_n(hvec.origin() + i0, nw, Ov.origin());
+  copy_n(hvec.base() + i0, nw, Ov.base());
 }
 
 /*
@@ -1427,13 +1427,13 @@ void NOMSD<devPsiT>::Overlap_shared(const WlkSet& wset, TVec&& Ov)
   using std::fill_n;
   // temporary runtime check for incompatible memory spaces
   {
-    auto dev_ptr_(make_device_ptr(Ov.origin()));
+    auto dev_ptr_(make_device_ptr(Ov.base()));
   }
   const int nw   = wset.size();
   const int ndet = ci.size();
   double LogOverlapFactor(wset.getLogOverlapFactor());
   assert(Ov.size() >= nw);
-  fill_n(Ov.origin(), nw, 0);
+  fill_n(Ov.base(), nw, 0);
   if (walker_type != COLLINEAR)
   {
     const int ntasks_percore      = (nw * ndet) / TG.getNCoresPerTG();
@@ -1545,7 +1545,7 @@ void NOMSD<devPsiT>::Overlap_shared(const WlkSet& wset, TVec&& Ov)
     }
   }
   if (TG.TG_local().size() > 1)
-    TG.TG_local().all_reduce_in_place_n(to_address(Ov.origin()), nw, std::plus<>());
+    TG.TG_local().all_reduce_in_place_n(to_address(Ov.base()), nw, std::plus<>());
 }
 
 // Computes walker averaged density matrix:
@@ -1570,7 +1570,7 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared(const WlkSet& wset,
   using std::fill_n;
   // temporary runtime check for incompatible memory spaces
   {
-    auto dev_ptr_(make_device_ptr(G.origin()));
+    auto dev_ptr_(make_device_ptr(G.base()));
   }
   const int nwalk = wset.size();
   const int ndet  = ci.size();
@@ -1589,7 +1589,7 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared(const WlkSet& wset,
     APP_ABORT(" Error: FIX FIX FIX need strided fill_n\n");
   }
   using std::fill_n;
-  fill_n(G.origin(), G.num_elements(), ComplexType(0.0));
+  fill_n(G.base(), G.num_elements(), ComplexType(0.0));
   TG.TG_local().barrier();
   if (Refs != nullptr)
   {
@@ -1607,18 +1607,18 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared(const WlkSet& wset,
     // Temporaries for determinant component of walker rdm function.
     StaticMatrix G2D_({Gdims.first, Gdims.second},
                       buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref G1D_(G2D_.origin(), iextensions<1u>{Gsize});
+    CVector_ref G1D_(G2D_.base(), iextensions<1u>{Gsize});
     // Accumulator for trial wavefunction sum.
     StaticVector G21D_(iextensions<1u>{Gsize}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     // 1D view of walker averaged RDM
-    CVector_ref G1D(make_device_ptr(G.origin()), iextensions<1u>{Gsize});
+    CVector_ref G1D(make_device_ptr(G.base()), iextensions<1u>{Gsize});
     for (int iw = 0; iw < nwalk; iw++)
     {
       if (iw % TG.TG_local().size() != TG.TG_local().rank())
         continue;
       if (std::abs(wgt[iw]) < 1e-10)
         continue;
-      fill_n(G21D_.origin(), G21D_.num_elements(), ComplexType(0.0));
+      fill_n(G21D_.base(), G21D_.num_elements(), ComplexType(0.0));
       ComplexType overlap = ComplexType(0.0, 0.0);
       for (int id = 0; id < ndet; id++)
       {
@@ -1626,10 +1626,10 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared(const WlkSet& wset,
         ComplexType ov(1.0, 0.0);
         if (Refs != nullptr)
         {
-          stdCMatrix_ref Orb(to_address((*Refs)[iw][id].origin()), {nrow, ncol});
+          stdCMatrix_ref Orb(to_address((*Refs)[iw][id].base()), {nrow, ncol});
           auto&& SM(*wset[iw].SlaterMatrixAux(Alpha));
           using std::copy_n;
-          copy_n(Orb.origin(), Orb.num_elements(), SM.origin());
+          copy_n(Orb.base(), Orb.num_elements(), SM.base());
           ComplexType ov_ = SDetOp.MixedDensityMatrix_noHerm(SM, *wset[iw].SlaterMatrixN(Alpha), G2D_, LogOverlapFactor,
                                                              compact, useSVD_in_Gfull);
           ov *= ov_ * ((*detR)[iw][id]);
@@ -1668,14 +1668,14 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared(const WlkSet& wset,
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
     StaticMatrix GB2D_({GBdims.first, GBdims.second},
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref GA1D_(GA2D_.origin(), iextensions<1u>{GAdims.first * GAdims.second});
-    CVector_ref GB1D_(GB2D_.origin(), iextensions<1u>{GBdims.first * GBdims.second});
+    CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GAdims.first * GAdims.second});
+    CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GBdims.first * GBdims.second});
     StaticVector GA21D_(iextensions<1u>{GAdims.first * GAdims.second},
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
     StaticVector GB21D_(iextensions<1u>{GBdims.first * GBdims.second},
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref GA1D(make_device_ptr(G.origin()), iextensions<1u>{GAdims.first * GAdims.second});
-    CVector_ref GB1D(make_device_ptr(G.origin()) + GAdims.first * GAdims.second,
+    CVector_ref GA1D(make_device_ptr(G.base()), iextensions<1u>{GAdims.first * GAdims.second});
+    CVector_ref GB1D(make_device_ptr(G.base()) + GAdims.first * GAdims.second,
                      iextensions<1u>{GBdims.first * GBdims.second});
     for (int iw = 0; iw < nwalk; iw++)
     {
@@ -1683,8 +1683,8 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared(const WlkSet& wset,
         continue;
       if (std::abs(wgt[iw]) < 1e-10)
         continue;
-      fill_n(GA21D_.origin(), GA21D_.num_elements(), ComplexType(0.0));
-      fill_n(GB21D_.origin(), GB21D_.num_elements(), ComplexType(0.0));
+      fill_n(GA21D_.base(), GA21D_.num_elements(), ComplexType(0.0));
+      fill_n(GB21D_.base(), GB21D_.num_elements(), ComplexType(0.0));
       ComplexType overlap = ComplexType(0.0, 0.0);
       for (int id = 0; id < ndet; id++)
       {
@@ -1692,13 +1692,13 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared(const WlkSet& wset,
         // Mixed density matrix.
         if (Refs != nullptr)
         {
-          stdCMatrix_ref OrbA(to_address((*Refs)[iw][id].origin()), {NMO, NAEA});
-          stdCMatrix_ref OrbB(OrbA.origin() + OrbA.num_elements(), {NMO, NAEB});
+          stdCMatrix_ref OrbA(to_address((*Refs)[iw][id].base()), {NMO, NAEA});
+          stdCMatrix_ref OrbB(OrbA.base() + OrbA.num_elements(), {NMO, NAEB});
           auto&& SMA(*wset[iw].SlaterMatrixAux(Alpha));
           auto&& SMB(*wset[iw].SlaterMatrixAux(Beta));
           using std::copy_n;
-          copy_n(OrbA.origin(), OrbA.num_elements(), SMA.origin());
-          copy_n(OrbB.origin(), OrbB.num_elements(), SMB.origin());
+          copy_n(OrbA.base(), OrbA.num_elements(), SMA.base());
+          copy_n(OrbB.base(), OrbB.num_elements(), SMB.base());
           ComplexType ov_ = SDetOp.MixedDensityMatrix_noHerm(SMA, *wset[iw].SlaterMatrixN(Alpha), GA2D_,
                                                              LogOverlapFactor, compact, useSVD_in_Gfull);
           ov *= ov_ * ((*detR)[iw][2 * id]);
@@ -1739,8 +1739,8 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared(const WlkSet& wset,
   // Average over walker's
   if (TG.Global().size() > 1)
   {
-    TG.Global().all_reduce_in_place_n(to_address(denom.origin()), 1, std::plus<>());
-    TG.Global().all_reduce_in_place_n(to_address(G.origin()), Gsize, std::plus<>());
+    TG.Global().all_reduce_in_place_n(to_address(denom.base()), 1, std::plus<>());
+    TG.Global().all_reduce_in_place_n(to_address(G.base()), Gsize, std::plus<>());
   }
   TG.local_barrier();
 }
@@ -1763,7 +1763,7 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared_single_det(const WlkSet&
   using std::fill_n;
   // temporary runtime check for incompatible memory spaces
   {
-    auto dev_ptr_(make_device_ptr(G.origin()));
+    auto dev_ptr_(make_device_ptr(G.base()));
   }
   const int nwalk = wset.size();
   const int ndet  = ci.size();
@@ -1782,7 +1782,7 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared_single_det(const WlkSet&
   {
     APP_ABORT(" Error: FIX FIX FIX need strided fill_n\n");
   }
-  fill_n(G.origin(), G.num_elements(), ComplexType(0.0));
+  fill_n(G.base(), G.num_elements(), ComplexType(0.0));
   TG.TG_local().barrier();
   if (Refs != nullptr)
   {
@@ -1795,8 +1795,8 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared_single_det(const WlkSet&
     assert(OrbMats.size() == get<1>((*detR).sizes()));
   }
 
-  fill_n(Ovlp.origin(), Ovlp.num_elements(), ComplexType(0.0));
-  fill_n(DMsum.origin(), DMsum.num_elements(), ComplexType(0.0));
+  fill_n(Ovlp.base(), Ovlp.num_elements(), ComplexType(0.0));
+  fill_n(DMsum.base(), DMsum.num_elements(), ComplexType(0.0));
 
   if (walker_type != COLLINEAR)
   {
@@ -1804,9 +1804,9 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared_single_det(const WlkSet&
     // Temporaries for determinant component of walker rdm function.
     StaticMatrix G2D_({Gdims.first, Gdims.second},
                       buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref G1D_(G2D_.origin(), iextensions<1u>{Gsize});
+    CVector_ref G1D_(G2D_.base(), iextensions<1u>{Gsize});
     // 1D view of walker averaged RDM
-    CVector_ref G1D(make_device_ptr(G.origin()), iextensions<1u>{Gsize});
+    CVector_ref G1D(make_device_ptr(G.base()), iextensions<1u>{Gsize});
     for (int iw = 0; iw < nwalk; iw++)
     {
       if (iw % TG.TG_local().size() != TG.TG_local().rank())
@@ -1814,15 +1814,15 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared_single_det(const WlkSet&
       if (std::abs(wgt[iw]) < 1e-10)
         continue;
       ComplexType overlap = ComplexType(1.0, 0.0);
-      fill_n(G1D_.origin(), G1D_.num_elements(), ComplexType(0.0));
+      fill_n(G1D_.base(), G1D_.num_elements(), ComplexType(0.0));
 
       // Mixed density matrix.
       if (Refs != nullptr)
       {
-        stdCMatrix_ref Orb(to_address((*Refs)[iw][0].origin()), {nrow, ncol});
+        stdCMatrix_ref Orb(to_address((*Refs)[iw][0].base()), {nrow, ncol});
         auto&& SM(*wset[iw].SlaterMatrixAux(Alpha));
         using std::copy_n;
-        copy_n(Orb.origin(), Orb.num_elements(), SM.origin());
+        copy_n(Orb.base(), Orb.num_elements(), SM.base());
         ComplexType ov_ = SDetOp.MixedDensityMatrix_noHerm(SM, *wset[iw].SlaterMatrixN(Alpha), G2D_, LogOverlapFactor,
                                                            compact, useSVD_in_Gfull);
         overlap *= ov_ * ((*detR)[iw][0]);
@@ -1859,10 +1859,10 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared_single_det(const WlkSet&
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
     StaticMatrix GB2D_({GBdims.first, GBdims.second},
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref GA1D_(GA2D_.origin(), iextensions<1u>{GAdims.first * GAdims.second});
-    CVector_ref GB1D_(GB2D_.origin(), iextensions<1u>{GBdims.first * GBdims.second});
-    CVector_ref GA1D(make_device_ptr(G.origin()), iextensions<1u>{GAdims.first * GAdims.second});
-    CVector_ref GB1D(make_device_ptr(G.origin()) + GAdims.first * GAdims.second,
+    CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GAdims.first * GAdims.second});
+    CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GBdims.first * GBdims.second});
+    CVector_ref GA1D(make_device_ptr(G.base()), iextensions<1u>{GAdims.first * GAdims.second});
+    CVector_ref GB1D(make_device_ptr(G.base()) + GAdims.first * GAdims.second,
                      iextensions<1u>{GBdims.first * GBdims.second});
     for (int iw = 0; iw < nwalk; iw++)
     {
@@ -1871,19 +1871,19 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared_single_det(const WlkSet&
       if (std::abs(wgt[iw]) < 1e-10)
         continue;
       ComplexType overlap = ComplexType(1.0, 0.0);
-      fill_n(GA1D_.origin(), GA1D_.num_elements(), ComplexType(0.0));
-      fill_n(GB1D_.origin(), GB1D_.num_elements(), ComplexType(0.0));
+      fill_n(GA1D_.base(), GA1D_.num_elements(), ComplexType(0.0));
+      fill_n(GB1D_.base(), GB1D_.num_elements(), ComplexType(0.0));
 
       // Mixed density matrix.
       if (Refs != nullptr)
       {
-        stdCMatrix_ref OrbA(to_address((*Refs)[iw][0].origin()), {NMO, NAEA});
-        stdCMatrix_ref OrbB(OrbA.origin() + OrbA.num_elements(), {NMO, NAEB});
+        stdCMatrix_ref OrbA(to_address((*Refs)[iw][0].base()), {NMO, NAEA});
+        stdCMatrix_ref OrbB(OrbA.base() + OrbA.num_elements(), {NMO, NAEB});
         auto&& SMA(*wset[iw].SlaterMatrixAux(Alpha));
         auto&& SMB(*wset[iw].SlaterMatrixAux(Beta));
         using std::copy_n;
-        copy_n(OrbA.origin(), OrbA.num_elements(), SMA.origin());
-        copy_n(OrbB.origin(), OrbB.num_elements(), SMB.origin());
+        copy_n(OrbA.base(), OrbA.num_elements(), SMA.base());
+        copy_n(OrbB.base(), OrbB.num_elements(), SMB.base());
         ComplexType ov1 = SDetOp.MixedDensityMatrix_noHerm(SMA, *wset[iw].SlaterMatrixN(Alpha), GA2D_, LogOverlapFactor,
                                                            compact, useSVD_in_Gfull);
         Ovlp[iw][0]     = ov1;
@@ -1943,8 +1943,8 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared_single_det(const WlkSet&
   // Average over walker's
   if (TG.Global().size() > 1)
   {
-    TG.Global().all_reduce_in_place_n(to_address(denom.origin()), 1, std::plus<>());
-    TG.Global().all_reduce_in_place_n(to_address(G.origin()), Gsize, std::plus<>());
+    TG.Global().all_reduce_in_place_n(to_address(denom.base()), 1, std::plus<>());
+    TG.Global().all_reduce_in_place_n(to_address(G.base()), Gsize, std::plus<>());
   }
   TG.local_barrier();
 }
@@ -1974,8 +1974,8 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_batched(const WlkSet& wset,
     using std::copy_n;
     // temporary runtime check for incompatible memory spaces
     {
-      auto dev_ptr_(make_device_ptr(Ov.origin()));
-      auto dev_ptr(make_device_ptr(G.origin()));
+      auto dev_ptr_(make_device_ptr(Ov.base()));
+      auto dev_ptr(make_device_ptr(G.base()));
     }
     using std::get;
     assert(get<1>(G.strides())==1);
@@ -1989,7 +1989,7 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_batched(const WlkSet& wset,
     if(get<1>(G.sizes()) != G.stride()) {
       APP_ABORT(" Error: FIX FIX FIX need strided fill_n\n");
     }
-    fill_n(G.origin(),G.num_elements(),ComplexType(0.0));
+    fill_n(G.base(),G.num_elements(),ComplexType(0.0));
     if(Refs!=nullptr) {
       assert(detR!=nullptr);
       assert(wset.size() <= (*Refs).size());
@@ -2003,15 +2003,15 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_batched(const WlkSet& wset,
     auto Gsize = dm_size(not compact);
     if(localGbuff.size() < nbatch__*Gsize+1)
       localGbuff.reextent(iextensions<1u>{nbatch__*Gsize+1});
-    pointer ov_(localGbuff.origin()+nbatch__*Gsize);  
+    pointer ov_(localGbuff.base()+nbatch__*Gsize);  
     std::vector<CMatrix_ref> Ai;
     Ai.reserve(nbatch__);
 
     if(walker_type != COLLINEAR) {
 
       auto GAdims = dm_dims(not compact,Alpha); 
-      CTensor_ref G3D_(localGbuff.origin(),{nbatch__,GAdims.first,GAdims.second});
-      CMatrix_ref G2D_(G3D_.origin(),iextensions<2u>{nbatch__,GAdims.first*GAdims.second});
+      CTensor_ref G3D_(localGbuff.base(),{nbatch__,GAdims.first,GAdims.second});
+      CMatrix_ref G2D_(G3D_.base(),iextensions<2u>{nbatch__,GAdims.first*GAdims.second});
 
       for(int idet=0; idet<ndet; ++idet) {
         for(int iw=0; iw<nw; iw+=nbatch__) {
@@ -2020,7 +2020,7 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_batched(const WlkSet& wset,
           for(int ni=0; ni<nb; ni++) Ai.emplace_back(*wset[iw+ni].SlaterMatrix(Alpha));
           SDetOp.BatchedMixedDensityMatrix_noherm(OrbMats[idet],Ai,
                                 G3D_.sliced(0,nb),ovlp2.sliced(0,nb),compact);
-          copy_n(ovlp2.origin(),nb,hvec.origin());
+          copy_n(ovlp2.base(),nb,hvec.base());
           for(int ib=0; ib<nb; ++ib) {
             ComplexType ov(hvec[ib]);
             if(walker_type==CLOSED) ov *= ov;
@@ -2028,7 +2028,7 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_batched(const WlkSet& wset,
             if(transpose) {
               ma::axpy(ov,G2D_[ib],G[iw+ib]);   
             } else {
-              ma::axpy(ov,G2D_[ib],G(G.extension(0),iw+ib));   
+              ma::axpy(ov,G2D_[ib],G(get<0>(G.extents()),iw+ib));   
             } 
             Ov[iw+ib] += ov;
           }
@@ -2039,10 +2039,10 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_batched(const WlkSet& wset,
 
       auto GAdims = dm_dims(not compact,Alpha); 
       auto GBdims = dm_dims(not compact,Beta);
-      CTensor_ref GA3D_(localGbuff.origin(),{nbatch__,GAdims.first,GAdims.second});
-      CMatrix_ref GA2D_(GA3D_.origin(),iextensions<2u>{nbatch__,GAdims.first*GAdims.second});
-      CTensor_ref GB3D_(GA3D_.origin()+GA3D_.num_elements(),{nbatch__,GBdims.first,GBdims.second});
-      CMatrix_ref GB2D_(GB3D_.origin(),iextensions<2u>{nbatch__,GBdims.first*GBdims.second});
+      CTensor_ref GA3D_(localGbuff.base(),{nbatch__,GAdims.first,GAdims.second});
+      CMatrix_ref GA2D_(GA3D_.base(),iextensions<2u>{nbatch__,GAdims.first*GAdims.second});
+      CTensor_ref GB3D_(GA3D_.base()+GA3D_.num_elements(),{nbatch__,GBdims.first,GBdims.second});
+      CMatrix_ref GB2D_(GB3D_.base(),iextensions<2u>{nbatch__,GBdims.first*GBdims.second});
 
       for(int idet=0; idet<ndet; ++idet) {
         for(int iw=0; iw<nw; iw+=nbatch__) {
@@ -2055,7 +2055,7 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_batched(const WlkSet& wset,
           for(int ni=0; ni<nb; ni++) Ai.emplace_back(*wset[iw+ni].SlaterMatrix(Beta));
           SDetOp.BatchedMixedDensityMatrix_noherm(OrbMats[2*idet+1],Ai,
                                 GB3D_.sliced(0,nb),ovlp2.sliced(nb,2*nb),compact);
-          copy_n(ovlp2.origin(),2*nb,hvec.origin());
+          copy_n(ovlp2.base(),2*nb,hvec.base());
           for(int ib=0; ib<nb; ++ib) {
             ComplexType ov = hvec[ib]*hvec[nb+ib]*ma::conj(ci[idet]);
             if(transpose) {
@@ -2186,9 +2186,9 @@ void NOMSD<devPsiT>::Orthogonalize_batched(WlkSet& wset, bool impSamp)
       }
       else
       {
-        SDetOp.BatchedOrthogonalize(Ai, LogOverlapFactor, ov.origin());
+        SDetOp.BatchedOrthogonalize(Ai, LogOverlapFactor, ov.base());
         using std::copy_n;
-        copy_n(ov.origin(), nb, detR.origin() + iw);
+        copy_n(ov.base(), nb, detR.base() + iw);
       }
     }
   }
@@ -2206,9 +2206,9 @@ void NOMSD<devPsiT>::Orthogonalize_batched(WlkSet& wset, bool impSamp)
       }
       else
       {
-        SDetOp.BatchedOrthogonalize(Ai, LogOverlapFactor, ov.origin());
+        SDetOp.BatchedOrthogonalize(Ai, LogOverlapFactor, ov.base());
         using std::copy_n;
-        copy_n(ov.origin(), nb, detR.origin() + iw);
+        copy_n(ov.base(), nb, detR.base() + iw);
       }
       Ai.clear();
       for (int ni = 0; ni < nb; ni++)
@@ -2219,9 +2219,9 @@ void NOMSD<devPsiT>::Orthogonalize_batched(WlkSet& wset, bool impSamp)
       }
       else
       {
-        SDetOp.BatchedOrthogonalize(Ai, LogOverlapFactor, ov.origin());
+        SDetOp.BatchedOrthogonalize(Ai, LogOverlapFactor, ov.base());
         using std::copy_n;
-        copy_n(ov.origin(), nb, detR.origin() + nw + iw);
+        copy_n(ov.base(), nb, detR.base() + nw + iw);
       }
     }
   }
@@ -2259,44 +2259,44 @@ void NOMSD<devPsiT>::OrthogonalizeExcited(Mat&& A, SpinTypes spin, double LogOve
   {
     if (extendedMatAlpha.size() != NMO || get<1>(extendedMatAlpha.sizes()) != maxOccupExtendedMat.first)
       extendedMatAlpha.reextent({NMO, maxOccupExtendedMat.first});
-    extendedMatAlpha(extendedMatAlpha.extension(0), {0, NAEA}) = A;
-    extendedMatAlpha(extendedMatAlpha.extension(0), {NAEA + 1, maxOccupExtendedMat.first}) =
-        excitedOrbMat[0](excitedOrbMat.extension(1), {NAEA + 1, maxOccupExtendedMat.first});
+    extendedMatAlpha(get<0>(extendedMatAlpha.extents()), {0, NAEA}) = A;
+    extendedMatAlpha(get<0>(extendedMatAlpha.extents()), {NAEA + 1, maxOccupExtendedMat.first}) =
+        excitedOrbMat[0](get<1>(excitedOrbMat.extents()), {NAEA + 1, maxOccupExtendedMat.first});
     // move i->a, copy trial orb i
     for (auto& i : excitations)
       if (i.first < NMO && i.second < NMO)
       {
-        extendedMatAlpha(extendedMatAlpha.extension(0), i.second) =
-            extendedMatAlpha(extendedMatAlpha.extension(0), i.first);
-        extendedMatAlpha(extendedMatAlpha.extension(0), i.first) =
-            excitedOrbMat[0](excitedOrbMat.extension(1), i.first);
+        extendedMatAlpha(get<0>(extendedMatAlpha.extents()), i.second) =
+            extendedMatAlpha(get<0>(extendedMatAlpha.extents()), i.first);
+        extendedMatAlpha(get<0>(extendedMatAlpha.extents()), i.first) =
+            excitedOrbMat[0](get<1>(excitedOrbMat.extents()), i.first);
       }
     ComplexType detR             = SDetOp.Orthogonalize(extendedMatAlpha, LogOverlapFactor);
-    A(A.extension(0), {0, NAEA}) = extendedMatAlpha(extendedMatAlpha.extension(0), {0, NAEA});
+    A(get<0>(A.extents()), {0, NAEA}) = extendedMatAlpha(get<0>(extendedMatAlpha.extents()), {0, NAEA});
     for (auto& i : excitations)
       if (i.first < NMO && i.second < NMO)
-        A(A.extension(0), i.first) = extendedMatAlpha(extendedMatAlpha.extension(0), i.second);
+        A(get<0>(A.extents()), i.first) = extendedMatAlpha(get<0>(extendedMatAlpha.extents()), i.second);
   }
   else
   {
     if (extendedMatBeta.size() != NMO || get<1>(extendedMatBeta.sizes()) != maxOccupExtendedMat.second)
       extendedMatBeta.reextent({NMO, maxOccupExtendedMat.second});
-    extendedMatBeta(extendedMatBeta.extension(0), {0, NAEB}) = A;
-    extendedMatBeta(extendedMatBeta.extension(0), {NAEB + 1, maxOccupExtendedMat.second}) =
-        excitedOrbMat[1](excitedOrbMat.extension(1), {NAEB + 1, maxOccupExtendedMat.second});
+    extendedMatBeta(get<0>(extendedMatBeta.extents()), {0, NAEB}) = A;
+    extendedMatBeta(get<0>(extendedMatBeta.extents()), {NAEB + 1, maxOccupExtendedMat.second}) =
+        excitedOrbMat[1](get<1>(excitedOrbMat.extents()), {NAEB + 1, maxOccupExtendedMat.second});
     // move i->a, copy trial orb i
     for (auto& i : excitations)
       if (i.first >= NMO && i.second >= NMO)
       {
-        extendedMatBeta(extendedMatBeta.extension(0), i.second) =
-            extendedMatBeta(extendedMatBeta.extension(0), i.first);
-        extendedMatBeta(extendedMatBeta.extension(0), i.first) = excitedOrbMat[1](excitedOrbMat.extension(1), i.first);
+        extendedMatBeta(get<0>(extendedMatBeta.extents()), i.second) =
+            extendedMatBeta(get<0>(extendedMatBeta.extents()), i.first);
+        extendedMatBeta(get<0>(extendedMatBeta.extents()), i.first) = excitedOrbMat[1](get<1>(excitedOrbMat.extents()), i.first);
       }
     ComplexType detR             = SDetOp.Orthogonalize(extendedMatBeta, LogOverlapFactor);
-    A(A.extension(0), {0, NAEB}) = extendedMatBeta(extendedMatBeta.extension(0), {0, NAEB});
+    A(get<0>(A.extents()), {0, NAEB}) = extendedMatBeta(get<0>(extendedMatBeta.extents()), {0, NAEB});
     for (auto& i : excitations)
       if (i.first >= NMO && i.second >= NMO)
-        A(A.extension(0), i.first) = extendedMatBeta(extendedMatBeta.extension(0), i.second);
+        A(get<0>(A.extents()), i.first) = extendedMatBeta(get<0>(extendedMatBeta.extents()), i.second);
   }
 }
 
@@ -2311,11 +2311,11 @@ void NOMSD<devPsiT>::vMF(Vec&& v)
   using std::fill_n;
   // temporary runtime check for incompatible memory spaces
   {
-    auto dev_ptr_(make_device_ptr(v.origin()));
+    auto dev_ptr_(make_device_ptr(v.base()));
   }
 
   assert(v.num_elements() == local_number_of_cholesky_vectors());
-  fill_n(v.origin(), v.num_elements(), ComplexType(0));
+  fill_n(v.base(), v.num_elements(), ComplexType(0));
 
   int ndets = ci.size();
   CMatrix PsiT, PsiTB;
@@ -2341,7 +2341,7 @@ void NOMSD<devPsiT>::vMF(Vec&& v)
       ma::Matrix2MA('H', OrbMats[1], PsiT);
       SDetOp.MixedDensityMatrix(OrbMats[1], PsiT, G.sliced(NAEA, NAEA + NAEB), 0.0, true);
     }
-    CVector_ref G1D(G.origin(), iextensions<1u>{G.num_elements()});
+    CVector_ref G1D(G.base(), iextensions<1u>{G.num_elements()});
     HamOp.vbias(G1D, std::forward<Vec>(v));
   }
   else
@@ -2349,12 +2349,12 @@ void NOMSD<devPsiT>::vMF(Vec&& v)
     auto Gsize = dm_size(true);
     auto Gdims = dm_dims(true, Alpha);
     CVector G1D(iextensions<1u>{Gsize});
-    fill_n(G1D.origin(), G1D.num_elements(), ComplexType(0));
+    fill_n(G1D.base(), G1D.num_elements(), ComplexType(0));
     ComplexType ov(0);
     if (walker_type != COLLINEAR)
     {
       CMatrix G_({Gdims.first, Gdims.second});
-      CVector_ref G1D_(G_.origin(), iextensions<1u>{Gdims.first * Gdims.second});
+      CVector_ref G1D_(G_.base(), iextensions<1u>{Gdims.first * Gdims.second});
       int n0, n1;
       std::tie(n0, n1) = FairDivideBoundary(TG.getGlobalRank(), ndets * (ndets + 1) / 2, TG.getGlobalSize());
       int last_p       = -1;
@@ -2384,7 +2384,7 @@ void NOMSD<devPsiT>::vMF(Vec&& v)
     else
     {
       CMatrix G_({2 * NMO, NMO});
-      CVector_ref G1D_(G_.origin(), iextensions<1u>{2 * NMO * NMO});
+      CVector_ref G1D_(G_.base(), iextensions<1u>{2 * NMO * NMO});
       int n0, n1;
       std::tie(n0, n1) = FairDivideBoundary(TG.getGlobalRank(), ndets * (ndets + 1) / 2, TG.getGlobalSize());
       int last_p       = -1;
@@ -2429,7 +2429,7 @@ void NOMSD<devPsiT>::vMF(Vec&& v)
       }
     }
     if (TG.Global().size() > 1)
-      TG.Global().all_reduce_in_place_n(to_address(G1D.origin()), G1D.num_elements(), std::plus<>());
+      TG.Global().all_reduce_in_place_n(to_address(G1D.base()), G1D.num_elements(), std::plus<>());
     ComplexType ov1 = (TG.Global() += ov);
     ma::scal(ComplexType(1.0, 0.0) / ov1, G1D);
     HamOp.vbias(G1D.sliced(0, Gdims.first * Gdims.second), std::forward<Vec>(v));
@@ -2438,7 +2438,7 @@ void NOMSD<devPsiT>::vMF(Vec&& v)
   }
   // since v is not in shared memory, we need to reduce
   if (TG.TG_local().size() > 1)
-    TG.TG_local().all_reduce_in_place_n(to_address(v.origin()), v.num_elements(), std::plus<>());
+    TG.TG_local().all_reduce_in_place_n(to_address(v.base()), v.num_elements(), std::plus<>());
   // NOTE: since SpvnT is a truncated structure the complex part of vMF,
   //       which should be exactly zero, suffers from truncation errors.
   //       Set it to zero.
@@ -2487,17 +2487,17 @@ inline void NOMSD<devPsiT>::recompute_ci()
         Psib.reextent({NMO, NAEB});
     }
     using std::fill_n;
-    fill_n(H.origin(), H.num_elements(), ComplexType(0.0));
-    fill_n(S.origin(), S.num_elements(), ComplexType(0.0));
-    fill_n(energy.origin(), energy.num_elements(), ComplexType(0.0));
+    fill_n(H.base(), H.num_elements(), ComplexType(0.0));
+    fill_n(S.base(), S.num_elements(), ComplexType(0.0));
+    fill_n(energy.base(), energy.num_elements(), ComplexType(0.0));
 
     ComplexType zero(0.0);
     auto Gsize = dm_size(false);
     int nr = Gsize, nc = 1;
     if (transposed_G_for_E_)
       std::swap(nr, nc);
-    CVector_ref ov_(make_device_ptr(shmbuff.origin()), iextensions<1u>{1});
-    CMatrix_ref G(ov_.origin() + 1, {nr, nc});
+    CVector_ref ov_(make_device_ptr(shmbuff.base()), iextensions<1u>{1});
+    CMatrix_ref G(ov_.base() + 1, {nr, nc});
     StaticMatrix eloc2({1, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
 
     for (int jdet = 0, ji = 0; jdet < ndets; jdet++)
@@ -2510,12 +2510,12 @@ inline void NOMSD<devPsiT>::recompute_ci()
           ComplexType cidet = ci[idet];
           if (TG.TG_local().root())
           {
-            CMatrix_ref Ga(G.origin(), {NAEA, NMO});
+            CMatrix_ref Ga(G.base(), {NAEA, NMO});
             ma::Matrix2MA('H', OrbMats[nspin * jdet], Psia);
             ov_[0] = SDetOp.MixedDensityMatrix(OrbMats[nspin * idet], Psia, Ga, LogOverlapFactor, true);
             if (walker_type == COLLINEAR)
             {
-              CMatrix_ref Gb(Ga.origin() + Ga.num_elements(), {NAEB, NMO});
+              CMatrix_ref Gb(Ga.base() + Ga.num_elements(), {NAEB, NMO});
               ma::Matrix2MA('H', OrbMats[nspin * jdet + 1], Psib);
               ov_[0] *= SDetOp.MixedDensityMatrix(OrbMats[nspin * idet + 1], Psib, Gb, LogOverlapFactor, true);
             }
@@ -2527,7 +2527,7 @@ inline void NOMSD<devPsiT>::recompute_ci()
           TG.local_barrier();
           HamOp.energy(eloc2, G, idet, TG.TG_local().root());
           if (TG.TG_local().size() > 1)
-            TG.TG_local().all_reduce_in_place_n(to_address(eloc2.origin()), 3, std::plus<>());
+            TG.TG_local().all_reduce_in_place_n(to_address(eloc2.base()), 3, std::plus<>());
           if (TG.TG_local().root())
           {
             if (idet != jdet)
@@ -2557,10 +2557,10 @@ inline void NOMSD<devPsiT>::recompute_ci()
     }
     TG.Global().barrier();
     if (TG.Node().root())
-      TG.Cores().all_reduce_in_place_n(to_address(H.origin()), H.num_elements(), std::plus<>());
+      TG.Cores().all_reduce_in_place_n(to_address(H.base()), H.num_elements(), std::plus<>());
     if (TG.Node().root())
-      TG.Cores().all_reduce_in_place_n(to_address(S.origin()), S.num_elements(), std::plus<>());
-    TG.Global().all_reduce_in_place_n(energy.origin(), 2, std::plus<>());
+      TG.Cores().all_reduce_in_place_n(to_address(S.base()), S.num_elements(), std::plus<>());
+    TG.Global().all_reduce_in_place_n(energy.base(), 2, std::plus<>());
 
     app_log() << " - Variational energy of trial wavefunction: " << std::setprecision(16) << energy[0] / energy[1]
               << "\n";
@@ -2570,8 +2570,8 @@ inline void NOMSD<devPsiT>::recompute_ci()
     // Want a "unique" solution for all cores/nodes.
     if (TG.Global().rank() == 0)
     {
-      boost::multi::array_ref<ComplexType, 2> H_(to_address(H.origin()), {ndets, ndets});
-      boost::multi::array_ref<ComplexType, 2> S_(to_address(S.origin()), {ndets, ndets});
+      boost::multi::array_ref<ComplexType, 2> H_(to_address(H.base()), {ndets, ndets});
+      boost::multi::array_ref<ComplexType, 2> S_(to_address(S.base()), {ndets, ndets});
       std::pair<RVector, CMatrix> Sol = ma::genEigSelect<RVector, CMatrix>(H_, S_, 1);
       app_log() << " - Updating CI coefficients. \n";
       app_log() << " - Recomputed coefficient of first determinant: " << Sol.second[0][0] << "\n";

--- a/src/AFQMC/Wavefunctions/PHMSD.hpp
+++ b/src/AFQMC/Wavefunctions/PHMSD.hpp
@@ -260,10 +260,10 @@ public:
     {
       assert(get<0>(G.sizes()) == get<1>(v.sizes()));
       assert(get<1>(G.sizes()) == size_of_G_for_vbias());
-      HamOp.vbias(G(G.extension(), {0, long(OrbMats[0].size() * NMO)}), std::forward<MatA>(v), scl * a, 0.0);
+      HamOp.vbias(G(G.extent(), {0, long(OrbMats[0].size() * NMO)}), std::forward<MatA>(v), scl * a, 0.0);
       if (walker_type == COLLINEAR) {
         APP_ABORT(" Error in PHMSD::vbias: transposed_G_for_vbias_ should be false. \n");
-        HamOp.vbias(G(G.extension(), {long(OrbMats[0].size() * NMO), get<1>(G.sizes())}),                                       std::forward<MatA>(v), scl * a, 1.0);
+        HamOp.vbias(G(G.extent(), {long(OrbMats[0].size() * NMO), get<1>(G.sizes())}),                                       std::forward<MatA>(v), scl * a, 1.0);
       }
     }
     else
@@ -521,8 +521,8 @@ public:
           auto c(abij.configuration(i));
           abij.get_configuration(0, std::get<0>(*c), Ac);
           abij.get_configuration(1, std::get<1>(*c), Bc);
-          boost::multi::array_ref<ComplexType, 2> A_(to_address(RefOrbMats[i].origin()), {NMO, NAEA});
-          boost::multi::array_ref<ComplexType, 2> B_(A_.origin() + A_.num_elements(), {NMO, NAEB});
+          boost::multi::array_ref<ComplexType, 2> A_(to_address(RefOrbMats[i].base()), {NMO, NAEA});
+          boost::multi::array_ref<ComplexType, 2> B_(A_.base() + A_.num_elements(), {NMO, NAEB});
           for (int i = 0, ia = 0; i < NMO; ++i)
             for (int a = 0; a < NAEA; ++a, ia++)
               A_[i][a] = OA_[i][Ac[a]];
@@ -552,7 +552,7 @@ public:
     int n0, n1;
     std::tie(n0, n1) = FairDivideBoundary(TG.getLocalTGRank(), int(get<1>(A.sizes())), TG.getNCoresPerTG());
     for (int i = 0; i < ndet; i++)
-      copy_n(RefOrbMats_[i].origin() + n0, n1 - n0, A_[i].origin() + n0);
+      copy_n(RefOrbMats_[i].base() + n0, n1 - n0, A_[i].base() + n0);
     TG.TG_local().barrier();
   }
 

--- a/src/AFQMC/Wavefunctions/PHMSD.icc
+++ b/src/AFQMC/Wavefunctions/PHMSD.icc
@@ -72,9 +72,9 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
   if (get<0>(eloc2.sizes()) != nwalk || get<1>(eloc2.sizes()) != 3)
     eloc2.reextent({nwalk, 3});
 
-  std::fill_n(Ov.origin(), nwalk, zero);
-  std::fill_n(E.origin(), 3 * nwalk, zero);
-  std::fill_n(opSpinEJ.origin(), nwalk, ComplexType(0.0));
+  std::fill_n(Ov.base(), nwalk, zero);
+  std::fill_n(E.base(), 3 * nwalk, zero);
+  std::fill_n(opSpinEJ.base(), nwalk, ComplexType(0.0));
 
   // dummy: ugly but not sure how to do it better
   SPCMatrix* dummyMatPtr(nullptr);
@@ -104,7 +104,7 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
     {
       if (nc % TG.TG_local().size() == TG.TG_local().rank())
       {
-        boost::multi::array_ref<ComplexType, 2> G2D_(localGbuff.origin(),
+        boost::multi::array_ref<ComplexType, 2> G2D_(localGbuff.base(),
                                                      {dm_dims_ref(false, Alpha).first,
                                                       dm_dims_ref(false, Alpha).second});
         Ovmsd[0][0][iw] = SDetOp.MixedDensityMatrixForWoodbury(OrbMats[0], *wset[iw].SlaterMatrix(Alpha), G2D_,
@@ -112,14 +112,14 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
         confg.resize(NAEA);
         abij.get_configuration(0, 0, confg);
         auto Gr = GrefA[iw];
-        std::fill_n(Gr.origin(), Gr.num_elements(), ComplexType(0.0));
+        std::fill_n(Gr.base(), Gr.num_elements(), ComplexType(0.0));
         for (int k = 0; k < confg.size(); ++k)
           Gr[confg[k]] = G2D_[k];
       }
       ++nc;
       if (nc % TG.TG_local().size() == TG.TG_local().rank())
       {
-        boost::multi::array_ref<ComplexType, 2> G2D_(localGbuff.origin(),
+        boost::multi::array_ref<ComplexType, 2> G2D_(localGbuff.base(),
                                                      {dm_dims_ref(false, Beta).first, dm_dims_ref(false, Beta).second});
         Ovmsd[1][0][iw] =
             SDetOp.MixedDensityMatrixForWoodbury(OrbMats.back(),
@@ -128,7 +128,7 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
         confg.resize(NAEB);
         abij.get_configuration(1, 0, confg);
         auto Gr = GrefB[iw];
-        std::fill_n(Gr.origin(), Gr.num_elements(), ComplexType(0.0));
+        std::fill_n(Gr.base(), Gr.num_elements(), ComplexType(0.0));
         for (int k = 0; k < confg.size(); ++k)
           Gr[confg[k]] = G2D_[k];
       }
@@ -152,12 +152,12 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
       confg.resize((spin == 0) ? NAEA : NAEB);
       auto Gdims     = dm_dims(false, SpinTypes(spin));
       auto Gdims_ref = dm_dims_ref(false, SpinTypes(spin));
-      boost::multi::array_ref<ComplexType, 2> G2D_(localGbuff.origin(), {Gdims_ref.first, Gdims_ref.second});
+      boost::multi::array_ref<ComplexType, 2> G2D_(localGbuff.base(), {Gdims_ref.first, Gdims_ref.second});
       int nr = Gdims.first * Gdims.second, nc = nwalk;
       if (transposed_G_for_E_)
         std::swap(nr, nc);
       // GrefA is guaranteed to have enough space
-      boost::multi::array_ref<ComplexType, 2> G(to_address(GrefA.origin()), {nr, nc});
+      boost::multi::array_ref<ComplexType, 2> G(to_address(GrefA.base()), {nr, nc});
       for (int nd = 0; nd < det_couplings[spin].size(); ++nd)
       {
         abij.get_configuration(spin, nd, confg);
@@ -172,14 +172,14 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
                                                            LogOverlapFactor, confg.data(), true);
             if (transposed_G_for_E_)
             {
-              boost::multi::array_ref<ComplexType, 3> G3D(to_address(G.origin()), {nwalk, Gdims.first, Gdims.second});
-              std::fill_n(G[iw].origin(), Gdims.first * Gdims.second, ComplexType(0.0));
+              boost::multi::array_ref<ComplexType, 3> G3D(to_address(G.base()), {nwalk, Gdims.first, Gdims.second});
+              std::fill_n(G[iw].base(), Gdims.first * Gdims.second, ComplexType(0.0));
               for (int k = 0; k < confg.size(); ++k)
                 G3D[iw][confg[k]] = G2D_[k];
             }
             else
             {
-              boost::multi::array_ref<ComplexType, 3> G3D(to_address(G.origin()), {Gdims.first, Gdims.second, nwalk});
+              boost::multi::array_ref<ComplexType, 3> G3D(to_address(G.base()), {Gdims.first, Gdims.second, nwalk});
               for (int k = 0; k < Gdims.first; ++k)
                 for (int j = 0; j < Gdims.second; ++j)
                   G3D[k][j][iw] = ComplexType(0.0);
@@ -194,7 +194,7 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
           auto KEr = KEright[nd];
           HamOp.energy(eloc2, G, orb_spin_indx, dummyMatPtr, std::addressof(KEr), TG.TG_local().root(), true, true);
           // reduce_n since Emsd is in shared memory (doing this instead of copy with mutex)
-          TG.TG_local().reduce_n(to_address(eloc2.origin()), 3 * nwalk, to_address(Emsd[spin][nd].origin()),
+          TG.TG_local().reduce_n(to_address(eloc2.base()), 3 * nwalk, to_address(Emsd[spin][nd].base()),
                                  std::plus<>(), 0);
           //std::cout<<" E: " <<spin <<" " <<nd <<" " <<Ovmsd[spin][nd][0] <<" "
           //<<eloc2[0][0] <<" "
@@ -210,7 +210,7 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
           //<<eloc2[0][1] <<" "
           //<<eloc2[0][2] <<std::endl;
           // reduce_n since Emsd is in shared memory (doing this instead of copy with mutex)
-          TG.TG_local().reduce_n(to_address(eloc2.origin()), 3 * nwalk, to_address(Emsd[spin][nd].origin()),
+          TG.TG_local().reduce_n(to_address(eloc2.base()), 3 * nwalk, to_address(Emsd[spin][nd].base()),
                                  std::plus<>(), 0);
           TG.local_barrier();
           // round-robin KE contributions
@@ -246,7 +246,7 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
       {
         auto it  = to_address(det_couplings[spin].values()) + (*det_couplings[spin].pointers_begin(nd));
         auto ite = to_address(det_couplings[spin].values()) + (*det_couplings[spin].pointers_end(nd));
-        std::fill_n(wgt.origin(), nwalk, ComplexType(0.0));
+        std::fill_n(wgt.base(), nwalk, ComplexType(0.0));
         if (spin == 0)
         {
           for (; it < ite; ++it)
@@ -288,9 +288,9 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
   }     // spin
 
   // 3. reduce over TG_local
-  TG.TG_local().all_reduce_in_place_n(to_address(opSpinEJ.origin()), nwalk, std::plus<>());
-  TG.TG_local().all_reduce_in_place_n(to_address(Ov.origin()), nwalk, std::plus<>());
-  TG.TG_local().all_reduce_in_place_n(to_address(E.origin()), 3 * nwalk, std::plus<>());
+  TG.TG_local().all_reduce_in_place_n(to_address(opSpinEJ.base()), nwalk, std::plus<>());
+  TG.TG_local().all_reduce_in_place_n(to_address(Ov.base()), nwalk, std::plus<>());
+  TG.TG_local().all_reduce_in_place_n(to_address(E.base()), 3 * nwalk, std::plus<>());
   for (int i = 0; i < nwalk; ++i)
   {
     E[i][0] /= Ov[i];
@@ -347,13 +347,13 @@ void PHMSD::Energy_distributed(const WlkSet& wset, Mat&& E, TVec&& Ov)
     int nr=Gsize,nc=nwalk;
     if(transposed_G_for_E_) std::swap(nr,nc);
     int displ=0;
-    boost::multi::array_ref<ComplexType,2> Gwork(to_address(shmbuff_for_E->origin()),
+    boost::multi::array_ref<ComplexType,2> Gwork(to_address(shmbuff_for_E->base()),
                                                 {nr,nc});
       displ += Gsize*nwalk;
-    boost::multi::array_ref<ComplexType,2> Grecv(to_address(shmbuff_for_E->origin())+displ,
+    boost::multi::array_ref<ComplexType,2> Grecv(to_address(shmbuff_for_E->base())+displ,
                                                 {nr,nc});
       displ += Gsize*nwalk;
-    boost::multi::array_ref<ComplexType,1> overlaps(to_address(shmbuff_for_E->origin())+displ,
+    boost::multi::array_ref<ComplexType,1> overlaps(to_address(shmbuff_for_E->base())+displ,
                                                    iextensions<1u>{nwalk});
     if(eloc2.size(0) != nnodes*nwalk || eloc2.size(1) != 3) 
         eloc2.resize({nnodes*nwalk,3});
@@ -367,13 +367,13 @@ void PHMSD::Energy_distributed(const WlkSet& wset, Mat&& E, TVec&& Ov)
           MPI_Request_free(&req_Grecv);
       if(req_Gsend!=MPI_REQUEST_NULL)
           MPI_Request_free(&req_Gsend);
-      MPI_Send_init(Gwork.origin()+nak0,(nak1-nak0)*sizeof(ComplexType),MPI_CHAR,
+      MPI_Send_init(Gwork.base()+nak0,(nak1-nak0)*sizeof(ComplexType),MPI_CHAR,
                     TG.prev_core(),1234,TG.TG().impl_,&req_Gsend);
-      MPI_Recv_init(Grecv.origin()+nak0,(nak1-nak0)*sizeof(ComplexType),MPI_CHAR,
+      MPI_Recv_init(Grecv.base()+nak0,(nak1-nak0)*sizeof(ComplexType),MPI_CHAR,
                     TG.next_core(),1234,TG.TG().impl_,&req_Grecv);
     }
    
-    std::fill_n(eloc2.origin(),3*nnodes*nwalk,ComplexType(0.0)); 
+    std::fill_n(eloc2.base(),3*nnodes*nwalk,ComplexType(0.0)); 
     TG.local_barrier();
 
     MPI_Status st;
@@ -387,7 +387,7 @@ void PHMSD::Energy_distributed(const WlkSet& wset, Mat&& E, TVec&& Ov)
       if(k>0) {
         MPI_Wait(&req_Grecv,&st);
         MPI_Wait(&req_Gsend,&st);     // need to wait for Gsend in order to overwrite Gwork  
-        std::copy_n(Grecv.origin()+nak0,(nak1-nak0),Gwork.origin()+nak0);
+        std::copy_n(Grecv.base()+nak0,(nak1-nak0),Gwork.base()+nak0);
         TG.local_barrier();
       }
 
@@ -404,10 +404,10 @@ void PHMSD::Energy_distributed(const WlkSet& wset, Mat&& E, TVec&& Ov)
       TG.local_barrier();
 
     }
-    TG.TG().all_reduce_in_place_n(eloc2.origin(),3*nnodes*nwalk,std::plus<>());
+    TG.TG().all_reduce_in_place_n(eloc2.base(),3*nnodes*nwalk,std::plus<>());
     TG.local_barrier();    
-    std::copy_n(elocal.origin(),3*nwalk,E.origin());
-    std::copy_n(overlaps.origin(),nwalk,Ov.origin());
+    std::copy_n(elocal.base(),3*nwalk,E.base());
+    std::copy_n(overlaps.base(),nwalk,Ov.base());
     TG.local_barrier();    
 */
 }
@@ -438,7 +438,7 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
   std::fill_n(Ov.begin(), nw, 0);
   for (int i = 0; i < get<0>(G.sizes()); i++)
     if (i % TG.TG_local().size() == TG.TG_local().rank())
-      std::fill_n(G[i].origin(), get<1>(G.sizes()), ComplexType(0.0));
+      std::fill_n(G[i].base(), get<1>(G.sizes()), ComplexType(0.0));
   TG.local_barrier();
   auto Gsize = dm_size(not compact);
   if (compact)
@@ -473,21 +473,21 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
     size_t cnt   = 0;
     // REDUCE ALL THIS TEMPORARY STORAGE!!!
     // storage for reference Green functions
-    boost::multi::array_ref<ComplexType, 2> GA2D0_(localGbuff.origin(), {GAdims0.first, GAdims0.second});
+    boost::multi::array_ref<ComplexType, 2> GA2D0_(localGbuff.base(), {GAdims0.first, GAdims0.second});
     cnt += GA2D0_.num_elements();
-    boost::multi::array_ref<ComplexType, 2> GB2D0_(localGbuff.origin() + cnt, {GBdims0.first, GBdims0.second});
+    boost::multi::array_ref<ComplexType, 2> GB2D0_(localGbuff.base() + cnt, {GBdims0.first, GBdims0.second});
     cnt += GB2D0_.num_elements();
     // storage for Gw in case need to transpose result at the end
-    boost::multi::array_ref<ComplexType, 2> GA2D_(localGbuff.origin() + cnt, {GAdims.first, GAdims.second});
+    boost::multi::array_ref<ComplexType, 2> GA2D_(localGbuff.base() + cnt, {GAdims.first, GAdims.second});
     cnt += GA2D_.num_elements();
-    boost::multi::array_ref<ComplexType, 2> GB2D_(localGbuff.origin() + cnt, {GBdims.first, GBdims.second});
+    boost::multi::array_ref<ComplexType, 2> GB2D_(localGbuff.base() + cnt, {GBdims.first, GBdims.second});
     cnt += GB2D_.num_elements();
-    boost::multi::array_ref<ComplexType, 1> GA1D_(GA2D_.origin(), iextensions<1u>{GAdims.first * GAdims.second});
-    boost::multi::array_ref<ComplexType, 1> GB1D_(GB2D_.origin(), iextensions<1u>{GBdims.first * GBdims.second});
+    boost::multi::array_ref<ComplexType, 1> GA1D_(GA2D_.base(), iextensions<1u>{GAdims.first * GAdims.second});
+    boost::multi::array_ref<ComplexType, 1> GB1D_(GB2D_.base(), iextensions<1u>{GBdims.first * GBdims.second});
     // storage for full G in case compact=false
-    boost::multi::array_ref<ComplexType, 2> Gfulla(localGbuff.origin() + cnt, {GAdims_full.first, GAdims_full.second});
+    boost::multi::array_ref<ComplexType, 2> Gfulla(localGbuff.base() + cnt, {GAdims_full.first, GAdims_full.second});
     cnt += Gfulla.num_elements();
-    boost::multi::array_ref<ComplexType, 2> Gfullb(localGbuff.origin() + cnt, {GBdims_full.first, GBdims_full.second});
+    boost::multi::array_ref<ComplexType, 2> Gfullb(localGbuff.base() + cnt, {GBdims_full.first, GBdims_full.second});
     cnt += Gfullb.num_elements();
 
     const int ntasks_percore      = nw / TG.getNCoresPerTG();
@@ -514,18 +514,18 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
         Ov[iw] += ma::conj(std::get<2>(*it)) * ov0 * local_ov[0][std::get<0>(*it)] * local_ov[1][std::get<1>(*it)];
 
       // 2. generate R[Nact,Nel] and generate G
-      boost::multi::array_ref<ComplexType, 2> Ra(Gwork.origin(), {NAEA, long(OrbMats[0].size(0))});
+      boost::multi::array_ref<ComplexType, 2> Ra(Gwork.base(), {NAEA, long(OrbMats[0].size(0))});
       calculate_R(0, 1, 0, abij, det_couplings[0], local_QQ0inv0, Qwork, local_ov[1], ov0, Ra);
       if (transpose)
       {
         if (compact)
         {
-          boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].origin()), {GAdims.first, GAdims.second});
+          boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].base()), {GAdims.first, GAdims.second});
           ma::product(T(Ra), GA2D0_, Gw);
         }
         else
         {
-          boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].origin()),
+          boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].base()),
                                                      {GAdims_full.first, GAdims_full.second});
           ma::product(T(Ra), GA2D0_, GA2D_);
           ma::product(T(OrbMats[0]), GA2D_, Gw);
@@ -541,7 +541,7 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
         }
         else
         {
-          boost::multi::array_ref<ComplexType, 1> G1D(Gfulla.origin(), iextensions<1u>{long(Gfulla.num_elements())});
+          boost::multi::array_ref<ComplexType, 1> G1D(Gfulla.base(), iextensions<1u>{long(Gfulla.num_elements())});
           ma::product(T(Ra), GA2D0_, GA2D_);
           ma::product(T(OrbMats[0]), GA2D_, Gfulla);
           ma::copy(G1D, G({0, Gfulla.num_elements()}, iw));
@@ -549,19 +549,19 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
         }
       }
 
-      boost::multi::array_ref<ComplexType, 2> Rb(Gwork.origin(), {NAEB, long(OrbMats.back().size(0))});
+      boost::multi::array_ref<ComplexType, 2> Rb(Gwork.base(), {NAEB, long(OrbMats.back().size(0))});
       calculate_R(0, 1, 1, abij, det_couplings[1], local_QQ0inv1, Qwork, local_ov[0], ov0, Rb);
       if (transpose)
       {
         if (compact)
         {
-          boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].origin()) + GAdims.first * GAdims.second,
+          boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].base()) + GAdims.first * GAdims.second,
                                                      {GBdims.first, GBdims.second});
           ma::product(T(Rb), GB2D0_, Gw);
         }
         else
         {
-          boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].origin()) +
+          boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].base()) +
                                                          GAdims_full.first * GAdims_full.second,
                                                      {GBdims_full.first, GBdims_full.second});
           ma::product(T(Rb), GB2D0_, GB2D_);
@@ -578,7 +578,7 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
         }
         else
         {
-          boost::multi::array_ref<ComplexType, 1> G1D(Gfullb.origin(), iextensions<1u>{Gfullb.num_elements()});
+          boost::multi::array_ref<ComplexType, 1> G1D(Gfullb.base(), iextensions<1u>{Gfullb.num_elements()});
           ma::product(T(Rb), GB2D0_, GB2D_);
           ma::product(T(OrbMats.back()), GB2D_, Gfullb);
           //G({Gfulla.num_elements(),G.size(0)},iw) = G1D;
@@ -657,34 +657,34 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
                 unique_overlaps[1][std::get<1>(*it)];
 
         // 2. generate R[Nact,Nel] and generate G
-        boost::multi::array_ref<ComplexType, 2> Ra(Gwork.origin(), {NAEA, long(OrbMats[0].size(0))});
+        boost::multi::array_ref<ComplexType, 2> Ra(Gwork.base(), {NAEA, long(OrbMats[0].size(0))});
         calculate_R(local_group_comm.rank(), local_group_comm.size(), 0, abij, det_couplings[0], QQ0inv0, Qwork,
                     unique_overlaps[1], ov0, Ra);
-        local_group_comm.all_reduce_in_place_n(to_address(Ra.origin()), Ra.num_elements(), std::plus<>());
+        local_group_comm.all_reduce_in_place_n(to_address(Ra.base()), Ra.num_elements(), std::plus<>());
         if (transpose)
         {
           if (compact)
           {
-            boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].origin()), {GAdims.first, GAdims.second});
-            ma::product(T(Ra), GA2D0_shm(GA2D0_shm.extension(0), {M0, Mn}), Gw(Gw.extension(0), {M0, Mn}));
+            boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].base()), {GAdims.first, GAdims.second});
+            ma::product(T(Ra), GA2D0_shm(get<0>(GA2D0_shm.extents()), {M0, Mn}), Gw(get<0>(Gw.extents()), {M0, Mn}));
           }
           else
           {
-            boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].origin()),
+            boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].base()),
                                                        {GAdims_full.first, GAdims_full.second});
-            ma::product(T(Ra), GA2D0_shm(GA2D0_shm.extension(0), {M0, Mn}),
-                        GA2D_(GA2D_.extension(0), {M0, Mn}));               // can be local
-            ma::product(T(OrbMats[0]), GA2D_(GA2D_.extension(0), {M0, Mn}), // can be local
-                        Gw(Gw.extension(0), {M0, Mn}));
+            ma::product(T(Ra), GA2D0_shm(get<0>(GA2D0_shm.extents()), {M0, Mn}),
+                        GA2D_(get<0>(GA2D_.extents()), {M0, Mn}));               // can be local
+            ma::product(T(OrbMats[0]), GA2D_(get<0>(GA2D_.extents()), {M0, Mn}), // can be local
+                        Gw(get<0>(Gw.extents()), {M0, Mn}));
           }
         }
         else
         {
           if (compact)
           {
-            ma::product(T(Ra), GA2D0_shm(GA2D0_shm.extension(0), {M0, Mn}),
-                        GA2D_(GA2D_.extension(0), {M0, Mn})); // can be local
-            boost::multi::array_ref<ComplexType, 3> Gw(to_address(G.origin()),
+            ma::product(T(Ra), GA2D0_shm(get<0>(GA2D0_shm.extents()), {M0, Mn}),
+                        GA2D_(get<0>(GA2D_.extents()), {M0, Mn})); // can be local
+            boost::multi::array_ref<ComplexType, 3> Gw(to_address(G.base()),
                                                        {GAdims.first, GAdims.second, long(get<1>(G.sizes()))});
             // copying by hand for now, implement strided copy in ma_blas
             for (size_t k = 0; k < get<0>(GA2D_.sizes()); ++k)
@@ -693,11 +693,11 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
           }
           else
           {
-            ma::product(T(Ra), GA2D0_shm(GA2D0_shm.extension(0), {M0, Mn}),
-                        GA2D_(GA2D_.extension(0), {M0, Mn})); // can be local
-            ma::product(T(OrbMats[0]), GA2D_(GA2D_.extension(0), {M0, Mn}),
-                        Gfulla(Gfulla.extension(0), {M0, Mn})); // can be local
-            boost::multi::array_ref<ComplexType, 3> Gw(to_address(G.origin()),
+            ma::product(T(Ra), GA2D0_shm(get<0>(GA2D0_shm.extents()), {M0, Mn}),
+                        GA2D_(get<0>(GA2D_.extents()), {M0, Mn})); // can be local
+            ma::product(T(OrbMats[0]), GA2D_(get<0>(GA2D_.extents()), {M0, Mn}),
+                        Gfulla(get<0>(Gfulla.extents()), {M0, Mn})); // can be local
+            boost::multi::array_ref<ComplexType, 3> Gw(to_address(G.base()),
                                                        {long(get<0>(Gfulla.sizes())), long(get<1>(Gfulla.sizes())), long(get<1>(G.sizes()))});
             // copying by hand for now, implement strided copy in ma_blas
             for (size_t k = 0; k < get<0>(Gfulla.sizes()); ++k)
@@ -706,36 +706,36 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
           }
         }
 
-        boost::multi::array_ref<ComplexType, 2> Rb(Gwork.origin(), {NAEB, long(OrbMats.back().size(0))});
+        boost::multi::array_ref<ComplexType, 2> Rb(Gwork.base(), {NAEB, long(OrbMats.back().size(0))});
         calculate_R(local_group_comm.rank(), local_group_comm.size(), 1, abij, det_couplings[1], QQ0inv1, Qwork,
                     unique_overlaps[0], ov0, Rb);
-        local_group_comm.all_reduce_in_place_n(to_address(Rb.origin()), Rb.num_elements(), std::plus<>());
+        local_group_comm.all_reduce_in_place_n(to_address(Rb.base()), Rb.num_elements(), std::plus<>());
         if (transpose)
         {
           if (compact)
           {
-            boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].origin()) + GAdims.first * GAdims.second,
+            boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].base()) + GAdims.first * GAdims.second,
                                                        {GBdims.first, GBdims.second});
-            ma::product(T(Rb), GB2D0_shm(GB2D0_shm.extension(0), {M0, Mn}), Gw(Gw.extension(0), {M0, Mn}));
+            ma::product(T(Rb), GB2D0_shm(get<0>(GB2D0_shm.extents()), {M0, Mn}), Gw(get<0>(Gw.extents()), {M0, Mn}));
           }
           else
           {
-            boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].origin()) +
+            boost::multi::array_ref<ComplexType, 2> Gw(to_address(G[iw].base()) +
                                                            GAdims_full.first * GAdims_full.second,
                                                        {GBdims_full.first, GBdims_full.second});
-            ma::product(T(Rb), GB2D0_shm(GB2D0_shm.extension(0), {M0, Mn}),
-                        GB2D_(GB2D_.extension(0), {M0, Mn}));                   // can be local
-            ma::product(T(OrbMats.back()), GB2D_(GB2D_.extension(0), {M0, Mn}), // can be local
-                        Gw(Gw.extension(0), {M0, Mn}));
+            ma::product(T(Rb), GB2D0_shm(get<0>(GB2D0_shm.extents()), {M0, Mn}),
+                        GB2D_(get<0>(GB2D_.extents()), {M0, Mn}));                   // can be local
+            ma::product(T(OrbMats.back()), GB2D_(get<0>(GB2D_.extents()), {M0, Mn}), // can be local
+                        Gw(get<0>(Gw.extents()), {M0, Mn}));
           }
         }
         else
         {
           if (compact)
           {
-            ma::product(T(Rb), GB2D0_shm(GB2D0_shm.extension(0), {M0, Mn}),
-                        GB2D_(GB2D_.extension(0), {M0, Mn})); // can be local
-            boost::multi::array_ref<ComplexType, 3> Gw(to_address(G[GAdims.first * GAdims.second].origin()),
+            ma::product(T(Rb), GB2D0_shm(get<0>(GB2D0_shm.extents()), {M0, Mn}),
+                        GB2D_(get<0>(GB2D_.extents()), {M0, Mn})); // can be local
+            boost::multi::array_ref<ComplexType, 3> Gw(to_address(G[GAdims.first * GAdims.second].base()),
                                                        {GBdims.first, GBdims.second, long(get<1>(G.sizes()))});
             // copying by hand for now, implement strided copy in ma_blas
             for (size_t k = 0; k < get<0>(GB2D_.sizes()); ++k)
@@ -744,11 +744,11 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
           }
           else
           {
-            ma::product(T(Rb), GB2D0_shm(GB2D0_shm.extension(0), {M0, Mn}),
-                        GB2D_(GB2D_.extension(0), {M0, Mn})); // can be local
-            ma::product(T(OrbMats[0]), GB2D_(GB2D_.extension(0), {M0, Mn}),
-                        Gfullb(Gfullb.extension(0), {M0, Mn})); // can be local
-            boost::multi::array_ref<ComplexType, 3> Gw(to_address(G[Gfulla.num_elements()].origin()),
+            ma::product(T(Rb), GB2D0_shm(get<0>(GB2D0_shm.extents()), {M0, Mn}),
+                        GB2D_(get<0>(GB2D_.extents()), {M0, Mn})); // can be local
+            ma::product(T(OrbMats[0]), GB2D_(get<0>(GB2D_.extents()), {M0, Mn}),
+                        Gfullb(get<0>(Gfullb.extents()), {M0, Mn})); // can be local
+            boost::multi::array_ref<ComplexType, 3> Gw(to_address(G[Gfulla.num_elements()].base()),
                                                        {long(get<0>(Gfullb.sizes())), long(get<1>(Gfullb.sizes())), long(get<1>(G.sizes()))});
             // copying by hand for now, implement strided copy in ma_blas
             for (size_t k = 0; k < get<0>(Gfullb.sizes()); ++k)
@@ -760,7 +760,7 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
     }
   }
   // normalize G
-  TG.TG_local().all_reduce_in_place_n(to_address(Ov.origin()), nw, std::plus<>());
+  TG.TG_local().all_reduce_in_place_n(to_address(Ov.base()), nw, std::plus<>());
   if (transpose)
   {
     for (size_t iw = 0; iw < G.size(); ++iw)
@@ -772,12 +772,12 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
   }
   else
   {
-    auto Ov_         = Ov.origin();
+    auto Ov_         = Ov.base();
     const size_t nw_ = get<1>(G.sizes());
     for (int ik = 0; ik < get<0>(G.sizes()); ++ik)
       if (ik % TG.TG_local().size() == TG.TG_local().rank())
       {
-        auto Gik = to_address(G[ik].origin());
+        auto Gik = to_address(G[ik].base());
         for (size_t iw = 0; iw < nw_; ++iw)
           Gik[iw] /= Ov_[iw];
       }
@@ -811,8 +811,8 @@ void PHMSD::DensityMatrix_shared(const WlkSet& wset,
   assert(Ov.size() >= nw);
   // to force synchronization before modifying structures in SHM
   TG.local_barrier();
-  fill_n(Ov.origin(), Ov.num_elements(), 0);
-  fill_n(G.origin(), G.num_elements(), ComplexType(0.0));
+  fill_n(Ov.base(), Ov.num_elements(), 0);
+  fill_n(G.base(), G.num_elements(), ComplexType(0.0));
   TG.local_barrier();
   double LogOverlapFactor(wset.getLogOverlapFactor());
   auto Gsize = dm_size(not compact);
@@ -827,8 +827,8 @@ void PHMSD::DensityMatrix_shared(const WlkSet& wset,
       assert(RefA.size(1) == dm_dims(false, Alpha).first && RefA.size(0) == dm_dims(false, Alpha).second);
 
     auto Gdims = dm_dims(not compact, Alpha);
-    CMatrix_ref G2D_(localGbuff.origin(), {Gdims.first, Gdims.second});
-    CVector_ref G1D_(G2D_.origin(), iextensions<1u>{G2D_.num_elements()});
+    CMatrix_ref G2D_(localGbuff.base(), {Gdims.first, Gdims.second});
+    CVector_ref G1D_(G2D_.base(), iextensions<1u>{G2D_.num_elements()});
 
     for (int iw = 0; iw < nw; ++iw)
     {
@@ -840,7 +840,7 @@ void PHMSD::DensityMatrix_shared(const WlkSet& wset,
       if (transposed)
         G[iw] = G1D_;
       else
-        G(G.extension(0), iw) = G1D_;
+        G(get<0>(G.extents()), iw) = G1D_;
     }
   }
   else
@@ -856,13 +856,13 @@ void PHMSD::DensityMatrix_shared(const WlkSet& wset,
 
     if (get<0>(ovlp2.sizes()) < 2 * nw)
       ovlp2.reextent(iextensions<1u>{2 * nw});
-    fill_n(ovlp2.origin(), 2 * nw, ComplexType(0.0));
+    fill_n(ovlp2.base(), 2 * nw, ComplexType(0.0));
     auto GAdims = dm_dims(not compact, Alpha);
     auto GBdims = dm_dims(not compact, Beta);
-    CMatrix_ref GA2D_(localGbuff.origin(), {GAdims.first, GAdims.second});
-    CMatrix_ref GB2D_(GA2D_.origin() + GA2D_.num_elements(), {GBdims.first, GBdims.second});
-    CVector_ref GA1D_(GA2D_.origin(), iextensions<1u>{GA2D_.num_elements()});
-    CVector_ref GB1D_(GB2D_.origin(), iextensions<1u>{GB2D_.num_elements()});
+    CMatrix_ref GA2D_(localGbuff.base(), {GAdims.first, GAdims.second});
+    CMatrix_ref GB2D_(GA2D_.base() + GA2D_.num_elements(), {GBdims.first, GBdims.second});
+    CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GA2D_.num_elements()});
+    CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GB2D_.num_elements()});
 
     for (int iw = 0; iw < 2 * nw; ++iw)
     {
@@ -889,7 +889,7 @@ void PHMSD::DensityMatrix_shared(const WlkSet& wset,
       }
     }
     if (TG.TG_local().size() > 1)
-      TG.TG_local().all_reduce_in_place_n(to_address(ovlp2.origin()), 2 * nw, std::plus<>());
+      TG.TG_local().all_reduce_in_place_n(to_address(ovlp2.base()), 2 * nw, std::plus<>());
     if (TG.TG_local().root())
       for (int iw = 0; iw < nw; ++iw)
         Ov[iw] = ovlp2[2 * iw] * ovlp2[2 * iw + 1];
@@ -1122,7 +1122,7 @@ void PHMSD::Overlap(const WlkSet& wset, TVec&& Ov)
       }
     }
   }
-  TG.TG_local().all_reduce_in_place_n(to_address(Ov.origin()), nw, std::plus<>());
+  TG.TG_local().all_reduce_in_place_n(to_address(Ov.base()), nw, std::plus<>());
 }
 
 /*
@@ -1208,45 +1208,45 @@ void PHMSD::OrthogonalizeExcited(Mat&& A, SpinTypes spin, double LogOverlapFacto
     using std::get;
     if (get<0>(extendedMatAlpha.sizes()) != NMO || get<1>(extendedMatAlpha.sizes()) != maxOccupExtendedMat.first)
       extendedMatAlpha.reextent({NMO, maxOccupExtendedMat.first});
-    extendedMatAlpha(extendedMatAlpha.extension(0), {0, NAEA}) = A;
-    extendedMatAlpha(extendedMatAlpha.extension(0), {NAEA + 1, maxOccupExtendedMat.first}) =
-        excitedOrbMat[0](excitedOrbMat.extension(1), {NAEA + 1, maxOccupExtendedMat.first});
+    extendedMatAlpha(get<0>(extendedMatAlpha.extents()), {0, NAEA}) = A;
+    extendedMatAlpha(get<0>(extendedMatAlpha.extents()), {NAEA + 1, maxOccupExtendedMat.first}) =
+        excitedOrbMat[0](get<1>(excitedOrbMat.extents()), {NAEA + 1, maxOccupExtendedMat.first});
     // move i->a, copy trial orb i
     for (auto& i : excitations)
       if (i.first < NMO && i.second < NMO)
       {
-        extendedMatAlpha(extendedMatAlpha.extension(0), i.second) =
-            extendedMatAlpha(extendedMatAlpha.extension(0), i.first);
-        extendedMatAlpha(extendedMatAlpha.extension(0), i.first) =
-            excitedOrbMat[0](excitedOrbMat.extension(1), i.first);
+        extendedMatAlpha(get<0>(extendedMatAlpha.extents()), i.second) =
+            extendedMatAlpha(get<0>(extendedMatAlpha.extents()), i.first);
+        extendedMatAlpha(get<0>(extendedMatAlpha.extents()), i.first) =
+            excitedOrbMat[0](get<1>(excitedOrbMat.extents()), i.first);
       }
     ComplexType det              = SDetOp.Orthogonalize(extendedMatAlpha, LogOverlapFactor);
-    A(A.extension(0), {0, NAEA}) = extendedMatAlpha(extendedMatAlpha.extension(0), {0, NAEA});
+    A(get<0>(A.extents()), {0, NAEA}) = extendedMatAlpha(get<0>(extendedMatAlpha.extents()), {0, NAEA});
     for (auto& i : excitations)
       if (i.first < NMO && i.second < NMO)
-        A(A.extension(0), i.first) = extendedMatAlpha(extendedMatAlpha.extension(0), i.second);
+        A(get<0>(A.extents()), i.first) = extendedMatAlpha(get<0>(extendedMatAlpha.extents()), i.second);
   }
   else
   {
     using std::get;
     if (get<0>(extendedMatBeta.sizes()) != NMO || get<1>(extendedMatBeta.sizes()) != maxOccupExtendedMat.second)
       extendedMatBeta.reextent({NMO, maxOccupExtendedMat.second});
-    extendedMatBeta(extendedMatBeta.extension(0), {0, NAEB}) = A;
-    extendedMatBeta(extendedMatBeta.extension(0), {NAEB + 1, maxOccupExtendedMat.second}) =
-        excitedOrbMat[1](excitedOrbMat.extension(1), {NAEB + 1, maxOccupExtendedMat.second});
+    extendedMatBeta(get<0>(extendedMatBeta.extents()), {0, NAEB}) = A;
+    extendedMatBeta(get<0>(extendedMatBeta.extents()), {NAEB + 1, maxOccupExtendedMat.second}) =
+        excitedOrbMat[1](get<1>(excitedOrbMat.extents()), {NAEB + 1, maxOccupExtendedMat.second});
     // move i->a, copy trial orb i
     for (auto& i : excitations)
       if (i.first >= NMO && i.second >= NMO)
       {
-        extendedMatBeta(extendedMatBeta.extension(0), i.second) =
-            extendedMatBeta(extendedMatBeta.extension(0), i.first);
-        extendedMatBeta(extendedMatBeta.extension(0), i.first) = excitedOrbMat[1](excitedOrbMat.extension(1), i.first);
+        extendedMatBeta(get<0>(extendedMatBeta.extents()), i.second) =
+            extendedMatBeta(get<0>(extendedMatBeta.extents()), i.first);
+        extendedMatBeta(get<0>(extendedMatBeta.extents()), i.first) = excitedOrbMat[1](get<1>(excitedOrbMat.extents()), i.first);
       }
     ComplexType detR             = SDetOp.Orthogonalize(extendedMatBeta, LogOverlapFactor);
-    A(A.extension(0), {0, NAEB}) = extendedMatBeta(extendedMatBeta.extension(0), {0, NAEB});
+    A(get<0>(A.extents()), {0, NAEB}) = extendedMatBeta(get<0>(extendedMatBeta.extents()), {0, NAEB});
     for (auto& i : excitations)
       if (i.first >= NMO && i.second >= NMO)
-        A(A.extension(0), i.first) = extendedMatBeta(extendedMatBeta.extension(0), i.second);
+        A(get<0>(A.extents()), i.first) = extendedMatBeta(get<0>(extendedMatBeta.extents()), i.second);
   }
 }
 
@@ -1266,7 +1266,7 @@ void PHMSD::vMF(Vec&& v)
   using std::get;
   using std::norm;
   assert(v.num_elements() == local_number_of_cholesky_vectors());
-  std::fill_n(v.origin(), v.num_elements(), ComplexType(0));
+  std::fill_n(v.base(), v.num_elements(), ComplexType(0));
   auto Gsize = dm_size(false);
   if (localGbuff.size() < Gsize)
     localGbuff.reextent(iextensions<1u>{Gsize});
@@ -1275,7 +1275,7 @@ void PHMSD::vMF(Vec&& v)
   //boost::multi::array<ComplexType,2> ovlps({2,maxn_unique_confg});
   boost::multi::array<ComplexType, 2> ovlps({2, static_cast<boost::multi::size_t>(maxn_unique_confg)});
   //if(TG.Node().root())
-  std::fill_n(to_address(ovlps.origin()), 2 * maxn_unique_confg, ComplexType(0.0));
+  std::fill_n(to_address(ovlps.base()), 2 * maxn_unique_confg, ComplexType(0.0));
 
   auto refc   = abij.reference_configuration();
   auto confgs = abij.configurations_begin();
@@ -1306,8 +1306,8 @@ void PHMSD::vMF(Vec&& v)
   }
   TG.Node().barrier();
   //if(TG.Node().root())
-  //  TG.Cores().all_reduce_in_place_n(to_address(ovlps.origin()),ovlps.num_elements(),std::plus<>());
-  TG.Global().all_reduce_in_place_n(to_address(ovlps.origin()), ovlps.num_elements(), std::plus<>());
+  //  TG.Cores().all_reduce_in_place_n(to_address(ovlps.base()),ovlps.num_elements(),std::plus<>());
+  TG.Global().all_reduce_in_place_n(to_address(ovlps.base()), ovlps.num_elements(), std::plus<>());
   TG.Node().barrier();
 
   ComplexType ov(0.0);
@@ -1323,12 +1323,12 @@ void PHMSD::vMF(Vec&& v)
     confg.resize((spin == 0) ? NAEA : NAEB);
     auto Gdims     = dm_dims(false, SpinTypes(spin));
     auto Gdims_ref = dm_dims_ref(false, SpinTypes(spin));
-    boost::multi::array_ref<ComplexType, 2> G2D_(localGbuff.origin(), {Gdims_ref.first, Gdims_ref.second});
-    boost::multi::array_ref<ComplexType, 1> G1D_(G2D_.origin(), iextensions<1u>{G2D_.num_elements()});
+    boost::multi::array_ref<ComplexType, 2> G2D_(localGbuff.base(), {Gdims_ref.first, Gdims_ref.second});
+    boost::multi::array_ref<ComplexType, 1> G1D_(G2D_.base(), iextensions<1u>{G2D_.num_elements()});
     boost::multi::array<ComplexType, 2> SM_({Gdims_ref.second, Gdims_ref.first});
     // store mean field G
     boost::multi::array<ComplexType, 2> G({Gdims.first, Gdims.second});
-    std::fill_n(G.origin(), G.num_elements(), ComplexType(0.0));
+    std::fill_n(G.base(), G.num_elements(), ComplexType(0.0));
 
     // diagonal contribution
     for (int nd = 0; nd < det_couplings[spin].size(); ++nd)
@@ -1389,15 +1389,15 @@ void PHMSD::vMF(Vec&& v)
         }
       }
     }
-    boost::multi::array_ref<ComplexType, 1> G1D(G.origin(), iextensions<1u>{G.num_elements()});
-    TG.Global().all_reduce_in_place_n(to_address(G1D.origin()), G1D.num_elements(), std::plus<>());
+    boost::multi::array_ref<ComplexType, 1> G1D(G.base(), iextensions<1u>{G.num_elements()});
+    TG.Global().all_reduce_in_place_n(to_address(G1D.base()), G1D.num_elements(), std::plus<>());
     ma::scal(ComplexType(1.0 / ov), G1D);
     HamOp.vbias(G1D, std::forward<Vec>(v), 0.5, 1.0);
   }
   TG.Node().barrier();
 
   // since v is not in shared memory, we need to reduce
-  TG.TG_local().all_reduce_in_place_n(to_address(v.origin()), v.num_elements(), std::plus<>());
+  TG.TG_local().all_reduce_in_place_n(to_address(v.base()), v.num_elements(), std::plus<>());
   // NOTE: since SpvnT is a truncated structure the complex part of vMF,
   //       which should be exactly zero, suffers from truncation errors.
   //       Set it to zero.

--- a/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
+++ b/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
@@ -264,7 +264,7 @@ Wavefunction WavefunctionFactory::fromASCII(TaskGroup_& TGprop,
       if (!newg.second)
         APP_ABORT(" Error: Problems adding new initial guess. \n");
       using ma::conj;
-      std::fill_n((newg.first)->second.origin(), 2 * NPOL * NMO * NAEA, ComplexType(0.0, 0.0));
+      std::fill_n((newg.first)->second.base(), 2 * NPOL * NMO * NAEA, ComplexType(0.0, 0.0));
       {
         auto pbegin = PsiT[iC].pointers_begin();
         auto pend   = PsiT[iC].pointers_end();
@@ -486,7 +486,7 @@ Wavefunction WavefunctionFactory::fromASCII(TaskGroup_& TGprop,
       if (iC >= abij.number_of_configurations())
         APP_ABORT(" Error: initial_configuration > ndets \n");
       using ma::conj;
-      std::fill_n((newg.first)->second.origin(), 2 * NMO * NAEA, ComplexType(0.0, 0.0));
+      std::fill_n((newg.first)->second.base(), 2 * NMO * NAEA, ComplexType(0.0, 0.0));
       //auto refc = abij.reference_configuration();
       {
         std::vector<int> alphaC(NAEA);
@@ -1018,7 +1018,7 @@ void WavefunctionFactory::getInitialGuess(hdf_archive& dump,
     if (!newg.second)
       APP_ABORT(" Error: Problems adding new initial guess. \n");
     using ma::conj;
-    std::fill_n((newg.first)->second.origin(), 2 * NPOL * NMO * NAEA, ComplexType(0.0, 0.0));
+    std::fill_n((newg.first)->second.base(), 2 * NPOL * NMO * NAEA, ComplexType(0.0, 0.0));
     {
       boost::multi::array<ComplexType, 2> Psi0Alpha({NPOL * NMO, NAEA});
       if (!dump.readEntry(Psi0Alpha, "Psi0_alpha"))
@@ -1083,13 +1083,13 @@ void WavefunctionFactory::computeVariationalEnergyPHMSD(TaskGroup_& TG,
   boost::multi::array<ComplexType, 2, shared_allocator<ComplexType>> H({dim, dim}, TG.Node());
   boost::multi::array<ComplexType, 1> energy(iextensions<1u>{2});
   using std::fill_n;
-  fill_n(H.origin(), H.num_elements(), ComplexType(0.0));           // this call synchronizes
-  fill_n(energy.origin(), energy.num_elements(), ComplexType(0.0)); // this call synchronizes
+  fill_n(H.base(), H.num_elements(), ComplexType(0.0));           // this call synchronizes
+  fill_n(energy.base(), energy.num_elements(), ComplexType(0.0)); // this call synchronizes
   ValueType enuc = ham.getNuclearCoulombEnergy();
   for (int idet = 0; idet < ndets; idet++)
   {
     // These should already be sorted.
-    boost::multi::array_ref<int, 1> deti(occs[idet].origin(), {NAEA + NAEB});
+    boost::multi::array_ref<int, 1> deti(occs[idet].base(), {NAEA + NAEB});
     ComplexType cidet = coeff[idet];
     for (int jdet = idet; jdet < ndets; jdet++)
     {
@@ -1108,7 +1108,7 @@ void WavefunctionFactory::computeVariationalEnergyPHMSD(TaskGroup_& TG,
         else
         {
           ComplexType Hij(0.0);
-          boost::multi::array_ref<int, 1> detj(occs[jdet].origin(), {NAEA + NAEB});
+          boost::multi::array_ref<int, 1> detj(occs[jdet].base(), {NAEA + NAEB});
           ComplexType cjdet = coeff[jdet];
           int perm          = 1;
           std::vector<int> excit;
@@ -1133,8 +1133,8 @@ void WavefunctionFactory::computeVariationalEnergyPHMSD(TaskGroup_& TG,
   }
   TG.Node().barrier();
   if (TG.Node().root() && recompute_ci)
-    TG.Cores().all_reduce_in_place_n(to_address(H.origin()), H.num_elements(), std::plus<>());
-  TG.Global().all_reduce_in_place_n(energy.origin(), 2, std::plus<>());
+    TG.Cores().all_reduce_in_place_n(to_address(H.base()), H.num_elements(), std::plus<>());
+  TG.Global().all_reduce_in_place_n(energy.base(), 2, std::plus<>());
   app_log() << " - Variational energy of trial wavefunction: " << std::setprecision(16) << energy[0] / energy[1]
             << "\n";
   if (recompute_ci)

--- a/src/AFQMC/Wavefunctions/phmsd_helpers.hpp
+++ b/src/AFQMC/Wavefunctions/phmsd_helpers.hpp
@@ -90,8 +90,8 @@ inline void calculate_overlaps(int rank, int ngrp, int spin, PH_EXCT const& abij
     }
     else
     {
-      boost::multi::array_ref<ComplexType, 2> Qwork_(Qwork.origin(), {nex, nex});
-      boost::multi::array_ref<ComplexType, 1> Qwork2_(Qwork.origin() + Qwork_.num_elements(),
+      boost::multi::array_ref<ComplexType, 2> Qwork_(Qwork.base(), {nex, nex});
+      boost::multi::array_ref<ComplexType, 1> Qwork2_(Qwork.base() + Qwork_.num_elements(),
                                                       iextensions<1u>{nex * nex});
       for (auto it = abij.unique_begin(nex)[spin]; it < abij.unique_end(nex)[spin]; ++it, ++nd)
         if (nd % ngrp == rank)
@@ -129,7 +129,7 @@ inline void calculate_R(int rank,
 
   using std::get;
   for (int i = 0; i < get<0>(R.sizes()); i++)
-    std::fill_n(R[i].origin(), get<1>(R.sizes()), ComplexType(0));
+    std::fill_n(R[i].base(), get<1>(R.sizes()), ComplexType(0));
   int NEL = get<1>(T.sizes());
   std::vector<int> orbs(NEL);
   ComplexType ov_a;
@@ -152,7 +152,7 @@ inline void calculate_R(int rank,
   }
   for (int nex = 1, nd = 1; nex < abij.maximum_excitation_number()[spin]; nex++)
   {
-    boost::multi::array_ref<ComplexType, 2> Q(Qwork.origin(), {nex, nex});
+    boost::multi::array_ref<ComplexType, 2> Q(Qwork.base(), {nex, nex});
     for (auto it = abij.unique_begin(nex)[spin]; it < abij.unique_end(nex)[spin]; ++it, ++nd)
     {
       if (nd % ngrp == rank)
@@ -244,7 +244,7 @@ void calculate_ph_energies_v1(int spin,
   auto confgs = abij.configurations_begin();
   auto refc = abij.reference_configuration(spin);
   for(int i=0; i<R.size(0); i++)
-    std::fill_n(R[i].origin(),R.size(1),ComplexType(0));
+    std::fill_n(R[i].base(),R.size(1),ComplexType(0));
   int NEL = T.size(1);
   std::vector<int> orbs(NEL);
   ComplexType ov_a;
@@ -265,7 +265,7 @@ void calculate_ph_energies_v1(int spin,
       R[i][refc[i]] += w;
   }
   for(int nex = 1, nd=1 ; nex<abij.maximum_excitation_number()[spin]; nex++) {
-    boost::multi::array_ref<ComplexType,2> Q(Qwork.origin(),{nex,nex});
+    boost::multi::array_ref<ComplexType,2> Q(Qwork.base(),{nex,nex});
     for(auto it = abij.unique_begin(nex)[spin]; it<abij.unique_end(nex)[spin]; ++it, ++nd) {
       if(nd%ngrp==rank) {
         auto e = *it;

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -154,7 +154,7 @@ void getBasicWavefunction(std::vector<int>& occs, std::vector<ComplexType>& coef
 void getSlaterMatrix(boost::multi::array<ComplexType, 2>& SM, boost::multi::array_ref<int, 1>& occs, int NEL)
 {
   using std::fill_n;
-  fill_n(SM.origin(), SM.num_elements(), ComplexType(0.0));
+  fill_n(SM.base(), SM.num_elements(), ComplexType(0.0));
   for (int i = 0; i < NEL; i++)
     SM[i][occs[i]] = ComplexType(1.0);
 }
@@ -228,7 +228,7 @@ void test_phmsd(boost::mpi3::communicator& world)
     REQUIRE(get<1>(initial_guess.sizes()) == NMO);
     REQUIRE(get<2>(initial_guess.sizes()) == NAEA);
 
-    wset.resize(nwalk, initial_guess[0], initial_guess[1](initial_guess.extension(1), {0, NAEB}));
+    wset.resize(nwalk, initial_guess[0], initial_guess[1](get<1>(initial_guess.extents()), {0, NAEB}));
     // 1. Test Overlap Explicitly
     // 1.a Get raw occupancies and coefficients from file.
     std::vector<ComplexType> coeffs;
@@ -250,18 +250,18 @@ void test_phmsd(boost::mpi3::communicator& world)
     for (int idet = 0; idet < coeffs.size(); idet++)
     {
       // Construct slater matrix from given set of occupied orbitals.
-      boost::multi::array_ref<int, 1> oa(occs[idet].origin(), {NAEA});
+      boost::multi::array_ref<int, 1> oa(occs[idet].base(), {NAEA});
       getSlaterMatrix(TrialA, oa, NAEA);
-      boost::multi::array_ref<int, 1> ob(occs[idet].origin() + NAEA, {NAEB});
+      boost::multi::array_ref<int, 1> ob(occs[idet].base() + NAEA, {NAEB});
       for (int i = 0; i < NAEB; i++)
         ob[i] -= NMO;
       getSlaterMatrix(TrialB, ob, NAEB);
       ComplexType ovlpa = sdet->Overlap(TrialA, *wset[0].SlaterMatrix(Alpha), logovlp);
       ComplexType ovlpb = sdet->Overlap(TrialB, *wset[0].SlaterMatrix(Beta), logovlp);
       ovlp_sum += ma::conj(coeffs[idet]) * ovlpa * ovlpb;
-      //boost::multi::array_ref<ComplexType,2> GB(to_address(GBuff.origin()), {NAEA,NMO});
+      //boost::multi::array_ref<ComplexType,2> GB(to_address(GBuff.base()), {NAEA,NMO});
       //sdet->MixedDensityMatrix(TrialB, wset[0].SlaterMatrix(Alpha), GA, logovlp, true);
-      //boost::multi::array_ref<ComplexType,2> GA(to_address(GBuff.origin()+NAEA*NMO), {NAEA,NMO});
+      //boost::multi::array_ref<ComplexType,2> GA(to_address(GBuff.base()+NAEA*NMO), {NAEA,NMO});
       //sdet->MixedDensityMatrix(TrialA, wset[0].SlaterMatrix(Alpha), GB, logovlp, true);
     }
     wfn.Overlap(wset);

--- a/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
@@ -150,7 +150,7 @@ void wfn_fac(boost::mpi3::communicator& world)
       REQUIRE(get<2>(initial_guess.sizes()) == NAEA);
 
       if (type == COLLINEAR)
-        wset.resize(nwalk, initial_guess[0], initial_guess[1](initial_guess.extension(1), {0, NAEB}));
+        wset.resize(nwalk, initial_guess[0], initial_guess[1](get<1>(initial_guess.extents()), {0, NAEB}));
       else
         wset.resize(nwalk, initial_guess[0], initial_guess[0]);
 
@@ -288,7 +288,7 @@ void wfn_fac(boost::mpi3::communicator& world)
       REQUIRE(get<2>(initial_guess.sizes()) == NAEA);
 
       if (type == COLLINEAR)
-        wset2.resize(nwalk, initial_guess[0], initial_guess[1](initial_guess.extension(1), {0, NAEB}));
+        wset2.resize(nwalk, initial_guess[0], initial_guess[1](get<1>(initial_guess.extents()), {0, NAEB}));
       else
         wset2.resize(nwalk, initial_guess[0], initial_guess[0]);
 
@@ -483,7 +483,7 @@ void wfn_fac_distributed(boost::mpi3::communicator& world, int ngroups)
     REQUIRE(get<2>(initial_guess.sizes()) == NAEA);
 
     if (type == COLLINEAR)
-      wset.resize(nwalk, initial_guess[0], initial_guess[1](initial_guess.extension(1), {0, NAEB}));
+      wset.resize(nwalk, initial_guess[0], initial_guess[1](get<1>(initial_guess.extents()), {0, NAEB}));
     else
       wset.resize(nwalk, initial_guess[0], initial_guess[0]);
 
@@ -559,12 +559,12 @@ void wfn_fac_distributed(boost::mpi3::communicator& world, int ngroups)
     {
       boost::multi::array<ComplexType, 2> T({nCV, nwalk});
       if (TGwfn.TG_local().root())
-        std::copy_n(X.origin(), X.num_elements(), T.origin());
+        std::copy_n(X.base(), X.num_elements(), T.base());
       else
-        std::fill_n(T.origin(), T.num_elements(), ComplexType(0.0, 0.0));
-      TGwfn.TG().all_reduce_in_place_n(to_address(T.origin()), T.num_elements(), std::plus<>());
+        std::fill_n(T.base(), T.num_elements(), ComplexType(0.0, 0.0));
+      TGwfn.TG().all_reduce_in_place_n(to_address(T.base()), T.num_elements(), std::plus<>());
       if (TGwfn.TG_local().root())
-        std::copy_n(T.origin(), T.num_elements(), X.origin());
+        std::copy_n(T.base(), T.num_elements(), X.base());
       TGwfn.TG_local().barrier();
     }
 
@@ -642,7 +642,7 @@ void wfn_fac_distributed(boost::mpi3::communicator& world, int ngroups)
     REQUIRE(get<2>(initial_guess.sizes()) == NAEA);
 
     if (type == COLLINEAR)
-      wset2.resize(nwalk, initial_guess[0], initial_guess[1](initial_guess.extension(1), {0, NAEB}));
+      wset2.resize(nwalk, initial_guess[0], initial_guess[1](get<1>(initial_guess.extents()), {0, NAEB}));
     else
       wset2.resize(nwalk, initial_guess[0], initial_guess[0]);
 
@@ -674,7 +674,7 @@ void wfn_fac_distributed(boost::mpi3::communicator& world, int ngroups)
     wfn2.MixedDensityMatrix_for_vbias(wset2, G);
 
     nCV = wfn2.local_number_of_cholesky_vectors();
-    boost::multi::array_ref<ComplexType, 2> X2(to_address(X.origin()), {nCV, nwalk});
+    boost::multi::array_ref<ComplexType, 2> X2(to_address(X.base()), {nCV, nwalk});
     wfn2.vbias(G, X2, sqrtdt);
     Xsum = 0;
     if (std::abs(file_data.Xsum) > 1e-8)
@@ -704,12 +704,12 @@ void wfn_fac_distributed(boost::mpi3::communicator& world, int ngroups)
     {
       boost::multi::array<ComplexType, 2> T({nCV, nwalk});
       if (TGwfn.TG_local().root())
-        std::copy_n(X2.origin(), X2.num_elements(), T.origin());
+        std::copy_n(X2.base(), X2.num_elements(), T.base());
       else
-        std::fill_n(T.origin(), T.num_elements(), ComplexType(0.0, 0.0));
-      TGwfn.TG().all_reduce_in_place_n(to_address(T.origin()), T.num_elements(), std::plus<>());
+        std::fill_n(T.base(), T.num_elements(), ComplexType(0.0, 0.0));
+      TGwfn.TG().all_reduce_in_place_n(to_address(T.base()), T.num_elements(), std::plus<>());
       if (TGwfn.TG_local().root())
-        std::copy_n(T.origin(), T.num_elements(), X.origin());
+        std::copy_n(T.base(), T.num_elements(), X.base());
       TGwfn.TG_local().barrier();
     }
 
@@ -868,7 +868,7 @@ TEST_CASE("wfn_fac_collinear_phmsd", "[wavefunction_factory]")
         //initial_guess[1][i][j] += distribution(generator);
     }
     wset.resize(nwalk,initial_guess[0],
-                         initial_guess[1](initial_guess.extension(1),{0,NAEB}));
+                         initial_guess[1](get<1>(initial_guess.extents()),{0,NAEB}));
     qmcplusplus::Timer Time;
     // no guarantee that overlap is 1.0
     double t1;
@@ -1022,7 +1022,7 @@ TEST_CASE("wfn_fac_collinear_phmsd", "[wavefunction_factory]")
       shmCMatrix G_({Gdim1_,Gdim2_},alloc_);
       nomsd.MixedDensityMatrix_for_vbias(wset,G_);
 
-      boost::multi::array_ref<ComplexType,2> X2(to_address(X.origin())+nCV*nwalk,{nCV,nwalk});
+      boost::multi::array_ref<ComplexType,2> X2(to_address(X.base())+nCV*nwalk,{nCV,nwalk});
       nomsd.vbias(G_,X2,sqrtdt);
       Xsum=0;
       ComplexType Xsum2(0.0);

--- a/src/AFQMC/config.h
+++ b/src/AFQMC/config.h
@@ -261,7 +261,7 @@ enum HamiltonianTypes
 
 template<std::ptrdiff_t D>
 using iextensions = typename boost::multi::iextensions<D>;
-//using extensions = typename boost::multi::layout_t<D>::extensions_type;
+//using extensions = typename boost::multi::layout_t<D>::extents_type;
 
 // general matrix definitions
 template<class Alloc = std::allocator<int>>

--- a/src/io/hdf/container_traits_multi.h
+++ b/src/io/hdf/container_traits_multi.h
@@ -46,7 +46,7 @@ struct container_traits<boost::multi::array<T, D, Alloc>>
 
   inline static size_t getSize(const CT& ref) { return ref.num_elements(); }
 
-  inline static auto getElementPtr(CT& ref) { return std::addressof(*ref.origin()); }
+  inline static auto getElementPtr(CT& ref) { return std::addressof(*ref.base()); }
 };
 
 template<typename T, boost::multi::dimensionality_type D>
@@ -63,7 +63,7 @@ struct container_traits<boost::multi::array_ref<T, D>>
 
   inline static size_t getSize(const CT& ref) { return ref.num_elements(); }
 
-  inline static auto getElementPtr(CT& ref) { return std::addressof(*ref.origin()); }
+  inline static auto getElementPtr(CT& ref) { return std::addressof(*ref.base()); }
 };
 
 } // namespace qmcplusplus

--- a/src/io/hdf/hdf_multi.h
+++ b/src/io/hdf/hdf_multi.h
@@ -45,12 +45,12 @@ struct h5data_proxy<boost::multi::array<T, 1, Alloc>> : public h5_space_type<T, 
     using iextensions = typename boost::multi::iextensions<1u>;
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
       ref.reextent(iextensions{static_cast<boost::multi::size_t>(dims[0])});
-    return h5d_read(grp, aname, get_address(std::addressof(*ref.origin())), xfer_plist);
+    return h5d_read(grp, aname, get_address(std::addressof(*ref.base())), xfer_plist);
   }
 
   inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.base())), xfer_plist);
   }
 };
 
@@ -73,12 +73,12 @@ struct h5data_proxy<boost::multi::array<T, 2, Alloc>> : public h5_space_type<T, 
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
       ref.reextent({static_cast<boost::multi::size_t>(dims[0]), static_cast<boost::multi::size_t>(dims[1])});
-    return h5d_read(grp, aname, get_address(std::addressof(*ref.origin())), xfer_plist);
+    return h5d_read(grp, aname, get_address(std::addressof(*ref.base())), xfer_plist);
   }
 
   inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.base())), xfer_plist);
   }
 };
 
@@ -104,12 +104,12 @@ struct h5data_proxy<boost::multi::array_ref<T, 1, Ptr>> : public h5_space_type<T
       }
       return false;
     }
-    return h5d_read(grp, aname, get_address(std::addressof(*ref.origin())), xfer_plist);
+    return h5d_read(grp, aname, get_address(std::addressof(*ref.base())), xfer_plist);
   }
 
   inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.base())), xfer_plist);
   }
 };
 
@@ -141,12 +141,12 @@ struct h5data_proxy<boost::multi::array_ref<T, 2, Ptr>> : public h5_space_type<T
       }
       return false;
     }
-    return h5d_read(grp, aname, get_address(std::addressof(*ref.origin())), xfer_plist);
+    return h5d_read(grp, aname, get_address(std::addressof(*ref.base())), xfer_plist);
   }
 
   inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.base())), xfer_plist);
   }
 };
 
@@ -173,14 +173,14 @@ struct h5data_proxy<boost::multi::array<T, 1, device::device_allocator<T>>> : pu
     using iextensions = typename boost::multi::iextensions<1u>;
     boost::multi::array<T, 1> buf(iextensions{sz});
     auto ret = h5d_read(grp, aname, get_address(buf.data()), xfer_plist);
-    device::copy_n(buf.data(), sz, ref.origin());
+    device::copy_n(buf.data(), sz, ref.base());
     return ret;
   }
 
   inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     throw std::runtime_error(" write from gpu not implemented yet.");
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.base())), xfer_plist);
   }
 };
 
@@ -206,14 +206,14 @@ struct h5data_proxy<boost::multi::array<T, 2, device::device_allocator<T>>> : pu
     using iextensions = typename boost::multi::iextensions<1u>;
     boost::multi::array<T, 1> buf(iextensions{sz});
     auto ret = h5d_read(grp, aname, get_address(buf.data()), xfer_plist);
-    device::copy_n(buf.data(), sz, ref.origin());
+    device::copy_n(buf.data(), sz, ref.base());
     return ret;
   }
 
   inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     throw std::runtime_error(" write from gpu not implemented yet.");
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.base())), xfer_plist);
   }
 };
 
@@ -242,14 +242,14 @@ struct h5data_proxy<boost::multi::array_ref<T, 1, device::device_pointer<T>>> : 
     using iextensions = typename boost::multi::iextensions<1u>;
     boost::multi::array<T, 1> buf(iextensions{sz});
     auto ret = h5d_read(grp, aname, get_address(buf.data()), xfer_plist);
-    device::copy_n(buf.data(), sz, ref.origin());
+    device::copy_n(buf.data(), sz, ref.base());
     return ret;
   }
 
   inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     throw std::runtime_error(" write from gpu not implemented yet.");
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.base())), xfer_plist);
   }
 };
 
@@ -284,14 +284,14 @@ struct h5data_proxy<boost::multi::array_ref<T, 2, device::device_pointer<T>>> : 
     using iextensions = typename boost::multi::iextensions<1u>;
     boost::multi::array<T, 1> buf(iextensions{sz});
     auto ret = h5d_read(grp, aname, get_address(buf.data()), xfer_plist);
-    device::copy_n(buf.data(), sz, ref.origin());
+    device::copy_n(buf.data(), sz, ref.base());
     return ret;
   }
 
   inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     throw std::runtime_error(" write from gpu not implemented yet.");
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.base())), xfer_plist);
   }
 };
 
@@ -311,8 +311,8 @@ struct h5data_proxy<hyperslab_proxy<boost::multi::array<T, 2, device::device_all
       auto sz = ref.ref.num_elements();
       boost::multi::array<T, 1> buf(typename boost::multi::layout_t<1u>::extensions_type{sz});
       auto ret = h5d_read(grp, aname.c_str(), ref.slab_rank, ref.slab_dims.data(), ref.slab_dims_local.data(),
-                          ref.slab_offset.data(), buf.origin(), xfer_plist);
-      device::copy_n(buf.data(), sz, ref.ref.origin());
+                          ref.slab_offset.data(), buf.base(), xfer_plist);
+      device::copy_n(buf.data(), sz, ref.ref.base());
       return ret;
     }
     else
@@ -350,8 +350,8 @@ struct h5data_proxy<hyperslab_proxy<boost::multi::array_ref<T, 2, device::device
       auto sz = ref.ref.num_elements();
       boost::multi::array<T, 1> buf(typename boost::multi::layout_t<1u>::extensions_type{sz});
       auto ret = h5d_read(grp, aname.c_str(), ref.slab_rank, ref.slab_dims.data(), ref.slab_dims_local.data(),
-                          ref.slab_offset.data(), buf.origin(), xfer_plist);
-      device::copy_n(buf.data(), sz, ref.ref.origin());
+                          ref.slab_offset.data(), buf.base(), xfer_plist);
+      device::copy_n(buf.data(), sz, ref.ref.base());
       return ret;
     }
     else


### PR DESCRIPTION

## Proposed changes

changes to stop using deprecated functions ifrom Multi


## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?

Ubuntu 24.04


## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
