### PR TITLE
Nexus: Remove unused/useless variables from `nexus_core`

### DIFF
--- a/nexus/nexus/__init__.py
+++ b/nexus/nexus/__init__.py
@@ -373,10 +373,6 @@ class Settings(NexusCore):
                         action='store_true',default=False,
                         help='Report status of all simulations and then exit.'
                         )
-        parser.add_option('--status',dest='status',
-                        default='none',
-                        help="Controls displayed simulation status information.  May be set to one of 'standard', 'active', 'failed', or 'ready'."
-                        )
         parser.add_option('--generate_only',dest='generate_only',
                         action='store_true',default=False,
                         help='Write inputs to all simulations and then exit.  Note that no dependencies are processed, e.g. if one simulation depends on another for an orbital file location or for a relaxed structure, this information will not be present in the generated input file for that simulation since no simulations are actually run with this option.'
@@ -568,11 +564,6 @@ class Settings(NexusCore):
 
 
     def process_core_settings(self,kw):
-        # process project manager settings
-        if nexus_core.debug:
-            nexus_core.verbose = True
-        #end if
-
         # process simulation settings
         if 'local_directory' in kw:
             nexus_core.file_locations.append(kw.local_directory)

--- a/nexus/nexus/__init__.py
+++ b/nexus/nexus/__init__.py
@@ -132,13 +132,13 @@ class Settings(NexusCore):
         })
 
     core_assign_vars = frozenset({
-        'results', 'load_images', 'remote_directory', 'verbose', 'progress_tty',
-        'command_line', 'sleep', 'timeout', 'monitor', 'debug', 'skip_submit', 'dynamic', 'runs',
-        'stages', 'pseudo_dir', 'graph_sims', 'generate_only', 'trace',
+        'results', 'load_images', 'remote_directory', 'progress_tty',
+        'command_line', 'sleep', 'timeout', 'monitor', 'skip_submit', 'dynamic', 'runs',
+        'pseudo_dir', 'graph_sims', 'generate_only',
         'local_directory', 'status_only'
         })
 
-    core_process_vars = frozenset({'file_locations', 'status', 'mode'})
+    core_process_vars = frozenset({'file_locations'})
 
     noncore_assign_vars = frozenset({'basis_dir'})
 

--- a/nexus/nexus/__init__.py
+++ b/nexus/nexus/__init__.py
@@ -572,21 +572,6 @@ class Settings(NexusCore):
         if nexus_core.debug:
             nexus_core.verbose = True
         #end if
-        if 'status' in kw:
-            if kw.status==None or kw.status==False:
-                nexus_core.status = nexus_core.status_modes.none
-            elif kw.status==True:
-                nexus_core.status = nexus_core.status_modes.standard
-            elif kw.status in nexus_core.status_modes:
-                nexus_core.status = nexus_core.status_modes[kw.status]
-            else:
-                msg = 'invalid status mode specified: {0}\nvalid status modes are: {1}'.format(kw.status,sorted(nexus_core.status_modes.keys()))
-                raise ValueError(msg)
-            #end if
-        #end if
-        if nexus_core.status_only and nexus_core.status==nexus_core.status_modes.none:
-            nexus_core.status = nexus_core.status_modes.standard
-        #end if
 
         # process simulation settings
         if 'local_directory' in kw:

--- a/nexus/nexus/__init__.py
+++ b/nexus/nexus/__init__.py
@@ -587,43 +587,6 @@ class Settings(NexusCore):
         if nexus_core.status_only and nexus_core.status==nexus_core.status_modes.none:
             nexus_core.status = nexus_core.status_modes.standard
         #end if
-        if 'mode' in kw:
-            if kw.mode in nexus_core.modes:
-                nexus_core.mode = kw.mode
-            else:
-                msg = 'invalid mode specified: {0}\nvalid modes are: {1}'.format(kw.mode,sorted(nexus_core.modes.keys()))
-                raise ValueError(msg)
-            #end if
-        #end if
-        mode  = nexus_core.mode
-        modes = nexus_core.modes
-        if mode==modes.stages:
-            stages = nexus_core.stages
-        elif mode==modes.all:
-            stages = list(nexus_core.primary_modes)
-        else:
-            stages = [kw.mode]
-        #end if
-        allowed_stages = set(nexus_core.primary_modes)
-        if isinstance(stages,str):
-            stages = [stages]
-        #end if
-        if len(stages)==0:
-            stages = list(nexus_core.primary_modes)
-        elif 'all' in stages:
-            stages = list(nexus_core.primary_modes)
-        else:
-            forbidden = set(nexus_core.stages)-allowed_stages
-            if len(forbidden)>0:
-                msg = 'some stages provided are not primary stages.\n  You provided '+str(list(forbidden))+'\n  Options are '+str(list(allowed_stages))
-                raise ValueError(msg)
-            #end if
-        #end if
-        # overide user input and always use stages mode 
-        # keep processing code above in case a change is desired in the future
-        nexus_core.mode       = modes.stages
-        nexus_core.stages     = stages
-        nexus_core.stages_set = set(nexus_core.stages)
 
         # process simulation settings
         if 'local_directory' in kw:

--- a/nexus/nexus/__init__.py
+++ b/nexus/nexus/__init__.py
@@ -564,6 +564,22 @@ class Settings(NexusCore):
 
 
     def process_core_settings(self,kw):
+        if 'status' in kw:
+            if kw.status==None or kw.status==False:
+                nexus_core.status = nexus_core.status_modes.none
+            elif kw.status==True:
+                nexus_core.status = nexus_core.status_modes.standard
+            elif kw.status in nexus_core.status_modes:
+                nexus_core.status = nexus_core.status_modes[kw.status]
+            else:
+                msg = 'invalid status mode specified: {0}\nvalid status modes are: {1}'.format(kw.status,sorted(nexus_core.status_modes.keys()))
+                raise ValueError(msg)
+            #end if
+        #end if
+        if nexus_core.status_only and nexus_core.status==nexus_core.status_modes.none:
+            nexus_core.status = nexus_core.status_modes.standard
+        #end if
+
         # process simulation settings
         if 'local_directory' in kw:
             nexus_core.file_locations.append(kw.local_directory)

--- a/nexus/nexus/nexus_base.py
+++ b/nexus/nexus/nexus_base.py
@@ -26,16 +26,17 @@
 
 
 import os
-from os import PathLike
-from copy import deepcopy
 import pickle
-from pickle import UnpicklingError
+from copy import deepcopy
+from enum import Flag, auto
+from os import PathLike
 from pathlib import Path
-from .utilities import path_string
-from .nexus_version import nexus_version
-from .memory import resident
-from .developer import DevBase, obj, log
+from pickle import UnpicklingError
 
+from .developer import DevBase, log, obj
+from .memory import resident
+from .nexus_version import nexus_version
+from .utilities import path_string
 
 # Nexus namespaces
 #  nexus_core:   to be used by NexusCore classes only
@@ -50,17 +51,6 @@ status_modes = obj(
     active   = 2,
     failed   = 3,
     ready    = 4,
-    )
-
-modes = obj(
-    none       = 0,
-    setup      = 1,
-    send_files = 2,
-    submit     = 3,
-    get_output = 4,
-    analyze    = 5,
-    stages     = 6,
-    all        = 7
     )
 
 nexus_noncore_defaults = obj(
@@ -86,19 +76,12 @@ nexus_core_defaults = obj(
     monitor           = True,              # used by: ProjectManager,Simulation,Machine
     skip_submit       = False,             # used by: Simulation
     load_images       = True,              # used by: ProjectManager
-    modes             = modes,             # used by: ProjectManager,Simulation
-    mode              = modes.stages,      # used by: Simulation
-    stages_set        = set(),             # used by: ProjectManager,Simulation
-    stages            = [],                # used by: Simulation
-    primary_modes     = ['setup','send_files','submit','get_output','analyze'], # used by: Settings
-    dependent_modes   = set(['submit']),   # used by: ProjectManager,Simulation
     verbose           = True,              # used by: NexusCore
     debug             = False,             # used by: NexusCore
     trace             = False,             # used by: NexusCore
     indent            = '  ',              # used by: NexusCore
     status_modes      = status_modes,      # used by: ProjectManager
     status            = status_modes.none, # used by: ProjectManager
-    emulate           = False,             # unused
     progress_tty      = False,             # used by: ProjectManager
     graph_sims        = False,             # used by: ProjectManager
     command_line      = True,              # used by: Settings

--- a/nexus/nexus/nexus_base.py
+++ b/nexus/nexus/nexus_base.py
@@ -45,14 +45,6 @@ nexus_core    = obj()
 nexus_noncore = obj()
 nexus_core_noncore = obj()
 
-status_modes = obj(
-    none     = 0,
-    standard = 1,
-    active   = 2,
-    failed   = 3,
-    ready    = 4,
-    )
-
 nexus_noncore_defaults = obj(
     basis_dir         = None,
     basissets         = None,
@@ -80,8 +72,6 @@ nexus_core_defaults = obj(
     debug             = False,             # used by: NexusCore
     trace             = False,             # used by: NexusCore
     indent            = '  ',              # used by: NexusCore
-    status_modes      = status_modes,      # used by: ProjectManager
-    status            = status_modes.none, # used by: ProjectManager
     progress_tty      = False,             # used by: ProjectManager
     graph_sims        = False,             # used by: ProjectManager
     command_line      = True,              # used by: Settings

--- a/nexus/nexus/nexus_base.py
+++ b/nexus/nexus/nexus_base.py
@@ -68,9 +68,6 @@ nexus_core_defaults = obj(
     monitor           = True,              # used by: ProjectManager,Simulation,Machine
     skip_submit       = False,             # used by: Simulation
     load_images       = True,              # used by: ProjectManager
-    verbose           = True,              # used by: NexusCore
-    debug             = False,             # used by: NexusCore
-    trace             = False,             # used by: NexusCore
     indent            = '  ',              # used by: NexusCore
     progress_tty      = False,             # used by: ProjectManager
     graph_sims        = False,             # used by: ProjectManager
@@ -159,26 +156,25 @@ class NexusCore(DevBase):
             If ``True`` and output is to a terminal, overwrite and update the
             last line, rather than scrolling.
         """
-        if nexus_core.verbose:
-            if len(kwargs)>0:
-                n = kwargs['n']
-            else:
-                n=0
-            #end if
-            is_progress = kwargs.get('progress',False)
-            text=''
-            for t in texts:
-                text+=str(t)+' '
-            #end for
-            pad = n*nexus_core.indent
-            output_text = pad+text.replace('\n','\n'+pad)
-            if nexus_core.progress_tty and is_progress and self._logfile.isatty():
-                # spaces to ensure previous line is overwritten.  Need better solution.
-                self._logfile.write(output_text+'        \r')
-                self._logfile.flush()
-            else:
-                self._logfile.write(output_text+'\n')
+        if len(kwargs)>0:
+            n = kwargs['n']
+        else:
+            n=0
         #end if
+        is_progress = kwargs.get('progress',False)
+        text=''
+        for t in texts:
+            text+=str(t)+' '
+        #end for
+        pad = n*nexus_core.indent
+        output_text = pad+text.replace('\n','\n'+pad)
+        if nexus_core.progress_tty and is_progress and self._logfile.isatty():
+            # spaces to ensure previous line is overwritten.  Need better solution.
+            self._logfile.write(output_text+'        \r')
+            self._logfile.flush()
+        else:
+            self._logfile.write(output_text+'\n')
+
         NexusCore.wrote_something = True
     #end def log
 

--- a/nexus/nexus/nexus_base.py
+++ b/nexus/nexus/nexus_base.py
@@ -45,6 +45,14 @@ nexus_core    = obj()
 nexus_noncore = obj()
 nexus_core_noncore = obj()
 
+status_modes = obj(
+    none     = 0,
+    standard = 1,
+    active   = 2,
+    failed   = 3,
+    ready    = 4,
+    )
+
 nexus_noncore_defaults = obj(
     basis_dir         = None,
     basissets         = None,
@@ -69,6 +77,8 @@ nexus_core_defaults = obj(
     skip_submit       = False,             # used by: Simulation
     load_images       = True,              # used by: ProjectManager
     indent            = '  ',              # used by: NexusCore
+    status_modes      = status_modes,      # used by: ProjectManager
+    status            = status_modes.none, # used by: ProjectManager
     progress_tty      = False,             # used by: ProjectManager
     graph_sims        = False,             # used by: ProjectManager
     command_line      = True,              # used by: Settings

--- a/nexus/nexus/project_manager.py
+++ b/nexus/nexus/project_manager.py
@@ -97,7 +97,7 @@ class ProjectManager(NexusCore):
         self.log('\nProject starting',n=0)
         self.init_cascades()
         status_only = status_only or nexus_core.status_only
-        status = status or status_only
+        status = status or status_only or nexus_core.status!=nexus_core.status_modes.none
         if status:
             self.write_simulation_status()
             if status_only:
@@ -281,16 +281,33 @@ class ProjectManager(NexusCore):
 
 
     def write_simulation_status(self):
+        status       = nexus_core.status
+        status_modes = nexus_core.status_modes
         self.log('\ncascade status',n=1)
         self.log('setup, sent_files, submitted, finished, got_output, analyzed, failed',n=2)
         all_sids = set()
         for sim in self.simulations.values():
-            all_sids.add(sim.simid)
-
+            add = False
+            if status==status_modes.active:
+                add = sim.active()
+            elif status==status_modes.ready:
+                add = sim.ready()
+            elif status==status_modes.failed:
+                add = sim.failed
+            else:
+                add = True
+            #end if
+            if add:
+                all_sids.add(sim.simid)
+            #end if
+        #end for
         sids = set()
         for isim in sorted(all_sids):
             sim = self.simulations[isim]
             if not sim.bundled:
+                if status==status_modes.active and not sim.active():
+                    continue
+                #end if
                 self.status_line(sim)
                 sids.add(sim.simid)
                 if sim.is_bundle:

--- a/nexus/nexus/project_manager.py
+++ b/nexus/nexus/project_manager.py
@@ -62,8 +62,6 @@ class ProjectManager(NexusCore):
     #end def restore_default_settings
 
     def __init__(self):
-        modes = nexus_core.modes
-        self.persistent_modes = set([modes.submit,modes.all])
         self.simulations = obj()
         self.cascades = obj()
         self.progressing_cascades = obj()
@@ -107,35 +105,32 @@ class ProjectManager(NexusCore):
             #end if
         #end if
         self.log('\nstarting runs:\n'+30*'~',n=1)
-        if nexus_core.dependent_modes <= nexus_core.stages_set:
-            if nexus_core.monitor:
-                start_time = time.time()
-                ipoll = 0
-                while len(self.progressing_cascades)>0:
-                    elapsed_time = time.time() - start_time
-                    self.log('elapsed time %.1f s'%elapsed_time,
-                             ' memory %3.2f MB'%(memory.resident(children=True)/1e6),
-                             n=1,progress=True)
-                    NexusCore.wrote_something = False
-                    ipoll+=1
-                    self.machine.query_queue()
-                    self.progress_cascades()
-                    self.machine.submit_jobs()
-                    self.update_process_ids()
-                    time.sleep(nexus_core.sleep)
-                    if NexusCore.wrote_something:
-                        self.log()
-                    #end if
-                #end while
-            elif len(self.progressing_cascades)>0:
+
+        if nexus_core.monitor:
+            start_time = time.time()
+            while len(self.progressing_cascades)>0:
+                elapsed_time = time.time() - start_time
+                self.log(
+                    f'elapsed time {elapsed_time:.1f} s',
+                    f' memory {(memory.resident(children=True)/1e6):3.2f} MB',
+                    n=1,
+                    progress=True,
+                    )
+                NexusCore.wrote_something = False
                 self.machine.query_queue()
                 self.progress_cascades()
                 self.machine.submit_jobs()
                 self.update_process_ids()
-            #end if
-        else:
+                time.sleep(nexus_core.sleep)
+                if NexusCore.wrote_something:
+                    self.log()
+
+        elif len(self.progressing_cascades)>0:
+            self.machine.query_queue()
             self.progress_cascades()
-        #end if
+            self.machine.submit_jobs()
+            self.update_process_ids()
+
         self.log('Project finished\n')
     #end def run_project
 

--- a/nexus/nexus/project_manager.py
+++ b/nexus/nexus/project_manager.py
@@ -97,7 +97,7 @@ class ProjectManager(NexusCore):
         self.log('\nProject starting',n=0)
         self.init_cascades()
         status_only = status_only or nexus_core.status_only
-        status = status or status_only or nexus_core.status!=nexus_core.status_modes.none
+        status = status or status_only
         if status:
             self.write_simulation_status()
             if status_only:
@@ -281,33 +281,16 @@ class ProjectManager(NexusCore):
 
 
     def write_simulation_status(self):
-        status       = nexus_core.status
-        status_modes = nexus_core.status_modes
         self.log('\ncascade status',n=1)
         self.log('setup, sent_files, submitted, finished, got_output, analyzed, failed',n=2)
         all_sids = set()
         for sim in self.simulations.values():
-            add = False
-            if status==status_modes.active:
-                add = sim.active()
-            elif status==status_modes.ready:
-                add = sim.ready()
-            elif status==status_modes.failed:
-                add = sim.failed
-            else:
-                add = True
-            #end if
-            if add:
-                all_sids.add(sim.simid)
-            #end if
-        #end for
+            all_sids.add(sim.simid)
+
         sids = set()
         for isim in sorted(all_sids):
             sim = self.simulations[isim]
             if not sim.bundled:
-                if status==status_modes.active and not sim.active():
-                    continue
-                #end if
                 self.status_line(sim)
                 sids.add(sim.simid)
                 if sim.is_bundle:

--- a/nexus/nexus/simulation.py
+++ b/nexus/nexus/simulation.py
@@ -65,27 +65,26 @@
 #====================================================================#
 
 
-import contextlib
 import os
-import sys
 import shutil
+import sys
 import tempfile
 import traceback
-from functools import partial
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from string import Template
 from subprocess import Popen
 from typing import ClassVar
-from .developer import DevBase, obj, unavailable, FileFormatError, NexusError
-from .structure import Structure, read_structure
-from .physical_system import PhysicalSystem
+
+from .developer import DevBase, FileFormatError, NexusError, obj, unavailable
 from .machines import Job, Workstation, get_machine
-from .nexus_base import NexusCore, nexus_core, dynamic_storage
+from .nexus_base import NexusCore, dynamic_storage, nexus_core
+from .physical_system import PhysicalSystem
+from .structure import Structure, read_structure
 from .utilities import path_string
 
- 
+
 class SimulationInput(NexusCore):
     def is_valid(self):
         raise NotImplementedError
@@ -279,7 +278,7 @@ class Simulation(NexusCore):
         'identifier','path','infile','outfile','errfile','imagefile',
         'input','job','files','dependencies','analysis_request',
         'block','block_subcascade','app_name','app_props','system',
-        'skip_submit','force_write','simlabel','fake_sim',
+        'skip_submit','simlabel','fake_sim',
         'restartable','force_restart'
         })
     sim_imagefile      = 'sim.p'
@@ -390,7 +389,6 @@ class Simulation(NexusCore):
         self.block          = False
         self.block_subcascade = False
         self.skip_submit    = nexus_core.skip_submit
-        self.force_write    = False
         self.loaded         = False
         self.ordered_dependencies = []
         self.process_id     = None
@@ -1374,96 +1372,36 @@ class Simulation(NexusCore):
     def progress(self,dependency_id=None):
         if dependency_id is not None:
             self.wait_ids.remove(dependency_id)
-        #end if
-        if len(self.wait_ids)==0 and not self.block and not self.failed:
-            modes = nexus_core.modes
-            mode  = nexus_core.mode
-            progress = True
-            if mode==modes.none:
-                return
-            elif mode==modes.setup:
-                self.write_inputs()
-            elif mode==modes.send_files:
-                self.send_files()
-            elif mode==modes.submit:
-                self.submit()
-                progress = self.finished
-            elif mode==modes.get_output:
+
+        if len(self.wait_ids) > 0 or self.block or self.failed:
+            return # No progression if we are waiting or blocked or failed
+
+        progress = True
+        conds_ops = (
+            (self.created_directories, self.create_directories),
+            (self.got_dependencies, self.get_dependencies),
+            (self.setup, self.write_inputs),
+            (self.sent_files, self.send_files),
+            (self.finished, self.submit),
+        )
+        for cond, op in conds_ops:
+            if not cond:
+                op()
+
+        progress_post = self.finished
+        progress = self.finished and self.analyzed
+
+        if progress_post:
+            if not self.got_output:
                 self.get_output()
-                progress = self.finished
-            elif mode==modes.analyze:
+
+            if not self.analyzed:
                 self.analyze()
-                progress = self.finished
-            elif mode==modes.stages:
-                if not self.created_directories:
-                    self.create_directories()
-                #end if
-                if not self.got_dependencies:
-                    self.get_dependencies()
-                #end if
-                if not self.setup and 'setup' in nexus_core.stages:
-                    self.write_inputs()
-                #end if
-                if not self.sent_files and 'send_files' in nexus_core.stages:
-                    self.send_files()
-                #end if
-                if not self.finished and 'submit' in nexus_core.stages:
-                    self.submit()
-                #end if
-                if nexus_core.dependent_modes <= nexus_core.stages_set:
-                    progress_post = self.finished
-                    progress = self.finished and self.analyzed
-                else:
-                    progress_post = progress
-                #end if
-                if progress_post:
-                    if not self.got_output and 'get_output' in nexus_core.stages:
-                        self.get_output()
-                    #end if
-                    if not self.analyzed and 'analyze' in nexus_core.stages:
-                        self.analyze()
-                    #end if
-                #end if
-            elif mode==modes.all:
-                if not self.setup:
-                    self.write_inputs()
-                    self.send_files(enter=False)
-                #end if
-                if not self.finished:
-                    self.submit()
-                #end if
-                if self.finished:
-                    if not self.got_output:
-                        self.get_output()
-                    #end if
-                    if not self.analyzed:
-                        self.analyze()
-                    #end if
-                #end if
-                progress = self.finished
-            #end if
-            if progress and not self.block_subcascade and not self.failed:
-                for sim in self.dependents.values():
-                    if not sim.bundled:
-                        sim.progress(self.simid)
-                    #end if
-                #end for
-            #end if
-        elif len(self.wait_ids)==0 and self.force_write:
-            modes = nexus_core.modes
-            mode  = nexus_core.mode
-            if mode==modes.stages:
-                if not self.got_dependencies:
-                    self.get_dependencies()
-                #end if
-                if 'setup' in nexus_core.stages:
-                    self.write_inputs()
-                #end if
-                if not self.sent_files and 'send_files' in nexus_core.stages:
-                    self.send_files()
-                #end if
-            #end if
-        #end if
+
+        if progress and not (self.block_subcascade or self.failed):
+            for sim in self.dependents.values():
+                if not sim.bundled:
+                    sim.progress(self.simid)
     #end def progress
 
 

--- a/nexus/nexus/tests/__init__.py
+++ b/nexus/nexus/tests/__init__.py
@@ -14,6 +14,7 @@ TEST_DIR = Path(__file__).resolve().parent
 NEXUS_CORE_KEYS = (
     "local_directory",
     "remote_directory",
+    "status",
     "sleep",
     "timeout",
     "file_locations",

--- a/nexus/nexus/tests/__init__.py
+++ b/nexus/nexus/tests/__init__.py
@@ -14,9 +14,6 @@ TEST_DIR = Path(__file__).resolve().parent
 NEXUS_CORE_KEYS = (
     "local_directory",
     "remote_directory",
-    "mode",
-    "stages",
-    "stages_set",
     "status",
     "sleep",
     "timeout",

--- a/nexus/nexus/tests/__init__.py
+++ b/nexus/nexus/tests/__init__.py
@@ -14,7 +14,6 @@ TEST_DIR = Path(__file__).resolve().parent
 NEXUS_CORE_KEYS = (
     "local_directory",
     "remote_directory",
-    "status",
     "sleep",
     "timeout",
     "file_locations",

--- a/nexus/nexus/tests/test_project_manager.py
+++ b/nexus/nexus/tests/test_project_manager.py
@@ -290,6 +290,8 @@ def test_write_simulation_status():
     pm = ProjectManager()
     pm.add_simulations(list(sims.values()))
 
+    status_modes = nexus_core.status_modes
+
     def status_log():
         log.reset()
         pm.write_simulation_status()
@@ -297,6 +299,7 @@ def test_write_simulation_status():
         return '\n'.join(line.rstrip() for line in s.splitlines())
     #end def status_log
 
+    assert(nexus_core.status==status_modes.none)
     status_ref = '''
   cascade status
     setup, sent_files, submitted, finished, got_output, analyzed, failed
@@ -307,6 +310,31 @@ def test_write_simulation_status():
     000000           ------    test_sim_s3  ./runs/
     000000           ------    test_sim_s4  ./runs/
     000000           ------    test_sim_s5  ./runs/
+    setup, sent_files, submitted, finished, got_output, analyzed, failed
+    '''
+    assert(status_log().strip()==status_ref.strip())
+
+    nexus_core.status = status_modes.standard
+    assert(status_log().strip()==status_ref.strip())
+
+    nexus_core.status = status_modes.active
+    status_ref = '''
+  cascade status
+    setup, sent_files, submitted, finished, got_output, analyzed, failed
+    000000           ------    test_sim_s11  ./runs/
+    000000           ------    test_sim_s12  ./runs/
+    setup, sent_files, submitted, finished, got_output, analyzed, failed
+    '''
+    assert(status_log().strip()==status_ref.strip())
+
+    nexus_core.status = status_modes.ready
+    assert(status_log().strip()==status_ref.strip())
+
+    nexus_core.status = status_modes.failed
+    status_ref = '''
+  cascade status
+    setup, sent_files, submitted, finished, got_output, analyzed, failed
+    (No simulations present)
     setup, sent_files, submitted, finished, got_output, analyzed, failed
     '''
     assert(status_log().strip()==status_ref.strip())

--- a/nexus/nexus/tests/test_project_manager.py
+++ b/nexus/nexus/tests/test_project_manager.py
@@ -9,13 +9,10 @@ from ..testing import failed,FailedTest
 
 def test_init():
     from ..developer import obj
-    from ..nexus_base import nexus_core
     from ..project_manager import ProjectManager
 
     pm = ProjectManager()
 
-    modes = nexus_core.modes
-    assert(pm.persistent_modes==set([modes.submit,modes.all]))
     def check(v):
         assert isinstance(v,obj)
         assert len(v)==0
@@ -413,19 +410,7 @@ def test_run_project(tmp_path):
     nexus_core.remote_directory = str(tmp_path)
     nexus_core.file_locations = nexus_core.file_locations + [str(tmp_path)]
 
-    assert(nexus_core.mode==nexus_core.modes.stages)
-    assert(len(nexus_core.stages)==0)
-
-    nexus_core.stages     = list(nexus_core.primary_modes)
-    nexus_core.stages_set = set(nexus_core.stages)
-
-    primary_modes = ['setup','send_files','submit','get_output','analyze']
-    assert(value_eq(nexus_core.stages,primary_modes))
-    assert(value_eq(nexus_core.stages_set,set(primary_modes)))
-
     nexus_core.sleep = 0.1
-
-    log = generic_settings.devlog
 
     flags = ['setup','sent_files','submitted','finished','got_output','analyzed']
 

--- a/nexus/nexus/tests/test_project_manager.py
+++ b/nexus/nexus/tests/test_project_manager.py
@@ -290,8 +290,6 @@ def test_write_simulation_status():
     pm = ProjectManager()
     pm.add_simulations(list(sims.values()))
 
-    status_modes = nexus_core.status_modes
-
     def status_log():
         log.reset()
         pm.write_simulation_status()
@@ -299,7 +297,6 @@ def test_write_simulation_status():
         return '\n'.join(line.rstrip() for line in s.splitlines())
     #end def status_log
 
-    assert(nexus_core.status==status_modes.none)
     status_ref = '''
   cascade status
     setup, sent_files, submitted, finished, got_output, analyzed, failed
@@ -310,31 +307,6 @@ def test_write_simulation_status():
     000000           ------    test_sim_s3  ./runs/
     000000           ------    test_sim_s4  ./runs/
     000000           ------    test_sim_s5  ./runs/
-    setup, sent_files, submitted, finished, got_output, analyzed, failed
-    '''
-    assert(status_log().strip()==status_ref.strip())
-
-    nexus_core.status = status_modes.standard
-    assert(status_log().strip()==status_ref.strip())
-
-    nexus_core.status = status_modes.active
-    status_ref = '''
-  cascade status
-    setup, sent_files, submitted, finished, got_output, analyzed, failed
-    000000           ------    test_sim_s11  ./runs/
-    000000           ------    test_sim_s12  ./runs/
-    setup, sent_files, submitted, finished, got_output, analyzed, failed
-    '''
-    assert(status_log().strip()==status_ref.strip())
-
-    nexus_core.status = status_modes.ready
-    assert(status_log().strip()==status_ref.strip())
-
-    nexus_core.status = status_modes.failed
-    status_ref = '''
-  cascade status
-    setup, sent_files, submitted, finished, got_output, analyzed, failed
-    (No simulations present)
     setup, sent_files, submitted, finished, got_output, analyzed, failed
     '''
     assert(status_log().strip()==status_ref.strip())

--- a/nexus/nexus/tests/test_settings.py
+++ b/nexus/nexus/tests/test_settings.py
@@ -45,25 +45,25 @@ def test_settings(tmp_path):
 
     def check_settings_core_noncore():
         nckeys_check = {
-                'command_line','debug',
+                'command_line',
                 'file_locations', 'generate_only', 'graph_sims', 'indent',
                 'load_images', 'local_directory', 'monitor',
                 'progress_tty', 'pseudo_dir',
                 'remote_directory', 'results', 'runs',
                 'skip_submit', 'sleep', 'timeout',
-                'status_only', 'trace', 'verbose', 'dynamic'
+                'status_only', 'dynamic'
                 }
         nnckeys_check = {
                 'basis_dir', 'basissets', 'pseudo_dir'
                 }
         setkeys_check = {
-                'command_line','basis_dir', 'basissets', 'debug',
+                'command_line', 'basis_dir', 'basissets',
                 'file_locations', 'generate_only',
                 'graph_sims', 'indent', 'load_images', 'local_directory',
                 'monitor', 'progress_tty',
                 'pseudo_dir', 'remote_directory', 'results',
                 'runs', 'skip_submit', 'sleep',
-                'timeout', 'status_only', 'trace', 'verbose', 'dynamic'
+                'timeout', 'status_only', 'dynamic'
                 }
         setkeys_allowed = setkeys_check | Settings.allowed_vars
 

--- a/nexus/nexus/tests/test_settings.py
+++ b/nexus/nexus/tests/test_settings.py
@@ -44,34 +44,33 @@ def test_settings(tmp_path):
     #end def aux_defaults
 
     def check_settings_core_noncore():
-        nckeys_check = set([
+        nckeys_check = {
                 'command_line','debug',
                 'file_locations', 'generate_only', 'graph_sims', 'indent',
                 'load_images', 'local_directory', 'monitor',
                 'progress_tty', 'pseudo_dir',
                 'remote_directory', 'results', 'runs',
-                'skip_submit', 'sleep', 'status', 'timeout',
-                'status_modes', 'status_only', 'trace', 'verbose', 'dynamic'
-                ])
-        nnckeys_check = set([
+                'skip_submit', 'sleep', 'timeout',
+                'status_only', 'trace', 'verbose', 'dynamic'
+                }
+        nnckeys_check = {
                 'basis_dir', 'basissets', 'pseudo_dir'
-                ])
-        setkeys_check = set([
+                }
+        setkeys_check = {
                 'command_line','basis_dir', 'basissets', 'debug',
                 'file_locations', 'generate_only',
                 'graph_sims', 'indent', 'load_images', 'local_directory',
                 'monitor', 'progress_tty',
                 'pseudo_dir', 'remote_directory', 'results',
-                'runs', 'skip_submit', 'sleep', 'status',
-                'timeout',
-                'status_modes', 'status_only', 'trace', 'verbose', 'dynamic'
-                ])
+                'runs', 'skip_submit', 'sleep',
+                'timeout', 'status_only', 'trace', 'verbose', 'dynamic'
+                }
         setkeys_allowed = setkeys_check | Settings.allowed_vars
 
         nckeys  = set(nexus_core.keys())
         nnckeys = set(nexus_noncore.keys())
         setkeys = set(settings.keys())
-        
+
         assert(nckeys==nckeys_check)
         assert(nnckeys==nnckeys_check)
         assert(setkeys>=setkeys_check)

--- a/nexus/nexus/tests/test_settings.py
+++ b/nexus/nexus/tests/test_settings.py
@@ -50,8 +50,8 @@ def test_settings(tmp_path):
                 'load_images', 'local_directory', 'monitor',
                 'progress_tty', 'pseudo_dir',
                 'remote_directory', 'results', 'runs',
-                'skip_submit', 'sleep', 'timeout',
-                'status_only', 'dynamic'
+                'skip_submit', 'sleep', 'status', 'timeout',
+                'status_modes', 'status_only', 'dynamic'
                 }
         nnckeys_check = {
                 'basis_dir', 'basissets', 'pseudo_dir'
@@ -62,15 +62,16 @@ def test_settings(tmp_path):
                 'graph_sims', 'indent', 'load_images', 'local_directory',
                 'monitor', 'progress_tty',
                 'pseudo_dir', 'remote_directory', 'results',
-                'runs', 'skip_submit', 'sleep',
-                'timeout', 'status_only', 'dynamic'
+                'runs', 'skip_submit', 'sleep', 'status',
+                'timeout',
+                'status_modes', 'status_only', 'dynamic'
                 }
         setkeys_allowed = setkeys_check | Settings.allowed_vars
 
         nckeys  = set(nexus_core.keys())
         nnckeys = set(nexus_noncore.keys())
         setkeys = set(settings.keys())
-
+        
         assert(nckeys==nckeys_check)
         assert(nnckeys==nnckeys_check)
         assert(setkeys>=setkeys_check)

--- a/nexus/nexus/tests/test_settings.py
+++ b/nexus/nexus/tests/test_settings.py
@@ -45,12 +45,12 @@ def test_settings(tmp_path):
 
     def check_settings_core_noncore():
         nckeys_check = set([
-                'command_line','debug', 'dependent_modes', 'emulate',
+                'command_line','debug',
                 'file_locations', 'generate_only', 'graph_sims', 'indent',
-                'load_images', 'local_directory', 'mode', 'modes', 'monitor',
-                'primary_modes', 'progress_tty', 'pseudo_dir',
+                'load_images', 'local_directory', 'monitor',
+                'progress_tty', 'pseudo_dir',
                 'remote_directory', 'results', 'runs',
-                'skip_submit', 'sleep', 'stages', 'stages_set', 'status', 'timeout',
+                'skip_submit', 'sleep', 'status', 'timeout',
                 'status_modes', 'status_only', 'trace', 'verbose', 'dynamic'
                 ])
         nnckeys_check = set([
@@ -58,11 +58,11 @@ def test_settings(tmp_path):
                 ])
         setkeys_check = set([
                 'command_line','basis_dir', 'basissets', 'debug',
-                'dependent_modes', 'emulate', 'file_locations', 'generate_only',
-                'graph_sims', 'indent', 'load_images', 'local_directory', 'mode',
-                'modes', 'monitor', 'primary_modes', 'progress_tty',
+                'file_locations', 'generate_only',
+                'graph_sims', 'indent', 'load_images', 'local_directory',
+                'monitor', 'progress_tty',
                 'pseudo_dir', 'remote_directory', 'results',
-                'runs', 'skip_submit', 'sleep', 'stages', 'stages_set', 'status',
+                'runs', 'skip_submit', 'sleep', 'status',
                 'timeout',
                 'status_modes', 'status_only', 'trace', 'verbose', 'dynamic'
                 ])
@@ -102,12 +102,9 @@ def test_settings(tmp_path):
         settings.command_line   = True
         nexus_core.command_line = True
         check_settings_core_noncore()
-        # nexus core sets basic run stages and PseudoSet registries are empty
-        assert(nexus_core.stages_set==set(nexus_core_defaults.primary_modes))
+        # PseudoSet registries are empty
         assert(len(PseudoSet.pseudo_files)==0)
         assert(len(PseudoSet.labeled_pseudosets)==0)
-        nexus_core.stages_set       = set()
-        nexus_core.stages           = []
         assert(object_eq(nexus_core,nexus_core_defaults))
         # nexus noncore sets a BasisSets object
         assert(isinstance(nexus_noncore.basissets,BasisSets))

--- a/nexus/nexus/tests/test_simulation_module.py
+++ b/nexus/nexus/tests/test_simulation_module.py
@@ -743,7 +743,6 @@ def test_init():
         files                = set([]),
         finished             = False,
         force_restart        = False,
-        force_write          = False,
         got_dependencies     = False,
         got_output           = False,
         identifier           = 'sim',
@@ -2186,16 +2185,6 @@ def test_progress(tmp_path):
     nexus_core.local_directory  = str(tmp_path)
     nexus_core.remote_directory = str(tmp_path)
     nexus_core.file_locations = nexus_core.file_locations + [str(tmp_path)]
-
-    assert(nexus_core.mode==nexus_core.modes.stages)
-    assert(len(nexus_core.stages)==0)
-
-    nexus_core.stages     = list(nexus_core.primary_modes)
-    nexus_core.stages_set = set(nexus_core.stages)
-
-    primary_modes = ['setup','send_files','submit','get_output','analyze']
-    assert(value_eq(nexus_core.stages,primary_modes))
-    assert(value_eq(nexus_core.stages_set,set(primary_modes)))
 
 
     template = '''


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

I noticed that there were a significant number of variables in `nexus_core` that were either unused, constant and unchangeable, or redundant. The complete list of removed variables is given below:

- `modes`
    - Defines allowed values for `mode`
- `mode`
    - Always overridden to be the same value by `Settings.process_core_settings()`
- `stages_set`
    - Created from `stages`, essentially always the same
- `stages`
    - Created by `mode`
- `primary_modes`
    - Only used to create `stages`
- `dependent_modes`
    - Static, and only checked if it is a subset of `stages_set`, which is essentially always the case.
- `verbose`
    - Always `True`.
- `debug`
    - Only used to set `verbose` to `True`, but `verbose` is always `True` no matter what.
- `trace`
    - Unused
- `status_modes`
    - Defines allowed values for `status`
- `status`
    - The only place this is checked is in `ProjectManager.write_simulation_status()`, but `standard` and `none` do the same thing, and since every status other than `standard` and `none` are basically unreachable via the user, this is useless.
- `emulate`
    - Unused.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->

- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

Desktop, Fedora Linux 44 (KDE Plasma Desktop Edition)
AMD Ryzen 9 7900X (12 cores, 24 logical processors)
```
Python        3.14.5
uv            0.12.3
cif2cell      2.1.0
coverage      7.15.4
h5py          3.16.0
matplotlib    3.11.1
numpy         2.5.2
pycifrw       4.4.6
pydot         4.0.1
pytest        9.1.1
pytest-cov    7.1.0
pytest-order  1.5.0
scipy         1.18.0
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [ ] I have read the pull request guidance and develop docs
* * [ ] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
