### PR TITLE
Nexus: Update `qdens` command-line argument parsing

### DIFF
--- a/nexus/nexus/bin/qdens
+++ b/nexus/nexus/bin/qdens
@@ -3,9 +3,9 @@
 import gc
 import os
 import sys
+from argparse import ArgumentParser
 from copy import deepcopy
 from pathlib import Path
-from optparse import OptionParser
 
 if sys.version_info[0:3] < (3, 10, 0):
     v = sys.version_info[0:3]
@@ -97,39 +97,6 @@ def h5_array(val):
 
 def first(d):
     return d[min(d.keys())]
-
-
-
-def comma_list(s):
-    if ',' in s:
-        s = s.replace(',',' ')
-    #end if
-    s = s.strip()
-    if ' ' in s:
-        tokens = s.split()
-        s = ''
-        for t in tokens:
-            s+=t+','
-        #end for
-        s=s[:-1]
-    #end if
-    return s
-#end def comma_list
-
-
-def input_list(s):
-    if ',' in s:
-        s = s.replace(',',' ')
-    #end if
-    s = s.strip()
-    if ' ' in s:
-        lst = s.split()
-    else:
-        lst = [s]
-    #end if
-    return lst
-#end def input_list
-
 
 
 def qmcpack_filepath(basepath,tokens,g=None):
@@ -1121,94 +1088,173 @@ class QMCDensityProcessor(QDBase):
 
 
     def read_command_line(self):
-        usage = '''usage: %prog [options] [file(s)]'''
-        parser = OptionParser(usage=usage,add_help_option=False,version='%prog {}.{}.{}'.format(*nexus_version))
-        parser.add_option('-h','--help',dest='help',
-                          action='store_true',default=False,
-                          help='Print help information and exit (default=%default).'
-                          )
-        parser.add_option('-v','--verbose',dest='verbose',
-                          action='store_true',default=False,
-                          help='Print detailed information (default=%default).'
-                          )
-        #parser.add_option('-q','--quantities',dest='quantities',
-        #                  default='all',
-        #                  help='Quantity or list of quantities to analyze.  See names and abbreviations below (default=%default).'
-        #                  )
-        parser.add_option('-f','--formats',dest='formats',
-                          default='None',
-                          help='Format or list of formats for density file output.  Options: dat, xsf, chgcar (default=%default).'
-                          )
-        parser.add_option('-e','--equilibration',dest='equilibration',
-                          default='0',
-                          help='Equilibration length in blocks (default=%default).'
-                          )
-        parser.add_option('-r','--reblock',dest='reblock',
-                          default='None',
-                          help='Block coarsening factor; use estimated autocorrelation length (default=%default).'
-                          )
-        parser.add_option('-a','--average',dest='average',
-                          action='store_true',default=False,
-                          help='Average over files in each series (default=%default).'
-                          )
-        parser.add_option('-w','--weights',dest='weights',
-                          default='None',
-                          help='List of weights for averaging (default=%default).'
-                          )
-        parser.add_option('-i','--input',dest='input',
-                          default='None',
-                          help='QMCPACK input file; matching estimator metadata is used per output series (default=%default).'
-                          )
-        parser.add_option('-s','--structure',dest='structure',
-                          default='None',
-                          help='File containing atomic structure (default=%default).'
-                          )
-        parser.add_option('-g','--grid',dest='grid',
-                          default='None',
-                          help='Fallback density grid dimensions; must match stored bins and is ignored when input metadata matches (default=%default).'
-                          )
-        parser.add_option('-c','--cell',dest='cell',
-                          default='None',
-                          help='Simulation cell axes (default=%default).'
-                          )
-        parser.add_option('--density_cell',dest='density_cell',
-                          default='None',
-                          help='Fallback density cell axes; ignored when input metadata matches (default=%default).'
-                          )
-        parser.add_option('--density_corner',dest='density_corner',
-                          default='None',
-                          help='Fallback density cell corner; ignored when input metadata matches (default=%default).'
-                          )
-        parser.add_option('--lineplot',dest='lineplot',
-                          default='None',
-                          help='Produce a line plot along the selected dimension: 0, 1, or 2 (default=%default).'
-                          )
-        parser.add_option('--noplot',dest='noplot',
-                          action='store_true',default=False,
-                          help='Do not show plots interactively (default=%default).'
-                          )
-        parser.add_option('--twist_info',dest='twist_info',
-                          default='use',
-                          help='Use twist weights in twist_info.dat files or not.  Options: "use", "ignore", "require".  "use" means use when present, "ignore" means do not use, "require" means must be used (default=%default).'
-                          )
+        parser = ArgumentParser(prog="Nexus")
+        parser.add_argument(
+            "--version",
+            action="version",
+            version='%(prog)s {}.{}.{}'.format(*nexus_version)
+        )
+        parser.add_argument(
+            "files_in",
+            nargs="+", # One or more
+            type=Path,
+            help="Files for qdens to use."
+        )
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            action="store_true",
+            help="Print detailed information (default: %(default)s).",
+        )
+        parser.add_argument(
+            "-f",
+            "--formats",
+            choices=("dat", "xsf", "chgcar"),
+            nargs="*",
+            help=(
+                "Format or list of formats for density file output. "
+                "(default: %(default)s)."
+                ),
+        )
+        parser.add_argument(
+            "-e",
+            "--equilibration",
+            nargs="*",
+            type=int,
+            default=0,
+            help="Equilibration length in blocks (default: %(default)s).",
+        )
+        parser.add_argument(
+            "-r",
+            "--reblock",
+            nargs="*",
+            type=int,
+            help="Block coarsening factor; use estimated autocorrelation length",
+        )
+        parser.add_argument(
+            "-a",
+            "--average",
+            action="store_true",
+            help="Average over files in each series (default: %(default)s).",
+        )
+        parser.add_argument(
+            "-w",
+            "--weights",
+            dest="weights",
+            type=float,
+            nargs="*",
+            help="List of weights for averaging (default: %(default)s).",
+        )
+        parser.add_argument(
+            "-i",
+            "--input",
+            type=Path,
+            help=(
+                "QMCPACK input file; matching estimator metadata is used per "
+                "output series (default: %(default)s)."
+            ),
+        )
+        parser.add_argument(
+            "-s",
+            "--structure",
+            type=Path,
+            help="File containing atomic structure. Incompatible with `--input`.",
+        )
+        parser.add_argument(
+            "-c",
+            "--cell",
+            nargs=9,
+            type=float,
+            help="Simulation cell axes, 9 values. Incompatible with `--input`.",
+        )
+        parser.add_argument(
+            "-g",
+            "--grid",
+            type=int,
+            nargs=3,
+            help=(
+                "Fallback density grid dimensions; must match stored bins and "
+                "is ignored when input metadata matches. Must be 0 or 3 values. "
+                "(default: %(default)s)."
+            ),
+        )
+        parser.add_argument(
+            "--density-cell",
+            "--density_cell",
+            nargs=9,
+            type=float,
+            help=(
+                "Fallback density cell axes; ignored when input metadata matches"
+                " (default: %(default)s)."
+            ),
+        )
+        parser.add_argument(
+            "--density-corner",
+            "--density_corner",
+            nargs=3,
+            type=float,
+            help=(
+                "Fallback density cell corner; ignored when input metadata matches "
+                "(default: %(default)s)."
+            ),
+        )
+        parser.add_argument(
+            "--lineplot",
+            choices=(0, 1, 2),
+            type=int,
+            help=(
+                "Produce a line plot along the selected dimension "
+                "(default: %(default)s)."
+            ),
+        )
+        parser.add_argument(
+            "--noplot",
+            action="store_true",
+            help="Do not show plots interactively (default: %(default)s).",
+        )
+        parser.add_argument(
+            "--twist-info",
+            "--twist_info",
+            default="use",
+            choices=("use", "ignore", "require"),
+            help=(
+                "Use twist weights in twist_info.dat files or not. "
+                "'use' means use when present, "
+                "'ignore' means do not use, "
+                "'require' means must be used "
+                "(default: %(default)s)."
+            ),
+        )
 
+        args = parser.parse_args()
 
-        options,files_in = parser.parse_args()
+        if (
+            args.input is not None
+            and (
+                args.structure is not None
+                or args.cell is not None
+            )
+        ):
+            msg = "Can not supply --input and --structure/--cell!"
+            raise ValueError(msg)
+
+        for file in args.files_in:
+            file = file.resolve(strict=True)
+            if not file.name.endswith('.stat.h5'):
+                msg = (
+                    'only stat.h5 files are allowed as inputs\n'
+                    f'received file: {file}'
+                    )
+                raise ValueError(msg)
+
+        self.file_list.extend([str(file) for file in args.files_in])
 
         QDBase.parser = parser
-        QDBase.options.update(**options.__dict__)
+        QDBase.options.update(**vars(args))
 
         opt = self.options
 
         QDBase.verbose = opt.verbose
-
-        if opt.help or len(files_in)==0:
-            self.help()
-            if opt.help:
-                sys.exit()
-            else:
-                sys.exit(1)
-        #end if
 
         self.vlog(f'\n{self.name} initializing')
 
@@ -1217,304 +1263,68 @@ class QMCDensityProcessor(QDBase):
             self.log(str(self.options))
         #end if
 
-
         # handle options
-        #   options initialized to "None"
-        for k,v in opt.items():
-            if isinstance(v,str) and v=='None':
-                opt[k] = None
-            #end if
-        #end for
-
-        #   --format option (output file formats)
-        if opt.formats is not None:
-            opt.formats = input_list(opt.formats)
-            allowed_formats = set(['dat','xsf','chgcar'])
-            invalid = set(opt.formats)-allowed_formats
-            if len(invalid)>0:
-                msg = (
-                    'invalid output file format(s) requested\n'
-                    f'invalid requests: {sorted(invalid)}\n'
-                    f'allowed options: {sorted(allowed_formats)}'
-                    )
-                raise ValueError(msg)
-            #end if
-        #end if
-
-        #   --equilibration option
-        opt.equilibration = comma_list(opt.equilibration)
-        equil_failed = False
-        try:
-            opt.equilibration = int(opt.equilibration)
-        except:
-            try:
-                ei = eval(opt.equilibration)
-                e = obj()
-                if isinstance(ei,int):
-                    e = ei
-                elif isinstance(ei,(list,tuple)):
-                    ei = np.array(ei,dtype=int)
-                    for s in range(len(ei)):
-                        e[s] = ei[s]
-                    #end for
-                elif isinstance(ei,dict):
-                    e.update(ei)
-                else:
-                    equil_failed = True
-                #end if
-                opt.equilibration = e
-            except:
-                equil_failed = True
-            #end try
-        #end try
-        if equil_failed:
-            msg = (
-                'cannot process equilibration option\n'
-                'value must be an integer, list, or dict\n'
-                'you provided: '+str(opt.equilibration)
-                )
-            raise TypeError(msg)
-        #end if
-
-        #   --reblock option
-        if opt.reblock is not None:
-            opt.reblock = comma_list(opt.reblock)
-            reblock_failed = False
-            try:
-                opt.reblock = int(opt.reblock)
-            except:
-                try:
-                    ei = eval(opt.reblock)
-                    e = obj()
-                    if isinstance(ei,int):
-                        e = ei
-                    elif isinstance(ei,(list,tuple)):
-                        ei = np.array(ei,dtype=int)
-                        for s in range(len(ei)):
-                            e[s] = ei[s]
-                        #end for
-                    elif isinstance(ei,dict):
-                        e.update(ei)
-                    else:
-                        reblock_failed = True
-                    #end if
-                    opt.reblock = e
-                except:
-                    reblock_failed = True
-                #end try
-            #end try
-            if reblock_failed:
-                msg = (
-                    'cannot process reblock option\n'
-                    'value must be an integer, list, or dict\n'
-                    'you provided: '+str(opt.reblock)
-                    )
-                raise TypeError(msg)
-            #end if
-        #end if
-
-        #   --average option
-        if opt.average:
-            if opt.weights is not None:
-                weight_failed = False
-                try:
-                    w = comma_list(opt.weights)
-                    w = np.array(eval(w),dtype=float)
-                    opt.weights = w
-                    weight_failed = len(w.shape)!=1
-                except:
-                    weight_failed = True
-                #end try
-                if weight_failed:
-                    msg = (
-                        'weights must be a list of values\n'
-                        f'you provided: {opt.weights}'
-                        )
-                    raise ValueError(msg)
-                #end if
-            #end if
-        #end if
 
         #   --input option
-        structure = None
-        cell      = None
-        density_cell = None
+        structure      = None
+        cell           = None
+        density_cell   = None
         density_corner = None
         opt.input_metadata = None
         if opt.input is not None:
-            if not os.path.exists(opt.input):
-                msg = f'qmcpack input file does not exist: {opt.input}'
-                raise FileNotFoundError(msg)
-            #end if
-            qi = QmcpackInput(opt.input)
+            input_file = opt.input.resolve(strict=True)
+            qi = QmcpackInput(input_file)
             ps = qi.return_system()
             structure = ps.structure
             cell = structure.axes.copy()
             opt.input_metadata = self.read_input_metadata(qi,structure)
-        #end if
 
         #   --structure option
         if opt.structure is not None:
-            if not os.path.exists(opt.structure):
-                msg = f'structure file does not exist: {opt.structure}'
-                raise FileNotFoundError(msg)
-            #end if
-            opt.structure = read_structure(opt.structure)
+            structure_path = opt.structure.resolve(strict=True)
+            opt.structure = read_structure(structure_path)
         else:
             opt.structure = structure
-        #end if
 
         #   --cell option
         if opt.cell is not None:
-            cell = input_list(opt.cell)
-            try:
-                cell = np.array(cell,dtype=float)
-            except:
-                msg = (
-                    '--cell input misformatted\n'
-                    'expected a list of real values\n'
-                    f'received: {cell}'
-                    )
-                raise ValueError(msg)
-            #end try
-            if len(cell)!=9:
-                msg = (
-                    '--cell input misformatted\n'
-                    'expected 9 elements for 3x3 matrix\n'
-                    f'received {len(cell)} elements with values: {cell}'
-                    )
-                raise ValueError(msg)
-            #end if
+            cell = np.array(cell,dtype=float)
             npe.reshape_inplace(cell, (3, 3))
             opt.cell = cell
         else:
             opt.cell = cell
-        #end if
+
         if opt.structure is not None and opt.cell is not None:
+            print("Overriding cell axes in structure with `--cell` argument!")
             opt.structure.axes = opt.cell.copy()
-        #end if
 
         #   --density_cell option
         if opt.density_cell is not None:
-            density_cell = input_list(opt.density_cell)
-            try:
-                density_cell = np.array(density_cell,dtype=float)
-            except:
-                msg = (
-                    '--density_cell input misformatted\n'
-                    'expected a list of real values\n'
-                    f'received: {density_cell}'
-                    )
-                raise ValueError(msg)
-            #end try
-            if len(np.array(density_cell).ravel())!=9:
-                msg = (
-                    '--density_cell input misformatted\n'
-                    'expected 9 elements for 3x3 matrix\n'
-                    f'received {len(density_cell)} elements with values: {density_cell}'
-                    )
-                raise ValueError(msg)
-            #end if
+            density_cell = np.array(density_cell,dtype=float)
             npe.reshape_inplace(density_cell, (3, 3))
             opt.density_cell = density_cell
         else:
             opt.density_cell = density_cell
-        #end if
 
         #   --density_corner option
         if opt.density_corner is not None:
-            density_corner = input_list(opt.density_corner)
-            try:
-                density_corner = np.array(density_corner,dtype=float)
-            except:
-                msg = (
-                    '--density_corner input misformatted\n'
-                    'expected a list of floats\n'
-                    f'received: {density_corner}'
-                    )
-                raise ValueError(msg)
-            #end try
-            if len(density_corner)!=3:
-                msg = (
-                    '--density_corner input misformatted\n'
-                    'expected 3 elements\n'
-                    f'received {len(density_corner)} elements with values: {density_corner}'
-                    )
-                raise ValueError(msg)
-            #end if
-            opt.density_corner = density_corner
+            opt.density_corner = np.array(density_corner, dtype=float)
         else:
             opt.density_corner = density_corner
-        #end if
 
         #   --grid option
         if opt.grid is not None:
-            grid = input_list(opt.grid)
-            try:
-                grid = np.array(grid,dtype=int)
-            except:
-                msg = (
-                    '--grid input misformatted\n'
-                    'expected a list of integers\n'
-                    f'received: {grid}'
-                    )
-                raise ValueError(msg)
-            #end try
-            if len(grid)!=3:
-                msg = (
-                    '--grid input misformatted\n'
-                    'expected 3 elements\n'
-                    f'received {len(grid)} elements with values: {grid}'
-                    )
-                raise ValueError(msg)
-            #end if
-            opt.grid = grid
-        #end if
+            opt.grid = np.array(opt.grid, dtype=int)
 
-        #   --lineplot option
-        if opt.lineplot is not None:
-            if opt.lineplot not in tuple('012'):
-                msg = (
-                    '--lineplot input misformatted\n'
-                    'expected 0, 1, or 2\n'
-                    f'received: {opt.lineplot}'
-                    )
-                raise ValueError(msg)
-            #end if
-            opt.lineplot = int(opt.lineplot)
-        #end if
-
-        #   --twist_info option
-        twist_info_options = ('use','ignore','require')
-        if opt.twist_info not in twist_info_options:
-            msg = (
-                'twist_info option is invalid\n'
-                f'twist_info must be one of: {twist_info_options}\n'
-                f'you provided: {opt.twist_info}'
-                )
-            raise ValueError(msg)
-        #end if
+        # Unpack into single int if length-one list
+        if isinstance(opt.equilibration, list) and len(opt.equilibration) == 1:
+            opt.equilibration = opt.equilibration[0]
 
         if opt.verbose and opt.input_metadata is not None:
-            self.log(f'input density metadata found for series: {sorted(opt.input_metadata.series.keys())}')
-        #end if
-
-        for file in files_in:
-            if not os.path.exists(file):
-                msg = f'file does not exist: {file}'
-                raise FileNotFoundError(msg)
-            #end if
-            if not file.endswith('.stat.h5'):
-                msg = (
-                    'only stat.h5 files are allowed as inputs\n'
-                    f'received file: {file}'
-                    )
-                raise ValueError(msg)
-            #end if
-        #end for
-
-        self.file_list.extend(files_in)
-
+            self.log(
+                'input density metadata found for series: '
+                f'{sorted(opt.input_metadata.series.keys())}'
+            )
     #end def read_command_line
 
 

--- a/nexus/nexus/tests/test_qdens.py
+++ b/nexus/nexus/tests/test_qdens.py
@@ -460,7 +460,7 @@ def test_spindensity_input_metadata_overrides_grid_fallback(tmp_path):
     stat = tmp_path / 'series_spindensity.s005.stat.h5'
     _write_spin_density_stat(stat,8)
 
-    out,err,_ = execute(f'{exe} -f xsf -g "1 1 8" -i {infile} {stat}')
+    out,err,_ = execute(f'{exe} -f xsf -g 1 1 8 -i {infile} {stat}')
     assert 'Ignoring --grid' in out + err
     assert '3 3 3' in (tmp_path / 'series_spindensity.s005.SpinDensity_u+d.xsf').read_text()
 #end def test_spindensity_input_metadata_overrides_grid_fallback
@@ -502,6 +502,6 @@ def test_spindensity_series_mismatch_requires_unambiguous_fallback(tmp_path):
     with pytest.raises(
             AssertionError,
             match='density grid does not match number of HDF5 data cells'):
-        execute(f'{exe} -f xsf -g "3 3 3" -i {infile} {stat}')
+        execute(f'{exe} -f xsf -g 3 3 3 -i {infile} {stat}')
     #end with
 #end def test_spindensity_series_mismatch_requires_unambiguous_fallback


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

This PR updates the argument parsing for `qdens` to use `argparse` and reduce custom input handling code.

Some changes include delegating type handling of arguments to `argparse`, delegating argument length handling to `argparse`, and simplifying the input format.

### Changes and Removals

This PR removes the ability to pass a dict into the input, which was undocumented, untested, and relied on the `eval` function in Python, which can lead to obscure errors. Also, the previous version would allow passing `--input` along with `--structure`/`--cell`, which would silently overwrite any structure/cell in the input file with the one passed through `--structure`/`--cell`. Due to the fact that the input must have these elements, it is likely undesirable behavior, so the arguments are now mutually exclusive.

This PR additionally changes the formatting that was used for list-like arguments, which was originally like `--grid "3 3 3"` and is now `--grid 3 3 3`, which `argparse` will automatically parse into a list of 3 integers.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Cleanup

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->

- Yes

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

Laptop, Fedora Linux 44 (KDE Plasma Desktop Edition)
AMD Ryzen 7 PRO 7840U (8 cores, 16 logical processors)
```
Python        3.14.6
uv            0.12.5
cif2cell      2.1.0
coverage      7.15.4
h5py          3.16.0
matplotlib    3.11.1
numpy         2.5.2
pycifrw       4.4.6
pydot         4.0.1
pytest        9.1.1
pytest-cov    7.1.0
pytest-order  1.5.0
scipy         1.18.0
seekpath      2.2.1
spglib        2.7.0
sphinx        9.1.0
```

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [ ] I have read the pull request guidance and develop docs
* * [ ] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
