### PR TITLE
Nexus: Remove unnecessary `return` statements from `xmlreader.py`

### DIFF
--- a/nexus/nexus/xmlreader.py
+++ b/nexus/nexus/xmlreader.py
@@ -34,7 +34,8 @@ from .utilities import path_string, valid_variable_name
 
 def parse_string(s, delim = None):
     if not isinstance(s, str):
-        raise TypeError("This function only parses strings!")
+        msg = f"This function only parses strings, but was passed {type(s).__name__}!"
+        raise TypeError(msg)
 
     # Check if number
     try:
@@ -115,23 +116,19 @@ class XMLelement(DevBase):
 
     def _set_parent(self,parent):
         self._parent=parent
-        return
     #end def set_parent
 
     def _add_xmlattribute(self,name,attribute):
         self._attributes[name]=attribute
-        return 
     #end def add_attribute
 
     def _add_element(self,name,element):
         element._name=name
         self._elements[name]=element
-        return 
     #end def add_element
 
     def _add_text(self,name,text):
         self._texts[name]=text
-        return 
     #end def add_text
 
     def _to_string(self):
@@ -177,7 +174,6 @@ class XMLelement(DevBase):
         self._escape_names=None
         #self._escape_names=set(dict(getmembers(self)).keys()) | set(keyword.kwlist)
         self._escape_names=set(keyword.kwlist)
-        return
     #end def __init__
 
 
@@ -341,8 +337,6 @@ class XMLreader(DevBase):
         # -is unpickleable
         # therefore it is removed after the dynamic object is built
         del self.parser
-
-        return
     #end def __init__
 
     # test needed
@@ -361,7 +355,6 @@ class XMLreader(DevBase):
                 self.xml = self.xml.replace(self.xml[il:ir],fcont)
             #end if
         #end while
-        return
     #end def include_files
 
     def increment_level(self):
@@ -371,13 +364,11 @@ class XMLreader(DevBase):
             self.cur.append(None)
         #end if
         self.pad = self.ilevel*'  '
-        return
     #end def increment_level
 
     def decrement_level(self):
         self.ilevel-=1
         self.pad = self.ilevel*'  '
-        return
     #end def decrement_level
 
     def found_element_start(self,ename,attributes):
@@ -489,13 +480,11 @@ class XMLreader(DevBase):
                 #end if
             #end if
         #end for
-        return
     #end def found_element_start
 
     def found_element_end(self,name):
         self.cur[self.ilevel]=None
         self.decrement_level()
-        return
     #end def found_element_end
 
     def found_text(self,rawtext):
@@ -510,11 +499,10 @@ class XMLreader(DevBase):
                 cur._ntexts+=1
             #end if
         #end if
-        return
     #end def found_text
 
     def found_attribute(self,ename,aname,atype,default,required):
-        return
+        pass
     #end def found_attribute
 #end class XMLreader
 


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Empty `return` statements have the same effect as no return, and are discouraged in Python. This removes them from many functions in `xmlreader.py`. Additionally, I cleaned up an error message at the top of the file by moving the message declaration outside the error.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Code style update (formatting, renaming)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->

- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

Laptop, Fedora Linux 44 (KDE Plasma Desktop Edition)
AMD Ryzen 7 PRO 7840U (8 cores, 16 logical processors)
```
Python        3.14.6
uv            0.12.5
cif2cell      2.1.0
coverage      7.15.4
h5py          3.16.0
matplotlib    3.11.1
numpy         2.5.2
pycifrw       4.4.6
pydot         4.0.1
pytest        9.1.1
pytest-cov    7.1.0
pytest-order  1.5.0
scipy         1.18.0
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [ ] I have read the pull request guidance and develop docs
* * [ ] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
