### PR TITLE
Nexus: Clean up some code in `vasp_input.py`, change `VKeywordFile.type` to `VKeywordFile.dtype`

### DIFF
--- a/nexus/nexus/tests/test_vasp_input.py
+++ b/nexus/nexus/tests/test_vasp_input.py
@@ -147,7 +147,7 @@ def test_keyword_consistency():
         assert(scalar_keywords==cls.scalar_keywords)
         assert(array_keywords==cls.array_keywords)
         assert(typed_keywords==cls.keywords)
-        assert(set(cls.type.keys())==cls.keywords)
+        assert(set(cls.dtype.keys())==cls.keywords)
         assert(set(cls.read_value.keys())==cls.keywords)
         assert(set(cls.write_value.keys())==cls.keywords)
         assert(set(cls.assign_value.keys())==cls.keywords)
@@ -159,7 +159,7 @@ def test_keyword_consistency():
 
     AdditionalKeywordFile.class_init()
     assert(AdditionalKeywordFile.keywords==frozenset({'flag'}))
-    assert(AdditionalKeywordFile.type.flag=='bools')
+    assert(AdditionalKeywordFile.dtype.flag=='bools')
 #end def test_keyword_consistency
 
 
@@ -193,7 +193,7 @@ def test_current_keyword_types():
 
     for keyword_type,keywords in expected.items():
         for keyword in keywords:
-            assert(Incar.type[keyword]==keyword_type)
+            assert(Incar.dtype[keyword]==keyword_type)
         #end for
     #end for
 
@@ -206,7 +206,7 @@ def test_current_keyword_types():
         }
     assert(dict(Incar.mixed_types)==expected_mixed)
     for keyword,types in expected_mixed.items():
-        assert(Incar.type[keyword]==types)
+        assert(Incar.dtype[keyword]==types)
     #end for
 #end def test_current_keyword_types
 

--- a/nexus/nexus/vasp_input.py
+++ b/nexus/nexus/vasp_input.py
@@ -199,9 +199,12 @@ def write_bool_array(a):
 #end def write_bool_array
 
 
-assign_bool_map = {True:True,False:False,1:True,0:False}
 def assign_bool(v):
-    return assign_bool_map[v]
+    if v in {True, False, 1, 0}:
+        return bool(v)
+    else:
+        msg = f"Expected one of `True`, `False`, `1`, or `0` but got {v}!"
+        raise ValueError(msg)
 #end def assign_bool
 
 
@@ -299,7 +302,7 @@ def assign_bool_array(a):
 #nexus objects:
 def vasp_to_nexus_elem(elem,elem_count):
     syselem=[]
-    for x,count in zip(elem,elem_count):
+    for x,count in zip(elem, elem_count, strict=True):
         syselem+=[x for i in range(0,count)]
     #end for
     return np.array(syselem)
@@ -606,16 +609,16 @@ class VKeywordFile(VFile):
         cls.keywords = frozenset(
             cls.scalar_keywords | cls.array_keywords
             )
-        cls.type = obj()
+        cls.dtype = obj()
         cls.read_value   = obj()
         cls.write_value  = obj()
         cls.assign_value = obj()
-        for type in cls.kw_scalars + cls.kw_arrays:
-            for name in getattr(cls,type):
-                cls.type[name] = type
-                cls.read_value[name]   = read_value_functions[type]
-                cls.write_value[name]  = write_value_functions[type]
-                cls.assign_value[name] = assign_value_functions[type]
+        for dtype in cls.kw_scalars + cls.kw_arrays:
+            for name in getattr(cls,dtype):
+                cls.dtype[name] = dtype
+                cls.read_value[name]   = read_value_functions[dtype]
+                cls.write_value[name]  = write_value_functions[dtype]
+                cls.assign_value[name] = assign_value_functions[dtype]
             #end for
         #end for
         for name,types in cls.mixed_types.items():
@@ -623,7 +626,7 @@ class VKeywordFile(VFile):
                 msg = 'mixed-type keyword is not classified: {}'.format(name)
                 raise ValueError(msg)
             #end if
-            classified_type = cls.type[name]
+            classified_type = cls.dtype[name]
             if classified_type not in types:
                 msg = (
                     'classified type {} is not permitted for keyword {}'
@@ -639,7 +642,7 @@ class VKeywordFile(VFile):
                     raise ValueError(msg)
                 #end if
             #end for
-            cls.type[name] = types
+            cls.dtype[name] = types
             cls.read_value[name] = partial(read_mixed,types=types)
             cls.write_value[name] = partial(write_mixed,types=types)
             cls.assign_value[name] = partial(assign_mixed,types=types)
@@ -738,7 +741,7 @@ class VKeywordFile(VFile):
                 msg = '{} is not an INCAR keyword'.format(field.upper())
                 raise ValueError(msg)
             #end if
-            return self.type[field]
+            return self.dtype[field]
         elif field not in schema:
             msg = '{} is not a field of block construct {}'.format(
                 field.upper(),block_name.upper()
@@ -927,7 +930,7 @@ class VKeywordFile(VFile):
                                         'input text: {}\n'
                                         'exception:\n'
                                         '{}'.format(
-                                            name,self.type[name],token,e
+                                            name,self.dtype[name],token,e
                                             )
                                         )
                                 #end try
@@ -979,7 +982,7 @@ class VKeywordFile(VFile):
                     'keyword type: {}\n'
                     'value: {}\n'
                     'exception:\n'
-                    '{}'.format(filepath,name,self.type[name],value,e)
+                    '{}'.format(filepath,name,self.dtype[name],value,e)
                     )
             #end try
             text += valfmt.format(name.upper(),svalue)
@@ -1007,7 +1010,7 @@ class VKeywordFile(VFile):
                     'keyword type: {}\n'
                     'value: {}\n'
                     'exception:\n'
-                    '{}'.format(name,self.type[name],value,e)
+                    '{}'.format(name,self.dtype[name],value,e)
                     )
             #end try
         #end for

--- a/nexus/nexus/vasp_input.py
+++ b/nexus/nexus/vasp_input.py
@@ -200,7 +200,7 @@ def write_bool_array(a):
 
 
 def assign_bool(v):
-    if v in {True, False, 1, 0}:
+    if v in {True, False}: # 1 and 0 hash to the same value as True and False
         return bool(v)
     else:
         msg = f"Expected one of `True`, `False`, `1`, or `0` but got {v}!"


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

The function `assign_bool()` in `vasp_input.py` used dictionary lookup to convert `1`, `0`, `True`, and `False` to `True` and `False`, but this is poor form as it results in a `KeyError` when trying to convert anything that is not one of those values, instead of the more appropriate `ValueError`. The function was updated to check if the value was in the set `{True, False}`, which is a fast O(1) lookup and if so, return the correct value, otherwise raise `ValueError`.

Additionally, an issue with building Nexus's documentation arose from `VKeywordFile` having an attribute called `type`, which made automatic crossreferencing through `intersphinx-registry` raise the following warning due to collision :

```
<unknown>:1: WARNING: more than one target found for cross-reference 'type': nexus.vasp_input.Incar.type, nexus.vasp_input.Stopcar.type [ref.python]
```

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->

- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

Laptop, Fedora Linux 44 (KDE Plasma Desktop Edition)
AMD Ryzen 7 PRO 7840U (8 cores, 16 logical processors)
```
Python        3.14.6
uv            0.12.5
cif2cell      2.1.0
coverage      7.15.4
h5py          3.16.0
matplotlib    3.11.1
numpy         2.5.2
pycifrw       4.4.6
pydot         4.0.1
pytest        9.1.1
pytest-cov    7.1.0
pytest-order  1.5.0
scipy         1.18.0
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [ ] I have read the pull request guidance and develop docs
* * [ ] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
