### PR TITLE
Remove WaveFunctionComponent as a base of MultiDiracDeterminant

### DIFF
--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -1193,7 +1193,7 @@ void QMCHamiltonian::evaluateIonDerivsFast(ParticleSet& P,
 
   // same order as Dets in msd; index of associated SPOset in psi_wrapper_in.sposets_
   std::vector<int> mdd_spo_ids;
-  std::vector<const WaveFunctionComponent*> mdd_list;
+  std::vector<const MultiDiracDeterminant*> mdd_list;
 
   if (psi_wrapper_in.hasMultiSlaterDet())
   {
@@ -1207,7 +1207,7 @@ void QMCHamiltonian::evaluateIonDerivsFast(ParticleSet& P,
     for (size_t i_mdd = 0; i_mdd < n_mdd; i_mdd++)
     {
       const MultiDiracDeterminant& multidiracdet_i = msd.getDet(i_mdd);
-      mdd_list.push_back(static_cast<const WaveFunctionComponent*>(&multidiracdet_i));
+      mdd_list.push_back(&multidiracdet_i);
       // particle group id for this multidiracdet
       const int gid = P.getGroupID(multidiracdet_i.getFirstIndex());
       // SPOSet location in psi_wrapper_in.sposets_ for this particle group

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -413,12 +413,12 @@ void test_msd_wrapper(const std::string& wffile,
 
   // same order as Dets in msd; index of associated SPOset in twf.sposets_
   std::vector<int> mdd_spo_ids;
-  std::vector<const WaveFunctionComponent*> mdd_list;
+  std::vector<const MultiDiracDeterminant*> mdd_list;
 
   for (size_t i_mdd = 0; i_mdd < n_mdd; i_mdd++)
   {
     const MultiDiracDeterminant& multidiracdet_i = msd.getDet(i_mdd);
-    mdd_list.push_back(static_cast<const WaveFunctionComponent*>(&multidiracdet_i));
+    mdd_list.push_back(&multidiracdet_i);
     // particle group id for this multidiracdet
     const int gid = elec.getGroupID(multidiracdet_i.getFirstIndex());
     // SPOSet location in twf.sposets_ for this particle group

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -888,7 +888,7 @@ void MultiDiracDeterminant::mw_accept_rejectMove(const RefVectorWithLeader<Multi
 
 // this has been fixed
 MultiDiracDeterminant::MultiDiracDeterminant(const MultiDiracDeterminant& s)
-    : WaveFunctionComponent(s),
+    : UpdateMode(s.UpdateMode),
       inverse_timer(s.inverse_timer),
       buildTable_timer(s.buildTable_timer),
       table2ratios_timer(s.table2ratios_timer),
@@ -922,34 +922,28 @@ MultiDiracDeterminant::MultiDiracDeterminant(const MultiDiracDeterminant& s)
 
 std::unique_ptr<SPOSet> MultiDiracDeterminant::clonePhi() const { return Phi->makeClone(); }
 
-std::unique_ptr<WaveFunctionComponent> MultiDiracDeterminant::makeClone(ParticleSet& tqp) const
-{
-  APP_ABORT(" Illegal action. Cannot use MultiDiracDeterminant::makeClone");
-  return std::unique_ptr<MultiDiracDeterminant>();
-}
-
 /** constructor
  *@param spos the single-particle orbital set
  *@param first index of the first particle
  *@param spinor flag to determinane if spin arrays need to be resized and used
  */
 MultiDiracDeterminant::MultiDiracDeterminant(std::unique_ptr<SPOSet>&& spos, bool spinor, int first, int nel)
-    : inverse_timer(createGlobalTimer(getClassName() + "::invertRefDet")),
-      buildTable_timer(createGlobalTimer(getClassName() + "::buildTable")),
-      table2ratios_timer(createGlobalTimer(getClassName() + "::table2ratios")),
-      evalWalker_timer(createGlobalTimer(getClassName() + "::evalWalker")),
-      evalOrbValue_timer(createGlobalTimer(getClassName() + "::evalOrbValue")),
-      evalOrbVGL_timer(createGlobalTimer(getClassName() + "::evalOrbVGL")),
-      updateInverse_timer(createGlobalTimer(getClassName() + "::updateRefDetInv")),
-      calculateRatios_timer(createGlobalTimer(getClassName() + "::calcRatios")),
-      calculateGradRatios_timer(createGlobalTimer(getClassName() + "::calcGradRatios")),
-      updateRatios_timer(createGlobalTimer(getClassName() + "::updateRatios")),
-      evaluateDetsForPtclMove_timer(createGlobalTimer(getClassName() + "::evaluateDet")),
-      evaluateDetsAndGradsForPtclMove_timer(createGlobalTimer(getClassName() + "::evaluateDetAndGrad")),
-      evaluateGrads_timer(createGlobalTimer(getClassName() + "::evaluateGrad")),
-      offload_timer(createGlobalTimer(getClassName() + "::offload")),
-      transferH2D_timer(createGlobalTimer(getClassName() + "::transferH2D")),
-      transferD2H_timer(createGlobalTimer(getClassName() + "::transferD2H")),
+    : inverse_timer(createGlobalTimer(class_name_ + "::invertRefDet")),
+      buildTable_timer(createGlobalTimer(class_name_ + "::buildTable")),
+      table2ratios_timer(createGlobalTimer(class_name_ + "::table2ratios")),
+      evalWalker_timer(createGlobalTimer(class_name_ + "::evalWalker")),
+      evalOrbValue_timer(createGlobalTimer(class_name_ + "::evalOrbValue")),
+      evalOrbVGL_timer(createGlobalTimer(class_name_ + "::evalOrbVGL")),
+      updateInverse_timer(createGlobalTimer(class_name_ + "::updateRefDetInv")),
+      calculateRatios_timer(createGlobalTimer(class_name_ + "::calcRatios")),
+      calculateGradRatios_timer(createGlobalTimer(class_name_ + "::calcGradRatios")),
+      updateRatios_timer(createGlobalTimer(class_name_ + "::updateRatios")),
+      evaluateDetsForPtclMove_timer(createGlobalTimer(class_name_ + "::evaluateDet")),
+      evaluateDetsAndGradsForPtclMove_timer(createGlobalTimer(class_name_ + "::evaluateDetAndGrad")),
+      evaluateGrads_timer(createGlobalTimer(class_name_ + "::evaluateGrad")),
+      offload_timer(createGlobalTimer(class_name_ + "::offload")),
+      transferH2D_timer(createGlobalTimer(class_name_ + "::transferH2D")),
+      transferD2H_timer(createGlobalTimer(class_name_ + "::transferD2H")),
       Phi(std::move(spos)),
       NumOrbitals(Phi->getOrbitalSetSize()),
       FirstIndex(first),

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -19,7 +19,8 @@
  */
 #ifndef QMCPLUSPLUS_MULTIDIRACDETERMINANT_H
 #define QMCPLUSPLUS_MULTIDIRACDETERMINANT_H
-#include "QMCWaveFunctions/WaveFunctionComponent.h"
+#include "Configuration.h"
+#include "Particle/ParticleSet.h"
 #include "QMCWaveFunctions/SPOSet.h"
 #include "QMCWaveFunctions/TWFFastDerivWrapper.h"
 #include "QMCWaveFunctions/Fermion/ci_configuration2.h"
@@ -31,17 +32,21 @@
 
 namespace qmcplusplus
 {
-class MultiDiracDeterminant : public WaveFunctionComponent
+class MultiDiracDeterminant : public QMCTraits
 {
 public:
-  NewTimer &inverse_timer, &buildTable_timer, &table2ratios_timer, &evalWalker_timer, &evalOrbValue_timer,
-      &evalOrbVGL_timer;
-  NewTimer &updateInverse_timer, &calculateRatios_timer, &calculateGradRatios_timer, &updateRatios_timer;
-  NewTimer &evaluateDetsForPtclMove_timer, &evaluateDetsAndGradsForPtclMove_timer, &evaluateGrads_timer;
-  NewTimer &offload_timer, &transferH2D_timer, &transferD2H_timer;
+  using LogValue     = std::complex<QTFull::RealType>;
+  using PsiValue     = QTFull::ValueType;
+  using WFBufferType = ParticleSet::Walker_t::WFBuffer_t;
 
-  // Optimizable parameter
-  OptVariables myVars;
+  enum
+  {
+    ORB_PBYP_RATIO,
+    ORB_PBYP_ALL,
+    ORB_PBYP_PARTIAL,
+    ORB_WALKER,
+    ORB_ALLWALKER
+  };
 
   template<typename DT>
   using OffloadVector = Vector<DT, OffloadPinnedAllocator<DT>>;
@@ -115,9 +120,6 @@ public:
     OffloadVector<GradType> ratioGradRef_list;
   };
 
-  //lookup table mapping the unique determinants to their element position in C2_node vector
-  std::vector<std::vector<int>> lookup_tbl;
-
   /** constructor
    *@param spos the single-particle orbital set
    *@param first index of the first particle
@@ -125,7 +127,7 @@ public:
   MultiDiracDeterminant(std::unique_ptr<SPOSet>&& spos, bool spinor, int first, int nel);
 
   ///default destructor
-  ~MultiDiracDeterminant() override;
+  ~MultiDiracDeterminant();
 
   /**copy constructor
    * @param s existing DiracDeterminant
@@ -143,15 +145,11 @@ public:
 
   SPOSetPtr getPhi() { return Phi.get(); };
 
-  std::string getClassName() const override { return "MultiDiracDeterminant"; }
+  inline bool isOptimizable() const { return Phi->isOptimizable(); }
 
-  bool isFermionic() const final { return true; }
-  inline bool isOptimizable() const final { return Phi->isOptimizable(); }
+  void extractOptimizableObjectRefs(UniqueOptObjRefs& opt_obj_refs) { Phi->extractOptimizableObjectRefs(opt_obj_refs); }
 
-  void extractOptimizableObjectRefs(UniqueOptObjRefs& opt_obj_refs) final
-  { Phi->extractOptimizableObjectRefs(opt_obj_refs); }
-
-  inline void checkOutVariables(const OptVariables& active) override
+  inline void checkOutVariables(const OptVariables& active)
   {
     if (Phi->isOptimizable())
       Phi->checkOutVariables(active);
@@ -161,12 +159,6 @@ public:
   void buildOptVariables(std::vector<size_t>& C2node);
   ///helper function to buildOptVariables
   int build_occ_vec(const OffloadVector<int>& data, const size_t nel, const size_t nmo, std::vector<int>& occ_vec);
-
-  void evaluateDerivatives(ParticleSet& P,
-                           const OptVariables& optvars,
-                           Vector<ValueType>& dlogpsi,
-                           Vector<ValueType>& dhpsioverpsi) override
-  {}
 
   void evaluateDerivatives(ParticleSet& P,
                            const OptVariables& optvars,
@@ -188,74 +180,32 @@ public:
                              const std::vector<size_t>& C2node_dn);
 
 
-  void registerData(ParticleSet& P, WFBufferType& buf) override;
+  void registerData(ParticleSet& P, WFBufferType& buf);
 
-  LogValue updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false) override;
+  LogValue updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false);
 
-  void copyFromBuffer(ParticleSet& P, WFBufferType& buf) override;
+  void copyFromBuffer(ParticleSet& P, WFBufferType& buf);
 
   /** move was accepted, update the real container
    */
-  void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false) override;
+  void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false);
 
   /** move was rejected. copy the real container to the temporary to move on
    */
-  void restore(int iat) override;
+  void restore(int iat);
 
   static void mw_accept_rejectMove(const RefVectorWithLeader<MultiDiracDeterminant>& wfc_list,
                                    const RefVectorWithLeader<ParticleSet>& p_list,
                                    int iat,
                                    const std::vector<bool>& isAccepted);
 
-  void createResource(ResourceCollection& collection) const override;
+  void createResource(ResourceCollection& collection) const;
   void acquireResource(ResourceCollection& collection,
                        const RefVectorWithLeader<MultiDiracDeterminant>& wfc_list) const;
   void releaseResource(ResourceCollection& collection,
                        const RefVectorWithLeader<MultiDiracDeterminant>& wfc_list) const;
-  void registerTWFFastDerivWrapper(const ParticleSet& P, TWFFastDerivWrapper& twf) const override;
+  void registerTWFFastDerivWrapper(const ParticleSet& P, TWFFastDerivWrapper& twf) const;
 
-  std::unique_ptr<WaveFunctionComponent> makeClone(ParticleSet& tqp) const override;
-
-  /****************************************************************************
-   * These functions should not be called.
-   ***************************************************************************/
-
-  PsiValue ratio(ParticleSet& P, int iat) override
-  {
-    APP_ABORT("  MultiDiracDeterminant: This should not be called. \n");
-    return PsiValue();
-  }
-
-  GradType evalGrad(ParticleSet& P, int iat) override
-  {
-    APP_ABORT("  MultiDiracDeterminant: This should not be called. \n");
-    return GradType();
-  }
-
-  PsiValue ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override
-  {
-    APP_ABORT("  MultiDiracDeterminant: This should not be called. \n");
-    return PsiValue();
-  }
-
-  LogValue evaluateLog(const ParticleSet& P,
-                       ParticleSet::ParticleGradient& G,
-                       ParticleSet::ParticleLaplacian& L) override
-  {
-    APP_ABORT("  MultiDiracDeterminant: This should not be called. \n");
-    return 0.0;
-  }
-
-  ValueType evaluate(const ParticleSet& P, ParticleSet::ParticleGradient& G, ParticleSet::ParticleLaplacian& L)
-  {
-    APP_ABORT("  MultiDiracDeterminant: This should not be called. \n");
-    return ValueType();
-  }
-
-
-  /****************************************************************************
-   * END END END
-   ***************************************************************************/
 
   /** create necessary structures related to unique determinants
    * sort configlist_unsorted by excitation level abd store the results in ciConfigList (class member)
@@ -516,6 +466,20 @@ private:
 
   ///reset the size: with the number of particles
   void resize();
+
+  // used by timers must be declared before them
+  const std::string class_name_ = "MultiDiracDeterminant";
+
+  int UpdateMode;
+
+  NewTimer &inverse_timer, &buildTable_timer, &table2ratios_timer, &evalWalker_timer, &evalOrbValue_timer,
+      &evalOrbVGL_timer;
+  NewTimer &updateInverse_timer, &calculateRatios_timer, &calculateGradRatios_timer, &updateRatios_timer;
+  NewTimer &evaluateDetsForPtclMove_timer, &evaluateDetsAndGradsForPtclMove_timer, &evaluateGrads_timer;
+  NewTimer &offload_timer, &transferH2D_timer, &transferD2H_timer;
+
+  //lookup table mapping the unique determinants to their element position in C2_node vector
+  std::vector<std::vector<int>> lookup_tbl;
 
   ///a set of single-particle orbitals used to fill in the  values of the matrix
   const std::unique_ptr<SPOSet> Phi;

--- a/src/QMCWaveFunctions/TWFFastDerivWrapper.cpp
+++ b/src/QMCWaveFunctions/TWFFastDerivWrapper.cpp
@@ -278,7 +278,7 @@ TWFFastDerivWrapper::ValueType TWFFastDerivWrapper::computeGSDerivative(const st
 void TWFFastDerivWrapper::computeMDDerivatives_Obs(const std::vector<ValueMatrix>& Minv_Mv,
                                                    const std::vector<ValueMatrix>& Minv_B,
                                                    const std::vector<IndexType>& mdd_spo_ids,
-                                                   const std::vector<const WaveFunctionComponent*>& mdds,
+                                                   const std::vector<const MultiDiracDeterminant*>& mdds,
                                                    std::vector<ValueVector>& dvals_O) const
 {
   // mdd_id is multidiracdet id as ordered in multislaterdet
@@ -287,7 +287,7 @@ void TWFFastDerivWrapper::computeMDDerivatives_Obs(const std::vector<ValueMatrix
     // sid is sposet id as ordered in TWFFastDerivWrapper (index into first dim of M, X, B, etc.)
     IndexType sid = mdd_spo_ids[mdd_id];
 
-    const auto& multidiracdet_i = static_cast<const MultiDiracDeterminant&>(*mdds[mdd_id]);
+    const auto& multidiracdet_i = *mdds[mdd_id];
 
     IndexType ndet     = multidiracdet_i.getNumDets();     // number of DiracDets in this MultiDiracDet
     size_t nelec       = multidiracdet_i.getNumPtcls();    // total occ orbs in refdet (should be same as n_elec)
@@ -451,7 +451,7 @@ void TWFFastDerivWrapper::computeMDDerivatives_dmu(const std::vector<ValueMatrix
                                                    const std::vector<ValueMatrix>& Minv_dM,
                                                    const std::vector<ValueMatrix>& Minv_dB,
                                                    const std::vector<IndexType>& mdd_spo_ids,
-                                                   const std::vector<const WaveFunctionComponent*>& mdds,
+                                                   const std::vector<const MultiDiracDeterminant*>& mdds,
                                                    std::vector<ValueVector>& dvals_dmu_O,
                                                    std::vector<ValueVector>& dvals_dmu) const
 {
@@ -461,7 +461,7 @@ void TWFFastDerivWrapper::computeMDDerivatives_dmu(const std::vector<ValueMatrix
     // sid is sposet id as ordered in TWFFastDerivWrapper (index into first dim of M, X, B, etc.)
     IndexType sid = mdd_spo_ids[mdd_id];
 
-    const auto& multidiracdet_i = static_cast<const MultiDiracDeterminant&>(*mdds[mdd_id]);
+    const auto& multidiracdet_i = *mdds[mdd_id];
 
     IndexType ndet     = multidiracdet_i.getNumDets();     // number of DiracDets in this MultiDiracDet
     size_t nelec       = multidiracdet_i.getNumPtcls();    // total occ orbs in refdet (should be same as n_elec)
@@ -650,7 +650,7 @@ void TWFFastDerivWrapper::computeMDDerivatives_dmu(const std::vector<ValueMatrix
 }
 
 std::tuple<TWFFastDerivWrapper::ValueType, TWFFastDerivWrapper::ValueType, TWFFastDerivWrapper::ValueType>
-    TWFFastDerivWrapper::computeMDDerivatives_total(const std::vector<const WaveFunctionComponent*>& mdds,
+    TWFFastDerivWrapper::computeMDDerivatives_total(const std::vector<const MultiDiracDeterminant*>& mdds,
                                                     const std::vector<ValueVector>& dvals_dmu_O,
                                                     const std::vector<ValueVector>& dvals_O,
                                                     const std::vector<ValueVector>& dvals_dmu) const

--- a/src/QMCWaveFunctions/TWFFastDerivWrapper.h
+++ b/src/QMCWaveFunctions/TWFFastDerivWrapper.h
@@ -23,6 +23,8 @@
 
 namespace qmcplusplus
 {
+class MultiDiracDeterminant;
+
 /**
  *  TWFFastDerivWrapper is a wrapper class for TrialWavefunction that provides separate and low level access to the Jastrow and 
  *  SPOSet objects.  This is so that observables can be recast in matrix form and their derivatives taken efficiently. 
@@ -275,7 +277,7 @@ public:
                                 const std::vector<ValueMatrix>& Minv_dM,
                                 const std::vector<ValueMatrix>& Minv_dB,
                                 const std::vector<IndexType>& mdd_spo_ids,
-                                const std::vector<const WaveFunctionComponent*>& mdds,
+                                const std::vector<const MultiDiracDeterminant*>& mdds,
                                 std::vector<ValueVector>& dvals_dmu_O,
                                 std::vector<ValueVector>& dvals_dmu) const;
 
@@ -292,7 +294,7 @@ public:
   void computeMDDerivatives_Obs(const std::vector<ValueMatrix>& Minv_Mv,
                                 const std::vector<ValueMatrix>& Minv_B,
                                 const std::vector<IndexType>& mdd_spo_ids,
-                                const std::vector<const WaveFunctionComponent*>& mdds,
+                                const std::vector<const MultiDiracDeterminant*>& mdds,
                                 std::vector<ValueVector>& dvals_O) const;
 
   /** @brief Uses per-det lists of derivatives to calculate total excited det contributions
@@ -304,7 +306,7 @@ public:
    *  @return  {d_mu(OPsi/Psi), d_mu(log(Psi)), OPsi/Psi}
    */
   std::tuple<TWFFastDerivWrapper::ValueType, TWFFastDerivWrapper::ValueType, TWFFastDerivWrapper::ValueType>
-      computeMDDerivatives_total(const std::vector<const WaveFunctionComponent*>& mdds,
+      computeMDDerivatives_total(const std::vector<const MultiDiracDeterminant*>& mdds,
                                  const std::vector<ValueVector>& dvals_dmu_O,
                                  const std::vector<ValueVector>& dvals_O,
                                  const std::vector<ValueVector>& dvals_dmu) const;


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

There is no reason/benefit having WaveFunctionComponent as a base.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->



## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [x] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
