### PR TITLE
Allow shared_ranks when using GPU

### DIFF
--- a/docs/intro_wavefunction.rst
+++ b/docs/intro_wavefunction.rst
@@ -318,7 +318,9 @@ Additional information:
 B-spline sposet sub-options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The exact behavior of the memory allocations of B-spline orbital coefficients can be managed by ``coefs_mem`` XML node
-when there are more than one MPI rank within each compute node.
+when there is more than one MPI rank within each compute node. The B-spline coefficients are by default replicated identically
+by every MPI rank. The ``coefs_mem`` sub-options reduce memory pressure by sharing and/or distributing B-spline coefficients
+over multiple ranks. 
 
 ``coefs_mem`` element:
 

--- a/docs/intro_wavefunction.rst
+++ b/docs/intro_wavefunction.rst
@@ -315,6 +315,36 @@ Additional information:
     of pw2qmcpack, there is missing ionic information. This flag bypasses the requirement
     that the ionic information in the eshdf.h5 file match the input XML. 
 
+B-spline sposet sub-options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The exact behavior of the memory allocations of B-spline orbital coefficients can be managed by ``coefs_mem`` XML node
+when there are more than one MPI rank within each compute node.
+
+``coefs_mem`` element:
+
+.. table::
+
+  +-----------------+------------+
+  | Parent elements | ``sposet`` |
+  +-----------------+------------+
+  | Child elements  |            |
+  +-----------------+------------+
+
+attribute:
+
++-----------------------+------------+---------------+---------+----------------------------------------------------------+
+| Name                  | Datatype   | Values        | Default | Description                                              |
++=======================+============+===============+=========+==========================================================+
+| ``shared_ranks``      | Integer    | :math:`\gt 0` | 1       | The number of MPI ranks sharing the same allocation      |
++-----------------------+------------+---------------+---------+----------------------------------------------------------+
+| ``distributed_ranks`` | Integer    | :math:`\gt 0` | 1       | The number of MPI ranks that allocations are distributed |
++-----------------------+------------+---------------+---------+----------------------------------------------------------+
+
+The product of ``shared_ranks`` and ``distributed_ranks`` may not execeed the total number of MPI ranks within a compute node.
+Sharing and/or distributing memory only affect the memory allocation on the host. Distributing memory cannot be enabled when
+using GPUs. Sharing memory can be used with GPUs enabled to reduce host memory footprint within the compute node. When evaluations
+of B-spline orbitals happen on the host, sharing and/or distributing memory across NUMA domains may cause performance penalty.
+
 .. _spo-lcao:
 
 Linear combination of atomic orbitals (LCAO) with Gaussian and/or Slater-type basis sets

--- a/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineSetReader.cpp
@@ -54,12 +54,11 @@ std::unique_ptr<SPOSet> SplineSetReader<ST>::create_spline_set(const std::string
 
   if (use_offload)
   {
-    if (distributed_ranks > 1 || shared_ranks > 1)
-      app_warning() << "Offload implemenation doesn't support distributing or sharing the memory of spline "
-                       "coefficients. Overriding distributed_ranks and shared_ranks to 1."
+    if (distributed_ranks > 1)
+      app_warning() << "Offload implemenation doesn't support distributing the memory of spline "
+                       "coefficients. Overriding distributed_ranks to 1."
                     << std::endl;
     distributed_ranks = 1;
-    shared_ranks      = 1;
   }
 
   auto dist_comm_ptr = std::make_unique<Communicate>(*myComm, myComm->size() / (distributed_ranks * shared_ranks));

--- a/src/spline2/MultiBsplineOffloadMapper.cpp
+++ b/src/spline2/MultiBsplineOffloadMapper.cpp
@@ -13,9 +13,12 @@
 #include "MultiBsplineOffloadMapper.hpp"
 #include "MultiBsplineEval_OMPoffload.hpp"
 #include "OMPTarget/OMPTargetMath.hpp"
+#include "OMPTarget/OMPallocator.hpp"
 
 namespace qmcplusplus
 {
+extern std::atomic<size_t> OMPallocator_device_mem_allocated;
+
 template<typename T>
 MultiBsplineOffloadMapper<T>::MultiBsplineOffloadMapper(const HostBspline& host_bsplines)
     : host_bsplines_(host_bsplines)
@@ -37,6 +40,7 @@ void MultiBsplineOffloadMapper<T>::mapToDevice()
     auto* spline_m = &host_bsplines_.getBlock(ib);
     auto* coefs    = block_coefs_[ib];
     PRAGMA_OFFLOAD("omp target enter data map(to: spline_m[:1]) map(alloc: coefs[:spline_m->coefs_size])")
+    OMPallocator_device_mem_allocated += sizeof(decltype(*spline_m)) + spline_m->coefs_size * sizeof(T);
   }
 }
 
@@ -48,6 +52,7 @@ MultiBsplineOffloadMapper<T>::~MultiBsplineOffloadMapper()
     auto* spline_m = &host_bsplines_.getBlock(ib);
     auto* coefs    = block_coefs_[ib];
     PRAGMA_OFFLOAD("omp target exit data map(delete: spline_m[:1]) map(delete: coefs[:spline_m->coefs_size])")
+    OMPallocator_device_mem_allocated -= sizeof(decltype(*spline_m)) + spline_m->coefs_size * sizeof(T);
   }
 }
 


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

1. allow shared_ranks > 1 in GPU runs. Unit test already in place.
2. Document "coefs_mem" XML node.
3. Fix OpenMP offload memory counting for MultiBsplineOffloadMapper.

I ran benchmark on Polaris with 4 GPUs and shared_ranks=4. No performance penalty observed.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Bugfix
- New feature

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

laptop and polaris.

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [x] Documentation has been added (if appropriate)
