### PR TITLE
SOA spherical tensor VGH

### DIFF
--- a/src/Numerics/SoaSphericalTensor.h
+++ b/src/Numerics/SoaSphericalTensor.h
@@ -94,6 +94,26 @@ public:
                                const T* normfactor,
                                size_t offset);
 
+private:
+  /** compute Ylm and its gradient for a single position, norm_factor NOT applied
+   *
+   * evaluateVGH uses the gradient recurrence which requires unnormalized values.
+   * Anywhere that needs the normed vals can call normalize_vg after evaluateVGL_bare
+   */
+  static void evaluateVGL_bare(const T x,
+                               const T y,
+                               const T z,
+                               T* restrict Ylm_vgl,
+                               int lmax,
+                               const T* factorL,
+                               const T* factorLM,
+                               const T* factor2L,
+                               size_t offset);
+
+  ///apply norm_factor to the value and gradient rows left bare by evaluateVGL_bare
+  static void normalize_vg(T* restrict Ylm_vgl, int nlm, const T* normfactor, size_t offset);
+
+public:
   /** apply the solid-harmonic first-derivative recurrence at (l,m)
    *
    * The recurrence writes the derivative of the unnormalized \f$ r^l S_l^m \f$ as a
@@ -101,11 +121,10 @@ public:
    * do not depend on position, it applies unchanged to the l-1 harmonics, giving the
    * gradient, and to the l-1 gradients, giving the Hessian.
    *
-   * @param lower callable (int lm) -> T returning the unnormalized l-1 quantity
+   * @param lower the unnormalized l-1 quantities, indexed by index(l-1, m)
    * @param gx, gy, gz derivatives with respect to x, y and z, normfactor NOT applied
    */
-  template<typename Accessor>
-  static void gradient_recurrence(const int l, const int m, const T fac, Accessor lower, T& gx, T& gy, T& gz);
+  static void gradient_recurrence(const int l, const int m, const T fac, const T* restrict lower, T& gx, T& gy, T& gz);
 
   ///compute Ylm
   inline void evaluateV(T x, T y, T z, T* Ylm) const
@@ -416,11 +435,10 @@ PRAGMA_OFFLOAD("omp end declare target")
 PRAGMA_OFFLOAD("omp declare target")
 
 template<typename T>
-template<typename Accessor>
 inline void SoaSphericalTensor<T>::gradient_recurrence(const int l,
                                                        const int m,
                                                        const T fac,
-                                                       Accessor lower,
+                                                       const T* restrict lower,
                                                        T& gx,
                                                        T& gy,
                                                        T& gz)
@@ -434,11 +452,11 @@ inline void SoaSphericalTensor<T>::gradient_recurrence(const int l,
   const T c0   = std::sqrt(fac * (l - ma) * (l + ma));
 
   T dpr, dpi, dmr, dmi;
-  gz = (l > ma) ? c0 * lower(lm + m) : czero;
+  gz = (l > ma) ? c0 * lower[lm + m] : czero;
   if (l > ma + 1)
   {
-    dpr = cp * lower(lm + ma + 1);
-    dpi = cp * lower(lm - ma - 1);
+    dpr = cp * lower[lm + ma + 1];
+    dpi = cp * lower[lm - ma - 1];
   }
   else
   {
@@ -450,21 +468,21 @@ inline void SoaSphericalTensor<T>::gradient_recurrence(const int l,
     switch (ma)
     {
     case 0:
-      dmr = -cm * lower(lm + 1);
-      dmi = cm * lower(lm - 1);
+      dmr = -cm * lower[lm + 1];
+      dmi = cm * lower[lm - 1];
       break;
     case 1:
-      dmr = cm * lower(lm);
+      dmr = cm * lower[lm];
       dmi = czero;
       break;
     default:
-      dmr = cm * lower(lm + ma - 1);
-      dmi = cm * lower(lm - ma + 1);
+      dmr = cm * lower[lm + ma - 1];
+      dmi = cm * lower[lm - ma + 1];
     }
   }
   else
   {
-    dmr = cm * lower(lm);
+    dmr = cm * lower[lm];
     dmi = czero;
   }
   if (m < 0)
@@ -480,6 +498,63 @@ inline void SoaSphericalTensor<T>::gradient_recurrence(const int l,
 }
 
 template<typename T>
+inline void SoaSphericalTensor<T>::evaluateVGL_bare(const T x,
+                                                    const T y,
+                                                    const T z,
+                                                    T* restrict Ylm_vgl,
+                                                    int lmax,
+                                                    const T* factorL,
+                                                    const T* factorLM,
+                                                    const T* factor2L,
+                                                    size_t offset)
+{
+  T* restrict Ylm = Ylm_vgl;
+  evaluate_bare(x, y, z, Ylm, lmax, factorL, factorLM);
+
+  constexpr T czero(0);
+  T* restrict gYlmX = Ylm_vgl + offset * 1;
+  T* restrict gYlmY = Ylm_vgl + offset * 2;
+  T* restrict gYlmZ = Ylm_vgl + offset * 3;
+
+  gYlmX[0] = czero;
+  gYlmY[0] = czero;
+  gYlmZ[0] = czero;
+
+  // Calculating Gradient now//
+  for (int l = 1; l <= lmax; l++)
+  {
+    //T fac = ((T) (2*l+1))/(2*l-1);
+    const T fac = factor2L[l];
+    for (int m = -l; m <= l; m++)
+    {
+      T gx, gy, gz;
+      gradient_recurrence(l, m, fac, Ylm, gx, gy, gz);
+      const int lm = index(l, m);
+      gYlmX[lm]    = gx;
+      gYlmY[lm]    = gy;
+      gYlmZ[lm]    = gz;
+    }
+  }
+}
+
+template<typename T>
+inline void SoaSphericalTensor<T>::normalize_vg(T* restrict Ylm_vgl, int nlm, const T* normfactor, size_t offset)
+{
+  T* restrict Ylm   = Ylm_vgl;
+  T* restrict gYlmX = Ylm_vgl + offset * 1;
+  T* restrict gYlmY = Ylm_vgl + offset * 2;
+  T* restrict gYlmZ = Ylm_vgl + offset * 3;
+  for (int i = 0; i < nlm; i++)
+  {
+    const T nf = normfactor[i];
+    Ylm[i] *= nf;
+    gYlmX[i] *= nf;
+    gYlmY[i] *= nf;
+    gYlmZ[i] *= nf;
+  }
+}
+
+template<typename T>
 inline void SoaSphericalTensor<T>::evaluateVGL_impl(const T x,
                                                     const T y,
                                                     const T z,
@@ -491,53 +566,13 @@ inline void SoaSphericalTensor<T>::evaluateVGL_impl(const T x,
                                                     const T* normfactor,
                                                     size_t offset)
 {
-  T* restrict Ylm = Ylm_vgl;
-  // T* restrict Ylm = cYlm.data(0);
-  evaluate_bare(x, y, z, Ylm, lmax, factorL, factorLM);
-  const size_t Nlm = (lmax + 1) * (lmax + 1);
+  const int Nlm = (lmax + 1) * (lmax + 1);
+  evaluateVGL_bare(x, y, z, Ylm_vgl, lmax, factorL, factorLM, factor2L, offset);
+  normalize_vg(Ylm_vgl, Nlm, normfactor, offset);
 
-  constexpr T czero(0);
-  constexpr T ahalf(0.5);
-  T* restrict gYlmX = Ylm_vgl + offset * 1;
-  T* restrict gYlmY = Ylm_vgl + offset * 2;
-  T* restrict gYlmZ = Ylm_vgl + offset * 3;
-  T* restrict lYlm  = Ylm_vgl + offset * 4; // just need to set to zero
-
-  gYlmX[0] = czero;
-  gYlmY[0] = czero;
-  gYlmZ[0] = czero;
-  lYlm[0]  = czero;
-
-  // Calculating Gradient now//
-  for (int l = 1; l <= lmax; l++)
-  {
-    //T fac = ((T) (2*l+1))/(2*l-1);
-    const T fac = factor2L[l];
-    for (int m = -l; m <= l; m++)
-    {
-      T gx, gy, gz;
-      gradient_recurrence(l, m, fac, [&](const int lower_lm) { return Ylm[lower_lm]; }, gx, gy, gz);
-      const int lm = index(l, m);
-      if (std::abs(m))
-      {
-        gYlmX[lm] = normfactor[lm] * gx;
-        gYlmY[lm] = normfactor[lm] * gy;
-        gYlmZ[lm] = normfactor[lm] * gz;
-      }
-      else
-      {
-        gYlmX[lm] = gx;
-        gYlmY[lm] = gy;
-        gYlmZ[lm] = gz;
-      }
-    }
-  }
+  T* restrict lYlm = Ylm_vgl + offset * 4; // just need to set to zero
   for (int i = 0; i < Nlm; i++)
-  {
-    Ylm[i] *= normfactor[i];
     lYlm[i] = 0;
-  }
-  //for (int i=0; i<Ylm.size(); i++) gradYlm[i]*= norm_factor_[i];
 }
 PRAGMA_OFFLOAD("omp end declare target")
 
@@ -551,19 +586,25 @@ inline void SoaSphericalTensor<T>::evaluateVGL(T x, T y, T z)
 template<typename T>
 inline void SoaSphericalTensor<T>::evaluateVGH(T x, T y, T z)
 {
-  evaluateVGL(x, y, z);
+  // The Hessian is the same recurrence applied a second time to the gradients, and
+  // the recurrence consumes unnormalized quantities. Stopping short of normalizing
+  // hands them over in exactly that form, so nothing has to be undone here;
+  // norm_factor_ goes on at the end, once the Hessian loop is done reading them.
+  const int Nlm = cYlm.size();
+  evaluateVGL_bare(x, y, z, cYlm.data(), Lmax, factorL_.data(), factorLM_.data(), factor2L_.data(), cYlm.capacity());
 
   constexpr T czero(0);
   constexpr T ahalf(0.5);
-  const T* restrict gYlmX = cYlm.data(1);
-  const T* restrict gYlmY = cYlm.data(2);
-  const T* restrict gYlmZ = cYlm.data(3);
-  T* restrict hYlmXX      = cYlm.data(4);
-  T* restrict hYlmXY      = cYlm.data(5);
-  T* restrict hYlmXZ      = cYlm.data(6);
-  T* restrict hYlmYY      = cYlm.data(7);
-  T* restrict hYlmYZ      = cYlm.data(8);
-  T* restrict hYlmZZ      = cYlm.data(9);
+  // not restrict-qualified: normalize_vg writes these same rows below
+  const T* gYlmX     = cYlm.data(1);
+  const T* gYlmY     = cYlm.data(2);
+  const T* gYlmZ     = cYlm.data(3);
+  T* restrict hYlmXX = cYlm.data(4);
+  T* restrict hYlmXY = cYlm.data(5);
+  T* restrict hYlmXZ = cYlm.data(6);
+  T* restrict hYlmYY = cYlm.data(7);
+  T* restrict hYlmYZ = cYlm.data(8);
+  T* restrict hYlmZZ = cYlm.data(9);
 
   hYlmXX[0] = czero;
   hYlmXY[0] = czero;
@@ -580,14 +621,12 @@ inline void SoaSphericalTensor<T>::evaluateVGH(T x, T y, T z)
       const int lm = index(l, m);
 
       // The recurrence coefficients do not depend on position, so differentiating
-      // a second time is the same recurrence applied to the l-1 gradients that
-      // evaluateVGL just stored. Those carry norm_factor_, so strip it on the way
-      // in and apply the target harmonic's norm_factor_ on the way out.
-      const auto differentiate_gradient = [&](const T* restrict lower_derivative) -> TinyVector<T, 3> {
+      // a second time is the same recurrence applied to the bare l-1 gradients that
+      // evaluateVGL_bare just stored, with the target harmonic's norm_factor_
+      // applied on the way out.
+      const auto differentiate_gradient = [&](const T* lower_derivative) -> TinyVector<T, 3> {
         T dx, dy, dz;
-        gradient_recurrence(
-            l, m, fac, [&](const int lower_lm) { return lower_derivative[lower_lm] / norm_factor_[lower_lm]; }, dx, dy,
-            dz);
+        gradient_recurrence(l, m, fac, lower_derivative, dx, dy, dz);
         return {dx, dy, dz};
       };
 
@@ -609,6 +648,8 @@ inline void SoaSphericalTensor<T>::evaluateVGH(T x, T y, T z)
       hYlmZZ[lm]   = norm * d_gz[2];
     }
   }
+
+  normalize_vg(cYlm.data(), Nlm, norm_factor_.data(), cYlm.capacity());
 }
 
 template<typename T>

--- a/src/Numerics/codegen/SoaSphericalTensor.h.in
+++ b/src/Numerics/codegen/SoaSphericalTensor.h.in
@@ -88,6 +88,26 @@ public:
                                const T* normfactor,
                                size_t offset);
 
+private:
+  /** compute Ylm and its gradient for a single position, norm_factor NOT applied
+   *
+   * evaluateVGH uses the gradient recurrence which requires unnormalized values.
+   * Anywhere that needs the normed vals can call normalize_vg after evaluateVGL_bare
+   */
+  static void evaluateVGL_bare(const T x,
+                               const T y,
+                               const T z,
+                               T* restrict Ylm_vgl,
+                               int lmax,
+                               const T* factorL,
+                               const T* factorLM,
+                               const T* factor2L,
+                               size_t offset);
+
+  ///apply norm_factor to the value and gradient rows left bare by evaluateVGL_bare
+  static void normalize_vg(T* restrict Ylm_vgl, int nlm, const T* normfactor, size_t offset);
+
+public:
   /** apply the solid-harmonic first-derivative recurrence at (l,m)
    *
    * The recurrence writes the derivative of the unnormalized \f$ r^l S_l^m \f$ as a
@@ -95,11 +115,16 @@ public:
    * do not depend on position, it applies unchanged to the l-1 harmonics, giving the
    * gradient, and to the l-1 gradients, giving the Hessian.
    *
-   * @param lower callable (int lm) -> T returning the unnormalized l-1 quantity
+   * @param lower the unnormalized l-1 quantities, indexed by index(l-1, m)
    * @param gx, gy, gz derivatives with respect to x, y and z, normfactor NOT applied
    */
-  template<typename Accessor>
-  static void gradient_recurrence(const int l, const int m, const T fac, Accessor lower, T& gx, T& gy, T& gz);
+  static void gradient_recurrence(const int l,
+                                  const int m,
+                                  const T fac,
+                                  const T* restrict lower,
+                                  T& gx,
+                                  T& gy,
+                                  T& gz);
 
   ///compute Ylm
   inline void evaluateV(T x, T y, T z, T* Ylm) const
@@ -412,6 +437,63 @@ PRAGMA_OFFLOAD("omp declare target")
 %gradient_recurrence
 
 template<typename T>
+inline void SoaSphericalTensor<T>::evaluateVGL_bare(const T x,
+                                                    const T y,
+                                                    const T z,
+                                                    T* restrict Ylm_vgl,
+                                                    int lmax,
+                                                    const T* factorL,
+                                                    const T* factorLM,
+                                                    const T* factor2L,
+                                                    size_t offset)
+{
+  T* restrict Ylm = Ylm_vgl;
+  evaluate_bare(x, y, z, Ylm, lmax, factorL, factorLM);
+
+  constexpr T czero(0);
+  T* restrict gYlmX = Ylm_vgl + offset * 1;
+  T* restrict gYlmY = Ylm_vgl + offset * 2;
+  T* restrict gYlmZ = Ylm_vgl + offset * 3;
+
+  gYlmX[0] = czero;
+  gYlmY[0] = czero;
+  gYlmZ[0] = czero;
+
+  // Calculating Gradient now//
+  for (int l = 1; l <= lmax; l++)
+  {
+    //T fac = ((T) (2*l+1))/(2*l-1);
+    const T fac = factor2L[l];
+    for (int m = -l; m <= l; m++)
+    {
+      T gx, gy, gz;
+      gradient_recurrence(l, m, fac, Ylm, gx, gy, gz);
+      const int lm = index(l, m);
+      gYlmX[lm]    = gx;
+      gYlmY[lm]    = gy;
+      gYlmZ[lm]    = gz;
+    }
+  }
+}
+
+template<typename T>
+inline void SoaSphericalTensor<T>::normalize_vg(T* restrict Ylm_vgl, int nlm, const T* normfactor, size_t offset)
+{
+  T* restrict Ylm   = Ylm_vgl;
+  T* restrict gYlmX = Ylm_vgl + offset * 1;
+  T* restrict gYlmY = Ylm_vgl + offset * 2;
+  T* restrict gYlmZ = Ylm_vgl + offset * 3;
+  for (int i = 0; i < nlm; i++)
+  {
+    const T nf = normfactor[i];
+    Ylm[i] *= nf;
+    gYlmX[i] *= nf;
+    gYlmY[i] *= nf;
+    gYlmZ[i] *= nf;
+  }
+}
+
+template<typename T>
 inline void SoaSphericalTensor<T>::evaluateVGL_impl(const T x,
                                                     const T y,
                                                     const T z,
@@ -423,53 +505,13 @@ inline void SoaSphericalTensor<T>::evaluateVGL_impl(const T x,
                                                     const T* normfactor,
                                                     size_t offset)
 {
-  T* restrict Ylm = Ylm_vgl;
-  // T* restrict Ylm = cYlm.data(0);
-  evaluate_bare(x, y, z, Ylm, lmax, factorL, factorLM);
-  const size_t Nlm = (lmax + 1) * (lmax + 1);
+  const int Nlm = (lmax + 1) * (lmax + 1);
+  evaluateVGL_bare(x, y, z, Ylm_vgl, lmax, factorL, factorLM, factor2L, offset);
+  normalize_vg(Ylm_vgl, Nlm, normfactor, offset);
 
-  constexpr T czero(0);
-  constexpr T ahalf(0.5);
-  T* restrict gYlmX = Ylm_vgl + offset * 1;
-  T* restrict gYlmY = Ylm_vgl + offset * 2;
-  T* restrict gYlmZ = Ylm_vgl + offset * 3;
-  T* restrict lYlm  = Ylm_vgl + offset * 4; // just need to set to zero
-
-  gYlmX[0] = czero;
-  gYlmY[0] = czero;
-  gYlmZ[0] = czero;
-  lYlm[0]  = czero;
-
-  // Calculating Gradient now//
-  for (int l = 1; l <= lmax; l++)
-  {
-    //T fac = ((T) (2*l+1))/(2*l-1);
-    const T fac = factor2L[l];
-    for (int m = -l; m <= l; m++)
-    {
-      T gx, gy, gz;
-      gradient_recurrence(l, m, fac, [&](const int lower_lm) { return Ylm[lower_lm]; }, gx, gy, gz);
-      const int lm = index(l, m);
-      if (std::abs(m))
-      {
-        gYlmX[lm] = normfactor[lm] * gx;
-        gYlmY[lm] = normfactor[lm] * gy;
-        gYlmZ[lm] = normfactor[lm] * gz;
-      }
-      else
-      {
-        gYlmX[lm] = gx;
-        gYlmY[lm] = gy;
-        gYlmZ[lm] = gz;
-      }
-    }
-  }
+  T* restrict lYlm = Ylm_vgl + offset * 4; // just need to set to zero
   for (int i = 0; i < Nlm; i++)
-  {
-    Ylm[i] *= normfactor[i];
     lYlm[i] = 0;
-  }
-  //for (int i=0; i<Ylm.size(); i++) gradYlm[i]*= norm_factor_[i];
 }
 PRAGMA_OFFLOAD("omp end declare target")
 

--- a/src/Numerics/codegen/SoaSphericalTensor.h.in
+++ b/src/Numerics/codegen/SoaSphericalTensor.h.in
@@ -10,13 +10,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-/*
- DO NOT MAKE PERMANENT EDITS IN THIS FILE
- This file is generated from src/Numerics/codegen/gen_spherical_tensor.py and
- SoaSphericalTensor.h.in.
-
- Edit the template or generator and rerun gen_spherical_tensor.py.
-*/
+%dire_codegen_warning
 
 #ifndef QMCPLUSPLUS_SOA_SPHERICAL_CARTESIAN_TENSOR_H
 #define QMCPLUSPLUS_SOA_SPHERICAL_CARTESIAN_TENSOR_H
@@ -415,69 +409,7 @@ PRAGMA_OFFLOAD("omp end declare target")
 
 PRAGMA_OFFLOAD("omp declare target")
 
-template<typename T>
-template<typename Accessor>
-inline void SoaSphericalTensor<T>::gradient_recurrence(const int l,
-                                                       const int m,
-                                                       const T fac,
-                                                       Accessor lower,
-                                                       T& gx,
-                                                       T& gy,
-                                                       T& gz)
-{
-  constexpr T czero(0);
-  constexpr T ahalf(0.5);
-  const int ma = std::abs(m);
-  const int lm = index(l - 1, 0);
-  const T cp   = std::sqrt(fac * (l - ma - 1) * (l - ma));
-  const T cm   = std::sqrt(fac * (l + ma - 1) * (l + ma));
-  const T c0   = std::sqrt(fac * (l - ma) * (l + ma));
-
-  T dpr, dpi, dmr, dmi;
-  gz = (l > ma) ? c0 * lower(lm + m) : czero;
-  if (l > ma + 1)
-  {
-    dpr = cp * lower(lm + ma + 1);
-    dpi = cp * lower(lm - ma - 1);
-  }
-  else
-  {
-    dpr = czero;
-    dpi = czero;
-  }
-  if (l > 1)
-  {
-    switch (ma)
-    {
-    case 0:
-      dmr = -cm * lower(lm + 1);
-      dmi = cm * lower(lm - 1);
-      break;
-    case 1:
-      dmr = cm * lower(lm);
-      dmi = czero;
-      break;
-    default:
-      dmr = cm * lower(lm + ma - 1);
-      dmi = cm * lower(lm - ma + 1);
-    }
-  }
-  else
-  {
-    dmr = cm * lower(lm);
-    dmi = czero;
-  }
-  if (m < 0)
-  {
-    gx = ahalf * (dpi - dmi);
-    gy = -ahalf * (dpr + dmr);
-  }
-  else
-  {
-    gx = ahalf * (dpr - dmr);
-    gy = ahalf * (dpi + dmi);
-  }
-}
+%gradient_recurrence
 
 template<typename T>
 inline void SoaSphericalTensor<T>::evaluateVGL_impl(const T x,
@@ -548,72 +480,9 @@ inline void SoaSphericalTensor<T>::evaluateVGL(T x, T y, T z)
                    cYlm.capacity());
 }
 
-template<typename T>
-inline void SoaSphericalTensor<T>::evaluateVGH(T x, T y, T z)
-{
-  evaluateVGL(x, y, z);
+%evaluate_vgh
 
-  constexpr T czero(0);
-  constexpr T ahalf(0.5);
-  const T* restrict gYlmX = cYlm.data(1);
-  const T* restrict gYlmY = cYlm.data(2);
-  const T* restrict gYlmZ = cYlm.data(3);
-  T* restrict hYlmXX      = cYlm.data(4);
-  T* restrict hYlmXY      = cYlm.data(5);
-  T* restrict hYlmXZ      = cYlm.data(6);
-  T* restrict hYlmYY      = cYlm.data(7);
-  T* restrict hYlmYZ      = cYlm.data(8);
-  T* restrict hYlmZZ      = cYlm.data(9);
-
-  hYlmXX[0] = czero;
-  hYlmXY[0] = czero;
-  hYlmXZ[0] = czero;
-  hYlmYY[0] = czero;
-  hYlmYZ[0] = czero;
-  hYlmZZ[0] = czero;
-
-  for (int l = 1; l <= Lmax; ++l)
-  {
-    const T fac = factor2L_[l];
-    for (int m = -l; m <= l; ++m)
-    {
-      const int lm = index(l, m);
-
-      // The recurrence coefficients do not depend on position, so differentiating
-      // a second time is the same recurrence applied to the l-1 gradients that
-      // evaluateVGL just stored. Those carry norm_factor_, so strip it on the way
-      // in and apply the target harmonic's norm_factor_ on the way out.
-      const auto differentiate_gradient = [&](const T* restrict lower_derivative) -> TinyVector<T, 3> {
-        T dx, dy, dz;
-        gradient_recurrence(
-            l, m, fac, [&](const int lower_lm) { return lower_derivative[lower_lm] / norm_factor_[lower_lm]; }, dx, dy,
-            dz);
-        return {dx, dy, dz};
-      };
-
-      // d_gx[i] is the i-th derivative of the stored x gradient, so the mixed
-      // second derivatives each come out of two separate recurrence passes.
-      const TinyVector<T, 3> d_gx = differentiate_gradient(gYlmX);
-      const TinyVector<T, 3> d_gy = differentiate_gradient(gYlmY);
-      const TinyVector<T, 3> d_gz = differentiate_gradient(gYlmZ);
-
-      // The Hessian is symmetric analytically, so d_gx[1] and d_gy[0] differ
-      // only by roundoff. Both are already in hand, so averaging them is free
-      // and keeps the stored Hessian exactly symmetric.
-      const T norm = norm_factor_[lm];
-      hYlmXX[lm]   = norm * d_gx[0];
-      hYlmXY[lm]   = norm * ahalf * (d_gx[1] + d_gy[0]);
-      hYlmXZ[lm]   = norm * ahalf * (d_gx[2] + d_gz[0]);
-      hYlmYY[lm]   = norm * d_gy[1];
-      hYlmYZ[lm]   = norm * ahalf * (d_gy[2] + d_gz[1]);
-      hYlmZZ[lm]   = norm * d_gz[2];
-    }
-  }
-}
-
-template<typename T>
-inline void SoaSphericalTensor<T>::evaluateVGHGH(T x, T y, T z)
-{ throw std::runtime_error("SoaSphericalTensor<T>::evaluateVGHGH(x,y,z):  Not implemented\n"); }
+%evaluate_vghgh
 
 extern template class SoaSphericalTensor<float>;
 extern template class SoaSphericalTensor<double>;

--- a/src/Numerics/codegen/gen_spherical_tensor.py
+++ b/src/Numerics/codegen/gen_spherical_tensor.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+# Generate SoaSphericalTensor using the solid-harmonic derivative recurrence.
+
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+from sympy import (Integer, Poly, Symbol, cos, diff, expand, expand_complex,
+                   expand_func, expand_trig, im, powdenest, re, simplify, sin,
+                   sqrt, sympify)
+from sympy.functions.special.spherical_harmonics import Ynm
+from sympy.printing.cxx import cxxcode
+
+
+X, Y, Z = Symbol("x", real=True), Symbol("y", real=True), Symbol("z", real=True)
+R, RHO = Symbol("r", positive=True), Symbol("rho", positive=True)
+THETA, PHI = Symbol("theta", real=True), Symbol("phi", real=True)
+
+
+def index(l, m):
+    """Return the QMCPACK storage index for a real solid harmonic."""
+    return l * (l + 1) + m
+
+
+@lru_cache(maxsize=None)
+def create_solid_harmonic_symbolic(l, m):
+    """Construct r**l S_l^m in the Gaussian real-harmonic convention.
+
+    This follows the addsign=true convention documented by
+    SoaSphericalTensor. It is constructed directly from SymPy's complex
+    spherical harmonic rather than from QMCPACK's runtime recurrence.
+    """
+    if m == 0:
+        angular = expand_func(Ynm(l, 0, THETA, PHI))
+    else:
+        complex_ylm = expand_complex(expand_func(Ynm(l, abs(m), THETA, PHI)))
+        real_part = re(complex_ylm) if m > 0 else im(complex_ylm)
+        angular = Integer(-1) ** m * sqrt(2) * real_part
+
+    angular = expand_trig(angular)
+    regular = expand(angular * R**l)
+    regular = regular.subs(
+        {
+            cos(PHI): X / RHO,
+            sin(PHI): Y / RHO,
+            cos(THETA): Z / R,
+            sin(THETA): RHO / R,
+        },
+        simultaneous=True,
+    )
+    regular = expand(regular)
+    regular = regular.subs(RHO**2, X**2 + Y**2).subs(R**2, X**2 + Y**2 + Z**2)
+    regular = powdenest(regular, force=True)
+    regular = simplify(
+        regular.subs(RHO, sqrt(X**2 + Y**2)).subs(R, sqrt(X**2 + Y**2 + Z**2))
+    )
+    regular = expand(regular)
+
+    # A regular solid harmonic must be a Cartesian polynomial.
+    Poly(regular, X, Y, Z)
+    return regular
+
+
+@lru_cache(maxsize=None)
+def create_raw_solid_harmonic_symbolic(l, m):
+    """Construct the solid harmonic before norm_factor is applied."""
+    solid_harmonic = create_solid_harmonic_symbolic(l, m)
+    if m:
+        solid_harmonic /= Integer(-1) ** m * sqrt(2)
+    return expand(solid_harmonic)
+
+
+def apply_gradient_recurrence(l, m, lower_value):
+    """Apply the runtime gradient recurrence to lower-l symbolic values."""
+    ma = abs(m)
+    fac = Integer(2 * l + 1) / Integer(2 * l - 1)
+    cp = sqrt(fac * (l - ma - 1) * (l - ma))
+    cm = sqrt(fac * (l + ma - 1) * (l + ma))
+    c0 = sqrt(fac * (l - ma) * (l + ma))
+
+    dz = c0 * lower_value(m) if l > ma else Integer(0)
+
+    if l > ma + 1:
+        dpr = cp * lower_value(ma + 1)
+        dpi = cp * lower_value(-ma - 1)
+    else:
+        dpr = Integer(0)
+        dpi = Integer(0)
+
+    if l > 1:
+        if ma == 0:
+            dmr = -cm * lower_value(1)
+            dmi = cm * lower_value(-1)
+        elif ma == 1:
+            dmr = cm * lower_value(0)
+            dmi = Integer(0)
+        else:
+            dmr = cm * lower_value(ma - 1)
+            dmi = cm * lower_value(-ma + 1)
+    else:
+        dmr = cm * lower_value(0)
+        dmi = Integer(0)
+
+    half = Integer(1) / 2
+    if m < 0:
+        dx = half * (dpi - dmi)
+        dy = -half * (dpr + dmr)
+    else:
+        dx = half * (dpr - dmr)
+        dy = half * (dpi + dmi)
+
+    return tuple(simplify(value) for value in (dx, dy, dz))
+
+
+def verify_hessian_recurrence(lmax=6):
+    """Verify the compact Hessian recurrence against symbolic harmonics."""
+    coordinates = (X, Y, Z)
+    for l in range(1, lmax + 1):
+        for m in range(-l, l + 1):
+            target = create_raw_solid_harmonic_symbolic(l, m)
+            for source_coordinate in coordinates:
+                lower_value = lambda lower_m: diff(
+                    create_raw_solid_harmonic_symbolic(l - 1, lower_m), source_coordinate
+                )
+                recurrence_derivatives = apply_gradient_recurrence(l, m, lower_value)
+                for derivative_coordinate, recurrence_derivative in zip(
+                    coordinates, recurrence_derivatives
+                ):
+                    expected = diff(target, source_coordinate, derivative_coordinate)
+                    difference = simplify(recurrence_derivative - expected)
+                    if difference != 0:
+                        raise RuntimeError(
+                            f"Hessian recurrence verification failed for l={l}, m={m}: "
+                            f"{difference}"
+                        )
+
+
+def gen_recurrence_coefficients():
+    """Emit the three recurrence coefficients of the gradient recurrence.
+
+    The factor association is pinned to the order the original evaluateVGL used, so
+    that factoring the recurrence out of evaluateVGL_impl is bitwise identical: a
+    three-way product reassociates under IEEE754, and reordering it perturbs the
+    stored gradients by a few ulp. SymPy's printer canonicalizes factor order and
+    cannot preserve the association, so the C++ is written out literally and SymPy
+    is used to check it against the symbolic form instead of to format it.
+    """
+    l, ma, fac = Symbol("l"), Symbol("ma"), Symbol("fac")
+    coefficients = (
+        ("cp", "fac * (l - ma - 1) * (l - ma)", sqrt(fac * (l - ma - 1) * (l - ma))),
+        ("cm", "fac * (l + ma - 1) * (l + ma)", sqrt(fac * (l + ma - 1) * (l + ma))),
+        ("c0", "fac * (l - ma) * (l + ma)", sqrt(fac * (l - ma) * (l + ma))),
+    )
+    lines = []
+    for name, emitted, expression in coefficients:
+        if simplify(sqrt(sympify(emitted)) - expression) != 0:
+            raise RuntimeError(f"emitted coefficient {name} does not match its symbolic form")
+        lines.append(f"  const T {name:<2} = std::sqrt({emitted});")
+    return "\n".join(lines)
+
+
+def gen_soa_gradient_recurrence():
+    """Generate the shared first-derivative recurrence used by VGL and VGH."""
+    return """template<typename T>
+template<typename Accessor>
+inline void SoaSphericalTensor<T>::gradient_recurrence(const int l,
+                                                       const int m,
+                                                       const T fac,
+                                                       Accessor lower,
+                                                       T& gx,
+                                                       T& gy,
+                                                       T& gz)
+{
+  constexpr T czero(0);
+  constexpr T ahalf(0.5);
+  const int ma = std::abs(m);
+  const int lm = index(l - 1, 0);
+%s
+
+  T dpr, dpi, dmr, dmi;
+  gz = (l > ma) ? c0 * lower(lm + m) : czero;
+  if (l > ma + 1)
+  {
+    dpr = cp * lower(lm + ma + 1);
+    dpi = cp * lower(lm - ma - 1);
+  }
+  else
+  {
+    dpr = czero;
+    dpi = czero;
+  }
+  if (l > 1)
+  {
+    switch (ma)
+    {
+    case 0:
+      dmr = -cm * lower(lm + 1);
+      dmi = cm * lower(lm - 1);
+      break;
+    case 1:
+      dmr = cm * lower(lm);
+      dmi = czero;
+      break;
+    default:
+      dmr = cm * lower(lm + ma - 1);
+      dmi = cm * lower(lm - ma + 1);
+    }
+  }
+  else
+  {
+    dmr = cm * lower(lm);
+    dmi = czero;
+  }
+  if (m < 0)
+  {
+    gx = ahalf * (dpi - dmi);
+    gy = -ahalf * (dpr + dmr);
+  }
+  else
+  {
+    gx = ahalf * (dpr - dmr);
+    gy = ahalf * (dpi + dmi);
+  }
+}
+""" % gen_recurrence_coefficients()
+
+
+def gen_soa_evaluate_vgh():
+    """Generate evaluateVGH by reapplying the shared gradient recurrence."""
+    return """template<typename T>
+inline void SoaSphericalTensor<T>::evaluateVGH(T x, T y, T z)
+{
+  evaluateVGL(x, y, z);
+
+  constexpr T czero(0);
+  constexpr T ahalf(0.5);
+  const T* restrict gYlmX = cYlm.data(1);
+  const T* restrict gYlmY = cYlm.data(2);
+  const T* restrict gYlmZ = cYlm.data(3);
+  T* restrict hYlmXX      = cYlm.data(4);
+  T* restrict hYlmXY      = cYlm.data(5);
+  T* restrict hYlmXZ      = cYlm.data(6);
+  T* restrict hYlmYY      = cYlm.data(7);
+  T* restrict hYlmYZ      = cYlm.data(8);
+  T* restrict hYlmZZ      = cYlm.data(9);
+
+  hYlmXX[0] = czero;
+  hYlmXY[0] = czero;
+  hYlmXZ[0] = czero;
+  hYlmYY[0] = czero;
+  hYlmYZ[0] = czero;
+  hYlmZZ[0] = czero;
+
+  for (int l = 1; l <= Lmax; ++l)
+  {
+    const T fac = factor2L_[l];
+    for (int m = -l; m <= l; ++m)
+    {
+      const int lm = index(l, m);
+
+      // The recurrence coefficients do not depend on position, so differentiating
+      // a second time is the same recurrence applied to the l-1 gradients that
+      // evaluateVGL just stored. Those carry norm_factor_, so strip it on the way
+      // in and apply the target harmonic's norm_factor_ on the way out.
+      const auto differentiate_gradient = [&](const T* restrict lower_derivative) -> TinyVector<T, 3> {
+        T dx, dy, dz;
+        gradient_recurrence(
+            l, m, fac, [&](const int lower_lm) { return lower_derivative[lower_lm] / norm_factor_[lower_lm]; }, dx, dy,
+            dz);
+        return {dx, dy, dz};
+      };
+
+      // d_gx[i] is the i-th derivative of the stored x gradient, so the mixed
+      // second derivatives each come out of two separate recurrence passes.
+      const TinyVector<T, 3> d_gx = differentiate_gradient(gYlmX);
+      const TinyVector<T, 3> d_gy = differentiate_gradient(gYlmY);
+      const TinyVector<T, 3> d_gz = differentiate_gradient(gYlmZ);
+
+      // The Hessian is symmetric analytically, so d_gx[1] and d_gy[0] differ
+      // only by roundoff. Both are already in hand, so averaging them is free
+      // and keeps the stored Hessian exactly symmetric.
+      const T norm = norm_factor_[lm];
+      hYlmXX[lm]   = norm * d_gx[0];
+      hYlmXY[lm]   = norm * ahalf * (d_gx[1] + d_gy[0]);
+      hYlmXZ[lm]   = norm * ahalf * (d_gx[2] + d_gz[0]);
+      hYlmYY[lm]   = norm * d_gy[1];
+      hYlmYZ[lm]   = norm * ahalf * (d_gy[2] + d_gz[1]);
+      hYlmZZ[lm]   = norm * d_gz[2];
+    }
+  }
+}
+"""
+
+
+def gen_soa_evaluate_vghgh():
+    return """template<typename T>
+inline void SoaSphericalTensor<T>::evaluateVGHGH(T x, T y, T z)
+{
+  throw std::runtime_error("SoaSphericalTensor<T>::evaluateVGHGH(x,y,z):  Not implemented\\n");
+}
+"""
+
+
+def run_template(template_path, output_path, bodies):
+    """Apply the same line-oriented template convention as the Cartesian generator."""
+    output = ""
+    with template_path.open("r", encoding="utf-8") as template_file:
+        for line in template_file:
+            if line.startswith("%"):
+                key = line.strip()[1:]
+                if key not in bodies:
+                    raise KeyError(f"Template item not found: {key}")
+                line = bodies[key]
+            output += line
+
+    output_path.write_text(output, encoding="utf-8")
+
+
+def create_soa_spherical_tensor_h():
+    script_dir = Path(__file__).resolve().parent
+    template_path = script_dir / "SoaSphericalTensor.h.in"
+    output_path = script_dir.parent / "SoaSphericalTensor.h"
+
+    verify_hessian_recurrence()
+
+    warning = """/*
+ DO NOT MAKE PERMANENT EDITS IN THIS FILE
+ This file is generated from src/Numerics/codegen/gen_spherical_tensor.py and
+ SoaSphericalTensor.h.in.
+
+ Edit the template or generator and rerun gen_spherical_tensor.py.
+*/
+"""
+    bodies = {
+        "dire_codegen_warning": warning,
+        "gradient_recurrence": gen_soa_gradient_recurrence(),
+        "evaluate_vgh": gen_soa_evaluate_vgh(),
+        "evaluate_vghgh": gen_soa_evaluate_vghgh(),
+    }
+    run_template(template_path, output_path, bodies)
+    subprocess.run(["clang-format", "-i", output_path], check=True)
+
+
+if __name__ == "__main__":
+    create_soa_spherical_tensor_h()

--- a/src/Numerics/codegen/gen_spherical_tensor.py
+++ b/src/Numerics/codegen/gen_spherical_tensor.py
@@ -162,11 +162,10 @@ def gen_recurrence_coefficients():
 def gen_soa_gradient_recurrence():
     """Generate the shared first-derivative recurrence used by VGL and VGH."""
     return """template<typename T>
-template<typename Accessor>
 inline void SoaSphericalTensor<T>::gradient_recurrence(const int l,
                                                        const int m,
                                                        const T fac,
-                                                       Accessor lower,
+                                                       const T* restrict lower,
                                                        T& gx,
                                                        T& gy,
                                                        T& gz)
@@ -178,11 +177,11 @@ inline void SoaSphericalTensor<T>::gradient_recurrence(const int l,
 %s
 
   T dpr, dpi, dmr, dmi;
-  gz = (l > ma) ? c0 * lower(lm + m) : czero;
+  gz = (l > ma) ? c0 * lower[lm + m] : czero;
   if (l > ma + 1)
   {
-    dpr = cp * lower(lm + ma + 1);
-    dpi = cp * lower(lm - ma - 1);
+    dpr = cp * lower[lm + ma + 1];
+    dpi = cp * lower[lm - ma - 1];
   }
   else
   {
@@ -194,21 +193,21 @@ inline void SoaSphericalTensor<T>::gradient_recurrence(const int l,
     switch (ma)
     {
     case 0:
-      dmr = -cm * lower(lm + 1);
-      dmi = cm * lower(lm - 1);
+      dmr = -cm * lower[lm + 1];
+      dmi = cm * lower[lm - 1];
       break;
     case 1:
-      dmr = cm * lower(lm);
+      dmr = cm * lower[lm];
       dmi = czero;
       break;
     default:
-      dmr = cm * lower(lm + ma - 1);
-      dmi = cm * lower(lm - ma + 1);
+      dmr = cm * lower[lm + ma - 1];
+      dmi = cm * lower[lm - ma + 1];
     }
   }
   else
   {
-    dmr = cm * lower(lm);
+    dmr = cm * lower[lm];
     dmi = czero;
   }
   if (m < 0)
@@ -230,13 +229,19 @@ def gen_soa_evaluate_vgh():
     return """template<typename T>
 inline void SoaSphericalTensor<T>::evaluateVGH(T x, T y, T z)
 {
-  evaluateVGL(x, y, z);
+  // The Hessian is the same recurrence applied a second time to the gradients, and
+  // the recurrence consumes unnormalized quantities. Stopping short of normalizing
+  // hands them over in exactly that form, so nothing has to be undone here;
+  // norm_factor_ goes on at the end, once the Hessian loop is done reading them.
+  const int Nlm = cYlm.size();
+  evaluateVGL_bare(x, y, z, cYlm.data(), Lmax, factorL_.data(), factorLM_.data(), factor2L_.data(), cYlm.capacity());
 
   constexpr T czero(0);
   constexpr T ahalf(0.5);
-  const T* restrict gYlmX = cYlm.data(1);
-  const T* restrict gYlmY = cYlm.data(2);
-  const T* restrict gYlmZ = cYlm.data(3);
+  // not restrict-qualified: normalize_vg writes these same rows below
+  const T* gYlmX = cYlm.data(1);
+  const T* gYlmY = cYlm.data(2);
+  const T* gYlmZ = cYlm.data(3);
   T* restrict hYlmXX      = cYlm.data(4);
   T* restrict hYlmXY      = cYlm.data(5);
   T* restrict hYlmXZ      = cYlm.data(6);
@@ -259,14 +264,12 @@ inline void SoaSphericalTensor<T>::evaluateVGH(T x, T y, T z)
       const int lm = index(l, m);
 
       // The recurrence coefficients do not depend on position, so differentiating
-      // a second time is the same recurrence applied to the l-1 gradients that
-      // evaluateVGL just stored. Those carry norm_factor_, so strip it on the way
-      // in and apply the target harmonic's norm_factor_ on the way out.
-      const auto differentiate_gradient = [&](const T* restrict lower_derivative) -> TinyVector<T, 3> {
+      // a second time is the same recurrence applied to the bare l-1 gradients that
+      // evaluateVGL_bare just stored, with the target harmonic's norm_factor_
+      // applied on the way out.
+      const auto differentiate_gradient = [&](const T* lower_derivative) -> TinyVector<T, 3> {
         T dx, dy, dz;
-        gradient_recurrence(
-            l, m, fac, [&](const int lower_lm) { return lower_derivative[lower_lm] / norm_factor_[lower_lm]; }, dx, dy,
-            dz);
+        gradient_recurrence(l, m, fac, lower_derivative, dx, dy, dz);
         return {dx, dy, dz};
       };
 
@@ -288,6 +291,8 @@ inline void SoaSphericalTensor<T>::evaluateVGH(T x, T y, T z)
       hYlmZZ[lm]   = norm * d_gz[2];
     }
   }
+
+  normalize_vg(cYlm.data(), Nlm, norm_factor_.data(), cYlm.capacity());
 }
 """
 

--- a/src/Numerics/tests/CMakeLists.txt
+++ b/src/Numerics/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(UTEST_SRCS
     test_gaussian_basis.cpp
     test_cartesian_tensor.cpp
     test_soa_cartesian_tensor.cpp
+    test_soa_spherical_tensor.cpp
     test_transform.cpp
     test_min_oned.cpp
     test_OneDimCubicSplineLinearGrid.cpp
@@ -30,7 +31,8 @@ set(UTEST_SRCS
     test_RotationMatrix3D.cpp)
 
 # Run gen_gto.py to create these files.  They may take a long time to compile.
-#SET(UTEST_SRCS ${UTEST_SRCS} test_full_cartesian_tensor.cpp test_full_soa_cartesian_tensor.cpp)
+#SET(UTEST_SRCS ${UTEST_SRCS} test_full_cartesian_tensor.cpp test_full_soa_cartesian_tensor.cpp
+#    test_full_soa_spherical_tensor.cpp)
 
 add_executable(${UTEST_EXE} ${UTEST_SRCS})
 

--- a/src/Numerics/tests/gen_gto.py
+++ b/src/Numerics/tests/gen_gto.py
@@ -1,5 +1,6 @@
 
 from collections import namedtuple, defaultdict
+from functools import lru_cache
 from sympy import *
 
 # See the GaussianOrbitals notebook in the qmc_algorithms repo for more explanation,
@@ -349,6 +350,90 @@ def compute_radial_values(p, print_value=False, print_grad=False, print_lap=Fals
 
   return out
 
+SPH_X, SPH_Y, SPH_Z = symbols('x y z', real=True)
+SPH_R, SPH_RHO = Symbol('r_sph', positive=True), Symbol('rho_sph', positive=True)
+SPH_THETA, SPH_PHI = symbols('theta_sph phi_sph', real=True)
+
+
+@lru_cache(maxsize=None)
+def create_real_solid_harmonic(l, m, addsign=True):
+  """Construct r**l S_l^m directly from SymPy's complex spherical harmonic."""
+  if m == 0:
+    angular = expand_func(Ynm(l, 0, SPH_THETA, SPH_PHI))
+  else:
+    complex_ylm = expand_complex(expand_func(Ynm(l, abs(m), SPH_THETA, SPH_PHI)))
+    real_part = re(complex_ylm) if m > 0 else im(complex_ylm)
+    sign = Integer(-1)**m if addsign else Integer(1)
+    angular = sign * sqrt(2) * real_part
+
+  regular = expand(expand_trig(angular) * SPH_R**l)
+  regular = regular.subs(
+      {
+          cos(SPH_PHI): SPH_X / SPH_RHO,
+          sin(SPH_PHI): SPH_Y / SPH_RHO,
+          cos(SPH_THETA): SPH_Z / SPH_R,
+          sin(SPH_THETA): SPH_RHO / SPH_R,
+      },
+      simultaneous=True)
+  regular = expand(regular)
+  regular = regular.subs(SPH_RHO**2, SPH_X**2 + SPH_Y**2)
+  regular = regular.subs(SPH_R**2, SPH_X**2 + SPH_Y**2 + SPH_Z**2)
+  regular = powdenest(regular, force=True)
+  regular = simplify(
+      regular.subs(SPH_RHO, sqrt(SPH_X**2 + SPH_Y**2)).subs(
+          SPH_R, sqrt(SPH_X**2 + SPH_Y**2 + SPH_Z**2)))
+  regular = expand(regular)
+  Poly(regular, SPH_X, SPH_Y, SPH_Z)
+  return regular
+
+
+@lru_cache(maxsize=None)
+def create_spherical_tensor_components(l, m, addsign=True):
+  """Return V, G, L, and the six unique Hessian components."""
+  expression = create_real_solid_harmonic(l, m, addsign)
+  gr0 = diff(expression, SPH_X)
+  gr1 = diff(expression, SPH_Y)
+  gr2 = diff(expression, SPH_Z)
+  lap = diff(expression, SPH_X, 2) + diff(expression, SPH_Y, 2) + diff(expression, SPH_Z, 2)
+  return tuple(simplify(component) for component in
+               (expression, gr0, gr1, gr2, lap,
+                diff(expression, SPH_X, 2),
+                diff(expression, SPH_X, SPH_Y),
+                diff(expression, SPH_X, SPH_Z),
+                diff(expression, SPH_Y, 2),
+                diff(expression, SPH_Y, SPH_Z),
+                diff(expression, SPH_Z, 2)))
+
+
+def compute_spherical_tensor_values(p, lmax=6, print_value=False, print_grad=False,
+                                    print_lap=False, print_hess=False, addsign=True):
+  """Generate checks from analytic regular solid harmonics, independently of QMCPACK."""
+  component_names = ('Ylm', 'gr0', 'gr1', 'gr2', 'lap',
+                     'h00', 'h01', 'h02', 'h11', 'h12', 'h22')
+  selected_components = []
+  if print_value:
+    selected_components.append(0)
+  if print_grad:
+    selected_components.extend((1, 2, 3))
+  if print_lap:
+    selected_components.append(4)
+  if print_hess:
+    selected_components.extend((5, 6, 7, 8, 9, 10))
+
+  substitutions = {SPH_X:p[0], SPH_Y:p[1], SPH_Z:p[2]}
+  out = ''
+  for l in range(lmax + 1):
+    for m in range(-l, l + 1):
+      lm = l * (l + 1) + m
+      components = create_spherical_tensor_components(l, m, addsign)
+      for component in selected_components:
+        value = float(components[component].subs(substitutions).evalf(17))
+        formatted_value = '0.0' if value == 0.0 else '%.15g' % value
+        out += '  CHECK(%s[%d] == Approx(%s));\n' % (component_names[component], lm, formatted_value)
+      out += '\n'
+  return out.rstrip() + '\n'
+
+
 # A simple template replacement engine.
 # Template items to be replaced start on a line with '%'.
 def run_template(fname_in, fname_out, bodies):
@@ -409,6 +494,19 @@ def create_test_full_soa_cartesian_tensor():
   run_template(fname_in, fname_out, bodies)
 
 
+def create_test_full_soa_spherical_tensor():
+  p = [1.3, 1.2, -0.5]
+  bodies = dict()
+  bodies['test_evaluateV'] = compute_spherical_tensor_values(p, print_value=True)
+  bodies['test_evaluateVGL'] = compute_spherical_tensor_values(
+      p, print_value=True, print_grad=True, print_lap=True)
+  bodies['test_evaluateVGH'] = compute_spherical_tensor_values(
+      p, print_value=True, print_grad=True, print_hess=True)
+
+  fname_in = 'test_full_soa_spherical_tensor.cpp.in'
+  fname_out = 'test_full_soa_spherical_tensor.cpp'
+
+  run_template(fname_in, fname_out, bodies)
 
 
 if __name__ == '__main__':
@@ -435,4 +533,5 @@ if __name__ == '__main__':
     # Create full test
     create_test_full_cartesian_tensor()
     create_test_full_soa_cartesian_tensor()
+    create_test_full_soa_spherical_tensor()
 

--- a/src/Numerics/tests/test_full_soa_spherical_tensor.cpp.in
+++ b/src/Numerics/tests/test_full_soa_spherical_tensor.cpp.in
@@ -1,0 +1,77 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2026 QMCPACK developers.
+//
+// File developed by: Shiv Upadhyay, shivnupadhyay@gmail.com, University of Washington
+//
+// File created by: Shiv Upadhyay, shivnupadhyay@gmail.com, University of Washington
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "Numerics/SoaSphericalTensor.h"
+#include "Utilities/for_testing/Catch2Approx.h"
+
+namespace qmcplusplus
+{
+
+// Use gen_gto.py to generate the checks.
+
+TEST_CASE("SoA Spherical Tensor evaluateV full", "[numerics]")
+{
+  SoaSphericalTensor<double> st(6, true);
+
+  const double x = 1.3;
+  const double y = 1.2;
+  const double z = -0.5;
+  st.evaluateV(x, y, z);
+
+  const double* Ylm = st[0];
+
+%test_evaluateV
+}
+
+TEST_CASE("SoA Spherical Tensor evaluateVGL full", "[numerics]")
+{
+  SoaSphericalTensor<double> st(6, true);
+
+  const double x = 1.3;
+  const double y = 1.2;
+  const double z = -0.5;
+  st.evaluateVGL(x, y, z);
+
+  const double* Ylm = st[0];
+  const double* gr0 = st[1];
+  const double* gr1 = st[2];
+  const double* gr2 = st[3];
+  const double* lap = st[4];
+
+%test_evaluateVGL
+}
+
+TEST_CASE("SoA Spherical Tensor evaluateVGH full", "[numerics]")
+{
+  SoaSphericalTensor<double> st(6, true);
+
+  const double x = 1.3;
+  const double y = 1.2;
+  const double z = -0.5;
+  st.evaluateVGH(x, y, z);
+
+  const double* Ylm = st[0];
+  const double* gr0 = st[1];
+  const double* gr1 = st[2];
+  const double* gr2 = st[3];
+  const double* h00 = st[4];
+  const double* h01 = st[5];
+  const double* h02 = st[6];
+  const double* h11 = st[7];
+  const double* h12 = st[8];
+  const double* h22 = st[9];
+
+%test_evaluateVGH
+}
+
+} // namespace qmcplusplus

--- a/src/Numerics/tests/test_soa_spherical_tensor.cpp
+++ b/src/Numerics/tests/test_soa_spherical_tensor.cpp
@@ -1,0 +1,256 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2026 QMCPACK developers.
+//
+// File developed by: Shiv Upadhyay, shivnupadhyay@gmail.com, University of Washington
+//
+// File created by: Shiv Upadhyay, shivnupadhyay@gmail.com, University of Washington
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "Numerics/SoaSphericalTensor.h"
+#include "Utilities/for_testing/Catch2Approx.h"
+
+#include <array>
+#include <vector>
+
+namespace qmcplusplus
+{
+
+// The hard-coded reference values below are the analytic real solid harmonics
+// r^l S_l^m and their Cartesian derivatives, in the addsign=true (Gaussian)
+// convention. They can be regenerated for every (l,m) rather than the spot
+// checks used here by running gen_gto.py, which fills in
+// test_full_soa_spherical_tensor.cpp.in from SymPy.
+
+TEST_CASE("SoA Spherical Tensor evaluateVGL subset", "[numerics]")
+{
+  SoaSphericalTensor<double> st(5, true);
+
+  const double x = 1.3;
+  const double y = 1.2;
+  const double z = -0.5;
+  st.evaluateVGL(x, y, z);
+
+  const double* Ylm = st[0];
+  const double* gr0 = st[1];
+  const double* gr1 = st[2];
+  const double* gr2 = st[3];
+  const double* lap = st[4];
+
+  CHECK(Ylm[0] == Approx(0.282094791773878));
+  CHECK(gr0[0] == Approx(0.0));
+  CHECK(gr1[0] == Approx(0.0));
+  CHECK(gr2[0] == Approx(0.0));
+  CHECK(lap[0] == Approx(0.0));
+
+  CHECK(Ylm[1] == Approx(0.586323014283504));
+  CHECK(gr0[1] == Approx(0.0));
+  CHECK(gr1[1] == Approx(0.488602511902920));
+  CHECK(gr2[1] == Approx(0.0));
+  CHECK(lap[1] == Approx(0.0));
+
+  CHECK(Ylm[6] == Approx(-0.829479816614128));
+  CHECK(gr0[6] == Approx(-0.820018069656552));
+  CHECK(gr1[6] == Approx(-0.756939756606048));
+  CHECK(gr2[6] == Approx(-0.630783130505040));
+  CHECK(lap[6] == Approx(0.0));
+
+  CHECK(Ylm[10] == Approx(-2.25467692525963));
+  CHECK(gr0[10] == Approx(-1.73436686558433));
+  CHECK(gr1[10] == Approx(-1.87889743771636));
+  CHECK(gr2[10] == Approx(4.50935385051926));
+  CHECK(lap[10] == Approx(0.0));
+
+  CHECK(Ylm[23] == Approx(3.02603855093879));
+  CHECK(gr0[23] == Approx(-0.663799038667474));
+  CHECK(gr1[23] == Approx(8.28421200257007));
+  CHECK(gr2[23] == Approx(-6.05207710187758));
+  CHECK(lap[23] == Approx(0.0));
+
+  CHECK(Ylm[26] == Approx(-1.61901660560721));
+  CHECK(gr0[26] == Approx(-18.0831700872436));
+  CHECK(gr1[26] == Approx(14.1933789091566));
+  CHECK(gr2[26] == Approx(3.23803321121443));
+  CHECK(lap[26] == Approx(0.0));
+}
+
+TEST_CASE("SoA Spherical Tensor evaluateVGH subset", "[numerics]")
+{
+  SoaSphericalTensor<double> st(5, true);
+
+  const double x = 1.3;
+  const double y = 1.2;
+  const double z = -0.5;
+  st.evaluateVGH(x, y, z);
+
+  const double* Ylm = st[0];
+  const double* gr0 = st[1];
+  const double* gr1 = st[2];
+  const double* gr2 = st[3];
+  const double* h00 = st[4];
+  const double* h01 = st[5];
+  const double* h02 = st[6];
+  const double* h11 = st[7];
+  const double* h12 = st[8];
+  const double* h22 = st[9];
+
+  CHECK(Ylm[0] == Approx(0.282094791773878));
+  CHECK(gr0[0] == Approx(0.0));
+  CHECK(gr1[0] == Approx(0.0));
+  CHECK(gr2[0] == Approx(0.0));
+  CHECK(h00[0] == Approx(0.0));
+  CHECK(h01[0] == Approx(0.0));
+  CHECK(h02[0] == Approx(0.0));
+  CHECK(h11[0] == Approx(0.0));
+  CHECK(h12[0] == Approx(0.0));
+  CHECK(h22[0] == Approx(0.0));
+
+  CHECK(Ylm[3] == Approx(0.635183265473796));
+  CHECK(gr0[3] == Approx(0.488602511902920));
+  CHECK(gr1[3] == Approx(0.0));
+  CHECK(gr2[3] == Approx(0.0));
+  CHECK(h00[3] == Approx(0.0));
+  CHECK(h01[3] == Approx(0.0));
+  CHECK(h02[3] == Approx(0.0));
+  CHECK(h11[3] == Approx(0.0));
+  CHECK(h12[3] == Approx(0.0));
+  CHECK(h22[3] == Approx(0.0));
+
+  CHECK(Ylm[6] == Approx(-0.829479816614128));
+  CHECK(gr0[6] == Approx(-0.820018069656552));
+  CHECK(gr1[6] == Approx(-0.756939756606048));
+  CHECK(gr2[6] == Approx(-0.630783130505040));
+  CHECK(h00[6] == Approx(-0.630783130505040));
+  CHECK(h01[6] == Approx(0.0));
+  CHECK(h02[6] == Approx(0.0));
+  CHECK(h11[6] == Approx(-0.630783130505040));
+  CHECK(h12[6] == Approx(0.0));
+  CHECK(h22[6] == Approx(1.26156626101008));
+
+  CHECK(Ylm[13] == Approx(-1.26555981871711));
+  CHECK(gr0[13] == Approx(-2.51832235504921));
+  CHECK(gr1[13] == Approx(-1.42598289432913));
+  CHECK(gr2[13] == Approx(-2.37663815721522));
+  CHECK(h00[13] == Approx(-3.56495723582283));
+  CHECK(h01[13] == Approx(-1.09690991871472));
+  CHECK(h02[13] == Approx(-1.82818319785786));
+  CHECK(h11[13] == Approx(-1.18831907860761));
+  CHECK(h12[13] == Approx(0.0));
+  CHECK(h22[13] == Approx(4.75327631443044));
+
+  CHECK(Ylm[16] == Approx(0.976303747300715));
+  CHECK(gr0[16] == Approx(10.9045618544664));
+  CHECK(gr1[16] == Approx(-8.55892951800293));
+  CHECK(gr2[16] == Approx(0.0));
+  CHECK(h00[16] == Approx(23.4312899352172));
+  CHECK(h01[16] == Approx(1.87750720634753));
+  CHECK(h02[16] == Approx(0.0));
+  CHECK(h11[16] == Approx(-23.4312899352172));
+  CHECK(h12[16] == Approx(0.0));
+  CHECK(h22[16] == Approx(0.0));
+
+  CHECK(Ylm[35] == Approx(-9.48174731062297));
+  CHECK(gr0[35] == Approx(-31.7423080777622));
+  CHECK(gr1[35] == Approx(-5.11978004335332));
+  CHECK(gr2[35] == Approx(0.0));
+  CHECK(h00[35] == Approx(-44.8834050467308));
+  CHECK(h01[35] == Approx(-57.1840047919156));
+  CHECK(h02[35] == Approx(0.0));
+  CHECK(h11[35] == Approx(44.8834050467308));
+  CHECK(h12[35] == Approx(0.0));
+  CHECK(h22[35] == Approx(0.0));
+}
+
+namespace
+{
+using ValueTable    = std::array<std::vector<double>, 4>;
+using GradientTable = std::array<std::vector<double>, 3>;
+
+ValueTable evaluateVGL(const int lmax, const bool addsign, const std::array<double, 3>& position)
+{
+  SoaSphericalTensor<double> st(lmax, addsign);
+  st.evaluateVGL(position[0], position[1], position[2]);
+
+  ValueTable values;
+  for (size_t component = 0; component < values.size(); ++component)
+    values[component].assign(st[component], st[component] + st.size());
+  return values;
+}
+
+GradientTable evaluateGradients(const int lmax, const bool addsign, const std::array<double, 3>& position)
+{
+  const ValueTable vgl = evaluateVGL(lmax, addsign, position);
+  return {vgl[1], vgl[2], vgl[3]};
+}
+} // namespace
+
+TEST_CASE("SoA Spherical Tensor evaluateVGH finite difference", "[numerics]")
+{
+  constexpr int lmax                = 6;
+  constexpr double h                = 1e-2;
+  const int hessian_component[3][3] = {{4, 5, 6}, {5, 7, 8}, {6, 8, 9}};
+
+  // The last two positions sit on the z axis and in the xy plane, which drive
+  // the r2xy < eps2 branch of evaluate_bare and the sin(theta) == 0 case that
+  // the generic points never reach.
+  const std::array<std::array<double, 3>, 3> positions{{{0.37, -0.29, 0.43}, {0.0, 0.0, 1.7}, {2.1, 0.0, 0.0}}};
+
+  for (const bool addsign : {false, true})
+    for (const auto& position : positions)
+    {
+      CAPTURE(addsign, position[0], position[1], position[2]);
+      const ValueTable reference_vgl = evaluateVGL(lmax, addsign, position);
+
+      SoaSphericalTensor<double> st(lmax, addsign);
+      st.evaluateVGH(position[0], position[1], position[2]);
+
+      for (size_t component = 0; component < reference_vgl.size(); ++component)
+        for (size_t lm = 0; lm < st.size(); ++lm)
+        {
+          CAPTURE(component, lm);
+          CHECK(st[component][lm] == Approx(reference_vgl[component][lm]).margin(1e-13));
+        }
+
+      // For l <= 6 the gradients are polynomials of degree at most five, so the
+      // six-point derivative stencil is exact apart from floating-point roundoff.
+      for (int derivative_direction = 0; derivative_direction < 3; ++derivative_direction)
+      {
+        std::array<GradientTable, 6> displaced_gradients;
+        constexpr std::array<int, 6> displacements{-3, -2, -1, 1, 2, 3};
+        for (size_t sample = 0; sample < displacements.size(); ++sample)
+        {
+          auto displaced_position = position;
+          displaced_position[derivative_direction] += displacements[sample] * h;
+          displaced_gradients[sample] = evaluateGradients(lmax, addsign, displaced_position);
+        }
+
+        for (int gradient_component = 0; gradient_component < 3; ++gradient_component)
+          for (size_t lm = 0; lm < st.size(); ++lm)
+          {
+            CAPTURE(derivative_direction, gradient_component, lm);
+            const double finite_difference = (-displaced_gradients[0][gradient_component][lm] +
+                                              9.0 * displaced_gradients[1][gradient_component][lm] -
+                                              45.0 * displaced_gradients[2][gradient_component][lm] +
+                                              45.0 * displaced_gradients[3][gradient_component][lm] -
+                                              9.0 * displaced_gradients[4][gradient_component][lm] +
+                                              displaced_gradients[5][gradient_component][lm]) /
+                (60.0 * h);
+            CHECK(st[hessian_component[gradient_component][derivative_direction]][lm] ==
+                  Approx(finite_difference).margin(2e-10).epsilon(2e-10));
+          }
+      }
+
+      // r^l S_l^m is harmonic, so the Hessian is traceless.
+      for (size_t lm = 0; lm < st.size(); ++lm)
+      {
+        CAPTURE(lm);
+        CHECK(st[4][lm] + st[7][lm] + st[9][lm] == Approx(0.0).margin(2e-12));
+      }
+    }
+}
+
+} // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes

Paul pinged me about progress on #5391 so I started looking into this again! Very exciting.

Implements `SoaSphericalTensor<T>::evaluateVGH` needed for backflow on molecules eventually.

I started trying to make a molecular backflow test (found while trying to make a test our of the Li2 results of [arXiv:0801.0518](https://arxiv.org/abs/0801.0518)).
This was the first missing piece evaluateVGHGH will come in a separate PR, which is needed for optimizations. 
In this we apply the derivative recurrence relations to the gradient to get the Hessian. 

The storage was sized only for VGL, but I resized the storage for future VGHGH even though the last elements (10-19) are not used yet. This is consistent with SoaCartesianTensor.

I used Codegen as the cartesian path does even though the code is actually simpler since we can apply the recurrence relations.

Sympy checks for the recurrence relations and tests for l<=6 and finite difference tests.

Code generated with GPT 5.6 Sol/Max using the Pi harness and reviewed using Claude Opus 5/Medium.

As far as I can tell the storage changes affect offload.

## What type(s) of changes does this code introduce?

- New feature
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?

Ryzen 9950x workstation, Linux, GCC

## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [x] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)