### PR TITLE
Nexus: start a statistics module

### DIFF
--- a/nexus/nexus/statistics.py
+++ b/nexus/nexus/statistics.py
@@ -1,5 +1,5 @@
 
-
+import numpy as np
 
 def series_stats(x,t_auto=None):
     if t_auto is None:

--- a/nexus/nexus/statistics.py
+++ b/nexus/nexus/statistics.py
@@ -1,0 +1,14 @@
+
+
+
+def series_stats(x,t_auto=None):
+    if t_auto is None:
+        #t_auto = autocorr_time(x)
+        t_auto = 1.0
+    N        = len(x)
+    N_eff    = N/t_auto
+    x_mean   = np.mean(x)
+    x_stderr = np.std(x)/np.sqrt(N_eff)
+    return x_mean,x_stderr,t_auto
+#end def series_stats
+


### PR DESCRIPTION

This PR adds a small (nearly empty) statistics module file.  This module will gradually be filled with methods needed to support a new version of the aging and overly-complex `QmcpackAnalyzer` class.

The sole function currently present will be integrated with more advanced autocorrelation methods in a later PR.