### PR TITLE
Fix AFQMC warnings caused by deprecation in multi

### DIFF
--- a/src/AFQMC/Estimators/BackPropagatedEstimator.hpp
+++ b/src/AFQMC/Estimators/BackPropagatedEstimator.hpp
@@ -55,7 +55,7 @@ class BackPropagatedEstimator : public EstimatorBase
   using mpi3CTensor    = boost::multi::array<ComplexType, 3, shared_allocator<ComplexType>>;
 
   using stack_alloc_type = DeviceBufferManager::template allocator_t<ComplexType>;
-  using StaticMatrix     = boost::multi::static_array<ComplexType, 2, stack_alloc_type>;
+  using StaticMatrix     = boost::multi::dynamic_array<ComplexType, 2, stack_alloc_type>;
 
 public:
   BackPropagatedEstimator(afqmc::TaskGroup_& tg_,

--- a/src/AFQMC/Estimators/BackPropagatedEstimator.hpp
+++ b/src/AFQMC/Estimators/BackPropagatedEstimator.hpp
@@ -55,7 +55,7 @@ class BackPropagatedEstimator : public EstimatorBase
   using mpi3CTensor    = boost::multi::array<ComplexType, 3, shared_allocator<ComplexType>>;
 
   using stack_alloc_type = DeviceBufferManager::template allocator_t<ComplexType>;
-  using StaticMatrix     = boost::multi::dynamic_array<ComplexType, 2, stack_alloc_type>;
+  using DynamicMatrix    = boost::multi::dynamic_array<ComplexType, 2, stack_alloc_type>;
 
 public:
   BackPropagatedEstimator(afqmc::TaskGroup_& tg_,
@@ -192,8 +192,8 @@ public:
       if (get<0>(Refs.sizes()) != wset.size() || get<1>(Refs.sizes()) != nrefs || get<2>(Refs.sizes()) != nrow * ncol)
         Refs = mpi3CTensor({wset.size(), nrefs, nrow * ncol}, Refs.get_allocator());
       DeviceBufferManager buffer_manager;
-      StaticMatrix detR({wset.size(), nrefs * nx},
-                        buffer_manager.get_generator().template get_allocator<ComplexType>());
+      DynamicMatrix detR({wset.size(), nrefs * nx},
+                         buffer_manager.get_generator().template get_allocator<ComplexType>());
 
       int n0, n1;
       std::tie(n0, n1) = FairDivideBoundary(TG.getLocalTGRank(), int(get<2>(Refs.sizes())), TG.getNCoresPerTG());

--- a/src/AFQMC/Estimators/EnergyEstimator.h
+++ b/src/AFQMC/Estimators/EnergyEstimator.h
@@ -62,11 +62,11 @@ public:
 
     using std::get;
     if (get<0>(eloc.sizes()) != nwalk || get<1>(eloc.sizes()) != 3)
-      eloc.reextent({static_cast<boost::multi::size_t>(nwalk), 3});
+      eloc.reextent({static_cast<boost::multi::ssize_t>(nwalk), 3});
     if (get<0>(ovlp.sizes()) != nwalk)
       ovlp.reextent(iextensions<1u>(nwalk));
     if (get<0>(wprop.sizes()) != 4 || get<1>(wprop.sizes()) != nwalk)
-      wprop.reextent({4, static_cast<boost::multi::size_t>(nwalk)});
+      wprop.reextent({4, static_cast<boost::multi::ssize_t>(nwalk)});
 
     ComplexType dum, et;
     wfn0.Energy(wset, eloc, ovlp);

--- a/src/AFQMC/Estimators/FullObsHandler.hpp
+++ b/src/AFQMC/Estimators/FullObsHandler.hpp
@@ -66,8 +66,8 @@ class FullObsHandler : public AFQMCInfo
   using stdCVector_ref = boost::multi::array_ref<ComplexType, 1>;
 
   using shm_stack_alloc_type = LocalTGBufferManager::template allocator_t<ComplexType>;
-  using StaticSHMVector      = boost::multi::static_array<ComplexType, 1, shm_stack_alloc_type>;
-  using StaticSHM4Tensor     = boost::multi::static_array<ComplexType, 4, shm_stack_alloc_type>;
+  using StaticSHMVector      = boost::multi::dynamic_array<ComplexType, 1, shm_stack_alloc_type>;
+  using StaticSHM4Tensor     = boost::multi::dynamic_array<ComplexType, 4, shm_stack_alloc_type>;
 
 public:
   FullObsHandler(afqmc::TaskGroup_& tg_,

--- a/src/AFQMC/Estimators/FullObsHandler.hpp
+++ b/src/AFQMC/Estimators/FullObsHandler.hpp
@@ -66,8 +66,8 @@ class FullObsHandler : public AFQMCInfo
   using stdCVector_ref = boost::multi::array_ref<ComplexType, 1>;
 
   using shm_stack_alloc_type = LocalTGBufferManager::template allocator_t<ComplexType>;
-  using StaticSHMVector      = boost::multi::dynamic_array<ComplexType, 1, shm_stack_alloc_type>;
-  using StaticSHM4Tensor     = boost::multi::dynamic_array<ComplexType, 4, shm_stack_alloc_type>;
+  using DynamicSHMVector     = boost::multi::dynamic_array<ComplexType, 1, shm_stack_alloc_type>;
+  using DynamicSHM4Tensor    = boost::multi::dynamic_array<ComplexType, 4, shm_stack_alloc_type>;
 
 public:
   FullObsHandler(afqmc::TaskGroup_& tg_,
@@ -198,10 +198,10 @@ public:
     int nrefs(get<1>(Refs.sizes()));
     double LogOverlapFactor(wset.getLogOverlapFactor());
     LocalTGBufferManager shm_buffer_manager;
-    StaticSHM4Tensor G4D({nw, nspins, get<0>(Gdims), get<1>(Gdims)},
-                         shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
-    StaticSHMVector DevOv(iextensions<1u>{2 * nw},
+    DynamicSHM4Tensor G4D({nw, nspins, get<0>(Gdims), get<1>(Gdims)},
                           shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicSHMVector DevOv(iextensions<1u>{2 * nw},
+                           shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
     sharedCMatrix_ref G2D(G4D.base(), {nw, dm_size});
 
     if (G4D_host.num_elements() != G4D.num_elements())

--- a/src/AFQMC/Estimators/Observables/atomcentered_correlators.hpp
+++ b/src/AFQMC/Estimators/Observables/atomcentered_correlators.hpp
@@ -72,8 +72,8 @@ class atomcentered_correlators : public AFQMCInfo
   using mpi3C4Tensor   = boost::multi::array<ComplexType, 4, shared_allocator<ComplexType>>;
 
   using shm_stack_alloc_type = LocalTGBufferManager::template allocator_t<ComplexType>;
-  using StaticMatrix         = boost::multi::dynamic_array<ComplexType, 2, shm_stack_alloc_type>;
-  using Static3Tensor        = boost::multi::dynamic_array<ComplexType, 3, shm_stack_alloc_type>;
+  using DynamicMatrix        = boost::multi::dynamic_array<ComplexType, 2, shm_stack_alloc_type>;
+  using Dynamic3Tensor       = boost::multi::dynamic_array<ComplexType, 3, shm_stack_alloc_type>;
 
   // MAM: Note -
   // This class uses lots of memory, but can be safely moved to single precision.
@@ -269,7 +269,8 @@ public:
       {
         DMWork2D = mpi3CTensor({nw, 3, ns2}, shared_allocator<ComplexType>{TG.TG_local()});
       }
-      if (get<0>(NwIJ.sizes()) != nsp || get<1>(NwIJ.sizes()) != nw || get<2>(NwIJ.sizes()) != nsites || get<3>(NwIJ.sizes()) != nsites)
+      if (get<0>(NwIJ.sizes()) != nsp || get<1>(NwIJ.sizes()) != nw || get<2>(NwIJ.sizes()) != nsites ||
+          get<3>(NwIJ.sizes()) != nsites)
       {
         NwIJ = mpi3C4Tensor({nsp, nw, nsites, nsites}, shared_allocator<ComplexType>{TG.TG_local()});
       }
@@ -285,12 +286,13 @@ public:
     }
     else
     {
-      if (get<0>(denom.sizes()) != nw || get<0>(DMWork1D.sizes()) != nw || get<1>(DMWork1D.sizes()) != 3 || get<2>(DMWork1D.sizes()) != nsites ||
-          get<0>(DMWork2D.sizes()) != nw || get<1>(DMWork2D.sizes()) != 3 || get<2>(DMWork2D.sizes()) != ns2 || get<0>(NwI.sizes()) != nsp ||
-          get<1>(NwI.sizes()) != nw || get<2>(NwI.sizes()) != nsites || get<0>(NwIJ.sizes()) != nsp || get<1>(NwIJ.sizes()) != nw ||
-          get<2>(NwIJ.sizes()) != nsites || get<3>(NwIJ.sizes()) != nsites || get<0>(DMAverage1D.sizes()) != nave || get<1>(DMAverage1D.sizes()) != 3 ||
-          get<2>(DMAverage1D.sizes()) != nsites || get<0>(DMAverage2D.sizes()) != nave || get<1>(DMAverage2D.sizes()) != 3 ||
-          get<2>(DMAverage2D.sizes()) != ns2)
+      if (get<0>(denom.sizes()) != nw || get<0>(DMWork1D.sizes()) != nw || get<1>(DMWork1D.sizes()) != 3 ||
+          get<2>(DMWork1D.sizes()) != nsites || get<0>(DMWork2D.sizes()) != nw || get<1>(DMWork2D.sizes()) != 3 ||
+          get<2>(DMWork2D.sizes()) != ns2 || get<0>(NwI.sizes()) != nsp || get<1>(NwI.sizes()) != nw ||
+          get<2>(NwI.sizes()) != nsites || get<0>(NwIJ.sizes()) != nsp || get<1>(NwIJ.sizes()) != nw ||
+          get<2>(NwIJ.sizes()) != nsites || get<3>(NwIJ.sizes()) != nsites || get<0>(DMAverage1D.sizes()) != nave ||
+          get<1>(DMAverage1D.sizes()) != 3 || get<2>(DMAverage1D.sizes()) != nsites ||
+          get<0>(DMAverage2D.sizes()) != nave || get<1>(DMAverage2D.sizes()) != 3 || get<2>(DMAverage2D.sizes()) != ns2)
         APP_ABORT(" Error: Invalid state in accumulate_reference. \n\n\n");
     }
 
@@ -311,11 +313,11 @@ public:
     {
       int nwlk = std::min(nwbatch, nw - iw0);
 
-      Static3Tensor QwI({nwlk, NAO, NMO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
-      Static3Tensor MwIJ({nwlk, NAO, NAO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
-      Static3Tensor devNwIJ({nwlk, nsites, nsites},
-                            buffer_manager.get_generator().template get_allocator<ComplexType>());
-      StaticMatrix devNwI({nwlk, nsites}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+      Dynamic3Tensor QwI({nwlk, NAO, NMO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+      Dynamic3Tensor MwIJ({nwlk, NAO, NAO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+      Dynamic3Tensor devNwIJ({nwlk, nsites, nsites},
+                             buffer_manager.get_generator().template get_allocator<ComplexType>());
+      DynamicMatrix devNwI({nwlk, nsites}, buffer_manager.get_generator().template get_allocator<ComplexType>());
 
       for (int is = 0; is < nsp; ++is)
       {

--- a/src/AFQMC/Estimators/Observables/atomcentered_correlators.hpp
+++ b/src/AFQMC/Estimators/Observables/atomcentered_correlators.hpp
@@ -72,8 +72,8 @@ class atomcentered_correlators : public AFQMCInfo
   using mpi3C4Tensor   = boost::multi::array<ComplexType, 4, shared_allocator<ComplexType>>;
 
   using shm_stack_alloc_type = LocalTGBufferManager::template allocator_t<ComplexType>;
-  using StaticMatrix         = boost::multi::static_array<ComplexType, 2, shm_stack_alloc_type>;
-  using Static3Tensor        = boost::multi::static_array<ComplexType, 3, shm_stack_alloc_type>;
+  using StaticMatrix         = boost::multi::dynamic_array<ComplexType, 2, shm_stack_alloc_type>;
+  using Static3Tensor        = boost::multi::dynamic_array<ComplexType, 3, shm_stack_alloc_type>;
 
   // MAM: Note -
   // This class uses lots of memory, but can be safely moved to single precision.

--- a/src/AFQMC/Estimators/Observables/full1rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full1rdm.hpp
@@ -68,7 +68,7 @@ class full1rdm : public AFQMCInfo
   using mpi3C4Tensor   = boost::multi::array<ComplexType, 4, shared_allocator<ComplexType>>;
 
   using stack_alloc_type = DeviceBufferManager::template allocator_t<ComplexType>;
-  using StaticMatrix     = boost::multi::dynamic_array<ComplexType, 2, stack_alloc_type>;
+  using DynamicMatrix    = boost::multi::dynamic_array<ComplexType, 2, stack_alloc_type>;
 
 public:
   full1rdm(afqmc::TaskGroup_& tg_, AFQMCInfo& info, xmlNodePtr cur, WALKER_TYPES wlk, int nave_ = 1, int bsize = 1)
@@ -137,8 +137,7 @@ public:
         dim[0] = R.size();
         dim[1] = 0;
         // conjugate rotation matrix
-        std::transform(R.base(), R.base() + R.num_elements(), R.base(),
-                       [](const auto& c) { return std::conj(c); });
+        std::transform(R.base(), R.base() + R.num_elements(), R.base(), [](const auto& c) { return std::conj(c); });
         stdIMatrix I;
         if (print_from_list)
         {
@@ -263,8 +262,8 @@ public:
     }
     else
     {
-      if (get<0>(denom.sizes()) != nw || get<0>(DMWork.sizes()) != nw || get<1>(DMWork.sizes()) != dm_size || get<0>(DMAverage.sizes()) != nave ||
-          get<1>(DMAverage.sizes()) != dm_size)
+      if (get<0>(denom.sizes()) != nw || get<0>(DMWork.sizes()) != nw || get<1>(DMWork.sizes()) != dm_size ||
+          get<0>(DMAverage.sizes()) != nave || get<1>(DMAverage.sizes()) != dm_size)
         APP_ABORT(" Error: Invalid state in accumulate_reference. \n\n\n");
     }
 
@@ -447,8 +446,8 @@ private:
     int nX   = XRot.size();
     int npts = (iN - i0) * nX;
     DeviceBufferManager buffer_manager;
-    StaticMatrix T1({(iN - i0), NMO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
-    StaticMatrix T2({(iN - i0), nX}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix T1({(iN - i0), NMO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix T2({(iN - i0), nX}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     if (Grot.size() != npts)
       Grot = stdCVector(iextensions<1u>(npts));
 

--- a/src/AFQMC/Estimators/Observables/full1rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full1rdm.hpp
@@ -68,7 +68,7 @@ class full1rdm : public AFQMCInfo
   using mpi3C4Tensor   = boost::multi::array<ComplexType, 4, shared_allocator<ComplexType>>;
 
   using stack_alloc_type = DeviceBufferManager::template allocator_t<ComplexType>;
-  using StaticMatrix     = boost::multi::static_array<ComplexType, 2, stack_alloc_type>;
+  using StaticMatrix     = boost::multi::dynamic_array<ComplexType, 2, stack_alloc_type>;
 
 public:
   full1rdm(afqmc::TaskGroup_& tg_, AFQMCInfo& info, xmlNodePtr cur, WALKER_TYPES wlk, int nave_ = 1, int bsize = 1)

--- a/src/AFQMC/Estimators/Observables/full2rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full2rdm.hpp
@@ -69,8 +69,8 @@ class full2rdm : public AFQMCInfo
   using mpi3C4Tensor   = boost::multi::array<ComplexType, 4, shared_allocator<ComplexType>>;
 
   using stack_alloc_type = DeviceBufferManager::template allocator_t<ComplexType>;
-  using StaticVector     = boost::multi::dynamic_array<ComplexType, 1, stack_alloc_type>;
-  using StaticMatrix     = boost::multi::dynamic_array<ComplexType, 2, stack_alloc_type>;
+  using DynamicVector    = boost::multi::dynamic_array<ComplexType, 1, stack_alloc_type>;
+  using DynamicMatrix    = boost::multi::dynamic_array<ComplexType, 2, stack_alloc_type>;
 
 public:
   full2rdm(afqmc::TaskGroup_& tg_, AFQMCInfo& info, xmlNodePtr cur, WALKER_TYPES wlk, int nave_ = 1, int bsize = 1)
@@ -131,8 +131,7 @@ public:
         dim[0] = R.size();
         dim[1] = 0;
         // conjugate rotation matrix
-        std::transform(R.base(), R.base() + R.num_elements(), R.base(),
-                       [](const auto& c) { return std::conj(c); });
+        std::transform(R.base(), R.base() + R.num_elements(), R.base(), [](const auto& c) { return std::conj(c); });
         TG.Node().broadcast_n(dim, 2, 0);
         XRot = sharedCMatrix({dim[0], NMO}, make_node_allocator<ComplexType>(TG));
         copy_n(R.base(), R.num_elements(), make_device_ptr(XRot.base()));
@@ -215,8 +214,8 @@ public:
     }
     else
     {
-      if (get<0>(denom.sizes()) != nw || get<0>(DMWork.sizes()) != nw || get<1>(DMWork.sizes()) != dm_size || get<0>(DMAverage.sizes()) != nave ||
-          get<1>(DMAverage.sizes()) != dm_size)
+      if (get<0>(denom.sizes()) != nw || get<0>(DMWork.sizes()) != nw || get<1>(DMWork.sizes()) != dm_size ||
+          get<0>(DMAverage.sizes()) != nave || get<1>(DMAverage.sizes()) != dm_size)
         APP_ABORT(" Error: Invalid state in accumulate_reference. \n\n\n");
     }
 
@@ -319,13 +318,13 @@ private:
     size_t M4(M2 * M2);
     size_t N = size_t(dN) * M2;
     DeviceBufferManager buffer_manager;
-    StaticMatrix R({dN, NMO * NMO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix R({dN, NMO * NMO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     CMatrix_ref Q(R.base(), {NMO * NMO, NMO});
     CVector_ref R1D(R.base(), R.num_elements());
     CVector_ref Q1D(Q.base(), Q.num_elements());
 
     // put this in shared memory!!!
-    StaticMatrix Gt({NMO, NMO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix Gt({NMO, NMO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     CMatrix_ref GtC(Gt.base(), {NMO * NMO, 1});
 #if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     if (Grot.size() < R.num_elements())

--- a/src/AFQMC/Estimators/Observables/full2rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full2rdm.hpp
@@ -69,8 +69,8 @@ class full2rdm : public AFQMCInfo
   using mpi3C4Tensor   = boost::multi::array<ComplexType, 4, shared_allocator<ComplexType>>;
 
   using stack_alloc_type = DeviceBufferManager::template allocator_t<ComplexType>;
-  using StaticVector     = boost::multi::static_array<ComplexType, 1, stack_alloc_type>;
-  using StaticMatrix     = boost::multi::static_array<ComplexType, 2, stack_alloc_type>;
+  using StaticVector     = boost::multi::dynamic_array<ComplexType, 1, stack_alloc_type>;
+  using StaticMatrix     = boost::multi::dynamic_array<ComplexType, 2, stack_alloc_type>;
 
 public:
   full2rdm(afqmc::TaskGroup_& tg_, AFQMCInfo& info, xmlNodePtr cur, WALKER_TYPES wlk, int nave_ = 1, int bsize = 1)

--- a/src/AFQMC/Estimators/Observables/generalizedFockMatrix.hpp
+++ b/src/AFQMC/Estimators/Observables/generalizedFockMatrix.hpp
@@ -70,7 +70,7 @@ class generalizedFockMatrix : public AFQMCInfo
   using mpi3C4Tensor   = boost::multi::array<ComplexType, 4, shared_allocator<ComplexType>>;
 
   using stack_alloc_type = DeviceBufferManager::template allocator_t<ComplexType>;
-  using Static3Tensor    = boost::multi::dynamic_array<ComplexType, 3, stack_alloc_type>;
+  using Dynamic3Tensor   = boost::multi::dynamic_array<ComplexType, 3, stack_alloc_type>;
 
 public:
   generalizedFockMatrix(afqmc::TaskGroup_& tg_,
@@ -150,13 +150,14 @@ public:
     }
     else
     {
-      if (get<0>(denom.sizes()) != nw || get<0>(DMWork.sizes()) != 2 || get<1>(DMWork.sizes()) != nw || get<2>(DMWork.sizes()) != dm_size ||
-          get<0>(DMAverage.sizes()) != 2 || get<1>(DMAverage.sizes()) != nave || get<2>(DMAverage.sizes()) != dm_size)
+      if (get<0>(denom.sizes()) != nw || get<0>(DMWork.sizes()) != 2 || get<1>(DMWork.sizes()) != nw ||
+          get<2>(DMWork.sizes()) != dm_size || get<0>(DMAverage.sizes()) != 2 || get<1>(DMAverage.sizes()) != nave ||
+          get<2>(DMAverage.sizes()) != dm_size)
         APP_ABORT(" Error: Invalid state in accumulate_reference. \n\n\n");
     }
 
     DeviceBufferManager buffer_manager;
-    Static3Tensor gFock({2, nw, dm_size}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    Dynamic3Tensor gFock({2, nw, dm_size}, buffer_manager.get_generator().template get_allocator<ComplexType>());
 
     HamOp->generalizedFockMatrix(G, gFock[0], gFock[1]);
 

--- a/src/AFQMC/Estimators/Observables/generalizedFockMatrix.hpp
+++ b/src/AFQMC/Estimators/Observables/generalizedFockMatrix.hpp
@@ -70,7 +70,7 @@ class generalizedFockMatrix : public AFQMCInfo
   using mpi3C4Tensor   = boost::multi::array<ComplexType, 4, shared_allocator<ComplexType>>;
 
   using stack_alloc_type = DeviceBufferManager::template allocator_t<ComplexType>;
-  using Static3Tensor    = boost::multi::static_array<ComplexType, 3, stack_alloc_type>;
+  using Static3Tensor    = boost::multi::dynamic_array<ComplexType, 3, stack_alloc_type>;
 
 public:
   generalizedFockMatrix(afqmc::TaskGroup_& tg_,

--- a/src/AFQMC/Estimators/Observables/realspace_correlators.hpp
+++ b/src/AFQMC/Estimators/Observables/realspace_correlators.hpp
@@ -66,7 +66,7 @@ class realspace_correlators : public AFQMCInfo
   using mpi3C4Tensor   = boost::multi::array<ComplexType, 4, shared_allocator<ComplexType>>;
 
   using shm_stack_alloc_type = LocalTGBufferManager::template allocator_t<ComplexType>;
-  using StaticMatrix         = boost::multi::dynamic_array<ComplexType, 2, shm_stack_alloc_type>;
+  using DynamicMatrix        = boost::multi::dynamic_array<ComplexType, 2, shm_stack_alloc_type>;
 
 public:
   realspace_correlators(afqmc::TaskGroup_& tg_,
@@ -251,7 +251,8 @@ public:
       {
         DMWork = mpi3CTensor({nw, 3, dm_size}, shared_allocator<ComplexType>{TG.TG_local()});
       }
-      if (get<0>(Gr_host.sizes()) != nw || get<1>(Gr_host.sizes()) != nsp || get<2>(Gr_host.sizes()) != npts || get<3>(Gr_host.sizes()) != npts)
+      if (get<0>(Gr_host.sizes()) != nw || get<1>(Gr_host.sizes()) != nsp || get<2>(Gr_host.sizes()) != npts ||
+          get<3>(Gr_host.sizes()) != npts)
       {
         Gr_host = mpi3C4Tensor({nw, nsp, npts, npts}, shared_allocator<ComplexType>{TG.TG_local()});
       }
@@ -260,9 +261,10 @@ public:
     }
     else
     {
-      if (get<0>(denom.sizes()) != nw || get<0>(DMWork.sizes()) != nw || get<1>(DMWork.sizes()) != 3 || get<2>(DMWork.sizes()) != dm_size ||
-          get<0>(Gr_host.sizes()) != nw || get<1>(Gr_host.sizes()) != nsp || get<2>(Gr_host.sizes()) != npts || get<3>(Gr_host.sizes()) != npts ||
-          get<0>(DMAverage.sizes()) != nave || get<1>(DMAverage.sizes()) != 3 || get<2>(DMAverage.sizes()) != dm_size)
+      if (get<0>(denom.sizes()) != nw || get<0>(DMWork.sizes()) != nw || get<1>(DMWork.sizes()) != 3 ||
+          get<2>(DMWork.sizes()) != dm_size || get<0>(Gr_host.sizes()) != nw || get<1>(Gr_host.sizes()) != nsp ||
+          get<2>(Gr_host.sizes()) != npts || get<3>(Gr_host.sizes()) != npts || get<0>(DMAverage.sizes()) != nave ||
+          get<1>(DMAverage.sizes()) != 3 || get<2>(DMAverage.sizes()) != dm_size)
         APP_ABORT(" Error: Invalid state in accumulate_reference. \n\n\n");
     }
 
@@ -271,8 +273,8 @@ public:
     // if memory becomes a problem, then batch over walkers
     {
       LocalTGBufferManager buffer_manager;
-      StaticMatrix T({nw * nsp * NMO, npts}, buffer_manager.get_generator().template get_allocator<ComplexType>());
-      StaticMatrix Gr({nsp * nw, npts * npts}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+      DynamicMatrix T({nw * nsp * NMO, npts}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+      DynamicMatrix Gr({nsp * nw, npts * npts}, buffer_manager.get_generator().template get_allocator<ComplexType>());
       CTensor_ref Gr3D(make_device_ptr(Gr.base()), {nw, nsp, npts * npts});
       CTensor_ref T3D(make_device_ptr(T.base()), {nw, nsp, NMO * npts});
       CMatrix_ref G2D(make_device_ptr(G.base()), {nw * nsp * NMO, NMO});

--- a/src/AFQMC/Estimators/Observables/realspace_correlators.hpp
+++ b/src/AFQMC/Estimators/Observables/realspace_correlators.hpp
@@ -66,7 +66,7 @@ class realspace_correlators : public AFQMCInfo
   using mpi3C4Tensor   = boost::multi::array<ComplexType, 4, shared_allocator<ComplexType>>;
 
   using shm_stack_alloc_type = LocalTGBufferManager::template allocator_t<ComplexType>;
-  using StaticMatrix         = boost::multi::static_array<ComplexType, 2, shm_stack_alloc_type>;
+  using StaticMatrix         = boost::multi::dynamic_array<ComplexType, 2, shm_stack_alloc_type>;
 
 public:
   realspace_correlators(afqmc::TaskGroup_& tg_,

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
@@ -40,7 +40,7 @@ namespace afqmc
 // testing the use of dynamic data transfer during execution to reduce memory in GPU
 // when an approach is found, integrate in original class through additional template parameter
 
-using std::get;  // for C++17 compatibility
+using std::get; // for C++17 compatibility
 
 template<class LQKankMatrix>
 class KP3IndexFactorization_batched
@@ -94,11 +94,11 @@ class KP3IndexFactorization_batched
   using Sp4Tensor_ref = SPComplexArray_ref<4, sp_pointer>;
   using Sp5Tensor_ref = SPComplexArray_ref<5, sp_pointer>;
 
-  using StaticIVector = boost::multi::dynamic_array<int, 1, device_alloc_Itype>;
-  using StaticVector  = boost::multi::dynamic_array<SPComplexType, 1, device_alloc_type>;
-  using StaticMatrix  = boost::multi::dynamic_array<SPComplexType, 2, device_alloc_type>;
-  using Static3Tensor = boost::multi::dynamic_array<SPComplexType, 3, device_alloc_type>;
-  using Static4Tensor = boost::multi::dynamic_array<SPComplexType, 4, device_alloc_type>;
+  using DynamicIVector = boost::multi::dynamic_array<int, 1, device_alloc_Itype>;
+  using DynamicVector  = boost::multi::dynamic_array<SPComplexType, 1, device_alloc_type>;
+  using DynamicMatrix  = boost::multi::dynamic_array<SPComplexType, 2, device_alloc_type>;
+  using Dynamic3Tensor = boost::multi::dynamic_array<SPComplexType, 3, device_alloc_type>;
+  using Dynamic4Tensor = boost::multi::dynamic_array<SPComplexType, 4, device_alloc_type>;
 
   using shmCVector  = ComplexVector<Allocator_shared>;
   using shmCMatrix  = ComplexMatrix<Allocator_shared>;
@@ -187,9 +187,9 @@ public:
         dev_QKToK2(QKToK2),
         EQ(nopk.size() + 2)
   {
-    using std::get;
     using std::copy_n;
     using std::fill_n;
+    using std::get;
     nocc_max = *std::max_element(nelpk.base(), nelpk.base() + nelpk.num_elements());
     fill_n(EQ.data(), EQ.size(), 0);
     int nkpts = nopk.size();
@@ -330,10 +330,10 @@ public:
 
   ~KP3IndexFactorization_batched() {}
 
-  KP3IndexFactorization_batched(const KP3IndexFactorization_batched& other) = delete;
+  KP3IndexFactorization_batched(const KP3IndexFactorization_batched& other)            = delete;
   KP3IndexFactorization_batched& operator=(const KP3IndexFactorization_batched& other) = delete;
   KP3IndexFactorization_batched(KP3IndexFactorization_batched&& other)                 = default;
-  KP3IndexFactorization_batched& operator=(KP3IndexFactorization_batched&& other) = default;
+  KP3IndexFactorization_batched& operator=(KP3IndexFactorization_batched&& other)      = default;
 
   // must have the same signature as shared classes, so keeping it with std::allocator
   // NOTE: THIS SHOULD USE mpi3::shm!!!
@@ -481,7 +481,7 @@ public:
                     bool addEJ  = true,
                     bool addEXX = true)
   {
-    using std::get;  // for C++17 compatibility
+    using std::get; // for C++17 compatibility
 
     using std::copy_n;
     using std::fill_n;
@@ -541,8 +541,8 @@ public:
     {
       APP_ABORT(" Error: Kr and/or Kl can only be calculated with addEJ=true.\n");
     }
-    StaticMatrix Kl({Knr, Knc}, device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    StaticMatrix Kr({Knr, Knc}, device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicMatrix Kl({Knr, Knc}, device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicMatrix Kr({Knr, Knc}, device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
     fill_n(Kr.base(), Knr * Knc, SPComplexType(0.0));
     fill_n(Kl.base(), Knr * Knc, SPComplexType(0.0));
 
@@ -555,8 +555,8 @@ public:
 
     // later on, rewrite routine to loop over spins, to avoid storage of both spin
     // components simultaneously
-    Static4Tensor GKK({nspin, nkpts, nkpts, nwalk * npol * nmo_max * nocc_max},
-                      device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    Dynamic4Tensor GKK({nspin, nkpts, nkpts, nwalk * npol * nmo_max * nocc_max},
+                       device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
     GKaKjw_to_GKKwaj(G3Da, GKK[0], nelpk[nd].sliced(0, nkpts), dev_nelpk[nd], dev_a0pk[nd]);
     if (walker_type == COLLINEAR)
       GKaKjw_to_GKKwaj(G3Db, GKK[1], nelpk[nd].sliced(nkpts, 2 * nkpts), dev_nelpk[nd].sliced(nkpts, 2 * nkpts),
@@ -627,21 +627,21 @@ public:
       std::vector<int> kdiag;
       kdiag.reserve(batch_size);
 
-      StaticIVector IMats(iextensions<1u>{batch_size},
-                          device_buffer_manager.get_generator().template get_allocator<int>());
+      DynamicIVector IMats(iextensions<1u>{batch_size},
+                           device_buffer_manager.get_generator().template get_allocator<int>());
       fill_n(IMats.base(), IMats.num_elements(), 0);
-      StaticVector dev_scl_factors(iextensions<1u>{batch_size},
-                                   device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
-      Static3Tensor T1({batch_size, nwalk * nocc_max, nocc_max * nchol_max},
-                       device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
+      DynamicVector dev_scl_factors(iextensions<1u>{batch_size},
+                                    device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
+      Dynamic3Tensor T1({batch_size, nwalk * nocc_max, nocc_max * nchol_max},
+                        device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
       SPRealType scl = (walker_type == CLOSED ? 2.0 : 1.0);
 
       // I WANT C++17!!!!!!
       long mem_ank(0);
       if (needs_copy)
         mem_ank = nkpts * nocc_max * nchol_max * npol * nmo_max;
-      StaticVector LBuff(iextensions<1u>{2 * mem_ank},
-                         device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
+      DynamicVector LBuff(iextensions<1u>{2 * mem_ank},
+                          device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
       sp_pointer LQptr(nullptr), LQmptr(nullptr);
       if (needs_copy)
       {
@@ -682,8 +682,7 @@ public:
           {
             copy_n(to_address(LQKank[nd * nspin * nkpts + spin * nkpts + Q].base()), LQ.num_elements(), LQ.base());
             if (Q != Qm)
-              copy_n(to_address(LQKank[nd * nspin * nkpts + spin * nkpts + Qm].base()), LQm.num_elements(),
-                     LQm.base());
+              copy_n(to_address(LQKank[nd * nspin * nkpts + spin * nkpts + Qm].base()), LQm.num_elements(), LQm.base());
           }
 
           for (int Ka = 0; Ka < nkpts; ++Ka)
@@ -723,16 +722,16 @@ public:
 
                 copy_n(scl_factors.data(), scl_factors.size(), dev_scl_factors.base());
                 using ma::batched_dot_wabn_wban;
-                batched_dot_wabn_wban(scl_factors.size(), nwalk, nocc_max, nchol_max, dev_scl_factors.base(),
-                                      T1.base(), to_address(E[0].base()) + 1, E.stride());
+                batched_dot_wabn_wban(scl_factors.size(), nwalk, nocc_max, nchol_max, dev_scl_factors.base(), T1.base(),
+                                      to_address(E[0].base()) + 1, E.stride());
 
                 if (addEJ)
                 {
                   int nc0 = Q2vbias[Q] / 2; //std::accumulate(ncholpQ.begin(),ncholpQ.begin()+Q,0);
                   copy_n(kdiag.data(), kdiag.size(), IMats.base());
                   using ma::batched_Tab_to_Klr;
-                  batched_Tab_to_Klr(kdiag.size(), nwalk, nocc_max, nchol_max, local_nCV, ncholpQ[Q], nc0,
-                                     IMats.base(), T1.base(), Kl.base(), Kr.base());
+                  batched_Tab_to_Klr(kdiag.size(), nwalk, nocc_max, nchol_max, local_nCV, ncholpQ[Q], nc0, IMats.base(),
+                                     T1.base(), Kl.base(), Kr.base());
                 }
 
                 // reset
@@ -767,7 +766,7 @@ public:
             }
           }
         } // Q
-      }   // COLLINEAR
+      } // COLLINEAR
     }
 
     if (addEJ)
@@ -1172,9 +1171,7 @@ public:
 
   template<class... Args>
   void fast_energy(Args&&... args)
-  {
-    APP_ABORT(" Error: fast_energy not implemented in KP3IndexFactorization_batched. \n");
-  }
+  { APP_ABORT(" Error: fast_energy not implemented in KP3IndexFactorization_batched. \n"); }
 
   template<
       class MatA,
@@ -1203,7 +1200,7 @@ public:
       >
   void vHS(MatA& X, MatB&& v, double a = 1., double c = 0.)
   {
-    using std::get;  // for C++17 compatibility
+    using std::get; // for C++17 compatibility
     int nkpts = nopk.size();
     int nwalk = get<1>(X.sizes());
     assert(v.size() == nwalk);
@@ -1219,17 +1216,17 @@ public:
     SPComplexType minusimhalfa(0.0, -0.5 * a);
     SPComplexType imhalfa(0.0, 0.5 * a);
 
-    Static3Tensor vKK({nkpts + number_of_symmetric_Q, nkpts, nwalk * nmo_max * nmo_max},
-                      device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    fill_n(vKK.base(), vKK.num_elements(), SPComplexType(0.0));
-    Static4Tensor XQnw({nkpts, 2, nchol_max, nwalk},
+    Dynamic3Tensor vKK({nkpts + number_of_symmetric_Q, nkpts, nwalk * nmo_max * nmo_max},
                        device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    fill_n(vKK.base(), vKK.num_elements(), SPComplexType(0.0));
+    Dynamic4Tensor XQnw({nkpts, 2, nchol_max, nwalk},
+                        device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
     fill_n(XQnw.base(), XQnw.num_elements(), SPComplexType(0.0));
 
     // "rotate" X
     //  XIJ = 0.5*a*(Xn+ -i*Xn-), XJI = 0.5*a*(Xn+ +i*Xn-)
 #if defined(MIXED_PRECISION)
-    StaticMatrix Xdev(X.extents(), device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicMatrix Xdev(X.extents(), device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
     copy_n_cast(make_device_ptr(X.base()), X.num_elements(), Xdev.base());
 #else
     SpMatrix_ref Xdev(make_device_ptr(X.base()), X.extents());
@@ -1325,7 +1322,7 @@ public:
 
     using vType = typename std::decay<MatB>::type::element;
     boost::multi::array_ref<vType, 3, decltype(make_device_ptr(v.base()))> v3D(make_device_ptr(v.base()),
-                                                                                 {nwalk, nmo_tot, nmo_tot});
+                                                                               {nwalk, nmo_tot, nmo_tot});
     vKKwij_to_vwKiKj(vKK, v3D);
     // do I need to "rotate" back, can be done if necessary
   }
@@ -1373,8 +1370,8 @@ public:
       >
   void vbias(const MatA& G, MatB&& v, double a = 1., double c = 0., int nd = 0)
   {
-    using std::get;  // for C++17 compatibility
     using ma::gemmBatched;
+    using std::get; // for C++17 compatibility
 
     int nkpts = nopk.size();
     assert(nd >= 0 && nd < nelpk.size());
@@ -1403,12 +1400,12 @@ public:
     // MAM: use reshape when available, then no need to deal with types
     using GType = typename std::decay<MatA>::type::element;
     boost::multi::array_ref<GType const, 3, decltype(make_device_ptr(G.base()))> G3Da(make_device_ptr(G.base()),
-                                                                                        {nocca_tot * npol, nmo_tot,
-                                                                                         nwalk});
+                                                                                      {nocca_tot * npol, nmo_tot,
+                                                                                       nwalk});
     boost::multi::array_ref<GType const, 3, decltype(make_device_ptr(G.base()))> G3Db(make_device_ptr(G.base()) +
-                                                                                            G3Da.num_elements() *
-                                                                                                (nspin - 1),
-                                                                                        {noccb_tot, nmo_tot, nwalk});
+                                                                                          G3Da.num_elements() *
+                                                                                              (nspin - 1),
+                                                                                      {noccb_tot, nmo_tot, nwalk});
 
     // assuming contiguous
     ma::scal(c, v);
@@ -1416,10 +1413,10 @@ public:
     for (int spin = 0; spin < nspin; spin++)
     {
       size_t cnt(0);
-      Static3Tensor v1({nkpts + number_of_symmetric_Q, nchol_max, nwalk},
-                       device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
-      Static3Tensor GQ({nkpts, nkpts * nocc_max * npol * nmo_max, nwalk},
-                       device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
+      Dynamic3Tensor v1({nkpts + number_of_symmetric_Q, nchol_max, nwalk},
+                        device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
+      Dynamic3Tensor GQ({nkpts, nkpts * nocc_max * npol * nmo_max, nwalk},
+                        device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
       fill_n(v1.base(), v1.num_elements(), SPComplexType(0.0));
       fill_n(GQ.base(), GQ.num_elements(), SPComplexType(0.0));
 
@@ -1463,9 +1460,7 @@ public:
 
   template<class Mat, class MatB>
   void generalizedFockMatrix(Mat&& G, MatB&& Fp, MatB&& Fm)
-  {
-    APP_ABORT(" Error: generalizedFockMatrix not implemented for this hamiltonian.\n");
-  }
+  { APP_ABORT(" Error: generalizedFockMatrix not implemented for this hamiltonian.\n"); }
 
   bool distribution_over_cholesky_vectors() const { return true; }
   int number_of_ke_vectors() const { return local_nCV; }
@@ -1590,7 +1585,7 @@ private:
   template<class MatA, class MatB, class IVec, class IVec2>
   void GKaKjw_to_GKKwaj(MatA const& GKaKj, MatB&& GKKaj, IVec&& nocc, IVec2&& dev_no, IVec2&& dev_a0)
   {
-    using std::get;  // for C++17 compatibility
+    using std::get; // for C++17 compatibility
 
     int npol    = (walker_type == NONCOLLINEAR) ? 2 : 1;
     int nmo_max = *std::max_element(nopk.begin(), nopk.end());
@@ -1601,8 +1596,8 @@ private:
     assert(GKKaj.num_elements() >= nkpts * nkpts * nwalk * nocc_max * npol * nmo_max);
 
     using ma::KaKjw_to_KKwaj;
-    KaKjw_to_KKwaj(nwalk, nkpts, npol, nmo_max, nmo_tot, nocc_max, dev_nopk.base(), dev_i0pk.base(),
-                   dev_no.base(), dev_a0.base(), GKaKj.base(), GKKaj.base());
+    KaKjw_to_KKwaj(nwalk, nkpts, npol, nmo_max, nmo_tot, nocc_max, dev_nopk.base(), dev_i0pk.base(), dev_no.base(),
+                   dev_a0.base(), GKaKj.base(), GKKaj.base());
   }
 
   template<class MatA, class MatB, class IVec, class IVec2>
@@ -1612,15 +1607,15 @@ private:
     int nmo_max = *std::max_element(nopk.begin(), nopk.end());
     //      int nocc_max = *std::max_element(nocc.begin(),nocc.end());
 
-    using std::get;  // for C++17 compatibility
+    using std::get; // for C++17 compatibility
     int nmo_tot = get<1>(GKaKj.sizes());
     int nwalk   = get<2>(GKaKj.sizes());
     int nkpts   = nopk.size();
     assert(GQKaj.num_elements() >= nkpts * nkpts * nwalk * nocc_max * npol * nmo_max);
 
     using ma::KaKjw_to_QKajw;
-    KaKjw_to_QKajw(nwalk, nkpts, npol, nmo_max, nmo_tot, nocc_max, dev_nopk.base(), dev_i0pk.base(),
-                   dev_no.base(), dev_a0.base(), dev_QKToK2.base(), GKaKj.base(), GQKaj.base());
+    KaKjw_to_QKajw(nwalk, nkpts, npol, nmo_max, nmo_tot, nocc_max, dev_nopk.base(), dev_i0pk.base(), dev_no.base(),
+                   dev_a0.base(), dev_QKToK2.base(), GKaKj.base(), GQKaj.base());
   }
 
 
@@ -1639,8 +1634,8 @@ private:
     int nkpts   = nopk.size();
 
     using ma::vKKwij_to_vwKiKj;
-    vKKwij_to_vwKiKj(nwalk, nkpts, nmo_max, nmo_tot, KKTransID.base(), dev_nopk.base(), dev_i0pk.base(),
-                     vKK.base(), vKiKj.base());
+    vKKwij_to_vwKiKj(nwalk, nkpts, nmo_max, nmo_tot, KKTransID.base(), dev_nopk.base(), dev_i0pk.base(), vKK.base(),
+                     vKiKj.base());
   }
 
   template<class MatA, class MatB>
@@ -1655,9 +1650,8 @@ private:
 
     using ma::vbias_from_v1;
     // using make_device_ptr(vbias.base()) to catch errors here
-    vbias_from_v1(nwalk, nkpts, nchol_max, dev_Qmap.base(), dev_kminus.base(), dev_ncholpQ.base(),
-                  dev_Q2vbias.base(), static_cast<BType>(a), v1.base(),
-                  to_address(make_device_ptr(vbias.base())));
+    vbias_from_v1(nwalk, nkpts, nchol_max, dev_Qmap.base(), dev_kminus.base(), dev_ncholpQ.base(), dev_Q2vbias.base(),
+                  static_cast<BType>(a), v1.base(), to_address(make_device_ptr(vbias.base())));
   }
 };
 

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
@@ -94,11 +94,11 @@ class KP3IndexFactorization_batched
   using Sp4Tensor_ref = SPComplexArray_ref<4, sp_pointer>;
   using Sp5Tensor_ref = SPComplexArray_ref<5, sp_pointer>;
 
-  using StaticIVector = boost::multi::static_array<int, 1, device_alloc_Itype>;
-  using StaticVector  = boost::multi::static_array<SPComplexType, 1, device_alloc_type>;
-  using StaticMatrix  = boost::multi::static_array<SPComplexType, 2, device_alloc_type>;
-  using Static3Tensor = boost::multi::static_array<SPComplexType, 3, device_alloc_type>;
-  using Static4Tensor = boost::multi::static_array<SPComplexType, 4, device_alloc_type>;
+  using StaticIVector = boost::multi::dynamic_array<int, 1, device_alloc_Itype>;
+  using StaticVector  = boost::multi::dynamic_array<SPComplexType, 1, device_alloc_type>;
+  using StaticMatrix  = boost::multi::dynamic_array<SPComplexType, 2, device_alloc_type>;
+  using Static3Tensor = boost::multi::dynamic_array<SPComplexType, 3, device_alloc_type>;
+  using Static4Tensor = boost::multi::dynamic_array<SPComplexType, 4, device_alloc_type>;
 
   using shmCVector  = ComplexVector<Allocator_shared>;
   using shmCMatrix  = ComplexMatrix<Allocator_shared>;

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
@@ -73,14 +73,14 @@ class Real3IndexFactorization_batched_v2
   using SpC4Tensor_ref = boost::multi::array_ref<SPComplexType, 4, sp_pointer>;
   using C4Tensor_ref   = boost::multi::array_ref<ComplexType, 4, pointer>;
 
-  using StaticVector   = boost::multi::static_array<SPComplexType, 1, device_alloc_type>;
-  using StaticMatrix   = boost::multi::static_array<SPComplexType, 2, device_alloc_type>;
-  using Static3Tensor  = boost::multi::static_array<SPComplexType, 3, device_alloc_type>;
-  using Static4Tensor  = boost::multi::static_array<SPComplexType, 4, device_alloc_type>;
-  using StaticRVector  = boost::multi::static_array<SPRealType, 1, device_alloc_Rtype>;
-  using StaticRMatrix  = boost::multi::static_array<SPRealType, 2, device_alloc_Rtype>;
-  using Static3RTensor = boost::multi::static_array<SPRealType, 3, device_alloc_Rtype>;
-  using Static4RTensor = boost::multi::static_array<SPRealType, 4, device_alloc_Rtype>;
+  using StaticVector   = boost::multi::dynamic_array<SPComplexType, 1, device_alloc_type>;
+  using StaticMatrix   = boost::multi::dynamic_array<SPComplexType, 2, device_alloc_type>;
+  using Static3Tensor  = boost::multi::dynamic_array<SPComplexType, 3, device_alloc_type>;
+  using Static4Tensor  = boost::multi::dynamic_array<SPComplexType, 4, device_alloc_type>;
+  using StaticRVector  = boost::multi::dynamic_array<SPRealType, 1, device_alloc_Rtype>;
+  using StaticRMatrix  = boost::multi::dynamic_array<SPRealType, 2, device_alloc_Rtype>;
+  using Static3RTensor = boost::multi::dynamic_array<SPRealType, 3, device_alloc_Rtype>;
+  using Static4RTensor = boost::multi::dynamic_array<SPRealType, 4, device_alloc_Rtype>;
 
   using shmCMatrix    = ComplexMatrix<Allocator_shared>;
   using shmSpC3Tensor = SPComplex3Tensor<SpAllocator_shared>;

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
@@ -73,14 +73,14 @@ class Real3IndexFactorization_batched_v2
   using SpC4Tensor_ref = boost::multi::array_ref<SPComplexType, 4, sp_pointer>;
   using C4Tensor_ref   = boost::multi::array_ref<ComplexType, 4, pointer>;
 
-  using StaticVector   = boost::multi::dynamic_array<SPComplexType, 1, device_alloc_type>;
-  using StaticMatrix   = boost::multi::dynamic_array<SPComplexType, 2, device_alloc_type>;
-  using Static3Tensor  = boost::multi::dynamic_array<SPComplexType, 3, device_alloc_type>;
-  using Static4Tensor  = boost::multi::dynamic_array<SPComplexType, 4, device_alloc_type>;
-  using StaticRVector  = boost::multi::dynamic_array<SPRealType, 1, device_alloc_Rtype>;
-  using StaticRMatrix  = boost::multi::dynamic_array<SPRealType, 2, device_alloc_Rtype>;
-  using Static3RTensor = boost::multi::dynamic_array<SPRealType, 3, device_alloc_Rtype>;
-  using Static4RTensor = boost::multi::dynamic_array<SPRealType, 4, device_alloc_Rtype>;
+  using DynamicVector   = boost::multi::dynamic_array<SPComplexType, 1, device_alloc_type>;
+  using DynamicMatrix   = boost::multi::dynamic_array<SPComplexType, 2, device_alloc_type>;
+  using Dynamic3Tensor  = boost::multi::dynamic_array<SPComplexType, 3, device_alloc_type>;
+  using Dynamic4Tensor  = boost::multi::dynamic_array<SPComplexType, 4, device_alloc_type>;
+  using DynamicRVector  = boost::multi::dynamic_array<SPRealType, 1, device_alloc_Rtype>;
+  using DynamicRMatrix  = boost::multi::dynamic_array<SPRealType, 2, device_alloc_Rtype>;
+  using Dynamic3RTensor = boost::multi::dynamic_array<SPRealType, 3, device_alloc_Rtype>;
+  using Dynamic4RTensor = boost::multi::dynamic_array<SPRealType, 4, device_alloc_Rtype>;
 
   using shmCMatrix    = ComplexMatrix<Allocator_shared>;
   using shmSpC3Tensor = SPComplex3Tensor<SpAllocator_shared>;
@@ -145,10 +145,10 @@ public:
 
   ~Real3IndexFactorization_batched_v2() {}
 
-  Real3IndexFactorization_batched_v2(const Real3IndexFactorization_batched_v2& other) = delete;
+  Real3IndexFactorization_batched_v2(const Real3IndexFactorization_batched_v2& other)            = delete;
   Real3IndexFactorization_batched_v2& operator=(const Real3IndexFactorization_batched_v2& other) = delete;
   Real3IndexFactorization_batched_v2(Real3IndexFactorization_batched_v2&& other)                 = default;
-  Real3IndexFactorization_batched_v2& operator=(Real3IndexFactorization_batched_v2&& other) = delete;
+  Real3IndexFactorization_batched_v2& operator=(Real3IndexFactorization_batched_v2&& other)      = delete;
 
   boost::multi::array<ComplexType, 2> getOneBodyPropagatorMatrix(TaskGroup_& TG,
                                                                  boost::multi::array<ComplexType, 1> const& vMF)
@@ -271,7 +271,7 @@ public:
     {
       APP_ABORT(" Error: Kr and/or Kl can only be calculated with addEJ=true.\n");
     }
-    StaticMatrix Kl({Knr, Knc}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicMatrix Kl({Knr, Knc}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
     fill_n(Kl.base(), Kl.num_elements(), SPComplexType(0.0));
 
     for (int n = 0; n < nwalk; n++)
@@ -302,8 +302,8 @@ public:
       if (nspin > 1)
         mem_needs = nwalk * std::max(nel[0], nel[1]) * NMO;
 #endif
-      StaticVector T1(iextensions<1u>{mem_needs},
-                      buffer_manager.get_generator().template get_allocator<SPComplexType>());
+      DynamicVector T1(iextensions<1u>{mem_needs},
+                       buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
       for (int ispin = 0, is0 = 0; ispin < nspin; ispin++)
       {
@@ -335,8 +335,8 @@ public:
         {
           int nvecs = std::min(local_nCV - nCV, max_nCV);
           SpCMatrix_ref Lna(make_device_ptr(Lnak[nd * nspin + ispin][nCV].base()), {nvecs * nel[ispin], NMO});
-          StaticMatrix Twbna({nwalk * nel[ispin], nvecs * nel[ispin]},
-                             buffer_manager.get_generator().template get_allocator<SPComplexType>());
+          DynamicMatrix Twbna({nwalk * nel[ispin], nvecs * nel[ispin]},
+                              buffer_manager.get_generator().template get_allocator<SPComplexType>());
           SpC4Tensor_ref T4Dwbna(Twbna.base(), {nwalk, nel[ispin], nvecs, nel[ispin]});
 
           ma::product(GF, ma::T(Lna), Twbna);
@@ -377,9 +377,7 @@ public:
 
   template<class... Args>
   void fast_energy(Args&&... args)
-  {
-    APP_ABORT(" Error: fast_energy not implemented in Real3IndexFactorization_batched_v2. \n");
-  }
+  { APP_ABORT(" Error: fast_energy not implemented in Real3IndexFactorization_batched_v2. \n"); }
 
   template<class MatA,
            class MatB,
@@ -416,8 +414,8 @@ public:
       Xmem = X.num_elements();
     if (not std::is_same<vType, SPComplexType>::value)
       vmem = v.num_elements();
-    StaticVector SPBuff(iextensions<1u>(Xmem + vmem),
-                        buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicVector SPBuff(iextensions<1u>(Xmem + vmem),
+                         buffer_manager.get_generator().template get_allocator<SPComplexType>());
     sp_pointer vptr(nullptr);
     const_sp_pointer Xptr(nullptr);
     // setup origin of Gsp and copy_n_cast if necessary
@@ -483,8 +481,8 @@ public:
       Gmem = G.num_elements();
     if (not std::is_same<vType, SPComplexType>::value)
       vmem = v.num_elements();
-    StaticVector SPBuff(iextensions<1u>(Gmem + vmem),
-                        buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicVector SPBuff(iextensions<1u>(Gmem + vmem),
+                         buffer_manager.get_generator().template get_allocator<SPComplexType>());
     sp_pointer vptr(nullptr);
     const_sp_pointer Gptr(nullptr);
     // setup origin of Gsp and copy_n_cast if necessary
@@ -530,7 +528,7 @@ public:
         c_[1] = c;
         if (std::abs(c) < 1e-8)
           c_[1] = 1.0;
-        assert((nel[0]+nel[1])*NMO == get<0>(G.sizes()));
+        assert((nel[0] + nel[1]) * NMO == get<0>(G.sizes()));
         for (int ispin = 0, is0 = 0; ispin < 2; ispin++)
         {
           assert(get<0>(Lnak[ispin].sizes()) == get<0>(v.sizes()));
@@ -544,7 +542,8 @@ public:
         assert(get<1>(G.sizes()) == get<1>(v.sizes()));
         assert(get<1>(Lnak[0].sizes()) * get<2>(Lnak[0].sizes()) == get<0>(G.sizes()));
         assert(get<0>(Lnak[0].sizes()) == get<0>(v.sizes()));
-        SpCMatrix_ref Ln(make_device_ptr(Lnak[0].base()), {local_nCV, get<1>(Lnak[0].sizes()) * get<2>(Lnak[0].sizes())});
+        SpCMatrix_ref Ln(make_device_ptr(Lnak[0].base()),
+                         {local_nCV, get<1>(Lnak[0].sizes()) * get<2>(Lnak[0].sizes())});
         ma::product(SPComplexType(a), Ln, Gsp, SPComplexType(c), vsp);
       }
     }
@@ -593,10 +592,10 @@ public:
     assert(nwmax >= 1 && nwmax <= nwmax);
 
 #if defined(MIXED_PRECISION)
-    StaticMatrix Fp_({nwalk, nspin * NMO * NMO},
-                     buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    StaticMatrix Fm_({nwalk, nspin * NMO * NMO},
-                     buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicMatrix Fp_({nwalk, nspin * NMO * NMO},
+                      buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicMatrix Fm_({nwalk, nspin * NMO * NMO},
+                      buffer_manager.get_generator().template get_allocator<SPComplexType>());
 #else
     SpCMatrix_ref Fp_(make_device_ptr(Fp.base()), {nwalk, nspin * NMO * NMO});
     SpCMatrix_ref Fm_(make_device_ptr(Fm.base()), {nwalk, nspin * NMO * NMO});
@@ -619,7 +618,7 @@ public:
     if (nspin > 1)
       gsz = nspin * nwmax * NMO * NMO;
 #endif
-    StaticVector GBuff(iextensions<1u>{gsz}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicVector GBuff(iextensions<1u>{gsz}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
     int nw0(0);
     while (nw0 < nwalk)
@@ -648,10 +647,10 @@ public:
       }
 #endif
       SpCTensor_ref GF(ptr, {nspin, nw * NMO, NMO}); // now contains G in the correct structure [spin][w][i][j]
-      StaticMatrix Gt({NMO * NMO, nw}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+      DynamicMatrix Gt({NMO * NMO, nw}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
       fill_n(Gt.base(), Gt.num_elements(), SPComplexType(0.0));
 
-      StaticMatrix Rnw({local_nCV, nw}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+      DynamicMatrix Rnw({local_nCV, nw}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
       // calculate Rwn
       for (int ispin = 0; ispin < nspin; ispin++)
       {
@@ -660,7 +659,7 @@ public:
       }
       // R[n,w] = \sum_ik L[n,ik] G[ik,w]
       ma::product(SPValueType(1.0), ma::T(Likn), Gt, SPValueType(0.0), Rnw);
-      StaticMatrix Rwn({nw, local_nCV}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+      DynamicMatrix Rwn({nw, local_nCV}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
       ma::transpose(Rnw, Rwn);
 
       // add coulomb contribution of <pr||qs>Grs term to Fp, reuse Gt for temporary storage
@@ -676,11 +675,11 @@ public:
       // L[i,kn]
       SpRMatrix_ref Ln(make_device_ptr(Likn.base()), {NMO, NMO * local_nCV});
       // T[w,p,t,n] = \sum_{l} L[l,t,n] P[w,l,p]
-      StaticMatrix Twptn({nw * NMO, NMO * local_nCV},
-                         buffer_manager.get_generator().template get_allocator<SPComplexType>());
+      DynamicMatrix Twptn({nw * NMO, NMO * local_nCV},
+                          buffer_manager.get_generator().template get_allocator<SPComplexType>());
       // transpose for faster contraction
-      StaticMatrix Taux({nw * NMO, NMO * local_nCV},
-                        buffer_manager.get_generator().template get_allocator<SPComplexType>());
+      DynamicMatrix Taux({nw * NMO, NMO * local_nCV},
+                         buffer_manager.get_generator().template get_allocator<SPComplexType>());
       SpCTensor_ref Taux3D(Taux.base(), {nw, NMO, NMO * local_nCV});
       SpCTensor_ref Twptn3D(Twptn.base(), {nw, NMO, NMO * local_nCV});
       SpCTensor_ref Twptn3D_(Twptn.base(), {nw, NMO * NMO, local_nCV});
@@ -852,7 +851,7 @@ public:
   int global_origin_cholesky_vector() const { return global_origin; }
 
   // transpose=true means G[nwalk][ik], false means G[ik][nwalk]
-  bool transposed_G_for_vbias() const { return false; } 
+  bool transposed_G_for_vbias() const { return false; }
   bool transposed_G_for_E() const { return true; }
   // transpose=true means vHS[nwalk][ik], false means vHS[ik][nwalk]
   bool transposed_vHS() const { return false; }

--- a/src/AFQMC/HamiltonianOperations/THCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOps.hpp
@@ -64,7 +64,7 @@ class THCOps
   using const_sp_pointer = typename device_allocator<SPComplexType>::const_pointer;
 
   template<class U, int N>
-  using Array = boost::multi::static_array<U, N, device_alloc_type<U>>;
+  using Array = boost::multi::dynamic_array<U, N, device_alloc_type<U>>;
   template<class U, int N>
   using Array_ref = boost::multi::array_ref<U, N, typename device_alloc_type<U>::pointer>;
   template<class U, int N>
@@ -72,7 +72,7 @@ class THCOps
   // arrays on shared work space
   // remember that this is device memory when built with accelerator support
   template<class U, int N>
-  using ShmArray = boost::multi::static_array<U, N, shm_alloc_type<U>>;
+  using ShmArray = boost::multi::dynamic_array<U, N, shm_alloc_type<U>>;
 
   // arrays on node allocator, for fixed arrays, e.g. Luv, Piu, ...
   // remember that this is device memory when built with accelerator support
@@ -543,7 +543,7 @@ public:
       boost::multi::array_ref<ComplexType,2> Tub(to_address(SM_TMats.base())+cnt,{nu,nel_});
       cnt+=Tub.num_elements();
       assert(cnt <= memory_needs);
-      boost::multi::static_array<ComplexType,3,dev_buffer_type> eloc({2,nwalk,3}
+      boost::multi::dynamic_array<ComplexType,3,dev_buffer_type> eloc({2,nwalk,3}
                         device_buffer_manager.get_generator().template get_allocator<ComplexType>());
       std::fill_n(eloc.base(),eloc.num_elements(),ComplexType(0.0));
 

--- a/src/AFQMC/HamiltonianOperations/THCOpsIO.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOpsIO.hpp
@@ -244,7 +244,7 @@ inline THCOps loadTHCOps(hdf_archive& dump,
     }
     else
     {
-      boost::multi::array<SPComplexType, 2> A({static_cast<boost::multi::size_t>(PsiT[0].size(1)), static_cast<boost::multi::size_t>(PsiT[0].size(0))});
+      boost::multi::array<SPComplexType, 2> A({static_cast<boost::multi::ssize_t>(PsiT[0].size(1)), static_cast<boost::multi::ssize_t>(PsiT[0].size(0))});
       for (int i = 0; i < ndet; i++)
       {
         ma::Matrix2MA('T', PsiT[i], A);

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
@@ -196,7 +196,7 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
   std::vector<shmSp3Tensor> Lank;
   Lank.reserve(PsiT.size());
   for (int nd = 0; nd < PsiT.size(); nd++)
-    Lank.emplace_back(shmSp3Tensor({static_cast<boost::multi::size_t>(PsiT[nd].size(0)), local_ncv, NMO}, shared_allocator<SPComplexType>{distNode}));
+    Lank.emplace_back(shmSp3Tensor({static_cast<boost::multi::ssize_t>(PsiT[nd].size(0)), local_ncv, NMO}, shared_allocator<SPComplexType>{distNode}));
   int nrow = NEL;
   if (ndet > 1)
     nrow = 0; // not used if ndet>1

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian_v2.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian_v2.cpp
@@ -191,7 +191,7 @@ HamiltonianOperations RealDenseHamiltonian_v2::getHamiltonianOperations(bool pur
   std::vector<shmSp3Tensor> Lnak;
   Lnak.reserve(PsiT.size());
   for (int nd = 0; nd < PsiT.size(); nd++)
-    Lnak.emplace_back(shmSp3Tensor({local_ncv, static_cast<boost::multi::size_t>(PsiT[nd].size(0)), NMO}, shared_allocator<SPComplexType>{distNode}));
+    Lnak.emplace_back(shmSp3Tensor({local_ncv, static_cast<boost::multi::ssize_t>(PsiT[nd].size(0)), NMO}, shared_allocator<SPComplexType>{distNode}));
   TG.Node().barrier();
 
   // for simplicity

--- a/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
@@ -216,8 +216,8 @@ HamiltonianOperations THCHamiltonian::getHamiltonianOperations(bool pureSD,
     size_t c0, cN, nc;
     std::tie(c0, cN) = FairDivideBoundary(size_t(TG.Global().rank()), gnmu, size_t(TG.Global().size()));
     nc               = cN - c0;
-    boost::multi::array<SPValueType, 2> Tuv({static_cast<boost::multi::size_t>(gnmu), static_cast<boost::multi::size_t>(nc)});
-    boost::multi::array<SPValueType, 2> Muv({static_cast<boost::multi::size_t>(gnmu), static_cast<boost::multi::size_t>(nc)});
+    boost::multi::array<SPValueType, 2> Tuv({static_cast<boost::multi::ssize_t>(gnmu), static_cast<boost::multi::ssize_t>(nc)});
+    boost::multi::array<SPValueType, 2> Muv({static_cast<boost::multi::ssize_t>(gnmu), static_cast<boost::multi::ssize_t>(nc)});
 
     // Muv = Luv * H(Luv)
     // This can benefit from 2D split of work
@@ -235,7 +235,7 @@ HamiltonianOperations THCHamiltonian::getHamiltonianOperations(bool pureSD,
       *(itT) = ma::conj(*itT) * (*itM);
 
     using std::get;
-    boost::multi::array<SPValueType, 2> T_({static_cast<boost::multi::size_t>(get<1>(Tuv.sizes())), NMO});
+    boost::multi::array<SPValueType, 2> T_({static_cast<boost::multi::ssize_t>(get<1>(Tuv.sizes())), NMO});
     ma::product(T(Tuv), H(Piu__), T_);
     ma::product(SPValueType(-0.5), T(T_), T(Piu__({0, long(NMO)}, {long(c0), long(cN)})), SPValueType(0.0), v0_);
 
@@ -269,8 +269,8 @@ HamiltonianOperations THCHamiltonian::getHamiltonianOperations(bool pureSD,
     size_t c0, cN, nc;
     std::tie(c0, cN) = FairDivideBoundary(size_t(TG.Global().rank()), gnmu, size_t(TG.Global().size()));
     nc               = cN - c0;
-    boost::multi::array<SPValueType, 2> Tuv({static_cast<boost::multi::size_t>(gnmu), static_cast<boost::multi::size_t>(nc)});
-    boost::multi::array<SPValueType, 2> Muv({static_cast<boost::multi::size_t>(gnmu), static_cast<boost::multi::size_t>(nc)});
+    boost::multi::array<SPValueType, 2> Tuv({static_cast<boost::multi::ssize_t>(gnmu), static_cast<boost::multi::ssize_t>(nc)});
+    boost::multi::array<SPValueType, 2> Muv({static_cast<boost::multi::ssize_t>(gnmu), static_cast<boost::multi::ssize_t>(nc)});
 
     // Muv = Luv * H(Luv)
     // This can benefit from 2D split of work
@@ -288,7 +288,7 @@ HamiltonianOperations THCHamiltonian::getHamiltonianOperations(bool pureSD,
       *(itT) = ma::conj(*itT) * (*itM);
 
     using std::get;
-    boost::multi::array<SPValueType, 2> T_({static_cast<boost::multi::size_t>(get<1>(Tuv.sizes())), NMO});
+    boost::multi::array<SPValueType, 2> T_({static_cast<boost::multi::ssize_t>(get<1>(Tuv.sizes())), NMO});
     ma::product(T(Tuv), H(Piu), T_);
     ma::product(SPValueType(-0.5), T(T_), T(Piu({0, long(NMO)}, {long(c0), long(cN)})), SPValueType(0.0), v0_);
 
@@ -341,7 +341,7 @@ HamiltonianOperations THCHamiltonian::getHamiltonianOperations(bool pureSD,
     }
     else
     {
-      boost::multi::array<SPComplexType, 2> A({static_cast<boost::multi::size_t>(PsiT[0].size(1)), static_cast<boost::multi::size_t>(PsiT[0].size(0))});
+      boost::multi::array<SPComplexType, 2> A({static_cast<boost::multi::ssize_t>(PsiT[0].size(1)), static_cast<boost::multi::ssize_t>(PsiT[0].size(0))});
       for (int i = 0; i < ndet; i++)
       {
         ma::Matrix2MA('T', PsiT[i], A);

--- a/src/AFQMC/Memory/multi_memory/fallback.hpp
+++ b/src/AFQMC/Memory/multi_memory/fallback.hpp
@@ -65,7 +65,7 @@ class fallback : public MemoryResource1 {
 	} {}
 
 	typename fallback::void_pointer
-	allocate(size_type required_bytes, typename fallback::size_type align = alignof(std::max_align_t)) try {
+	allocate(std::size_t required_bytes, typename fallback::size_type align = alignof(std::max_align_t)) try {
 		return MemoryResource1::allocate(required_bytes, align);
 	} catch(...) {
 		++fallbacks_;

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.cpp
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.cpp
@@ -196,8 +196,8 @@ void AFQMCBasePropagator::reset_nextra(int nextra)
 
 /*
 void AFQMCBasePropagator::assemble_X(size_t nsteps, size_t nwalk, RealType sqrtdt, 
-                          StaticMatrix& X, StaticMatrix & vbias, StaticMatrix& MF, 
-                          StaticMatrix& HWs, bool addRAND) 
+                          DynamicMatrix& X, DynamicMatrix & vbias, DynamicMatrix& MF, 
+                          DynamicMatrix& HWs, bool addRAND) 
 {
   // remember to call vbi = apply_bound_vbias(*vb);
   // X[m,ni,iw] = rand[m,ni,iw] + im * ( vbias[m,iw] - vMF[m]  )

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -54,12 +54,12 @@ protected:
   using stack_alloc_type   = LocalTGBufferManager::template allocator_t<ComplexType>;
   using stack_alloc_SPtype = LocalTGBufferManager::template allocator_t<SPComplexType>;
 
-  using StaticVector    = boost::multi::static_array<ComplexType, 1, stack_alloc_type>;
-  using StaticMatrix    = boost::multi::static_array<ComplexType, 2, stack_alloc_type>;
-  using Static3Tensor   = boost::multi::static_array<ComplexType, 3, stack_alloc_type>;
-  using StaticSPVector  = boost::multi::static_array<SPComplexType, 1, stack_alloc_SPtype>;
-  using StaticSPMatrix  = boost::multi::static_array<SPComplexType, 2, stack_alloc_SPtype>;
-  using StaticSP3Tensor = boost::multi::static_array<SPComplexType, 3, stack_alloc_SPtype>;
+  using StaticVector    = boost::multi::dynamic_array<ComplexType, 1, stack_alloc_type>;
+  using StaticMatrix    = boost::multi::dynamic_array<ComplexType, 2, stack_alloc_type>;
+  using Static3Tensor   = boost::multi::dynamic_array<ComplexType, 3, stack_alloc_type>;
+  using StaticSPVector  = boost::multi::dynamic_array<SPComplexType, 1, stack_alloc_SPtype>;
+  using StaticSPMatrix  = boost::multi::dynamic_array<SPComplexType, 2, stack_alloc_SPtype>;
+  using StaticSP3Tensor = boost::multi::dynamic_array<SPComplexType, 3, stack_alloc_SPtype>;
 
   using CVector          = boost::multi::array<ComplexType, 1, allocator>;
   using CMatrix          = boost::multi::array<ComplexType, 2, allocator>;

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -54,12 +54,12 @@ protected:
   using stack_alloc_type   = LocalTGBufferManager::template allocator_t<ComplexType>;
   using stack_alloc_SPtype = LocalTGBufferManager::template allocator_t<SPComplexType>;
 
-  using StaticVector    = boost::multi::dynamic_array<ComplexType, 1, stack_alloc_type>;
-  using StaticMatrix    = boost::multi::dynamic_array<ComplexType, 2, stack_alloc_type>;
-  using Static3Tensor   = boost::multi::dynamic_array<ComplexType, 3, stack_alloc_type>;
-  using StaticSPVector  = boost::multi::dynamic_array<SPComplexType, 1, stack_alloc_SPtype>;
-  using StaticSPMatrix  = boost::multi::dynamic_array<SPComplexType, 2, stack_alloc_SPtype>;
-  using StaticSP3Tensor = boost::multi::dynamic_array<SPComplexType, 3, stack_alloc_SPtype>;
+  using DynamicVector    = boost::multi::dynamic_array<ComplexType, 1, stack_alloc_type>;
+  using DynamicMatrix    = boost::multi::dynamic_array<ComplexType, 2, stack_alloc_type>;
+  using Dynamic3Tensor   = boost::multi::dynamic_array<ComplexType, 3, stack_alloc_type>;
+  using DynamicSPVector  = boost::multi::dynamic_array<SPComplexType, 1, stack_alloc_SPtype>;
+  using DynamicSPMatrix  = boost::multi::dynamic_array<SPComplexType, 2, stack_alloc_SPtype>;
+  using DynamicSP3Tensor = boost::multi::dynamic_array<SPComplexType, 3, stack_alloc_SPtype>;
 
   using CVector          = boost::multi::array<ComplexType, 1, allocator>;
   using CMatrix          = boost::multi::array<ComplexType, 2, allocator>;
@@ -120,10 +120,10 @@ public:
 
   ~AFQMCBasePropagator() {}
 
-  AFQMCBasePropagator(AFQMCBasePropagator const& other) = delete;
+  AFQMCBasePropagator(AFQMCBasePropagator const& other)            = delete;
   AFQMCBasePropagator& operator=(AFQMCBasePropagator const& other) = delete;
   AFQMCBasePropagator(AFQMCBasePropagator&& other)                 = default;
-  AFQMCBasePropagator& operator=(AFQMCBasePropagator&& other) = delete;
+  AFQMCBasePropagator& operator=(AFQMCBasePropagator&& other)      = delete;
 
   template<class WlkSet>
   void Propagate(int steps, WlkSet& wset, RealType E1, RealType dt, int fix_bias = 1)

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.icc
@@ -82,11 +82,11 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     generateP1(dt, walker_type);
   AFQMCTimers[setup_timer].get().stop();
 
-  StaticMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
 
   { // using scope to control lifetime of StaticArrays, avoiding unnecessary buffer space
 
-    StaticSPMatrix G(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix G(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
     // 1. Calculate Green function for all walkers
     AFQMCTimers[G_for_vbias_timer].get().start();
@@ -94,7 +94,7 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     {
       int Gak0, GakN;
       std::tie(Gak0, GakN) = FairDivideBoundary(TG.getLocalTGRank(), int(G.num_elements()), TG.getNCoresPerTG());
-      StaticMatrix Gc(G_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
+      DynamicMatrix Gc(G_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
       wfn.MixedDensityMatrix_for_vbias(wset, Gc);
       copy_n_cast(make_device_ptr(Gc.base()) + Gak0, GakN - Gak0, make_device_ptr(G.base()) + Gak0);
     }
@@ -105,8 +105,8 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     AFQMCTimers[G_for_vbias_timer].get().stop();
     //std::cout<<" G: " <<ma::dot(G(get<0>(G.extents()),0),G(get<0>(G.extents()),0)) <<std::endl;
 
-    StaticSPMatrix vbias({long(localnCV), long(nwalk)},
-                         buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix vbias({long(localnCV), long(nwalk)},
+                          buffer_manager.get_generator().template get_allocator<SPComplexType>());
     // 2. Calculate vbias for initial configuration
     AFQMCTimers[vbias_timer].get().start();
     if (free_projection)
@@ -120,8 +120,8 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     AFQMCTimers[vbias_timer].get().stop();
     //std::cout<<" vbias: " <<ma::sum(vbias) <<std::endl;
 
-    StaticSPMatrix X({long(localnCV), long(nwalk * nsteps)},
-                     buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix X({long(localnCV), long(nwalk * nsteps)},
+                      buffer_manager.get_generator().template get_allocator<SPComplexType>());
     // 3. Assemble X(nCV,nsteps,nwalk)
     AFQMCTimers[assemble_X_timer].get().start();
     assemble_X(nsteps, nwalk, sqrtdt, X, vbias, MFfactor, hybrid_weight);
@@ -275,9 +275,9 @@ void AFQMCBasePropagator::BackPropagate(int nbpsteps, int nStabalize, WlkSet& ws
     vhs3d_ext = iextensions<3u>{nwalk, NMO, NMO};
   }
 
-  StaticMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
-  StaticSPMatrix X({long(globalnCV), long(nwalk)},
-                   buffer_manager.get_generator().template get_allocator<SPComplexType>());
+  DynamicMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicSPMatrix X({long(globalnCV), long(nwalk)},
+                    buffer_manager.get_generator().template get_allocator<SPComplexType>());
   C3Tensor_ref vHS3D(make_device_ptr(vHS.base()), vhs3d_ext);
 
   using std::get;
@@ -736,8 +736,7 @@ void AFQMCBasePropagator::assemble_X(size_t nsteps,
 // TODO: Move this
 #if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
   kernels::construct_X(nCV, nsteps, nwalk, free_projection, sqrtdt, vbias_bound, to_address(vMF.base()),
-                       to_address(vbias.base()), to_address(HWs.base()), to_address(MF.base()),
-                       to_address(X.base()));
+                       to_address(vbias.base()), to_address(HWs.base()), to_address(MF.base()), to_address(X.base()));
 #else
   boost::multi::array_ref<XType, 3> X3D(to_address(X.base()), {long(X.size()), long(nsteps), long(nwalk)});
   int m0, mN;
@@ -745,18 +744,18 @@ void AFQMCBasePropagator::assemble_X(size_t nsteps,
   TG.local_barrier();
   for (int m = m0; m < mN; ++m)
   {
-    auto X_m = X3D[m];
-    auto vb_ = to_address(vbias[m].base());
+    auto X_m   = X3D[m];
+    auto vb_   = to_address(vbias[m].base());
     auto vmf_t = sqrtdt * apply_bound_vbias(vMF[m], 1.0);
-    auto vmf_ = sqrtdt * vMF[m];
+    auto vmf_  = sqrtdt * vMF[m];
     // apply bounds to vbias
     for (int iw = 0; iw < nwalk; iw++)
       vb_[iw] = apply_bound_vbias(vb_[iw], sqrtdt);
     for (int ni = 0; ni < nsteps; ni++)
     {
-      auto X_ = X3D[m][ni].base();
+      auto X_   = X3D[m][ni].base();
       auto hws_ = to_address(HWs[ni].base());
-      auto mf_ = to_address(MF[ni].base());
+      auto mf_  = to_address(MF[ni].base());
       for (int iw = 0; iw < nwalk; iw++)
       {
         // No force bias term when doing free projection.

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagator.icc
@@ -84,10 +84,10 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
   TG.local_barrier();
   AFQMCTimers[setup_timer].get().stop();
 
-  StaticMatrix vHS_buff(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicMatrix vHS_buff(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
   SPCMatrix_ref vHS(sp_pointer(make_device_ptr(vHS_buff.base())), vhs_ext);
   {
-    StaticSPMatrix G(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix G(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
     // 1. Calculate Green function for all (local) walkers
     AFQMCTimers[G_for_vbias_timer].get().start();
@@ -95,7 +95,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
     { // control scope of Gc
       int Gak0, GakN;
       std::tie(Gak0, GakN) = FairDivideBoundary(TG.getLocalTGRank(), int(G.num_elements()), TG.getNCoresPerTG());
-      StaticMatrix Gc(G_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
+      DynamicMatrix Gc(G_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
       wfn.MixedDensityMatrix_for_vbias(wset, Gc);
       TG.local_barrier();
       copy_n_cast(make_device_ptr(Gc.base()) + Gak0, GakN - Gak0, make_device_ptr(G.base()) + Gak0);
@@ -106,14 +106,14 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
 #endif
     AFQMCTimers[G_for_vbias_timer].get().stop();
 
-    StaticSPMatrix Gwork(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    StaticSPMatrix X({long(nCV), long(nwalk * nsteps)},
-                     buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    StaticSPMatrix vbias({long(nCV), long(nwalk)},
-                         buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    StaticSPMatrix RNG({long(nCV), long(nwalk * nsteps)},
-                       buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    StaticSPMatrix vHSwork(vhs_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix Gwork(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix X({long(nCV), long(nwalk * nsteps)},
+                      buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix vbias({long(nCV), long(nwalk)},
+                          buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix RNG({long(nCV), long(nwalk * nsteps)},
+                        buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix vHSwork(vhs_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
     // partition G and v for communications: all cores communicate a piece of the matrix
     long vak0, vakN;
@@ -180,8 +180,8 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
       AFQMCTimers[vHS_timer].get().stop();
 
       AFQMCTimers[vHS_comm_overhead_timer].get().start();
-      core_comm.reduce_n(to_address(vHSwork.base()) + vak0, vakN - vak0, to_address(vHS.base()) + vak0,
-                         std::plus<>(), k);
+      core_comm.reduce_n(to_address(vHSwork.base()) + vak0, vakN - vak0, to_address(vHS.base()) + vak0, std::plus<>(),
+                         k);
       TG.local_barrier();
       AFQMCTimers[vHS_comm_overhead_timer].get().stop();
     }

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
@@ -88,16 +88,16 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     generateP1(dt, walker_type);
   TG.local_barrier();
 
-  StaticMatrix vrecv_buff(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicMatrix vrecv_buff(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
   SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.base())), vhs_ext);
 
   { // using scope to control lifetime of StaticArrays, avoiding unnecessary buffer space
 
-    Static3Tensor globalMFfactor({nnodes, nsteps, nwalk},
-                                 buffer_manager.get_generator().template get_allocator<ComplexType>());
-    Static3Tensor globalhybrid_weight({nnodes, nsteps, nwalk},
-                                      buffer_manager.get_generator().template get_allocator<ComplexType>());
-    StaticSPMatrix Gwork(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    Dynamic3Tensor globalMFfactor({nnodes, nsteps, nwalk},
+                                  buffer_manager.get_generator().template get_allocator<ComplexType>());
+    Dynamic3Tensor globalhybrid_weight({nnodes, nsteps, nwalk},
+                                       buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicSPMatrix Gwork(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
     // 1. Calculate Green function for all (local) walkers
     AFQMCTimers[G_for_vbias_timer].get().start();
@@ -105,7 +105,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     { // control scope of Gc
       int Gak0, GakN;
       std::tie(Gak0, GakN) = FairDivideBoundary(TG.getLocalTGRank(), int(Gwork.num_elements()), TG.getNCoresPerTG());
-      StaticMatrix Gc(G_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
+      DynamicMatrix Gc(G_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
       wfn.MixedDensityMatrix_for_vbias(wset, Gc);
       copy_n_cast(make_device_ptr(Gc.base()) + Gak0, GakN - Gak0, make_device_ptr(Gwork.base()) + Gak0);
     }
@@ -116,18 +116,18 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     AFQMCTimers[G_for_vbias_timer].get().stop();
 
 
-    StaticSPMatrix Grecv(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    StaticSPMatrix vbias({long(localnCV), long(nwalk)},
-                         buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    StaticSPMatrix X({long(localnCV), long(nwalk * nsteps)},
-                     buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix Grecv(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix vbias({long(localnCV), long(nwalk)},
+                          buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix X({long(localnCV), long(nwalk * nsteps)},
+                      buffer_manager.get_generator().template get_allocator<SPComplexType>());
 #if defined(MIXED_PRECISION)
     // in MIXED_PRECISION, use second half of vrecv_buff for vsend
     SPCMatrix_ref vsend(sp_pointer(make_device_ptr(vrecv_buff.base())) + vrecv_buff.num_elements(), vhs_ext);
 #else
-    StaticSPMatrix vsend(vhs_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix vsend(vhs_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 #endif
-    StaticSPMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
     // partition G and v for communications: all cores communicate a piece of the matrix
     int vak0, vakN;
@@ -154,7 +154,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       size_t m_(globalnCV * nwalk * nsteps * 2);
       if (bpX.num_elements() < m_)
       {
-        bpX     = mpi3SPCVector(iextensions<1u>(m_), shared_allocator<SPComplexType>{TG.TG_local()});
+        bpX = mpi3SPCVector(iextensions<1u>(m_), shared_allocator<SPComplexType>{TG.TG_local()});
         if (TG.TG_local().root())
           fill_n(bpX.base(), bpX.num_elements(), SPComplexType(0.0));
       }
@@ -170,10 +170,10 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
 
     if (bp_step >= 0 && bp_step < bp_max)
     {
-      MPI_Send_init(Xsend.base() + Xg0, (XgN - Xg0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(), 3456, TG.TG().get(),
-                    &req_X2send);
-      MPI_Recv_init(Xrecv.base() + Xg0, (XgN - Xg0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(), 3456, TG.TG().get(),
-                    &req_X2recv);
+      MPI_Send_init(Xsend.base() + Xg0, (XgN - Xg0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(), 3456,
+                    TG.TG().get(), &req_X2send);
+      MPI_Recv_init(Xrecv.base() + Xg0, (XgN - Xg0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(), 3456,
+                    TG.TG().get(), &req_X2recv);
     }
 
     TG.local_barrier();
@@ -458,17 +458,17 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     generateP1(dt, walker_type);
   TG.local_barrier();
 
-  StaticMatrix vrecv_buff(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicMatrix vrecv_buff(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
   C3Tensor_ref vHS3D(make_device_ptr(vrecv_buff.base()), vhs3d_ext);
   SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.base())), vhs_ext);
 
   // scope controlling lifetime of temporary arrays
   {
-    Static3Tensor globalMFfactor({nnodes, nsteps, nwalk},
-                                 buffer_manager.get_generator().template get_allocator<ComplexType>());
-    Static3Tensor globalhybrid_weight({nnodes, nsteps, nwalk},
-                                      buffer_manager.get_generator().template get_allocator<ComplexType>());
-    StaticSPMatrix Gstore(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    Dynamic3Tensor globalMFfactor({nnodes, nsteps, nwalk},
+                                  buffer_manager.get_generator().template get_allocator<ComplexType>());
+    Dynamic3Tensor globalhybrid_weight({nnodes, nsteps, nwalk},
+                                       buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicSPMatrix Gstore(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
     int Gak0, GakN;
     std::tie(Gak0, GakN) = FairDivideBoundary(TG.getLocalTGRank(), int(Gstore.num_elements()), TG.getNCoresPerTG());
@@ -477,7 +477,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     AFQMCTimers[G_for_vbias_timer].get().start();
 #if defined(MIXED_PRECISION)
     {
-      StaticMatrix Gstore_(G_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
+      DynamicMatrix Gstore_(G_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
       wfn.MixedDensityMatrix_for_vbias(wset, Gstore_);
       copy_n_cast(make_device_ptr(Gstore_.base()) + Gak0, GakN - Gak0, make_device_ptr(Gstore.base()) + Gak0);
     }
@@ -487,16 +487,16 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     TG.local_barrier();
     AFQMCTimers[G_for_vbias_timer].get().stop();
 
-    StaticSPMatrix Gwork(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    StaticSPMatrix vbias({long(localnCV), long(nwalk)},
-                         buffer_manager.get_generator().template get_allocator<SPComplexType>());
-    StaticSPMatrix X({long(localnCV), long(nwalk * nsteps)},
-                     buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix Gwork(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix vbias({long(localnCV), long(nwalk)},
+                          buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicSPMatrix X({long(localnCV), long(nwalk * nsteps)},
+                      buffer_manager.get_generator().template get_allocator<SPComplexType>());
 // reusing second half of vrecv buffer reinterpreted as a SPComplex Array
 #if defined(MIXED_PRECISION)
     SPCMatrix_ref vHS(sp_pointer(make_device_ptr(vrecv_buff.base())) + vrecv_buff.num_elements(), vhs_ext);
 #else
-    StaticMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
 #endif
 
     // partition G and v for communications: all cores communicate a piece of the matrix
@@ -512,7 +512,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
       size_t m_(globalnCV * nwalk * nsteps);
       if (bpX.num_elements() < m_)
       {
-        bpX     = mpi3SPCVector(iextensions<1u>(m_), shared_allocator<SPComplexType>{TG.TG_local()});
+        bpX = mpi3SPCVector(iextensions<1u>(m_), shared_allocator<SPComplexType>{TG.TG_local()});
         if (TG.TG_local().root())
           fill_n(bpX.base(), bpX.num_elements(), SPComplexType(0.0));
       }
@@ -621,8 +621,8 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
 #error "BUILD_AFQMC_WITH_NCCL only with ENABLE_CUDA"
 #endif
 #else
-      TG.TG_Cores().reduce_n(to_address(vHS.base()) + vak0, vakN - vak0, to_address(vrecv.base()) + vak0,
-                             std::plus<>(), k);
+      TG.TG_Cores().reduce_n(to_address(vHS.base()) + vak0, vakN - vak0, to_address(vrecv.base()) + vak0, std::plus<>(),
+                             k);
 #endif
 
       TG.local_barrier();
@@ -662,9 +662,8 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     {
 #ifdef BUILD_AFQMC_WITH_NCCL
 #ifdef ENABLE_CUDA
-      NCCLCHECK(ncclAllReduce((const void*)to_address(globalMFfactor.base()),
-                              (void*)to_address(globalMFfactor.base()), 2 * globalMFfactor.num_elements(), ncclDouble,
-                              ncclSum, TG.ncclTG(), TG.ncclStream()));
+      NCCLCHECK(ncclAllReduce((const void*)to_address(globalMFfactor.base()), (void*)to_address(globalMFfactor.base()),
+                              2 * globalMFfactor.num_elements(), ncclDouble, ncclSum, TG.ncclTG(), TG.ncclStream()));
       NCCLCHECK(ncclAllReduce((const void*)to_address(globalhybrid_weight.base()),
                               (void*)to_address(globalhybrid_weight.base()), 2 * globalhybrid_weight.num_elements(),
                               ncclDouble, ncclSum, TG.ncclTG(), TG.ncclStream()));
@@ -802,20 +801,20 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
   //  vHS:             [ NMO*NMO * nwalk ] (3 copies)
   // memory_needs: nwalk * ( localnCV + NMO*NMO )
 
-  StaticSPMatrix X({long(localnCV), long(nwalk)},
-                   buffer_manager.get_generator().template get_allocator<SPComplexType>());
-  StaticSPMatrix Xsend({long(globalnCV), long(nwalk)},
-                       buffer_manager.get_generator().template get_allocator<SPComplexType>());
-  StaticSPMatrix Xrecv({long(globalnCV), long(nwalk)},
-                       buffer_manager.get_generator().template get_allocator<SPComplexType>());
-  StaticMatrix vrecv_buff(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicSPMatrix X({long(localnCV), long(nwalk)},
+                    buffer_manager.get_generator().template get_allocator<SPComplexType>());
+  DynamicSPMatrix Xsend({long(globalnCV), long(nwalk)},
+                        buffer_manager.get_generator().template get_allocator<SPComplexType>());
+  DynamicSPMatrix Xrecv({long(globalnCV), long(nwalk)},
+                        buffer_manager.get_generator().template get_allocator<SPComplexType>());
+  DynamicMatrix vrecv_buff(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
   SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.base())), vhs_ext);
 #if defined(MIXED_PRECISION)
   SPCMatrix_ref vsend(sp_pointer(make_device_ptr(vrecv_buff.base())) + vrecv_buff.num_elements(), vhs_ext);
 #else
-  StaticSPMatrix vsend(vhs_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+  DynamicSPMatrix vsend(vhs_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 #endif
-  StaticSPMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+  DynamicSPMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
   // partition G and v for communications: all cores communicate a piece of the matrix
   int vak0, vakN;
@@ -826,10 +825,10 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
                 TG.TG().get(), &req_Xsend);
   MPI_Recv_init(to_address(Xrecv.base()) + X0, (XN - X0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(), 2345,
                 TG.TG().get(), &req_Xrecv);
-  MPI_Send_init(to_address(vsend.base()) + vak0, (vakN - vak0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(),
-                6789, TG.TG().get(), &req_bpvsend);
-  MPI_Recv_init(to_address(vrecv.base()) + vak0, (vakN - vak0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(),
-                6789, TG.TG().get(), &req_bpvrecv);
+  MPI_Send_init(to_address(vsend.base()) + vak0, (vakN - vak0) * sizeof(SPComplexType), MPI_CHAR, TG.prev_core(), 6789,
+                TG.TG().get(), &req_bpvsend);
+  MPI_Recv_init(to_address(vrecv.base()) + vak0, (vakN - vak0) * sizeof(SPComplexType), MPI_CHAR, TG.next_core(), 6789,
+                TG.TG().get(), &req_bpvrecv);
   TG.local_barrier();
 
   auto&& Fields(*wset.getFields());
@@ -905,8 +904,7 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
         MPI_Wait(&req_Xsend, &st); // need to wait for Gsend in order to overwrite Gwork
         copy_n(make_device_ptr(Xrecv.base()) + X0, XN - X0, make_device_ptr(Xsend.base()) + X0);
         TG.local_barrier();
-        copy_n(make_device_ptr(Xsend[global_origin + cv0].base()), nwalk * (cvN - cv0),
-               make_device_ptr(X[cv0].base()));
+        copy_n(make_device_ptr(Xsend[global_origin + cv0].base()), nwalk * (cvN - cv0), make_device_ptr(X[cv0].base()));
         TG.local_barrier();
       }
 

--- a/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_base.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_base.hpp
@@ -39,10 +39,10 @@ public:
   using buffer_type_R = typename BufferManager::template allocator_t<R>;
   using buffer_type_T = typename BufferManager::template allocator_t<T>;
 
-  using IVector = boost::multi::static_array<int, 1, buffer_type_I>;
-  using RVector = boost::multi::static_array<R, 1, buffer_type_R>;
-  using TVector = boost::multi::static_array<T, 1, buffer_type_T>;
-  using TMatrix = boost::multi::static_array<T, 2, buffer_type_T>;
+  using IVector = boost::multi::dynamic_array<int, 1, buffer_type_I>;
+  using RVector = boost::multi::dynamic_array<R, 1, buffer_type_R>;
+  using TVector = boost::multi::dynamic_array<T, 1, buffer_type_T>;
+  using TMatrix = boost::multi::dynamic_array<T, 2, buffer_type_T>;
 
   SlaterDetOperations_base(BufferManager b) : buffer_manager(b) {}
 

--- a/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_serial.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_serial.hpp
@@ -45,7 +45,7 @@ public:
   using IVector       = typename Base::IVector;
   using TVector       = typename Base::TVector;
   using TMatrix       = typename Base::TMatrix;
-  using TTensor       = boost::multi::static_array<T, 3, buffer_type_T>;
+  using TTensor       = boost::multi::dynamic_array<T, 3, buffer_type_T>;
 
   using Base::MixedDensityMatrix;
   using Base::MixedDensityMatrix_noHerm;

--- a/src/AFQMC/Utilities/ArraySizeHelper.hpp
+++ b/src/AFQMC/Utilities/ArraySizeHelper.hpp
@@ -23,7 +23,7 @@ template<class T> auto generic_sizes(T const& A)
 	return std::array<std::size_t, 2>{A.size(0), A.size(1)}; }
 
 template<typename T, boost::multi::dimensionality_type DIM, class Alloc>
-auto generic_sizes(boost::multi::static_array<T, DIM, Alloc> const& A)
+auto generic_sizes(boost::multi::dynamic_array<T, DIM, Alloc> const& A)
 ->decltype(A.sizes()) {
 	return A.sizes(); }
 

--- a/src/AFQMC/Wavefunctions/NOMSD.hpp
+++ b/src/AFQMC/Wavefunctions/NOMSD.hpp
@@ -86,12 +86,12 @@ class NOMSD : public AFQMCInfo
 
   using stdCMatrix_ref = boost::multi::array_ref<ComplexType, 2>;
 
-  using StaticVector  = boost::multi::static_array<ComplexType, 1, buffer_alloc_type>;
-  using StaticMatrix  = boost::multi::static_array<ComplexType, 2, buffer_alloc_type>;
-  using Static3Tensor = boost::multi::static_array<ComplexType, 3, buffer_alloc_type>;
+  using StaticVector  = boost::multi::dynamic_array<ComplexType, 1, buffer_alloc_type>;
+  using StaticMatrix  = boost::multi::dynamic_array<ComplexType, 2, buffer_alloc_type>;
+  using Static3Tensor = boost::multi::dynamic_array<ComplexType, 3, buffer_alloc_type>;
 
-  using StaticSHMVector = boost::multi::static_array<ComplexType, 1, shm_buffer_alloc_type>;
-  using StaticSHMMatrix = boost::multi::static_array<ComplexType, 2, shm_buffer_alloc_type>;
+  using StaticSHMVector = boost::multi::dynamic_array<ComplexType, 1, shm_buffer_alloc_type>;
+  using StaticSHMMatrix = boost::multi::dynamic_array<ComplexType, 2, shm_buffer_alloc_type>;
 
 public:
   template<class MType>

--- a/src/AFQMC/Wavefunctions/NOMSD.hpp
+++ b/src/AFQMC/Wavefunctions/NOMSD.hpp
@@ -86,12 +86,12 @@ class NOMSD : public AFQMCInfo
 
   using stdCMatrix_ref = boost::multi::array_ref<ComplexType, 2>;
 
-  using StaticVector  = boost::multi::dynamic_array<ComplexType, 1, buffer_alloc_type>;
-  using StaticMatrix  = boost::multi::dynamic_array<ComplexType, 2, buffer_alloc_type>;
-  using Static3Tensor = boost::multi::dynamic_array<ComplexType, 3, buffer_alloc_type>;
+  using DynamicVector  = boost::multi::dynamic_array<ComplexType, 1, buffer_alloc_type>;
+  using DynamicMatrix  = boost::multi::dynamic_array<ComplexType, 2, buffer_alloc_type>;
+  using Dynamic3Tensor = boost::multi::dynamic_array<ComplexType, 3, buffer_alloc_type>;
 
-  using StaticSHMVector = boost::multi::dynamic_array<ComplexType, 1, shm_buffer_alloc_type>;
-  using StaticSHMMatrix = boost::multi::dynamic_array<ComplexType, 2, shm_buffer_alloc_type>;
+  using DynamicSHMVector = boost::multi::dynamic_array<ComplexType, 1, shm_buffer_alloc_type>;
+  using DynamicSHMMatrix = boost::multi::dynamic_array<ComplexType, 2, shm_buffer_alloc_type>;
 
 public:
   template<class MType>
@@ -212,10 +212,10 @@ public:
 
   ~NOMSD() {}
 
-  NOMSD(NOMSD const& other) = delete;
+  NOMSD(NOMSD const& other)            = delete;
   NOMSD& operator=(NOMSD const& other) = delete;
   NOMSD(NOMSD&& other)                 = default;
-  NOMSD& operator=(NOMSD&& other) = delete;
+  NOMSD& operator=(NOMSD&& other)      = delete;
 
   int local_number_of_cholesky_vectors() const { return HamOp.local_number_of_cholesky_vectors(); }
   int global_number_of_cholesky_vectors() const { return HamOp.global_number_of_cholesky_vectors(); }
@@ -268,7 +268,7 @@ public:
         HamOp.vbias(G, std::forward<MatA>(v), a);
       else
       {
-        if(transposed_G_for_vbias_)
+        if (transposed_G_for_vbias_)
           APP_ABORT(" Error in NOMSD::vbias: transposed_G_for_vbias_ should be false. \n");
         // HamOp expects either alpha or beta, so must be called twice
         HamOp.vbias(G.sliced(0, NMO * NMO), std::forward<MatA>(v), a, 0.0);
@@ -304,8 +304,8 @@ public:
   void Energy(WlkSet& wset)
   {
     int nw = wset.size();
-    StaticVector ovlp(iextensions<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
-    StaticMatrix eloc({nw, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector ovlp(iextensions<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix eloc({nw, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     Energy(wset, eloc, ovlp);
     TG.local_barrier();
     if (TG.getLocalTGRank() == 0)
@@ -343,7 +343,7 @@ public:
   void MixedDensityMatrix(const WlkSet& wset, MatG&& G, bool compact = true, bool transpose = false)
   {
     int nw = wset.size();
-    StaticVector ovlp(iextensions<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector ovlp(iextensions<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     MixedDensityMatrix(wset, std::forward<MatG>(G), ovlp, compact, transpose);
   }
 
@@ -432,7 +432,7 @@ public:
   void MixedDensityMatrix_for_vbias(const WlkSet& wset, MatG&& G)
   {
     int nw = wset.size();
-    StaticVector ovlp(iextensions<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector ovlp(iextensions<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     MixedDensityMatrix(wset, std::forward<MatG>(G), ovlp, compact_G_for_vbias, transposed_G_for_vbias_);
   }
 
@@ -455,7 +455,7 @@ public:
   void Overlap(WlkSet& wset)
   {
     int nw = wset.size();
-    StaticVector ovlp(iextensions<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector ovlp(iextensions<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     Overlap(wset, ovlp);
     TG.local_barrier();
     if (TG.getLocalTGRank() == 0)
@@ -537,7 +537,7 @@ public:
             ma::Matrix2MAREF('H', OrbMats[2 * i + 1], B_);
           }
         }
-      }                    // TG.Node().root()
+      } // TG.Node().root()
       TG.Node().barrier(); // for safety
     }
     using std::get;

--- a/src/AFQMC/Wavefunctions/NOMSD.icc
+++ b/src/AFQMC/Wavefunctions/NOMSD.icc
@@ -68,11 +68,11 @@ void NOMSD<devPsiT>::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
   int nr = Gsize, nc = nwalk;
   if (transposed_G_for_E_)
     std::swap(nr, nc);
-  StaticSHMVector shmbuff(iextensions<1u>{(Gsize + 1) * nwalk},
-                          shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicSHMVector shmbuff(iextensions<1u>{(Gsize + 1) * nwalk},
+                           shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
   CMatrix_ref G(make_device_ptr(shmbuff.base()), {nr, nc});
   CVector_ref ov_(G.base() + G.num_elements(), iextensions<1u>{nwalk});
-  StaticMatrix eloc2({nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicMatrix eloc2({nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
 
   using std::fill_n;
   fill_n(Ov.base(), nwalk, zero);
@@ -131,8 +131,8 @@ void NOMSD<devPsiT>::Energy_distributed_singleDet(const WlkSet& wset, Mat&& E, T
   //  iii. energies[3] for all walkers on all nodes of TG (assume all nodes have same # of walkers)
   int nt = nwalk * (2 * Gsize + 1);
   // in case the number of walkers changes
-  StaticSHMVector shmbuff(iextensions<1u>{nt},
-                          shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicSHMVector shmbuff(iextensions<1u>{nt},
+                           shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
   assert(E.dimensionality == 2);
   assert(Ov.dimensionality == 1);
   assert(E.size() == wset.size());
@@ -147,7 +147,7 @@ void NOMSD<devPsiT>::Energy_distributed_singleDet(const WlkSet& wset, Mat&& E, T
   CMatrix_ref Gwork(make_device_ptr(shmbuff.base()), {nr, nc});
   CMatrix_ref Grecv(Gwork.base() + Gwork.num_elements(), {nr, nc});
   CVector_ref overlaps(Grecv.base() + Grecv.num_elements(), iextensions<1u>{nwalk});
-  StaticMatrix eloc2({ngroups * nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicMatrix eloc2({ngroups * nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
   int nak0, nak1;
   std::tie(nak0, nak1) = FairDivideBoundary(TG.getLocalTGRank(), Gsize * nwalk, TG.getNCoresPerTG());
 
@@ -237,8 +237,8 @@ void NOMSD<devPsiT>::Energy_distributed_multiDet(const WlkSet& wset, Mat&& E, TV
   //  ii.  1 copy of G (always compact),
   //  iii. ovlps for local walkers
   int nt = nwalk * (3 * Gsize + 1);
-  StaticSHMVector shmbuff(iextensions<1u>{nt},
-                          shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicSHMVector shmbuff(iextensions<1u>{nt},
+                           shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
   assert(E.dimensionality == 2);
   assert(Ov.dimensionality == 1);
   assert(E.size() == wset.size());
@@ -255,8 +255,8 @@ void NOMSD<devPsiT>::Energy_distributed_multiDet(const WlkSet& wset, Mat&& E, TV
   CMatrix_ref Gwork(SMrecv.base() + SMrecv.num_elements(), {nr, nc});
   CVector_ref overlaps(Gwork.base() + Gwork.num_elements(), iextensions<1u>{nwalk});
   // used for temporary storage in ndet loop for local calculation
-  StaticMatrix eloc2({nnodes * nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
-  StaticMatrix eloc3({nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicMatrix eloc2({nnodes * nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicMatrix eloc3({nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
   // matrix view to local segment of eloc2, for wasy access later
   // split SM evenly for communication
   int nak0, nak1;
@@ -375,8 +375,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_for_E_from_SM(const MatSM& SM,
   if (walker_type != COLLINEAR)
   {
     auto Gdims = dm_dims(false, Alpha);
-    StaticMatrix G2D_({Gdims.first, Gdims.second},
-                      buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix G2D_({Gdims.first, Gdims.second},
+                       buffer_manager.get_generator().template get_allocator<ComplexType>());
     CVector_ref G1D_(G2D_.base(), iextensions<1u>{Gsize});
     // notice interchange of dimensions
     CTensor_cref A(SM.base(), {nw, Gdims.second, Gdims.first});
@@ -397,12 +397,12 @@ void NOMSD<devPsiT>::MixedDensityMatrix_for_E_from_SM(const MatSM& SM,
   else
   {
     // store overlaps locally to be able to split alpha/beta pairs
-    StaticVector ovlp2(iextensions<1u>{2 * nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector ovlp2(iextensions<1u>{2 * nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     fill_n(ovlp2.base(), 2 * nw, ComplexType(0.0));
     auto GAdims = dm_dims(false, Alpha);
     auto GBdims = dm_dims(false, Beta);
-    StaticMatrix GA2D_({GAdims.first, GAdims.second},
-                       buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix GA2D_({GAdims.first, GAdims.second},
+                        buffer_manager.get_generator().template get_allocator<ComplexType>());
     // can reuse space!!!
     CMatrix_ref GB2D_(GA2D_.base(), {GBdims.first, GBdims.second});
     CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GA2D_.num_elements()});
@@ -499,8 +499,8 @@ void NOMSD<devPsiT>::DensityMatrix_shared(const WlkSet& wset,
     }
 
     auto Gdims = dm_dims(not compact, Alpha);
-    StaticMatrix G2D_({Gdims.first, Gdims.second},
-                      buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix G2D_({Gdims.first, Gdims.second},
+                       buffer_manager.get_generator().template get_allocator<ComplexType>());
     CVector_ref G1D_(G2D_.base(), iextensions<1u>{G2D_.num_elements()});
 
     for (int iw = 0; iw < nw; ++iw)
@@ -534,20 +534,18 @@ void NOMSD<devPsiT>::DensityMatrix_shared(const WlkSet& wset,
     }
     if (herm)
     {
-      assert(get<0>(RefB.sizes()) == dm_dims(false, Beta).first &&
-             get<1>(RefB.sizes()) == dm_dims(false, Beta).second);
+      assert(get<0>(RefB.sizes()) == dm_dims(false, Beta).first && get<1>(RefB.sizes()) == dm_dims(false, Beta).second);
     }
     else
     {
-      assert(get<1>(RefB.sizes()) == dm_dims(false, Beta).first &&
-             get<0>(RefB.sizes()) == dm_dims(false, Beta).second);
+      assert(get<1>(RefB.sizes()) == dm_dims(false, Beta).first && get<0>(RefB.sizes()) == dm_dims(false, Beta).second);
     }
-    StaticVector ovlp2(iextensions<1u>{2 * nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector ovlp2(iextensions<1u>{2 * nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     fill_n(ovlp2.base(), 2 * nw, ComplexType(0.0));
     auto GAdims = dm_dims(not compact, Alpha);
     auto GBdims = dm_dims(not compact, Beta);
-    StaticMatrix GA2D_({GAdims.first, GAdims.second},
-                       buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix GA2D_({GAdims.first, GAdims.second},
+                        buffer_manager.get_generator().template get_allocator<ComplexType>());
     CMatrix_ref GB2D_(GA2D_.base(), {GBdims.first, GBdims.second});
     CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GA2D_.num_elements()});
     CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GB2D_.num_elements()});
@@ -628,8 +626,8 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
   TG.local_barrier();
   fill_n(Ov.base(), nw, 0);
   fill_n(G.base(), G.num_elements(), ComplexType(0.0));
-  StaticVector ovlp2(iextensions<1u>{2 * nbatch__},
-                     buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicVector ovlp2(iextensions<1u>{2 * nbatch__},
+                      buffer_manager.get_generator().template get_allocator<ComplexType>());
   fill_n(ovlp2.base(), ovlp2.num_elements(), ComplexType(0.0));
 
   using std::get;
@@ -662,8 +660,8 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
       assert(get<1>(RefA.sizes()) == dm_dims(false, Alpha).first &&
              get<0>(RefA.sizes()) == dm_dims(false, Alpha).second);
     }
-    Static3Tensor G3D_({nbatch__, GAdims.first, GAdims.second},
-                       buffer_manager.get_generator().template get_allocator<ComplexType>());
+    Dynamic3Tensor G3D_({nbatch__, GAdims.first, GAdims.second},
+                        buffer_manager.get_generator().template get_allocator<ComplexType>());
     CMatrix_ref G2D_(G3D_.base(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
 
     for (int iw = 0; iw < nw; iw += nbatch__)
@@ -709,18 +707,16 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
     }
     if (herm)
     {
-      assert(get<0>(RefB.sizes()) == dm_dims(false, Beta).first &&
-             get<1>(RefB.sizes()) == dm_dims(false, Beta).second);
+      assert(get<0>(RefB.sizes()) == dm_dims(false, Beta).first && get<1>(RefB.sizes()) == dm_dims(false, Beta).second);
     }
     else
     {
-      assert(get<1>(RefB.sizes()) == dm_dims(false, Beta).first &&
-             get<0>(RefB.sizes()) == dm_dims(false, Beta).second);
+      assert(get<1>(RefB.sizes()) == dm_dims(false, Beta).first && get<0>(RefB.sizes()) == dm_dims(false, Beta).second);
     }
 
     auto GBdims = dm_dims(not compact, Beta);
-    Static3Tensor GA3D_({nbatch__, GAdims.first, GAdims.second},
-                        buffer_manager.get_generator().template get_allocator<ComplexType>());
+    Dynamic3Tensor GA3D_({nbatch__, GAdims.first, GAdims.second},
+                         buffer_manager.get_generator().template get_allocator<ComplexType>());
     CMatrix_ref GA2D_(GA3D_.base(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
     CTensor_ref GB3D_(GA3D_.base(), {nbatch__, GBdims.first, GBdims.second});
     CMatrix_ref GB2D_(GB3D_.base(), iextensions<2u>{nbatch__, GBdims.first * GBdims.second});
@@ -830,7 +826,7 @@ void NOMSD<devPsiT>::DensityMatrix_batched(std::vector<MatA>& Left,
   Li.reserve(nbatch__);
   Ri.reserve(nbatch__);
   Gi.reserve(nbatch__);
-  StaticVector ovlp2(iextensions<1u>{nbatch__}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicVector ovlp2(iextensions<1u>{nbatch__}, buffer_manager.get_generator().template get_allocator<ComplexType>());
   fill_n(ovlp2.base(), ovlp2.num_elements(), ComplexType(0.0));
 
   for (int iw = 0; iw < nw; iw += nbatch__)
@@ -903,8 +899,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
   if (walker_type != COLLINEAR)
   {
     auto Gdims = dm_dims(not compact, Alpha);
-    StaticMatrix G2D_({Gdims.first, Gdims.second},
-                      buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix G2D_({Gdims.first, Gdims.second},
+                       buffer_manager.get_generator().template get_allocator<ComplexType>());
     CVector_ref G1D_(G2D_.base(), iextensions<1u>{G2D_.num_elements()});
 
     const int ntasks_percore      = (nw * ndet) / TG.getNCoresPerTG();
@@ -997,10 +993,10 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
   {
     auto GAdims = dm_dims(not compact, Alpha);
     auto GBdims = dm_dims(not compact, Beta);
-    StaticMatrix GA2D_({GAdims.first, GAdims.second},
-                       buffer_manager.get_generator().template get_allocator<ComplexType>());
-    StaticMatrix GB2D_({GBdims.first, GBdims.second},
-                       buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix GA2D_({GAdims.first, GAdims.second},
+                        buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix GB2D_({GBdims.first, GBdims.second},
+                        buffer_manager.get_generator().template get_allocator<ComplexType>());
     CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GA2D_.num_elements()});
     CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GB2D_.num_elements()});
 
@@ -1067,13 +1063,11 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
       {
         boost::multi::array_ref<ComplexType, 2> GA2D_2(to_address(shmbuff_for_G->base()),
                                                        {GAdims.first, GAdims.second});
-        boost::multi::array_ref<ComplexType, 2> GB2D_2(to_address(shmbuff_for_G->base()) +
-                                                           GAdims.first * GAdims.second,
+        boost::multi::array_ref<ComplexType, 2> GB2D_2(to_address(shmbuff_for_G->base()) + GAdims.first * GAdims.second,
                                                        {GBdims.first, GBdims.second});
         boost::multi::array_ref<ComplexType, 1> GA1D_2(to_address(shmbuff_for_G->base()),
                                                        iextensions<1u>{GAdims.first * GAdims.second});
-        boost::multi::array_ref<ComplexType, 1> GB1D_2(to_address(shmbuff_for_G->base()) +
-                                                           GAdims.first * GAdims.second,
+        boost::multi::array_ref<ComplexType, 1> GB1D_2(to_address(shmbuff_for_G->base()) + GAdims.first * GAdims.second,
                                                        iextensions<1u>{GBdims.first * GBdims.second});
         int task       = (last_task_index + ntasks_total_serial);
         int iw         = task / ndet;
@@ -1122,8 +1116,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
     int ik0, ikN;
     std::tie(ik0, ikN) = FairDivideBoundary(TG.TG_local().rank(), int(G.size()), TG.TG_local().size());
     using ma::term_by_term_matrix_vector;
-    term_by_term_matrix_vector(ma::TOp_DIV, 1, ikN - ik0, get<1>(G.sizes()), make_device_ptr(G[ik0].base()),
-                               G.stride(), make_device_ptr(Ov.base()), Ov.stride());
+    term_by_term_matrix_vector(ma::TOp_DIV, 1, ikN - ik0, get<1>(G.sizes()), make_device_ptr(G[ik0].base()), G.stride(),
+                               make_device_ptr(Ov.base()), Ov.stride());
   }
   TG.local_barrier();
 }
@@ -1163,8 +1157,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
   double LogOverlapFactor(wset.getLogOverlapFactor());
   assert(Ov.size() >= nw);
   fill_n(Ov.base(), nw, 0);
-  StaticVector ovlp2(iextensions<1u>{2 * nbatch__},
-                     buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicVector ovlp2(iextensions<1u>{2 * nbatch__},
+                      buffer_manager.get_generator().template get_allocator<ComplexType>());
   fill_n(ovlp2.base(), ovlp2.num_elements(), ComplexType(0.0));
   // need strided fill_n????
 
@@ -1187,8 +1181,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
   if (walker_type != COLLINEAR)
   {
     auto GAdims = dm_dims(not compact, Alpha);
-    Static3Tensor G3D_({nbatch__, GAdims.first, GAdims.second},
-                       buffer_manager.get_generator().template get_allocator<ComplexType>());
+    Dynamic3Tensor G3D_({nbatch__, GAdims.first, GAdims.second},
+                        buffer_manager.get_generator().template get_allocator<ComplexType>());
     CMatrix_ref G2D_(G3D_.base(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
     std::vector<pointer> Gx;
     std::vector<pointer> Gy;
@@ -1236,10 +1230,10 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
   {
     auto GAdims = dm_dims(not compact, Alpha);
     auto GBdims = dm_dims(not compact, Beta);
-    Static3Tensor GA3D_({nbatch__, GAdims.first, GAdims.second},
-                        buffer_manager.get_generator().template get_allocator<ComplexType>());
-    Static3Tensor GB3D_({nbatch__, GBdims.first, GBdims.second},
-                        buffer_manager.get_generator().template get_allocator<ComplexType>());
+    Dynamic3Tensor GA3D_({nbatch__, GAdims.first, GAdims.second},
+                         buffer_manager.get_generator().template get_allocator<ComplexType>());
+    Dynamic3Tensor GB3D_({nbatch__, GBdims.first, GBdims.second},
+                         buffer_manager.get_generator().template get_allocator<ComplexType>());
     CMatrix_ref GA2D_(GA3D_.base(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
     CMatrix_ref GB2D_(GB3D_.base(), iextensions<2u>{nbatch__, GBdims.first * GBdims.second});
     std::vector<pointer> Gxa;
@@ -1324,8 +1318,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
   else
   {
     using ma::term_by_term_matrix_vector;
-    term_by_term_matrix_vector(ma::TOp_DIV, 1, G.size(), get<1>(G.sizes()), make_device_ptr(G.base()),
-                               G.stride(), make_device_ptr(Ov.base()), Ov.stride());
+    term_by_term_matrix_vector(ma::TOp_DIV, 1, G.size(), get<1>(G.sizes()), make_device_ptr(G.base()), G.stride(),
+                               make_device_ptr(Ov.base()), Ov.stride());
   }
   TG.local_barrier();
 }
@@ -1351,8 +1345,8 @@ void NOMSD<devPsiT>::Overlap_batched(const WlkSet& wset, TVec&& Ov)
   double LogOverlapFactor(wset.getLogOverlapFactor());
   assert(Ov.size() >= nw);
   fill_n(Ov.base(), nw, 0);
-  StaticVector ovlp2(iextensions<1u>{2 * ndet * nw},
-                     buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicVector ovlp2(iextensions<1u>{2 * ndet * nw},
+                      buffer_manager.get_generator().template get_allocator<ComplexType>());
   fill_n(ovlp2.base(), ovlp2.num_elements(), ComplexType(0.0));
   stdCVector hvec(iextensions<1u>{(2 * ndet + 1) * nw});
   fill_n(hvec.base(), hvec.num_elements(), ComplexType(0.0));
@@ -1605,11 +1599,11 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared(const WlkSet& wset,
   {
     auto Gdims = dm_dims(not compact, Alpha);
     // Temporaries for determinant component of walker rdm function.
-    StaticMatrix G2D_({Gdims.first, Gdims.second},
-                      buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix G2D_({Gdims.first, Gdims.second},
+                       buffer_manager.get_generator().template get_allocator<ComplexType>());
     CVector_ref G1D_(G2D_.base(), iextensions<1u>{Gsize});
     // Accumulator for trial wavefunction sum.
-    StaticVector G21D_(iextensions<1u>{Gsize}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector G21D_(iextensions<1u>{Gsize}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     // 1D view of walker averaged RDM
     CVector_ref G1D(make_device_ptr(G.base()), iextensions<1u>{Gsize});
     for (int iw = 0; iw < nwalk; iw++)
@@ -1664,16 +1658,16 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared(const WlkSet& wset,
   {
     auto GAdims = dm_dims(not compact, Alpha);
     auto GBdims = dm_dims(not compact, Beta);
-    StaticMatrix GA2D_({GAdims.first, GAdims.second},
-                       buffer_manager.get_generator().template get_allocator<ComplexType>());
-    StaticMatrix GB2D_({GBdims.first, GBdims.second},
-                       buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix GA2D_({GAdims.first, GAdims.second},
+                        buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix GB2D_({GBdims.first, GBdims.second},
+                        buffer_manager.get_generator().template get_allocator<ComplexType>());
     CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GAdims.first * GAdims.second});
     CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GBdims.first * GBdims.second});
-    StaticVector GA21D_(iextensions<1u>{GAdims.first * GAdims.second},
-                        buffer_manager.get_generator().template get_allocator<ComplexType>());
-    StaticVector GB21D_(iextensions<1u>{GBdims.first * GBdims.second},
-                        buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector GA21D_(iextensions<1u>{GAdims.first * GAdims.second},
+                         buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector GB21D_(iextensions<1u>{GBdims.first * GBdims.second},
+                         buffer_manager.get_generator().template get_allocator<ComplexType>());
     CVector_ref GA1D(make_device_ptr(G.base()), iextensions<1u>{GAdims.first * GAdims.second});
     CVector_ref GB1D(make_device_ptr(G.base()) + GAdims.first * GAdims.second,
                      iextensions<1u>{GBdims.first * GBdims.second});
@@ -1802,8 +1796,8 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared_single_det(const WlkSet&
   {
     auto Gdims = dm_dims(not compact, Alpha);
     // Temporaries for determinant component of walker rdm function.
-    StaticMatrix G2D_({Gdims.first, Gdims.second},
-                      buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix G2D_({Gdims.first, Gdims.second},
+                       buffer_manager.get_generator().template get_allocator<ComplexType>());
     CVector_ref G1D_(G2D_.base(), iextensions<1u>{Gsize});
     // 1D view of walker averaged RDM
     CVector_ref G1D(make_device_ptr(G.base()), iextensions<1u>{Gsize});
@@ -1855,10 +1849,10 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared_single_det(const WlkSet&
   {
     auto GAdims = dm_dims(not compact, Alpha);
     auto GBdims = dm_dims(not compact, Beta);
-    StaticMatrix GA2D_({GAdims.first, GAdims.second},
-                       buffer_manager.get_generator().template get_allocator<ComplexType>());
-    StaticMatrix GB2D_({GBdims.first, GBdims.second},
-                       buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix GA2D_({GAdims.first, GAdims.second},
+                        buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix GB2D_({GBdims.first, GBdims.second},
+                        buffer_manager.get_generator().template get_allocator<ComplexType>());
     CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GAdims.first * GAdims.second});
     CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GBdims.first * GBdims.second});
     CVector_ref GA1D(make_device_ptr(G.base()), iextensions<1u>{GAdims.first * GAdims.second});
@@ -2171,7 +2165,7 @@ void NOMSD<devPsiT>::Orthogonalize_batched(WlkSet& wset, bool impSamp)
   stdCVector detR(iextensions<1u>{2 * nw});
   std::vector<CMatrix_ptr> Ai;
   Ai.reserve(nbatch__);
-  StaticVector ov(iextensions<1u>{nbatch__}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicVector ov(iextensions<1u>{nbatch__}, buffer_manager.get_generator().template get_allocator<ComplexType>());
   if (walker_type != COLLINEAR)
   {
     for (int iw = 0; iw < nw; iw += nbatch__)
@@ -2271,7 +2265,7 @@ void NOMSD<devPsiT>::OrthogonalizeExcited(Mat&& A, SpinTypes spin, double LogOve
         extendedMatAlpha(get<0>(extendedMatAlpha.extents()), i.first) =
             excitedOrbMat[0](get<1>(excitedOrbMat.extents()), i.first);
       }
-    ComplexType detR             = SDetOp.Orthogonalize(extendedMatAlpha, LogOverlapFactor);
+    ComplexType detR                  = SDetOp.Orthogonalize(extendedMatAlpha, LogOverlapFactor);
     A(get<0>(A.extents()), {0, NAEA}) = extendedMatAlpha(get<0>(extendedMatAlpha.extents()), {0, NAEA});
     for (auto& i : excitations)
       if (i.first < NMO && i.second < NMO)
@@ -2290,9 +2284,10 @@ void NOMSD<devPsiT>::OrthogonalizeExcited(Mat&& A, SpinTypes spin, double LogOve
       {
         extendedMatBeta(get<0>(extendedMatBeta.extents()), i.second) =
             extendedMatBeta(get<0>(extendedMatBeta.extents()), i.first);
-        extendedMatBeta(get<0>(extendedMatBeta.extents()), i.first) = excitedOrbMat[1](get<1>(excitedOrbMat.extents()), i.first);
+        extendedMatBeta(get<0>(extendedMatBeta.extents()), i.first) =
+            excitedOrbMat[1](get<1>(excitedOrbMat.extents()), i.first);
       }
-    ComplexType detR             = SDetOp.Orthogonalize(extendedMatBeta, LogOverlapFactor);
+    ComplexType detR                  = SDetOp.Orthogonalize(extendedMatBeta, LogOverlapFactor);
     A(get<0>(A.extents()), {0, NAEB}) = extendedMatBeta(get<0>(extendedMatBeta.extents()), {0, NAEB});
     for (auto& i : excitations)
       if (i.first >= NMO && i.second >= NMO)
@@ -2469,8 +2464,8 @@ inline void NOMSD<devPsiT>::recompute_ci()
   else
   {
     auto nt = (1 + dm_size(false) + NMO * NAEA);
-    StaticSHMVector shmbuff(iextensions<1u>{nt},
-                            shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicSHMVector shmbuff(iextensions<1u>{nt},
+                             shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
 
     boost::multi::array<ComplexType, 2, shared_allocator<ComplexType>> H({ndets, ndets},
                                                                          shared_allocator<ComplexType>(TG.Node()));
@@ -2498,7 +2493,7 @@ inline void NOMSD<devPsiT>::recompute_ci()
       std::swap(nr, nc);
     CVector_ref ov_(make_device_ptr(shmbuff.base()), iextensions<1u>{1});
     CMatrix_ref G(ov_.base() + 1, {nr, nc});
-    StaticMatrix eloc2({1, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicMatrix eloc2({1, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
 
     for (int jdet = 0, ji = 0; jdet < ndets; jdet++)
     {

--- a/src/AFQMC/Wavefunctions/NOMSD.icc
+++ b/src/AFQMC/Wavefunctions/NOMSD.icc
@@ -357,11 +357,11 @@ void NOMSD<devPsiT>::MixedDensityMatrix_for_E_from_SM(const MatSM& SM,
 
   if (transposed_G_for_E_)
   {
-    assert((G.extents() == boost::multi::extensions_t<2>{nw, static_cast<boost::multi::size_t>(dm_size(false))}));
+    assert((G.extents() == boost::multi::extensions_t<2>{nw, static_cast<boost::multi::ssize_t>(dm_size(false))}));
   }
   else
   {
-    assert((G.extents() == boost::multi::extensions_t<2>{static_cast<boost::multi::size_t>(dm_size(false)), nw}));
+    assert((G.extents() == boost::multi::extensions_t<2>{static_cast<boost::multi::ssize_t>(dm_size(false)), nw}));
   }
   assert(Ov.size() >= nw);
 
@@ -467,12 +467,12 @@ void NOMSD<devPsiT>::DensityMatrix_shared(const WlkSet& wset,
   if (transposed)
   {
     assert((G.extents() ==
-            boost::multi::extensions_t<2>{wset.size(), static_cast<boost::multi::size_t>(dm_size(not compact))}));
+            boost::multi::extensions_t<2>{wset.size(), static_cast<boost::multi::ssize_t>(dm_size(not compact))}));
   }
   else
   {
     assert((G.extents() ==
-            boost::multi::extensions_t<2>{static_cast<boost::multi::size_t>(dm_size(not compact)), wset.size()}));
+            boost::multi::extensions_t<2>{static_cast<boost::multi::ssize_t>(dm_size(not compact)), wset.size()}));
   }
   const int nw = wset.size();
   assert(Ov.size() >= nw);
@@ -613,12 +613,12 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
   if (transposed)
   {
     assert((G.extents() ==
-            boost::multi::extensions_t<2>{wset.size(), static_cast<boost::multi::size_t>(dm_size(not compact))}));
+            boost::multi::extensions_t<2>{wset.size(), static_cast<boost::multi::ssize_t>(dm_size(not compact))}));
   }
   else
   {
     assert((G.extents() ==
-            boost::multi::extensions_t<2>{static_cast<boost::multi::size_t>(dm_size(not compact)), wset.size()}));
+            boost::multi::extensions_t<2>{static_cast<boost::multi::ssize_t>(dm_size(not compact)), wset.size()}));
   }
 
   const int nw = wset.size();
@@ -879,12 +879,12 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
   if (transpose)
   {
     assert((G.extents() ==
-            boost::multi::extensions_t<2>{wset.size(), static_cast<boost::multi::size_t>(dm_size(not compact))}));
+            boost::multi::extensions_t<2>{wset.size(), static_cast<boost::multi::ssize_t>(dm_size(not compact))}));
   }
   else
   {
     assert((G.extents() ==
-            boost::multi::extensions_t<2>{static_cast<boost::multi::size_t>(dm_size(not compact)), wset.size()}));
+            boost::multi::extensions_t<2>{static_cast<boost::multi::ssize_t>(dm_size(not compact)), wset.size()}));
   }
   const int nw   = wset.size();
   const int ndet = ci.size();
@@ -1149,12 +1149,12 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
   if (transpose)
   {
     assert((G.extents() ==
-            boost::multi::extensions_t<2>{wset.size(), static_cast<boost::multi::size_t>(dm_size(not compact))}));
+            boost::multi::extensions_t<2>{wset.size(), static_cast<boost::multi::ssize_t>(dm_size(not compact))}));
   }
   else
   {
     assert((G.extents() ==
-            boost::multi::extensions_t<2>{static_cast<boost::multi::size_t>(dm_size(not compact)), wset.size()}));
+            boost::multi::extensions_t<2>{static_cast<boost::multi::ssize_t>(dm_size(not compact)), wset.size()}));
   }
   const int nw   = wset.size();
   const int ndet = ci.size();

--- a/src/AFQMC/Wavefunctions/PHMSD.hpp
+++ b/src/AFQMC/Wavefunctions/PHMSD.hpp
@@ -136,12 +136,12 @@ public:
         QQ0inv1({1, 1}, shared_allocator<ComplexType>{TG.TG_local()}),
         GA2D0_shm({1, 1}, shared_allocator<ComplexType>{TG.TG_local()}),
         GB2D0_shm({1, 1}, shared_allocator<ComplexType>{TG.TG_local()}),
-        local_ov  ({2, static_cast<boost::multi::size_t>(maxn_unique_confg)}),
-        local_etot({2, static_cast<boost::multi::size_t>(maxn_unique_confg)}),
-        local_QQ0inv0({static_cast<boost::multi::size_t>(OrbMats[0].size()), NAEA}),
-        local_QQ0inv1({static_cast<boost::multi::size_t>(OrbMats.back().size()), NAEB}),
-        Qwork({2 * static_cast<boost::multi::size_t>(max_exct_n), static_cast<boost::multi::size_t>(max_exct_n)}),
-        Gwork({NAEA, static_cast<boost::multi::size_t>(maxnactive)}),
+        local_ov  ({2, static_cast<boost::multi::ssize_t>(maxn_unique_confg)}),
+        local_etot({2, static_cast<boost::multi::ssize_t>(maxn_unique_confg)}),
+        local_QQ0inv0({static_cast<boost::multi::ssize_t>(OrbMats[0].size()), NAEA}),
+        local_QQ0inv1({static_cast<boost::multi::ssize_t>(OrbMats.back().size()), NAEB}),
+        Qwork({2 * static_cast<boost::multi::ssize_t>(max_exct_n), static_cast<boost::multi::ssize_t>(max_exct_n)}),
+        Gwork({NAEA, static_cast<boost::multi::ssize_t>(maxnactive)}),
         Ovmsd({1, 1, 1}, shared_allocator<ComplexType>{TG.TG_local()}),
         Emsd({1, 1, 1, 1}, shared_allocator<ComplexType>{TG.TG_local()}),
         QQ0A({1, 1, 1}, shared_allocator<ComplexType>{TG.TG_local()}),
@@ -502,14 +502,14 @@ public:
       if (TG.Node().root())
       {
         boost::multi::array<ComplexType, 2> OA_({
-			static_cast<boost::multi::size_t>(get<1>(OrbMats[0].sizes())),
-			static_cast<boost::multi::size_t>(get<0>(OrbMats[0].sizes()))
+			static_cast<boost::multi::ssize_t>(get<1>(OrbMats[0].sizes())),
+			static_cast<boost::multi::ssize_t>(get<0>(OrbMats[0].sizes()))
 		});
         boost::multi::array<ComplexType, 2> OB_({0, 0});
         if (OrbMats.size() > 1)
           OB_.reextent({
-            static_cast<boost::multi::size_t>(get<1>(OrbMats[1].sizes())),
-            static_cast<boost::multi::size_t>(get<0>(OrbMats[1].sizes()))
+            static_cast<boost::multi::ssize_t>(get<1>(OrbMats[1].sizes())),
+            static_cast<boost::multi::ssize_t>(get<0>(OrbMats[1].sizes()))
           });
         ma::Matrix2MAREF('H', OrbMats[0], OA_);
         if (OrbMats.size() > 1)

--- a/src/AFQMC/Wavefunctions/PHMSD.icc
+++ b/src/AFQMC/Wavefunctions/PHMSD.icc
@@ -54,9 +54,9 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
   double LogOverlapFactor(wset.getLogOverlapFactor());
   // resize shm structures if needed
 
-  Ovmsd.reextent({nspins, static_cast<boost::multi::size_t>(maxn_unique_confg), nwalk});
+  Ovmsd.reextent({nspins, static_cast<boost::multi::ssize_t>(maxn_unique_confg), nwalk});
 
-  Emsd.reextent({nspins, static_cast<boost::multi::size_t>(maxn_unique_confg), nwalk, 3});
+  Emsd.reextent({nspins, static_cast<boost::multi::ssize_t>(maxn_unique_confg), nwalk, 3});
 
   // resize Alpha here, if beta is needed resize below
 
@@ -96,9 +96,9 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
 
     GrefB.reextent({nwalk, dm_dims(false, Beta).first, dm_dims(false, Beta).second});
 
-    QQ0A .reextent({nwalk, static_cast<boost::multi::size_t>(OrbMats[0].size(0)), NAEA});
+    QQ0A .reextent({nwalk, static_cast<boost::multi::ssize_t>(OrbMats[0].size(0)), NAEA});
 
-    QQ0B .reextent({nwalk, static_cast<boost::multi::size_t>(OrbMats.back().size(0)), NAEB});
+    QQ0B .reextent({nwalk, static_cast<boost::multi::ssize_t>(OrbMats.back().size(0)), NAEB});
 
     for (int iw = 0, nc = 0; iw < nwalk; iw++)
     {
@@ -141,9 +141,9 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
   {
     ComplexType ov0;
 
-    KEright.reextent({static_cast<boost::multi::size_t>(abij.number_of_unique_excitations()[0]), nwalk, static_cast<boost::multi::size_t>(nkev)});
+    KEright.reextent({static_cast<boost::multi::ssize_t>(abij.number_of_unique_excitations()[0]), nwalk, static_cast<boost::multi::ssize_t>(nkev)});
 
-    KEleft.reextent({nwalk, static_cast<boost::multi::size_t>(nkev)});
+    KEleft.reextent({nwalk, static_cast<boost::multi::ssize_t>(nkev)});
 
     for (int spin = 0; spin < nspins; ++spin)
     {
@@ -1273,7 +1273,7 @@ void PHMSD::vMF(Vec&& v)
 
   //shmCMatrix ovlps({2,maxn_unique_confg},shared_allocator<ComplexType>{TG.Node()});
   //boost::multi::array<ComplexType,2> ovlps({2,maxn_unique_confg});
-  boost::multi::array<ComplexType, 2> ovlps({2, static_cast<boost::multi::size_t>(maxn_unique_confg)});
+  boost::multi::array<ComplexType, 2> ovlps({2, static_cast<boost::multi::ssize_t>(maxn_unique_confg)});
   //if(TG.Node().root())
   std::fill_n(to_address(ovlps.base()), 2 * maxn_unique_confg, ComplexType(0.0));
 

--- a/src/io/hdf/container_traits_multi.h
+++ b/src/io/hdf/container_traits_multi.h
@@ -41,7 +41,7 @@ struct container_traits<boost::multi::array<T, D, Alloc>>
     std::array<I, 2> shape;
     for (int i = 0; i < d; ++i)
       shape[i] = n[i];
-    ref.reextent({static_cast<boost::multi::size_t>(shape[0]), static_cast<boost::multi::size_t>(shape[1])});
+    ref.reextent({static_cast<boost::multi::ssize_t>(shape[0]), static_cast<boost::multi::ssize_t>(shape[1])});
   }
 
   inline static size_t getSize(const CT& ref) { return ref.num_elements(); }

--- a/src/io/hdf/hdf_multi.h
+++ b/src/io/hdf/hdf_multi.h
@@ -44,7 +44,7 @@ struct h5data_proxy<boost::multi::array<T, 1, Alloc>> : public h5_space_type<T, 
   {
     using iextensions = typename boost::multi::iextensions<1u>;
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
-      ref.reextent(iextensions{static_cast<boost::multi::size_t>(dims[0])});
+      ref.reextent(iextensions{static_cast<boost::multi::ssize_t>(dims[0])});
     return h5d_read(grp, aname, get_address(std::addressof(*ref.base())), xfer_plist);
   }
 
@@ -72,7 +72,7 @@ struct h5data_proxy<boost::multi::array<T, 2, Alloc>> : public h5_space_type<T, 
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
-      ref.reextent({static_cast<boost::multi::size_t>(dims[0]), static_cast<boost::multi::size_t>(dims[1])});
+      ref.reextent({static_cast<boost::multi::ssize_t>(dims[0]), static_cast<boost::multi::ssize_t>(dims[1])});
     return h5d_read(grp, aname, get_address(std::addressof(*ref.base())), xfer_plist);
   }
 


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Deprecation warning fix following warning messages.
1. static_array ->dynamic_array
2. boost::multi::size_t ->boost::multi::ssize_t
3. size_type -> size_t

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->
laptop

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
