### PR TITLE
Trap SPOSet::applyRotation call on SPOSet without rotation support.

### DIFF
--- a/src/QMCWaveFunctions/SPOSet.cpp
+++ b/src/QMCWaveFunctions/SPOSet.cpp
@@ -289,6 +289,10 @@ void SPOSetT<T>::applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy)
     throw std::logic_error("Bug!! " + getClassName() +
                            "::applyRotation "
                            "must be overloaded when the SPOSet supports rotation.");
+  else
+    throw std::logic_error("Bug!! " + getClassName() +
+                           "::applyRotation "
+                           "gets called while the SPOSet doesn't support rotation.");
 }
 
 template<typename T>

--- a/src/QMCWaveFunctions/tests/FakeSPO.cpp
+++ b/src/QMCWaveFunctions/tests/FakeSPO.cpp
@@ -146,6 +146,10 @@ void FakeSPO<T>::evaluate_notranspose(const ParticleSet& P,
   }
 }
 
+template<typename T>
+void FakeSPO<T>::applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy)
+{}
+
 #if !defined(MIXED_PRECISION)
 template class FakeSPO<double>;
 template class FakeSPO<std::complex<double>>;

--- a/src/QMCWaveFunctions/tests/FakeSPO.h
+++ b/src/QMCWaveFunctions/tests/FakeSPO.h
@@ -57,6 +57,10 @@ public:
                             GradMatrix& dlogdet,
                             ValueMatrix& d2logdet) override;
 
+  bool isRotationSupported() const override { return true; }
+
+  void applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy) override;
+
 private:
   using SPOSet::OrbitalSetSize;
 };


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

as title. Adds trap for developers.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Other (please describe): improve internal implementation consistency.

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

laptop

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
