### PR TITLE
Remove unnecessary use of layout

### DIFF
--- a/src/AFQMC/Estimators/BackPropagatedEstimator.hpp
+++ b/src/AFQMC/Estimators/BackPropagatedEstimator.hpp
@@ -211,7 +211,7 @@ public:
 
       //4. calculate properties
       // adjust weights here is path restoration
-      stdCVector wgt(iextensions<1u>{wset.size()});
+      stdCVector wgt(extents_t<1u>{wset.size()});
       wset.getProperty(WEIGHT, wgt);
       if (path_restoration)
       {
@@ -231,7 +231,7 @@ public:
       }
       else if (!importanceSampling)
       {
-        stdCVector phase(iextensions<1u>{wset.size()});
+        stdCVector phase(extents_t<1u>{wset.size()});
         wset.getProperty(PHASE, phase);
         for (int i = 0; i < wgt.size(); i++)
           wgt[i] *= phase[i];

--- a/src/AFQMC/Estimators/EnergyEstimator.h
+++ b/src/AFQMC/Estimators/EnergyEstimator.h
@@ -64,7 +64,7 @@ public:
     if (get<0>(eloc.sizes()) != nwalk || get<1>(eloc.sizes()) != 3)
       eloc.reextent({static_cast<boost::multi::ssize_t>(nwalk), 3});
     if (get<0>(ovlp.sizes()) != nwalk)
-      ovlp.reextent(iextensions<1u>(nwalk));
+      ovlp.reextent(extents_t<1u>(nwalk));
     if (get<0>(wprop.sizes()) != 4 || get<1>(wprop.sizes()) != nwalk)
       wprop.reextent({4, static_cast<boost::multi::ssize_t>(nwalk)});
 

--- a/src/AFQMC/Estimators/FullObsHandler.hpp
+++ b/src/AFQMC/Estimators/FullObsHandler.hpp
@@ -167,7 +167,7 @@ public:
 
     writer = (TG.getGlobalRank() == 0);
 
-    denominator = stdCVector(iextensions<1u>{nave});
+    denominator = stdCVector(extents_t<1u>{nave});
     fill_n(denominator.begin(), denominator.num_elements(), ComplexType(0.0, 0.0));
   }
 
@@ -200,7 +200,7 @@ public:
     LocalTGBufferManager shm_buffer_manager;
     DynamicSHM4Tensor G4D({nw, nspins, get<0>(Gdims), get<1>(Gdims)},
                           shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
-    DynamicSHMVector DevOv(iextensions<1u>{2 * nw},
+    DynamicSHMVector DevOv(extents_t<1u>{2 * nw},
                            shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
     sharedCMatrix_ref G2D(G4D.base(), {nw, dm_size});
 
@@ -210,9 +210,9 @@ public:
       TG.TG_local().barrier();
     }
 
-    stdCVector Xw(iextensions<1u>{nw});
+    stdCVector Xw(extents_t<1u>{nw});
     std::fill_n(Xw.base(), Xw.num_elements(), ComplexType(1.0, 0.0));
-    stdCVector Ov(iextensions<1u>{2 * nw});
+    stdCVector Ov(extents_t<1u>{2 * nw});
     stdCMatrix detR(DevdetR);
 
     using SMType = typename WlkSet::reference::SMType;
@@ -262,8 +262,8 @@ public:
         {
           SMA.emplace_back(wset[iw].SlaterMatrixN(Alpha));
           SMB.emplace_back(wset[iw].SlaterMatrixN(Beta));
-          GA.emplace_back(make_device_ptr(G2D[iw].base()), iextensions<2u>{NMO, NMO});
-          GB.emplace_back(make_device_ptr(G2D[iw].base()) + NMO * NMO, iextensions<2u>{NMO, NMO});
+          GA.emplace_back(make_device_ptr(G2D[iw].base()), extents_t<2u>{NMO, NMO});
+          GB.emplace_back(make_device_ptr(G2D[iw].base()) + NMO * NMO, extents_t<2u>{NMO, NMO});
           RefsA.emplace_back(wset[iw].SlaterMatrixAux(Alpha));
           RefsB.emplace_back(wset[iw].SlaterMatrixAux(Beta));
           copy_n(Refs[iw][iref].base(), (*RefsA.back()).num_elements(), (*RefsA.back()).base());
@@ -278,7 +278,7 @@ public:
         for (int iw = 0; iw < nw; iw++)
         {
           SMA.emplace_back(wset[iw].SlaterMatrixN(Alpha));
-          GA.emplace_back(make_device_ptr(G2D[iw].base()), iextensions<2u>{NMO, NMO});
+          GA.emplace_back(make_device_ptr(G2D[iw].base()), extents_t<2u>{NMO, NMO});
           RefsA.emplace_back(wset[iw].SlaterMatrixAux(Alpha));
           copy_n(Refs[iw][iref].base(), (*RefsA.back()).num_elements(), (*RefsA.back()).base());
         }

--- a/src/AFQMC/Estimators/MixedRDMEstimator.h
+++ b/src/AFQMC/Estimators/MixedRDMEstimator.h
@@ -65,11 +65,11 @@ public:
     }
     if (DMBuffer.size() < dm_size)
     {
-      DMBuffer.reextent(iextensions<1u>{dm_size});
+      DMBuffer.reextent(extents_t<1u>{dm_size});
     }
     if (DMAverage.size() < dm_size)
     {
-      DMAverage.reextent(iextensions<1u>{dm_size});
+      DMAverage.reextent(extents_t<1u>{dm_size});
     }
     std::fill(DMBuffer.begin(), DMBuffer.end(), ComplexType(0.0, 0.0));
     std::fill(DMAverage.begin(), DMAverage.end(), ComplexType(0.0, 0.0));
@@ -88,7 +88,7 @@ public:
     CMatrix_ref OneRDM(DMBuffer.data(), {dm_dims.first, dm_dims.second});
     denom[0] = ComplexType(0.0, 0.0);
     std::fill(DMBuffer.begin(), DMBuffer.end(), ComplexType(0.0, 0.0));
-    stdCVector wgt(iextensions<1u>{wset.size()});
+    stdCVector wgt(extents_t<1u>{wset.size()});
     wset.getProperty(WEIGHT, wgt);
 
     int nx((wset.getWalkerType() == COLLINEAR) ? 2 : 1);
@@ -101,7 +101,7 @@ public:
 
     if (!importanceSampling)
     {
-      stdCVector phase(iextensions<1u>{wset.size()});
+      stdCVector phase(extents_t<1u>{wset.size()});
       wset.getProperty(PHASE, phase);
       for (int i = 0; i < wgt.size(); i++)
         wgt[i] *= phase[i];

--- a/src/AFQMC/Estimators/Observables/atomcentered_correlators.hpp
+++ b/src/AFQMC/Estimators/Observables/atomcentered_correlators.hpp
@@ -101,12 +101,12 @@ public:
         writer(false),
         S({0, 0, 0}, make_node_allocator<ComplexType>(TG)),
         XY({0, 0}, make_node_allocator<ComplexType>(TG)),
-        shapes(iextensions<1u>{0}, IAllocator{}),
+        shapes(extents_t<1u>{0}, IAllocator{}),
         DMAverage2D({0, 0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
         DMWork2D({0, 0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
         DMAverage1D({0, 0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
         DMWork1D({0, 0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
-        denom(iextensions<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()}),
+        denom(extents_t<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()}),
         NwIJ({0, 0, 0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
         NwI({0, 0, 0}, shared_allocator<ComplexType>{TG.TG_local()})
   {
@@ -259,7 +259,7 @@ public:
     {
       if (denom.size() != nw)
       {
-        denom = mpi3CVector(iextensions<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
+        denom = mpi3CVector(extents_t<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
       }
       if (get<0>(DMWork1D.sizes()) != nw || get<1>(DMWork1D.sizes()) != 3 || get<2>(DMWork1D.sizes()) != nsites)
       {
@@ -279,7 +279,7 @@ public:
         NwI = mpi3CTensor({nsp, nw, nsites}, shared_allocator<ComplexType>{TG.TG_local()});
       }
       if (shapes.size() < 2 * nw * nsites * nsites)
-        shapes = IVector(iextensions<1u>{2 * nw * nsites * nsites}, IAllocator{});
+        shapes = IVector(extents_t<1u>{2 * nw * nsites * nsites}, IAllocator{});
       fill_n(denom.base(), denom.num_elements(), ComplexType(0.0, 0.0));
       fill_n(DMWork1D.base(), DMWork1D.num_elements(), ComplexType(0.0, 0.0));
       fill_n(DMWork2D.base(), DMWork2D.num_elements(), ComplexType(0.0, 0.0));

--- a/src/AFQMC/Estimators/Observables/diagonal2rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/diagonal2rdm.hpp
@@ -68,7 +68,7 @@ public:
         hdf_walker_output(""),
         DMAverage({0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
         DMWork({0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
-        denom(iextensions<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()})
+        denom(extents_t<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()})
   {
     app_log() << "  --  Adding Back Propagated Diagonal 2RDM (Diag2RDM) estimator. -- \n";
 
@@ -139,7 +139,7 @@ public:
     {
       if (denom.size() != nw)
       {
-        denom = mpi3CVector(iextensions<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
+        denom = mpi3CVector(extents_t<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
       }
       if (get<0>(DMWork.sizes()) != nw || get<1>(DMWork.sizes()) != dm_size)
       {

--- a/src/AFQMC/Estimators/Observables/full1rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full1rdm.hpp
@@ -86,7 +86,7 @@ public:
         XRot({0, 0}, make_node_allocator<ComplexType>(TG)),
         print_from_list(false),
         index_list({0, 0}, shared_allocator<int>{TG.Node()}),
-        denom(iextensions<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()}),
+        denom(extents_t<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()}),
         DMAverage({0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
         DMWork({0, 0}, shared_allocator<ComplexType>{TG.TG_local()})
   {
@@ -251,7 +251,7 @@ public:
     {
       if (denom.size() != nw)
       {
-        denom = mpi3CVector(iextensions<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
+        denom = mpi3CVector(extents_t<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
       }
       if (get<0>(DMWork.sizes()) != nw || get<1>(DMWork.sizes()) != dm_size)
       {
@@ -449,7 +449,7 @@ private:
     DynamicMatrix T1({(iN - i0), NMO}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     DynamicMatrix T2({(iN - i0), nX}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     if (Grot.size() != npts)
-      Grot = stdCVector(iextensions<1u>(npts));
+      Grot = stdCVector(extents_t<1u>(npts));
 
     // round-robin for now
     int cnt = 0;

--- a/src/AFQMC/Estimators/Observables/full2rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full2rdm.hpp
@@ -83,7 +83,7 @@ public:
         counter(0),
         apply_rotation(false),
         XRot({0, 0}, make_node_allocator<ComplexType>(TG)),
-        denom(iextensions<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()}),
+        denom(extents_t<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()}),
         DMAverage({0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
         DMWork({0, 0}, shared_allocator<ComplexType>{TG.TG_local()})
   {
@@ -203,7 +203,7 @@ public:
     {
       if (denom.size() != nw)
       {
-        denom = mpi3CVector(iextensions<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
+        denom = mpi3CVector(extents_t<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
       }
       if (get<0>(DMWork.sizes()) != nw || get<1>(DMWork.sizes()) != dm_size)
       {
@@ -328,7 +328,7 @@ private:
     CMatrix_ref GtC(Gt.base(), {NMO * NMO, 1});
 #if defined(ENABLE_CUDA) || defined(BUILD_AFQMC_HIP)
     if (Grot.size() < R.num_elements())
-      Grot = stdCVector(iextensions<1u>(R.num_elements()));
+      Grot = stdCVector(extents_t<1u>(R.num_elements()));
 #endif
 
     if (TG.TG_local().size() > 1)
@@ -418,7 +418,7 @@ private:
       CVector_ref R1D( Buff.base(), {dN*NMO*NMO});
 #if defined(ENABLE_CUDA)
       if(Grot.size() < R.num_elements()) 
-        Grot = stdCVector(iextensions<1u>(R.num_elements()));
+        Grot = stdCVector(extents_t<1u>(R.num_elements()));
 #endif
         
 
@@ -461,7 +461,7 @@ private:
     CMatrix_ref T1(Buff.base(),{(iN-i0),NMO});
     CMatrix_ref T2(T1.base()+T1.num_elements(),{(iN-i0),nX});
     if(Grot.size() != npts) 
-      Grot = stdCVector(iextensions<1u>(npts));
+      Grot = stdCVector(extents_t<1u>(npts));
 
     // round-robin for now
     int cnt=0;

--- a/src/AFQMC/Estimators/Observables/generalizedFockMatrix.hpp
+++ b/src/AFQMC/Estimators/Observables/generalizedFockMatrix.hpp
@@ -88,7 +88,7 @@ public:
         block_size(bsize),
         nave(nave_),
         counter(0),
-        denom(iextensions<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()}),
+        denom(extents_t<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()}),
         DMAverage({0, 0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
         DMWork({0, 0, 0}, shared_allocator<ComplexType>{TG.TG_local()})
   {
@@ -139,7 +139,7 @@ public:
     {
       if (denom.size() != nw)
       {
-        denom = mpi3CVector(iextensions<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
+        denom = mpi3CVector(extents_t<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
       }
       if (get<0>(DMWork.sizes()) != 3 || get<1>(DMWork.sizes()) != nw || get<2>(DMWork.sizes()) != dm_size)
       {

--- a/src/AFQMC/Estimators/Observables/n2r.hpp
+++ b/src/AFQMC/Estimators/Observables/n2r.hpp
@@ -98,9 +98,9 @@ public:
         Orbitals({0, 0}, orb_alloc_),
         DMAverage({0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
         DMWork({0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
-        denom(iextensions<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()}),
-        Buff(iextensions<1u>{0}, alloc_),
-        Buff2(iextensions<1u>{0})
+        denom(extents_t<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()}),
+        Buff(extents_t<1u>{0}, alloc_),
+        Buff2(extents_t<1u>{0})
   {
     app_log() << "  --  Adding Back Propagated on-top pair density (N2R) estimator. -- \n ";
     std::string orb_file("");
@@ -119,8 +119,8 @@ public:
       APP_ABORT("");
     }
 
-    stdIVector norbs(iextensions<1u>{0});
-    stdIVector grid_dim(iextensions<1u>{3});
+    stdIVector norbs(extents_t<1u>{0});
+    stdIVector grid_dim(extents_t<1u>{3});
     dm_size = 0;
 
     // read orbitals
@@ -166,7 +166,7 @@ public:
       {
         for (int i = 0; i < norbs[k]; i++, kn++)
         {
-          stdCVector orb(iextensions<1u>{dm_size});
+          stdCVector orb(extents_t<1u>{dm_size});
           if (!dump.readEntry(orb, "kp" + std::to_string(k) + "_b" + std::to_string(i)))
           {
             app_error() << " Error in n2r: Problems reading orbital: " << k << " " << i << std::endl;
@@ -230,7 +230,7 @@ public:
     {
       if (denom.size() != nw)
       {
-        denom = mpi3CVector(iextensions<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
+        denom = mpi3CVector(extents_t<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
       }
       if (get<0>(DMWork.sizes()) != nw || get<1>(DMWork.sizes()) != dm_size)
       {
@@ -255,7 +255,7 @@ public:
     int N = dm_size * NMO + dm_size;
     set_buffer(N);
     auxCMatrix_ref T(Buff.base(), {NMO, dm_size});
-    auxCVector_ref Gr(Buff.base() + T.num_elements(), iextensions<1u>{dm_size});
+    auxCVector_ref Gr(Buff.base() + T.num_elements(), extents_t<1u>{dm_size});
 
     int N2 = nsp * (iN - i0);
     set_buffer2(N2);
@@ -406,14 +406,14 @@ private:
   void set_buffer(size_t N)
   {
     if (Buff.num_elements() < N)
-      Buff = auxCVector(iextensions<1u>(N), aux_alloc);
+      Buff = auxCVector(extents_t<1u>(N), aux_alloc);
     using std::fill_n;
     fill_n(Buff.base(), N, ComplexType(0.0));
   }
   void set_buffer2(size_t N)
   {
     if (Buff2.num_elements() < N)
-      Buff2 = stdCVector(iextensions<1u>(N));
+      Buff2 = stdCVector(extents_t<1u>(N));
     using std::fill_n;
     fill_n(Buff2.base(), N, ComplexType(0.0));
   }

--- a/src/AFQMC/Estimators/Observables/realspace_correlators.hpp
+++ b/src/AFQMC/Estimators/Observables/realspace_correlators.hpp
@@ -87,7 +87,7 @@ public:
         Orbitals({0, 0}, alloc),
         DMAverage({0, 0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
         DMWork({0, 0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
-        denom(iextensions<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()}),
+        denom(extents_t<1u>{0}, shared_allocator<ComplexType>{TG.TG_local()}),
         Gr_host({0, 0, 0, 0}, shared_allocator<ComplexType>{TG.TG_local()}),
         Orrp({0, 0}, shared_allocator<ComplexType>{TG.TG_local()})
   {
@@ -108,7 +108,7 @@ public:
       APP_ABORT("");
     }
 
-    stdIVector norbs(iextensions<1u>{0});
+    stdIVector norbs(extents_t<1u>{0});
     dm_size     = 0;
     int npoints = 0;
 
@@ -124,7 +124,7 @@ public:
       dump.push("OrbsR", false);
 
       // read one orbital to check size and later corroborate all orbitals have same size
-      stdCVector orb(iextensions<1u>{1});
+      stdCVector orb(extents_t<1u>{1});
       if (!dump.readEntry(orb, "kp0_b0"))
       {
         app_error() << " Error in realspace_correlators: Problems reading orbital: 0  0" << std::endl;
@@ -245,7 +245,7 @@ public:
     {
       if (denom.size() != nw)
       {
-        denom = mpi3CVector(iextensions<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
+        denom = mpi3CVector(extents_t<1u>{nw}, shared_allocator<ComplexType>{TG.TG_local()});
       }
       if (get<0>(DMWork.sizes()) != nw || get<1>(DMWork.sizes()) != 3 || get<2>(DMWork.sizes()) != dm_size)
       {

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -168,7 +168,7 @@ void reduced_density_matrix(boost::mpi3::communicator& world)
       estimators[0]->print(out, dump, wset);
     }
     dump.close();
-    boost::multi::array<ComplexType, 1> read_data(boost::multi::iextensions<1u>{2 * NMO * NMO});
+    boost::multi::array<ComplexType, 1> read_data(boost::multi::extents_t<1u>{2 * NMO * NMO});
 
     ComplexType denom;
     hdf_archive reader;

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
@@ -183,7 +183,7 @@ public:
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
 
     // making a copy of vMF since it will be modified
-    shmCVector vMF_(iextensions<1u>{vMF.num_elements()}, shared_allocator<ComplexType>{*comm});
+    shmCVector vMF_(extents_t<1u>{vMF.num_elements()}, shared_allocator<ComplexType>{*comm});
     comm->barrier();
     //if(comm->root())
     {

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
@@ -345,7 +345,7 @@ public:
     int npol  = (walker_type == NONCOLLINEAR) ? 2 : 1;
 
     CVector vMF_(vMF);
-    CVector P0D(iextensions<1u>{NMO * NMO});
+    CVector P0D(extents_t<1u>{NMO * NMO});
     fill_n(P0D.base(), P0D.num_elements(), ComplexType(0));
     vHS(vMF_, P0D);
     if (TG_.TG().size() > 1)
@@ -627,10 +627,10 @@ public:
       std::vector<int> kdiag;
       kdiag.reserve(batch_size);
 
-      DynamicIVector IMats(iextensions<1u>{batch_size},
+      DynamicIVector IMats(extents_t<1u>{batch_size},
                            device_buffer_manager.get_generator().template get_allocator<int>());
       fill_n(IMats.base(), IMats.num_elements(), 0);
-      DynamicVector dev_scl_factors(iextensions<1u>{batch_size},
+      DynamicVector dev_scl_factors(extents_t<1u>{batch_size},
                                     device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
       Dynamic3Tensor T1({batch_size, nwalk * nocc_max, nocc_max * nchol_max},
                         device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
@@ -640,7 +640,7 @@ public:
       long mem_ank(0);
       if (needs_copy)
         mem_ank = nkpts * nocc_max * nchol_max * npol * nmo_max;
-      DynamicVector LBuff(iextensions<1u>{2 * mem_ank},
+      DynamicVector LBuff(extents_t<1u>{2 * mem_ank},
                           device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
       sp_pointer LQptr(nullptr), LQmptr(nullptr);
       if (needs_copy)
@@ -970,7 +970,7 @@ public:
         }
         size_t local_memory_needs = 2*nocca_max*nocca_max*nchol_max; 
         if(TMats.num_elements() < local_memory_needs) { 
-          TMats = std::move(SpVector(iextensions<1u>{local_memory_needs})); 
+          TMats = std::move(SpVector(extents_t<1u>{local_memory_needs})); 
           using std::fill_n;
           fill_n(TMats.base(),TMats.num_elements(),SPComplexType(0.0));
         }
@@ -1062,7 +1062,7 @@ public:
       if(addEJ) {
         size_t local_memory_needs = 2*nchol_max*nwalk; 
         if(TMats.num_elements() < local_memory_needs) { 
-          TMats = std::move(SpVector(iextensions<1u>{local_memory_needs}));
+          TMats = std::move(SpVector(extents_t<1u>{local_memory_needs}));
           using std::fill_n;
           fill_n(TMats.base(),TMats.num_elements(),SPComplexType(0.0));
         }

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
@@ -295,7 +295,7 @@ public:
     if (addH1)
     {
       boost::multi::array_cref<ComplexType, 1> haj_ref(to_address(haj[nd].base()),
-                                                       iextensions<1u>{haj[nd].num_elements()});
+                                                       extents_t<1u>{haj[nd].num_elements()});
       ma::product(ComplexType(1.), Gc, haj_ref, ComplexType(1.), E(get<0>(E.extents()), 0));
       for (int i = 0; i < nwalk; i++)
         E[i][0] += E0;

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched.hpp
@@ -99,7 +99,7 @@ public:
         Lank(std::move(move_vector<shmSpC3Tensor>(std::move(vank)))),
         Lakn(std::move(vak)),
         vn0(std::move(vn0_)),
-        TBuff(iextensions<1u>{1}, sp_allocator_)
+        TBuff(extents_t<1u>{1}, sp_allocator_)
   {
     local_nCV = Likn.size(1);
     size_t lank(0);
@@ -128,7 +128,7 @@ public:
     // for now, stay collinear
 
     CVector vMF_(vMF);
-    CVector P1D(iextensions<1u>{NMO * NMO});
+    CVector P1D(extents_t<1u>{NMO * NMO});
     fill_n(P1D.base(), P1D.num_elements(), ComplexType(0));
     vHS(vMF_, P1D);
     if (TG.TG().size() > 1)
@@ -283,7 +283,7 @@ public:
     // not parallelized for now, since it would require customization of Wfn
     if (addH1)
     {
-      CVector_ref haj_ref(make_device_ptr(haj[nd].base()), iextensions<1u>{haj[nd].num_elements()});
+      CVector_ref haj_ref(make_device_ptr(haj[nd].base()), extents_t<1u>{haj[nd].num_elements()});
       ma::product(ComplexType(1.), Gc, haj_ref, ComplexType(1.), E(get<0>(E.extents()), 0));
       for (int i = 0; i < nwalk; i++)
         E[i][0] += E0;
@@ -599,7 +599,7 @@ private:
       app_log() << " Resizing buffer space in Real3IndexFactorization_batched to "
                 << N * sizeof(SPComplexType) / 1024.0 / 1024.0 << " MBs. \n";
       {
-        TBuff = std::move(SpVector(iextensions<1u>{N}));
+        TBuff = std::move(SpVector(extents_t<1u>{N}));
       }
       memory_report();
       using std::fill_n;

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
@@ -158,7 +158,7 @@ public:
     // for now, stay collinear
 
     CVector vMF_(vMF);
-    CVector P1D(iextensions<1u>{NMO * NMO});
+    CVector P1D(extents_t<1u>{NMO * NMO});
     fill_n(P1D.base(), P1D.num_elements(), ComplexType(0));
     vHS(vMF_, P1D);
     if (TG.TG().size() > 1)
@@ -282,7 +282,7 @@ public:
     // not parallelized for now, since it would require customization of Wfn
     if (addH1)
     {
-      CVector_ref haj_ref(make_device_ptr(haj[nd].base()), iextensions<1u>{haj[nd].num_elements()});
+      CVector_ref haj_ref(make_device_ptr(haj[nd].base()), extents_t<1u>{haj[nd].num_elements()});
       ma::product(ComplexType(1.), Gc, haj_ref, ComplexType(1.), E(get<0>(E.extents()), 0));
       for (int i = 0; i < nwalk; i++)
         E[i][0] += E0;
@@ -302,7 +302,7 @@ public:
       if (nspin > 1)
         mem_needs = nwalk * std::max(nel[0], nel[1]) * NMO;
 #endif
-      DynamicVector T1(iextensions<1u>{mem_needs},
+      DynamicVector T1(extents_t<1u>{mem_needs},
                        buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
       for (int ispin = 0, is0 = 0; ispin < nspin; ispin++)
@@ -414,7 +414,7 @@ public:
       Xmem = X.num_elements();
     if (not std::is_same<vType, SPComplexType>::value)
       vmem = v.num_elements();
-    DynamicVector SPBuff(iextensions<1u>(Xmem + vmem),
+    DynamicVector SPBuff(extents_t<1u>(Xmem + vmem),
                          buffer_manager.get_generator().template get_allocator<SPComplexType>());
     sp_pointer vptr(nullptr);
     const_sp_pointer Xptr(nullptr);
@@ -481,7 +481,7 @@ public:
       Gmem = G.num_elements();
     if (not std::is_same<vType, SPComplexType>::value)
       vmem = v.num_elements();
-    DynamicVector SPBuff(iextensions<1u>(Gmem + vmem),
+    DynamicVector SPBuff(extents_t<1u>(Gmem + vmem),
                          buffer_manager.get_generator().template get_allocator<SPComplexType>());
     sp_pointer vptr(nullptr);
     const_sp_pointer Gptr(nullptr);
@@ -618,7 +618,7 @@ public:
     if (nspin > 1)
       gsz = nspin * nwmax * NMO * NMO;
 #endif
-    DynamicVector GBuff(iextensions<1u>{gsz}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
+    DynamicVector GBuff(extents_t<1u>{gsz}, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
     int nw0(0);
     while (nw0 < nwalk)

--- a/src/AFQMC/HamiltonianOperations/SparseTensor.hpp
+++ b/src/AFQMC/HamiltonianOperations/SparseTensor.hpp
@@ -111,7 +111,7 @@ public:
         SpvnT(std::move(vnT)),
         SpvnT_view(std::move(vnTview)),
         vn0(std::move(vn0_)),
-        SM_TMats(iextensions<1u>{0}, shared_allocator<SPComplexType>{c_}),
+        SM_TMats(extents_t<1u>{0}, shared_allocator<SPComplexType>{c_}),
         separateEJ(true)
   {
     assert(haj.size() == Vakbl.size());
@@ -194,7 +194,7 @@ public:
     assert(k >= 0 && k < Vakbl_view.size());
     using std::get;
     if (Gcloc.num_elements() < get<1>(Gc.sizes()) * get<0>(Vakbl_view[k].sizes()))
-      Gcloc.reextent(iextensions<1u>(get<0>(Vakbl_view[k].sizes()) * get<1>(Gc.sizes())));
+      Gcloc.reextent(extents_t<1u>(get<0>(Vakbl_view[k].sizes()) * get<1>(Gc.sizes())));
     boost::multi::array_ref<SPComplexType, 2> buff(Gcloc.data(), {long(get<0>(Vakbl_view[k].sizes())), long(get<1>(Gc.sizes()))});
 
     int nwalk = get<1>(Gc.sizes());
@@ -226,7 +226,7 @@ public:
     if (addH1)
     {
       boost::multi::array_cref<ComplexType, 1> haj_ref(to_address(haj[k].base()),
-                                                       iextensions<1u>{haj[k].num_elements()});
+                                                       extents_t<1u>{haj[k].num_elements()});
       ma::product(ComplexType(1.), ma::T(Gc), haj_ref, ComplexType(1.), E(get<0>(E.extents()), 0));
       for (int i = 0; i < nwalk; i++)
         E[i][0] += E0;
@@ -243,7 +243,7 @@ public:
     {
       using ma::T;
       if (Gcloc.num_elements() < get<0>(SpvnT[k].sizes()) * get<1>(Gc.sizes()))
-        Gcloc.reextent(iextensions<1u>(get<0>(SpvnT[k].sizes()) * get<1>(Gc.sizes())));
+        Gcloc.reextent(extents_t<1u>(get<0>(SpvnT[k].sizes()) * get<1>(Gc.sizes())));
       assert(get<1>(SpvnT_view[k].sizes()) == get<0>(Gc.sizes()));
       RealType scl = (walker_type == CLOSED ? 4.0 : 1.0);
 
@@ -525,7 +525,7 @@ private:
   {
     if (SM_TMats.num_elements() < N)
     {
-      SM_TMats.reextent(iextensions<1u>(N));
+      SM_TMats.reextent(extents_t<1u>(N));
       using std::fill_n;
       fill_n(SM_TMats.base(), N, SPComplexType(0.0));
       comm->barrier();

--- a/src/AFQMC/HamiltonianOperations/THCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOps.hpp
@@ -194,7 +194,7 @@ public:
     // for now, stay collinear
 
     ShmArray<ComplexType, 1> vMF_(vMF, shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
-    ShmArray<ComplexType, 1> P1D(iextensions<1u>{NMO * NMO}, ComplexType(0),
+    ShmArray<ComplexType, 1> P1D(extents_t<1u>{NMO * NMO}, ComplexType(0),
                                  shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
 
     vHS(vMF_, P1D);
@@ -308,7 +308,7 @@ public:
     Bytes -= mem_needs * long(sizeof(SPComplexType));
     Bytes /= long((nu * nv + nv + nv * nup) * sizeof(SPComplexType));
     int nwmax = std::min(nwalk, std::max(1, int(Bytes)));
-    ShmArray<SPComplexType, 1> Gbuff(iextensions<1u>{mem_needs},
+    ShmArray<SPComplexType, 1> Gbuff(extents_t<1u>{mem_needs},
                                      shm_buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
     const_sp_pointer Gptr(nullptr);
@@ -526,7 +526,7 @@ public:
       boost::multi::array_ref<ComplexType,2> Guv(to_address(SM_TMats.base()),{nu,nv});
       cnt+=Guv.num_elements();
       // Gvv[v]: summed over spin
-      boost::multi::array_ref<ComplexType,1> Gvv(to_address(SM_TMats.base())+cnt,iextensions<1u>{nv});
+      boost::multi::array_ref<ComplexType,1> Gvv(to_address(SM_TMats.base())+cnt,extents_t<1u>{nv});
       cnt+=Gvv.num_elements();
       // S[nel_][nv]
       boost::multi::array_ref<ComplexType,2> Scu(to_address(SM_TMats.base())+cnt,{nel_,nv});
@@ -534,7 +534,7 @@ public:
       // Qub[nu][nel_]:
       boost::multi::array_ref<ComplexType,2> Qub(to_address(SM_TMats.base())+cnt,{nu,nel_});
       cnt+=Qub.num_elements();
-      boost::multi::array_ref<ComplexType,1> Tuu(to_address(SM_TMats.base())+cnt,iextensions<1u>{nu});
+      boost::multi::array_ref<ComplexType,1> Tuu(to_address(SM_TMats.base())+cnt,extents_t<1u>{nu});
       cnt+=Tuu.num_elements();
       boost::multi::array_ref<ComplexType,2> Jcb(to_address(SM_TMats.base())+cnt,{nel_,nel_});
       cnt+=Jcb.num_elements();
@@ -571,7 +571,7 @@ public:
         { // Alpha
           auto Gw = GrefA[wi];
           boost::multi::array_cref<ComplexType,1> G1D(to_address(Gw.base()),
-                                                        iextensions<1u>{Gw.num_elements()});
+                                                        extents_t<1u>{Gw.num_elements()});
           Guv_Guu2(Gw,Guv,Gvv,Scu,0);
           if(u0!=uN)
             ma::product(rotMuv.sliced(u0,uN),Gvv,
@@ -612,7 +612,7 @@ public:
         { // Beta: Unnecessary in CLOSED walker type (on Walker)
           auto Gw = GrefB[wi];
           boost::multi::array_cref<ComplexType,1> G1D(to_address(Gw.base()),
-                                                        iextensions<1u>{Gw.num_elements()});
+                                                        extents_t<1u>{Gw.num_elements()});
           Guv_Guu2(Gw,Guv,Gvv,Scu,0);
           if(u0!=uN)
             ma::product(rotMuv.sliced(u0,uN),Gvv,
@@ -716,7 +716,7 @@ public:
     Bytes /= size_t(nmo_ * nu * sizeof(SPComplexType));
     int nwmax = std::min(nwalk, std::max(1, int(Bytes)));
     memory_needs += nwmax * nmo_ * nu;
-    ShmArray<SPComplexType, 1> SM_TMats(iextensions<1u>(memory_needs),
+    ShmArray<SPComplexType, 1> SM_TMats(extents_t<1u>(memory_needs),
                                         shm_buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
     size_t cnt(0);
@@ -873,7 +873,7 @@ public:
       memory_needs += G.num_elements();
     if (not std::is_same<vType, SPComplexType>::value)
       memory_needs += v.num_elements();
-    ShmArray<SPComplexType, 1> SM_TMats(iextensions<1u>(memory_needs),
+    ShmArray<SPComplexType, 1> SM_TMats(extents_t<1u>(memory_needs),
                                         shm_buffer_manager.get_generator().template get_allocator<SPComplexType>());
     size_t cnt(0);
     const_sp_pointer Gptr(nullptr);
@@ -1110,7 +1110,7 @@ protected:
 
     for (int iw = 0; iw < nw; ++iw)
     {
-      Gwaj.emplace_back(make_device_ptr(G[iw].base()) + ispin * nup * nmo_, iextensions<2u>{nelec[ispin], nmo_});
+      Gwaj.emplace_back(make_device_ptr(G[iw].base()) + ispin * nup * nmo_, extents_t<2u>{nelec[ispin], nmo_});
       Pjv.emplace_back(&(rotPiu({0, nmo_}, {v0, vN})));
       Twav.emplace_back(&(Tav[iw]({0, nelec[ispin]}, {v0, vN})));
       Pua.emplace_back(Pua_ptr);
@@ -1130,7 +1130,7 @@ protected:
     for (int iw = 0; iw < nw; ++iw)
     {
       Twva.emplace_back(&(Tva[iw]({v0, vN}, {0, nelec[ispin]})));
-      Gwja.emplace_back(make_device_ptr(Gja[iw].base()), iextensions<2u>{nmo_, nelec[ispin]});
+      Gwja.emplace_back(make_device_ptr(Gja[iw].base()), extents_t<2u>{nmo_, nelec[ispin]});
       ma::transpose((*(Gwaj[iw]))({0, nelec[ispin]}, {k0, kN}), (*(Gwja[iw])).sliced(k0, kN));
     }
     comm->barrier();

--- a/src/AFQMC/Hamiltonians/Hamiltonian.hpp
+++ b/src/AFQMC/Hamiltonians/Hamiltonian.hpp
@@ -70,7 +70,7 @@ public:
   boost::multi::array<SPComplexType, 1> halfRotatedHij(WALKER_TYPES type, PsiT_Matrix* Alpha, PsiT_Matrix* Beta)
   {
     throw std::runtime_error("calling visitor on dummy object");
-    return boost::multi::array<SPComplexType, 1>(iextensions<1u>{1});
+    return boost::multi::array<SPComplexType, 1>(extents_t<1u>{1});
   }
 
   SpCType_shm_csr_matrix halfRotatedHijkl(WALKER_TYPES type,

--- a/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
@@ -118,10 +118,10 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
 
   // partition Q over nodes if distributed Q
 
-  IVector nmo_per_kp(iextensions<1u>{nkpts});
-  IVector nchol_per_kp(iextensions<1u>{nkpts});
-  IVector kminus(iextensions<1u>{nkpts});
-  IVector Qmap(iextensions<1u>{nkpts});
+  IVector nmo_per_kp(extents_t<1u>{nkpts});
+  IVector nchol_per_kp(extents_t<1u>{nkpts});
+  IVector kminus(extents_t<1u>{nkpts});
+  IVector Qmap(extents_t<1u>{nkpts});
   shmIMatrix QKtok2({nkpts, nkpts}, shared_allocator<int>{TG.Node()});
   ValueType E0;
   if (TG.Global().root())
@@ -851,10 +851,10 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
 
   // partition Q over nodes if distributed Q
 
-  IVector nmo_per_kp(iextensions<1u>{nkpts});
-  IVector nchol_per_kp(iextensions<1u>{nkpts});
-  IVector kminus(iextensions<1u>{nkpts});
-  IVector Qmap(iextensions<1u>{nkpts});
+  IVector nmo_per_kp(extents_t<1u>{nkpts});
+  IVector nchol_per_kp(extents_t<1u>{nkpts});
+  IVector kminus(extents_t<1u>{nkpts});
+  IVector Qmap(extents_t<1u>{nkpts});
   shmIMatrix QKtok2({nkpts, nkpts}, shared_allocator<int>{TG.Node()});
   ValueType E0;
   if (TG.Global().root())

--- a/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
@@ -93,9 +93,9 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
 
   nQ = QN - Qbeg;
 
-  IntegerVector<std::allocator<int>> nmo_per_kp(iextensions<1u>{nkpts});
-  IntegerVector<std::allocator<int>> nchol_per_kp(iextensions<1u>{nkpts});
-  IntegerVector<std::allocator<int>> kminus(iextensions<1u>{nkpts});
+  IntegerVector<std::allocator<int>> nmo_per_kp(extents_t<1u>{nkpts});
+  IntegerVector<std::allocator<int>> nchol_per_kp(extents_t<1u>{nkpts});
+  IntegerVector<std::allocator<int>> kminus(extents_t<1u>{nkpts});
   shmIMatrix QKtok2({nkpts, nkpts}, shared_allocator<int>{TG.Node()});
   shmIMatrix QKtoG({nkpts, nkpts}, shared_allocator<int>{TG.Node()});
   ValueType E0;
@@ -1035,7 +1035,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
   int nsampleQ = -1;
 
 
-  IntegerVector<std::allocator<int>> nchol_per_kp_(iextensions<1u>{nkpts});
+  IntegerVector<std::allocator<int>> nchol_per_kp_(extents_t<1u>{nkpts});
 
   hdf_archive dump_(TGwfn.Global());
   // right now only Node.root() reads

--- a/src/AFQMC/Hamiltonians/rotateHamiltonian.hpp
+++ b/src/AFQMC/Hamiltonians/rotateHamiltonian.hpp
@@ -91,14 +91,14 @@ inline boost::multi::array<ComplexType, 1> rotateHij(WALKER_TYPES walker_type,
   int NAEA = Alpha->size(0);
   int NMO  = Alpha->size(1);
 
-  boost::multi::array<ComplexType, 1> N(iextensions<1u>{1});
+  boost::multi::array<ComplexType, 1> N(extents_t<1u>{1});
   const ComplexType one  = ComplexType(1.0);
   const ComplexType zero = ComplexType(0.0);
 
   // 1-body part
   if (walker_type == CLOSED || walker_type == NONCOLLINEAR)
   {
-    N.reextent(iextensions<1u>{NAEA * NMO});
+    N.reextent(extents_t<1u>{NAEA * NMO});
     boost::multi::array_ref<ComplexType, 2> N_(N.base(), {NAEA, NMO});
 
     ma::product(*Alpha, H1, N_);
@@ -109,7 +109,7 @@ inline boost::multi::array<ComplexType, 1> rotateHij(WALKER_TYPES walker_type,
     assert(Beta != nullptr);
     int NAEB = Beta->size(0);
 
-    N.reextent(iextensions<1u>{(NAEA + NAEB) * NMO});
+    N.reextent(extents_t<1u>{(NAEA + NAEB) * NMO});
     boost::multi::array_ref<ComplexType, 2> NA_(N.base(), {NAEA, NMO});
     boost::multi::array_ref<ComplexType, 2> NB_(N.base() + NAEA * NMO, {NAEB, NMO});
 
@@ -434,12 +434,12 @@ inline void rotateHijkl(std::string& type,
             << norb * NAEA * maxnk * NAEA * sizeof(SPComplexType) / 1024.0 / 1024.0 << " MB " << std::endl;
 
   // temporary shared memory space for local "dense" result
-  shmSpVector Ta_shmbuff(iextensions<1u>{norb * NAEA * maxnk * NAEA}, shared_allocator<SPComplexType>{TG.Node()});
+  shmSpVector Ta_shmbuff(extents_t<1u>{norb * NAEA * maxnk * NAEA}, shared_allocator<SPComplexType>{TG.Node()});
 
   // setup working sparse matrix
   dummy_nrow = maxnk * NAEA;
   dummy_ncol = nvec;
-  shmSpVector tQk_shmbuff(iextensions<1u>{1}, shared_allocator<SPComplexType>{TG.Node()});
+  shmSpVector tQk_shmbuff(extents_t<1u>{1}, shared_allocator<SPComplexType>{TG.Node()});
   SpCType_shm_csr_matrix SptQk(tp_ul_ul{maxnk * NAEA, nvec}, tp_ul_ul{0, 0}, 0, Alloc(TG.Node()));
   if (sparseQk)
   {
@@ -447,7 +447,7 @@ inline void rotateHijkl(std::string& type,
     SptQk.reserve(sz_);
   }
   else
-    tQk_shmbuff.reextent(iextensions<1u>{maxnk * NAEA * nvec});
+    tQk_shmbuff.reextent(extents_t<1u>{maxnk * NAEA * nvec});
   if (sparseQk)
     dummy_nrow = dummy_ncol = 0;
 
@@ -818,7 +818,7 @@ inline void rotateHijkl_single_node(std::string& type,
   app_log() << "   Temporary integral matrix Ta: "
             << NMO * NAEA * maxnk * NAEA * sizeof(SPComplexType) / 1024.0 / 1024.0 << " MB " << std::endl;
 
-  shmSpVector Ta_shmbuff(iextensions<1u>{NMO * NAEA * maxnk * NAEA}, shared_allocator<SPComplexType>{TG.Node()});
+  shmSpVector Ta_shmbuff(extents_t<1u>{NMO * NAEA * maxnk * NAEA}, shared_allocator<SPComplexType>{TG.Node()});
   myTimer Timer_;
 
   SPComplexType EJX(0.0);

--- a/src/AFQMC/Memory/CUDA/cuda_init.cpp
+++ b/src/AFQMC/Memory/CUDA/cuda_init.cpp
@@ -101,7 +101,7 @@ void CUDA_INIT(boost::mpi3::shared_communicator& node, unsigned long long int is
   /*
     device::cusparse_buffer = new boost::multi::array<std::complex<double>,1,
                                  device::device_allocator<std::complex<double>>>(
-                                 (typename boost::multi::layout_t<1u>::extents_type{1},
+                                 (boost::multi::extents_t<1u>{1},
                                  device::device_allocator<std::complex<double>>{}));
 */
 }

--- a/src/AFQMC/Memory/HIP/hip_init.cpp
+++ b/src/AFQMC/Memory/HIP/hip_init.cpp
@@ -106,7 +106,7 @@ void HIP_INIT(boost::mpi3::shared_communicator& node, unsigned long long int ise
   /*
     device::cusparse_buffer = new boost::multi::array<std::complex<double>,1,
                                  device::device_allocator<std::complex<double>>>(
-                                 (typename boost::multi::layout_t<1u>::extents_type{1},
+                                 (boost::multi::extents_t<1u>{1},
                                  device::device_allocator<std::complex<double>>{}));
 */
 }

--- a/src/AFQMC/Numerics/detail/CUDA/sparse_cuda_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/sparse_cuda_gpu_ptr.hpp
@@ -158,11 +158,11 @@ void csrmm(const char transa,
     {
       cusparse_buffer = new boost::multi::array<
           std::complex<double>, 1,
-          device::device_allocator<std::complex<double>>>(typename boost::multi::layout_t<1u>::extents_type{M * M},
+          device::device_allocator<std::complex<double>>>(boost::multi::extents_t<1u>{M * M},
                                                           device::device_allocator<std::complex<double>>{});
     }
     else if (cusparse_buffer->num_elements() < M * N)
-      cusparse_buffer->reextent(typename boost::multi::layout_t<1u>::extents_type{M * N});
+      cusparse_buffer->reextent(boost::multi::extents_t<1u>{M * N});
     device_pointer<T> C_(cusparse_buffer->base().pointer_cast<T>());
 
     // if beta != 0, transpose C into C_
@@ -195,12 +195,11 @@ void csrmm(const char transa,
     {
       cusparse_buffer = new boost::multi::array<
           std::complex<double>, 1,
-          device::device_allocator<std::complex<double>>>(typename boost::multi::layout_t<1u>::extents_type{(M + K) *
-                                                                                                               N},
+          device::device_allocator<std::complex<double>>>(boost::multi::extents_t<1u>{(M + K) * N},
                                                           device::device_allocator<std::complex<double>>{});
     }
     else if (cusparse_buffer->num_elements() < (M + K) * N)
-      cusparse_buffer->reextent(typename boost::multi::layout_t<1u>::extents_type{(M + K) * N});
+      cusparse_buffer->reextent(boost::multi::extents_t<1u>{(M + K) * N});
     // A is MxK
     // B should be MxN
     device_pointer<T> B_(cusparse_buffer->base().pointer_cast<T>());

--- a/src/AFQMC/Numerics/detail/HIP/sparse_hip_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/HIP/sparse_hip_gpu_ptr.hpp
@@ -97,11 +97,11 @@ void csrmm(const char transa,
     {
       hipsparse_buffer = new boost::multi::array<
           std::complex<double>, 1,
-          device::device_allocator<std::complex<double>>>(typename boost::multi::layout_t<1u>::extents_type{M * M},
+          device::device_allocator<std::complex<double>>>(boost::multi::extents_t<1u>{M * M},
                                                           device::device_allocator<std::complex<double>>{});
     }
     else if (hipsparse_buffer->num_elements() < M * N)
-      hipsparse_buffer->reextent(typename boost::multi::layout_t<1u>::extents_type{M * N});
+      hipsparse_buffer->reextent(boost::multi::extents_t<1u>{M * N});
     device_pointer<T> C_(hipsparse_buffer->base().pointer_cast<T>());
 
     // if beta != 0, transpose C into C_
@@ -143,12 +143,11 @@ void csrmm(const char transa,
     {
       hipsparse_buffer = new boost::multi::array<
           std::complex<double>, 1,
-          device::device_allocator<std::complex<double>>>(typename boost::multi::layout_t<1u>::extents_type{(M + K) *
-                                                                                                               N},
+          device::device_allocator<std::complex<double>>>(boost::multi::extents_t<1u>{(M + K) * N},
                                                           device::device_allocator<std::complex<double>>{});
     }
     else if (hipsparse_buffer->num_elements() < (M + K) * N)
-      hipsparse_buffer->reextent(typename boost::multi::layout_t<1u>::extents_type{(M + K) * N});
+      hipsparse_buffer->reextent(boost::multi::extents_t<1u>{(M + K) * N});
     // A is MxK
     // B should be MxN
     device_pointer<T> B_(hipsparse_buffer->base().pointer_cast<T>());

--- a/src/AFQMC/Numerics/ma_operations.hpp
+++ b/src/AFQMC/Numerics/ma_operations.hpp
@@ -775,15 +775,15 @@ int main()
     boost::multi::array_ref<double, 2> M(m.data(), {3, 3});
     assert(M.num_elements() == m.size());
     std::vector<double> x = {1., 2., 3.};
-    boost::multi::array_ref<double, 1> X(x.data(), boost::iextensions<1u>{x.size()});
+    boost::multi::array_ref<double, 1> X(x.data(), boost::multi::extents_t<1u>{x.size()});
     std::vector<double> y(3);
-    boost::multi::array_ref<double, 1> Y(y.data(), boost::iextensions<1u>{y.size()});
+    boost::multi::array_ref<double, 1> Y(y.data(), boost::multi::extents_t<1u>{y.size()});
 
     using ma::T;
     ma::product(M, X, Y); // Y := M X
 
     std::vector<double> mx = {147., 60., 154.};
-    boost::multi::array_ref<double, 1> MX(mx.data(), boost::iextensions<1u>{mx.size()});
+    boost::multi::array_ref<double, 1> MX(mx.data(), boost::multi::extents_t<1u>{mx.size()});
     assert(MX == Y);
   }
   {
@@ -791,15 +791,15 @@ int main()
     boost::multi::array_ref<double, 2> M(m.data(), {3, 4});
     assert(M.num_elements() == m.size());
     std::vector<double> x = {1., 2., 3., 4.};
-    boost::multi::array_ref<double, 1> X(x.data(), boost::iextensions<1u>{x.size()});
+    boost::multi::array_ref<double, 1> X(x.data(), boost::multi::extents_t<1u>{x.size()});
     std::vector<double> y(3);
-    boost::multi::array_ref<double, 1> Y(y.data(), boost::iextensions<1u>{y.size()});
+    boost::multi::array_ref<double, 1> Y(y.data(), boost::multi::extents_t<1u>{y.size()});
 
     using ma::T;
     ma::product(M, X, Y); // Y := M X
 
     std::vector<double> mx = {155., 64., 234.};
-    boost::multi::array_ref<double, 1> MX(mx.data(), boost::iextensions<1u>{mx.size()});
+    boost::multi::array_ref<double, 1> MX(mx.data(), boost::multi::extents_t<1u>{mx.size()});
     assert(MX == Y);
   }
   {
@@ -807,28 +807,28 @@ int main()
     boost::multi::array_ref<double, 2> M(m.data(), {3, 4});
     assert(M.num_elements() == m.size());
     std::vector<double> x = {1., 2., 3.};
-    boost::multi::array_ref<double, 1> X(x.data(), boost::iextensions<1u>{x.size()});
+    boost::multi::array_ref<double, 1> X(x.data(), boost::multi::extents_t<1u>{x.size()});
     std::vector<double> y(4);
-    boost::multi::array_ref<double, 1> Y(y.data(), boost::iextensions<1u>{y.size()});
+    boost::multi::array_ref<double, 1> Y(y.data(), boost::multi::extents_t<1u>{y.size()});
 
     using ma::T;
     ma::product(T(M), X, Y); // Y := T(M) X
 
     std::vector<double> mx = {59., 92., 162., 64.};
-    boost::multi::array_ref<double, 1> MX(mx.data(), boost::iextensions<1u>{mx.size()});
+    boost::multi::array_ref<double, 1> MX(mx.data(), boost::multi::extents_t<1u>{mx.size()});
     assert(MX == Y);
   }
   {
     std::vector<double> m = {9., 24., 30., 9., 4., 10., 12., 7., 14., 16., 36., 1.};
     boost::multi::array_ref<double, 2> M(m.data(), {3, 4});
     std::vector<double> x = {1., 2., 3., 4.};
-    boost::multi::array_ref<double, 1> X(x.data(), boost::iextensions<1u>{x.size()});
+    boost::multi::array_ref<double, 1> X(x.data(), boost::multi::extents_t<1u>{x.size()});
     std::vector<double> y = {4., 5., 6.};
-    boost::multi::array_ref<double, 1> Y(y.data(), boost::iextensions<1u>{y.size()});
+    boost::multi::array_ref<double, 1> Y(y.data(), boost::multi::extents_t<1u>{y.size()});
     ma::product(M, X, Y); // y := M x
 
     std::vector<double> y2 = {183., 88., 158.};
-    boost::multi::array_ref<double, 1> Y2(y2.data(), boost::iextensions<1u>{y2.size()});
+    boost::multi::array_ref<double, 1> Y2(y2.data(), boost::multi::extents_t<1u>{y2.size()});
     assert(Y == Y2);
   }
 

--- a/src/AFQMC/Numerics/performance/performance.cpp
+++ b/src/AFQMC/Numerics/performance/performance.cpp
@@ -106,10 +106,10 @@ void timeBatchedQR(std::ostream& out, Allocator& alloc, Buff& buffer, int nbatch
   offset += T_.num_elements();
   int sz = ma::gqr_optimal_workspace_size(AT[0]);
   //std::cout << buffer.num_elements() << " " << 2*nbatch*m*n + 2*nbatch*m + nbatch*sz << " " << offset << std::endl;
-  Tensor1D_ref<T> WORK(buffer.origin() + offset, boost::multi::iextensions<1u>{nbatch * sz});
+  Tensor1D_ref<T> WORK(buffer.origin() + offset, boost::multi::extents_t<1u>{nbatch * sz});
   Alloc<int> ialloc{};
   std::vector<pointer<T>> Aarray;
-  Tensor1D<int> IWORK(boost::multi::iextensions<1u>{nbatch * (m + 1)}, ialloc);
+  Tensor1D<int> IWORK(boost::multi::extents_t<1u>{nbatch * (m + 1)}, ialloc);
   using std::copy_n;
   for (int i = 0; i < nbatch; i++)
   {
@@ -144,7 +144,7 @@ void timeQR(std::ostream& out, Allocator& alloc, Buff& buffer, int m)
   Tensor1D_ref<T> TAU(buffer.origin() + offset, {m});
   offset += TAU.num_elements();
   int sz = ma::gqr_optimal_workspace_size(A);
-  Tensor1D_ref<T> WORK(buffer.origin() + offset, boost::multi::iextensions<1u>{sz});
+  Tensor1D_ref<T> WORK(buffer.origin() + offset, boost::multi::extents_t<1u>{sz});
   Timer timer;
   using ma::geqrf;
   geqrf(A, TAU, WORK);
@@ -164,9 +164,9 @@ void timeExchangeKernel(std::ostream& out, Allocator& alloc, Buff& buffer, int n
   int offset = 0;
   Tensor3D_ref<T> Twabn(buffer.origin(), {2 * nbatch, nwalk * nocc, nocc * nchol});
   offset += Twabn.num_elements();
-  Tensor1D_ref<T> scal(buffer.origin() + offset, boost::multi::iextensions<1u>{nbatch});
+  Tensor1D_ref<T> scal(buffer.origin() + offset, boost::multi::extents_t<1u>{nbatch});
   offset += scal.num_elements();
-  Tensor1D_ref<T> result(buffer.origin() + offset, boost::multi::iextensions<1u>{nwalk});
+  Tensor1D_ref<T> result(buffer.origin() + offset, boost::multi::extents_t<1u>{nwalk});
   using ma::batched_dot_wabn_wban;
   Timer timer;
   batched_dot_wabn_wban(nbatch, nwalk, nocc, nchol, scal.origin(), Twabn.origin(), to_address(result.data()), 1);
@@ -229,7 +229,7 @@ void timeBatchedMatrixInverse(std::ostream& out, Allocator& alloc, Buff& buffer,
   Tensor3D_ref<T> a(buffer.origin(), {nbatch, m, m});
   Tensor3D_ref<T> b(buffer.origin() + a.num_elements(), {nbatch, m, m});
   Alloc<int> ialloc{};
-  Tensor1D<int> IWORK(boost::multi::iextensions<1u>{nbatch * (m + 1)}, ialloc);
+  Tensor1D<int> IWORK(boost::multi::extents_t<1u>{nbatch * (m + 1)}, ialloc);
   std::vector<pointer<T>> A_array, B_array;
   A_array.reserve(nbatch);
   B_array.reserve(nbatch);
@@ -258,9 +258,9 @@ void timeMatrixInverse(std::ostream& out, Allocator& alloc, Buff& buffer, int m)
   using T    = typename Allocator::value_type;
   int offset = 0;
   Tensor2D_ref<T> a(buffer.origin(), {m, m});
-  Tensor1D_ref<T> WORK(buffer.origin() + a.num_elements(), boost::multi::iextensions<1u>{m * m});
+  Tensor1D_ref<T> WORK(buffer.origin() + a.num_elements(), boost::multi::extents_t<1u>{m * m});
   Alloc<int> ialloc{};
-  Tensor1D<int> IWORK(boost::multi::iextensions<1u>{m + 1}, ialloc);
+  Tensor1D<int> IWORK(boost::multi::extents_t<1u>{m + 1}, ialloc);
   using ma::getrf;
   Timer timer;
   getrf(a, IWORK, WORK);
@@ -293,7 +293,7 @@ int main(int argc, char* argv[])
     int max_rows              = num_rows[num_rows.size() - 1];
     int size                  = (2 * max_batch * max_rows * (max_rows / 2.0) + 3 * max_batch * max_rows);
     Alloc<std::complex<double>> alloc{};
-    Tensor1D<std::complex<double>> buffer(iextensions<1u>{size}, 1.0, alloc);
+    Tensor1D<std::complex<double>> buffer(extents_t<1u>{size}, 1.0, alloc);
     for (auto nb : batches)
     {
       for (auto m : num_rows)
@@ -311,7 +311,7 @@ int main(int argc, char* argv[])
     out << "      M     M      tzgeqrf        tzungqr\n";
     int size = 3 * 1000 * 1000;
     Alloc<std::complex<double>> alloc{};
-    Tensor1D<std::complex<double>> buffer(iextensions<1u>{size}, 1.0, alloc);
+    Tensor1D<std::complex<double>> buffer(extents_t<1u>{size}, 1.0, alloc);
     std::vector<int> dims = {100, 200, 500, 800, 1000};
     for (auto d : dims)
     {
@@ -325,7 +325,7 @@ int main(int argc, char* argv[])
     out << "       M     M       tsgemm\n";
     int size = 3 * 8000 * 8000;
     Alloc<float> alloc{};
-    Tensor1D<float> buffer(iextensions<1u>{size}, 1.0, alloc);
+    Tensor1D<float> buffer(extents_t<1u>{size}, 1.0, alloc);
     std::vector<int> dims = {200, 500, 800, 1000, 2000, 3000, 4000, 8000};
     for (auto d : dims)
     {
@@ -343,7 +343,7 @@ int main(int argc, char* argv[])
     int max_batch             = batches[batches.size() - 1];
     int max_rows              = num_rows[num_rows.size() - 1];
     int size                  = 3 * max_batch * max_rows * max_rows;
-    Tensor1D<float> buffer(iextensions<1u>{size}, 1.0, alloc);
+    Tensor1D<float> buffer(extents_t<1u>{size}, 1.0, alloc);
     for (auto nb : batches)
     {
       for (auto m : num_rows)
@@ -364,7 +364,7 @@ int main(int argc, char* argv[])
     std::vector<int> batches = {100, 200, 400, 800};
     int nbatch_max           = batches[batches.size() - 1];
     int size                 = 2 * nbatch_max * nwalk * nocc * nocc * nchol + nbatch_max + nwalk;
-    Tensor1D<std::complex<double>> buffer(iextensions<1u>{size}, 1.0, alloc);
+    Tensor1D<std::complex<double>> buffer(extents_t<1u>{size}, 1.0, alloc);
     for (auto b : batches)
     {
       timeExchangeKernel(out, alloc, buffer, b, nwalk, nocc, nchol);
@@ -382,7 +382,7 @@ int main(int argc, char* argv[])
     int max_batch             = batches[batches.size() - 1];
     int max_rows              = num_rows[num_rows.size() - 1];
     int size                  = 2 * max_batch * max_rows * max_rows;
-    Tensor1D<std::complex<double>> buffer(iextensions<1u>{size}, alloc);
+    Tensor1D<std::complex<double>> buffer(extents_t<1u>{size}, alloc);
     {
       std::vector<std::complex<double>> tmp(size);
       fillRandomMatrix(tmp);
@@ -407,7 +407,7 @@ int main(int argc, char* argv[])
     std::vector<int> num_rows = {100, 110, 120, 200, 210, 300, 400, 500, 600, 700, 800, 1000, 2000, 4000};
     int max_rows              = num_rows[num_rows.size() - 1];
     int size                  = 2 * max_rows * max_rows;
-    Tensor1D<std::complex<double>> buffer(iextensions<1u>{size}, alloc);
+    Tensor1D<std::complex<double>> buffer(extents_t<1u>{size}, alloc);
     {
       std::vector<std::complex<double>> tmp(size);
       fillRandomMatrix(tmp);

--- a/src/AFQMC/Numerics/shm_tests/test_shm_gemm.cpp
+++ b/src/AFQMC/Numerics/shm_tests/test_shm_gemm.cpp
@@ -50,7 +50,7 @@ void timing_shm_blas(int c)
   auto node  = world.split_shared();
 
   int memory_needs = nmax * (c * c * nmax + 2 * c * nmax);
-  boost::multi::array<Type, 1, shared_allocator<Type>> buff(iextensions<1u>{memory_needs},
+  boost::multi::array<Type, 1, shared_allocator<Type>> buff(extents_t<1u>{memory_needs},
                                                             shared_allocator<Type>{node});
 
   std::vector<std::pair<int, int>> pairs;

--- a/src/AFQMC/Numerics/tests/test_batched_operations.cpp
+++ b/src/AFQMC/Numerics/tests/test_batched_operations.cpp
@@ -28,7 +28,7 @@
 
 using boost::multi::array;
 using boost::multi::array_ref;
-using boost::multi::iextensions;
+using boost::multi::extents_t;
 using std::copy_n;
 
 namespace qmcplusplus
@@ -90,7 +90,7 @@ TEST_CASE("Tab_to_Kl", "[Numerics][batched_operations]")
   Tensor2D<ComplexType> Kl({nwalk, nchol}, 0.0, alloc);
   using ma::Tab_to_Kl;
   Tab_to_Kl(nwalk, nel, nchol, Twban.base(), Kl.base());
-  array_ref<ComplexType, 1, pointer<ComplexType>> Kl_(Kl.base(), iextensions<1u>{nwalk * nchol});
+  array_ref<ComplexType, 1, pointer<ComplexType>> Kl_(Kl.base(), extents_t<1u>{nwalk * nchol});
   array<ComplexType, 1, Alloc<ComplexType>> ref = {84.0,  87.0,  90.0,  93.0,  96.0,  99.0,  102.0,
                                                    273.0, 276.0, 279.0, 282.0, 285.0, 288.0, 291.0,
                                                    462.0, 465.0, 468.0, 471.0, 474.0, 477.0, 480.0};
@@ -108,7 +108,7 @@ TEST_CASE("batched_Tab_to_Klr", "[batched_operations]")
   int ncholQ             = 2;
   int ncholQ0            = 2;
   std::vector<int> kdiag = {0, 1, 2, 3};
-  Tensor1D<int> dev_kdiag(iextensions<1u>{nbatch}, alloc);
+  Tensor1D<int> dev_kdiag(extents_t<1u>{nbatch}, alloc);
   copy_n(kdiag.data(), kdiag.size(), dev_kdiag.base());
   std::vector<ComplexType> buffer(2 * nbatch * nwalk * nel * nel * nchol_max);
   create_data(buffer, ComplexType(1.0));
@@ -140,7 +140,7 @@ TEST_CASE("Tanb_to_Kl", "[batched_operations]")
   Tensor2D<ComplexType> Kl({nwalk, nchol}, 0.0, alloc);
   using ma::Tanb_to_Kl;
   Tanb_to_Kl(nwalk, nel, nchol, nchol, Twanb.base(), Kl.base());
-  array_ref<ComplexType, 1, pointer<ComplexType>> Kl_(Kl.base(), iextensions<1u>{nwalk * nchol});
+  array_ref<ComplexType, 1, pointer<ComplexType>> Kl_(Kl.base(), extents_t<1u>{nwalk * nchol});
   //std::cout << "{";
   //for (auto i : Kl_)
   //std::cout << "ComplexType(" << real(i) << ")," << std::endl;
@@ -169,7 +169,7 @@ TEST_CASE("batched_dot_wabn_wban", "[Numerics][batched_operations]")
   Tensor1D<ComplexType> scal({nbatch}, 1.0, alloc);
   copy_n(buffer.data(), buffer.size(), Twabn.base());
   std::vector<pointer<ComplexType>> Aarray;
-  array<ComplexType, 1, Alloc<ComplexType>> out(iextensions<1u>{nwalk}, alloc);
+  array<ComplexType, 1, Alloc<ComplexType>> out(extents_t<1u>{nwalk}, alloc);
   array<ComplexType, 1, Alloc<ComplexType>> ref = {ComplexType(1693.073254599684), ComplexType(1930.853888599637),
                                                    ComplexType(2189.312510839587)};
   using ma::batched_dot_wabn_wban;
@@ -193,7 +193,7 @@ TEST_CASE("batched_dot_wanb_wbna", "[Numerics][batched_operations]")
   Tensor1D<ComplexType> scal({nbatch}, 1.0, alloc);
   copy_n(buffer.data(), buffer.size(), Twabn.base());
   std::vector<pointer<ComplexType>> Aarray;
-  array<ComplexType, 1, Alloc<ComplexType>> out(iextensions<1u>{nwalk}, alloc);
+  array<ComplexType, 1, Alloc<ComplexType>> out(extents_t<1u>{nwalk}, alloc);
   array<ComplexType, 1, Alloc<ComplexType>> ref = {ComplexType(1692.867783879684), ComplexType(1930.648417879638),
                                                    ComplexType(2189.107040119586)};
   using ma::batched_dot_wanb_wbna;
@@ -213,7 +213,7 @@ TEST_CASE("dot_wabn", "[Numerics][batched_operations]")
   create_data(buffer, ComplexType(100));
   Tensor4D<ComplexType> Twabn({nwalk, nocc, nocc, nchol}, alloc);
   copy_n(buffer.data(), buffer.size(), Twabn.base());
-  array<ComplexType, 1, Alloc<ComplexType>> out(iextensions<1u>{nwalk}, alloc);
+  array<ComplexType, 1, Alloc<ComplexType>> out(extents_t<1u>{nwalk}, alloc);
   using ma::dot_wabn;
   dot_wabn(nwalk, nocc, nchol, ComplexType(1.0), Twabn.base(), to_address(out.base()), 1);
   array<ComplexType, 1, Alloc<ComplexType>> ref = {ComplexType(7045.35), ComplexType(58699.7), ComplexType(162049.0)};
@@ -231,7 +231,7 @@ TEST_CASE("dot_wanb", "[Numerics][batched_operations]")
   create_data(buffer, ComplexType(100));
   Tensor4D<ComplexType> Twanb({nwalk, nocc, nchol, nocc}, alloc);
   copy_n(buffer.data(), buffer.size(), Twanb.base());
-  array<ComplexType, 1, Alloc<ComplexType>> out(iextensions<1u>{nwalk}, 0.0, alloc);
+  array<ComplexType, 1, Alloc<ComplexType>> out(extents_t<1u>{nwalk}, 0.0, alloc);
   using ma::dot_wanb;
   // out = numpy.einsum('wanb,wbna->w', Twanb, Twanb)
   dot_wanb(nwalk, nocc, nchol, ComplexType(1.0), Twanb.base(), to_address(out.base()), 1);
@@ -399,10 +399,10 @@ TEST_CASE("inplace_product", "[Numerics][batched_operations]")
 //int ncols = 7;
 //std::vector<int> packed_dims = {7,7,7,7,7,7,7,7};
 //Tensor1D<ComplexType> Buff;
-//Buff = std::move(Tensor1D<ComplexType>(iextensions<1u>{2*nrows*ncols+nbatch}, alloc));
+//Buff = std::move(Tensor1D<ComplexType>(extents_t<1u>{2*nrows*ncols+nbatch}, alloc));
 //Tensor2D_ref<ComplexType> A(make_device_ptr(Buff.base()), {nrows,ncols});
 //Tensor2D_ref<ComplexType> B(make_device_ptr(Buff.base()+nrows*ncols), {nrows,ncols});
-//Tensor1D_ref<ComplexType> C(make_device_ptr(Buff.base()+2*nrows*ncols), iextensions<1u>{nbatch});
+//Tensor1D_ref<ComplexType> C(make_device_ptr(Buff.base()+2*nrows*ncols), extents_t<1u>{nbatch});
 
 ////Tensor2D<ComplexType> A({nrows, ncols}, alloc);
 ////Tensor2D<ComplexType> B({ncols, nrows}, alloc);

--- a/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
@@ -54,7 +54,7 @@ using std::endl;
 using std::string;
 using std::vector;
 template<std::ptrdiff_t D>
-using iextensions = typename boost::multi::iextensions<D>;
+using extents_t = typename boost::multi::extents_t<D>;
 
 namespace qmcplusplus
 {
@@ -66,15 +66,15 @@ void test_dense_matrix_mult()
     array_ref<double, 2> M(m.data(), {3, 3});
     REQUIRE(M.num_elements() == m.size());
     vector<double> x = {1., 2., 3.};
-    array_ref<double, 1> X(x.data(), iextensions<1u>(x.size()));
+    array_ref<double, 1> X(x.data(), extents_t<1u>(x.size()));
     vector<double> y(3);
-    array_ref<double, 1> Y(y.data(), iextensions<1u>(y.size()));
+    array_ref<double, 1> Y(y.data(), extents_t<1u>(y.size()));
 
     using ma::T;
     ma::product(M, X, Y); // Y := M X
 
     vector<double> mx = {147., 60., 154.};
-    array_ref<double, 1> MX(mx.data(), iextensions<1u>(mx.size()));
+    array_ref<double, 1> MX(mx.data(), extents_t<1u>(mx.size()));
     verify_approx(MX, Y);
   }
   {
@@ -82,15 +82,15 @@ void test_dense_matrix_mult()
     array_ref<double, 2> M(m.data(), {3, 4});
     REQUIRE(M.num_elements() == m.size());
     vector<double> x = {1., 2., 3., 4.};
-    array_ref<double, 1> X(x.data(), iextensions<1u>(x.size()));
+    array_ref<double, 1> X(x.data(), extents_t<1u>(x.size()));
     vector<double> y(3);
-    array_ref<double, 1> Y(y.data(), iextensions<1u>(y.size()));
+    array_ref<double, 1> Y(y.data(), extents_t<1u>(y.size()));
 
     using ma::T;
     ma::product(M, X, Y); // Y := M X
 
     vector<double> mx = {155., 64., 234.};
-    array_ref<double, 1> MX(mx.data(), iextensions<1u>(mx.size()));
+    array_ref<double, 1> MX(mx.data(), extents_t<1u>(mx.size()));
     verify_approx(MX, Y);
   }
   {
@@ -98,28 +98,28 @@ void test_dense_matrix_mult()
     array_ref<double, 2> M(m.data(), {3, 4});
     REQUIRE(M.num_elements() == m.size());
     vector<double> x = {1., 2., 3.};
-    array_ref<double, 1> X(x.data(), iextensions<1u>(x.size()));
+    array_ref<double, 1> X(x.data(), extents_t<1u>(x.size()));
     vector<double> y(4);
-    array_ref<double, 1> Y(y.data(), iextensions<1u>(y.size()));
+    array_ref<double, 1> Y(y.data(), extents_t<1u>(y.size()));
 
     using ma::T;
     ma::product(T(M), X, Y); // Y := T(M) X
 
     vector<double> mx = {59., 92., 162., 64.};
-    array_ref<double, 1> MX(mx.data(), iextensions<1u>(mx.size()));
+    array_ref<double, 1> MX(mx.data(), extents_t<1u>(mx.size()));
     verify_approx(MX, Y);
   }
   {
     vector<double> m = {9., 24., 30., 9., 4., 10., 12., 7., 14., 16., 36., 1.};
     array_ref<double, 2> M(m.data(), {3, 4});
     vector<double> x = {1., 2., 3., 4.};
-    array_ref<double, 1> X(x.data(), iextensions<1u>(x.size()));
+    array_ref<double, 1> X(x.data(), extents_t<1u>(x.size()));
     vector<double> y = {4., 5., 6.};
-    array_ref<double, 1> Y(y.data(), iextensions<1u>(y.size()));
+    array_ref<double, 1> Y(y.data(), extents_t<1u>(y.size()));
     ma::product(M, X, Y); // y := M x
 
     vector<double> y2 = {183., 88., 158.};
-    array_ref<double, 1> Y2(y2.data(), iextensions<1u>(y2.size()));
+    array_ref<double, 1> Y2(y2.data(), extents_t<1u>(y2.size()));
     verify_approx(Y, Y2);
   }
 
@@ -210,7 +210,7 @@ void test_dense_matrix_mult()
   }
   {
     std::vector<double> WORK;
-    array<double, 1> TAU(iextensions<1u>{3});
+    array<double, 1> TAU(extents_t<1u>{3});
 
     vector<double> a = {37., 45., 59., 53., 81., 97., 87., 105., 129.};
     array_ref<double, 2> A(a.data(), {3, 3});
@@ -230,7 +230,7 @@ void test_dense_matrix_mult()
   }
   {
     std::vector<double> WORK;
-    array<double, 1> TAU(iextensions<1u>{4});
+    array<double, 1> TAU(extents_t<1u>{4});
 
     vector<double> a = {37., 45., 59., 53., 81., 97., 87., 105., 129., 10., 23., 35.};
     array_ref<double, 2> A(a.data(), {4, 3});
@@ -250,7 +250,7 @@ void test_dense_matrix_mult()
   }
   {
     std::vector<double> WORK;
-    array<double, 1> TAU(iextensions<1u>{3});
+    array<double, 1> TAU(extents_t<1u>{3});
 
     vector<double> a = {37., 45., 59., 53., 81., 97., 87., 105., 129.};
     array_ref<double, 2> A(a.data(), {3, 3});
@@ -270,7 +270,7 @@ void test_dense_matrix_mult()
   }
   {
     std::vector<double> WORK;
-    array<double, 1> TAU(iextensions<1u>{4});
+    array<double, 1> TAU(extents_t<1u>{4});
 
     vector<double> a = {37., 45., 59., 53., 81., 97., 87., 105., 129., 10., 23., 35.};
     array_ref<double, 2> A(a.data(), {3, 4});
@@ -339,8 +339,8 @@ void test_dense_mat_vec_device(Allocator& alloc)
     vector<T> y(3);
 
     array<T, 2, Allocator> M({3, 3}, alloc);
-    array<T, 1, Allocator> X(iextensions<1u>(x.size()), alloc);
-    array<T, 1, Allocator> Y(iextensions<1u>(y.size()), alloc);
+    array<T, 1, Allocator> X(extents_t<1u>(x.size()), alloc);
+    array<T, 1, Allocator> Y(extents_t<1u>(y.size()), alloc);
 
     copy_n(m.data(), m.size(), M.base());
     REQUIRE(M.num_elements() == m.size());
@@ -352,7 +352,7 @@ void test_dense_mat_vec_device(Allocator& alloc)
     ma::product(M, X, Y); // Y := M X
 
     vector<T> mx = {147., 60., 154.};
-    array_ref<T, 1> MX(mx.data(), iextensions<1u>(mx.size()));
+    array_ref<T, 1> MX(mx.data(), extents_t<1u>(mx.size()));
     verify_approx(MX, Y);
   }
 
@@ -363,8 +363,8 @@ void test_dense_mat_vec_device(Allocator& alloc)
     vector<T> y(3);
 
     array<T, 2, Allocator> M({3, 4}, alloc);
-    array<T, 1, Allocator> X(iextensions<1u>(x.size()), alloc);
-    array<T, 1, Allocator> Y(iextensions<1u>(y.size()), alloc);
+    array<T, 1, Allocator> X(extents_t<1u>(x.size()), alloc);
+    array<T, 1, Allocator> Y(extents_t<1u>(y.size()), alloc);
 
     copy_n(m.data(), m.size(), M.base());
     REQUIRE(M.num_elements() == m.size());
@@ -375,7 +375,7 @@ void test_dense_mat_vec_device(Allocator& alloc)
     ma::product(M, X, Y); // Y := M X
 
     vector<T> mx = {155., 64., 234.};
-    array_ref<T, 1> MX(mx.data(), iextensions<1u>(mx.size()));
+    array_ref<T, 1> MX(mx.data(), extents_t<1u>(mx.size()));
     verify_approx(MX, Y);
   }
   //SECTION("mat_vec_trans")
@@ -385,8 +385,8 @@ void test_dense_mat_vec_device(Allocator& alloc)
     vector<T> y(4);
 
     array<T, 2, Allocator> M({3, 4}, alloc);
-    array<T, 1, Allocator> X(iextensions<1u>(x.size()), alloc);
-    array<T, 1, Allocator> Y(iextensions<1u>(y.size()), alloc);
+    array<T, 1, Allocator> X(extents_t<1u>(x.size()), alloc);
+    array<T, 1, Allocator> Y(extents_t<1u>(y.size()), alloc);
 
     copy_n(m.data(), m.size(), M.base());
     REQUIRE(M.num_elements() == m.size());
@@ -397,7 +397,7 @@ void test_dense_mat_vec_device(Allocator& alloc)
     ma::product(ma::T(M), X, Y); // Y := M X
 
     vector<T> mx = {59., 92., 162., 64.};
-    array_ref<T, 1> MX(mx.data(), iextensions<1u>(mx.size()));
+    array_ref<T, 1> MX(mx.data(), extents_t<1u>(mx.size()));
     verify_approx(MX, Y);
   }
   //SECTION("mat_vec_add")
@@ -410,17 +410,17 @@ void test_dense_mat_vec_device(Allocator& alloc)
     copy_n(m.data(), m.size(), M.base());
     REQUIRE(M.num_elements() == m.size());
 
-    array<T, 1, Allocator> X(iextensions<1u>(x.size()), alloc);
+    array<T, 1, Allocator> X(extents_t<1u>(x.size()), alloc);
     copy_n(x.data(), x.size(), X.base());
     REQUIRE(X.num_elements() == x.size());
 
-    array<T, 1, Allocator> Y(iextensions<1u>(y.size()), alloc);
+    array<T, 1, Allocator> Y(extents_t<1u>(y.size()), alloc);
     REQUIRE(Y.num_elements() == y.size());
 
     ma::product(M, X, Y); // Y := M X
 
     vector<T> y2 = {183., 88., 158.};
-    array_ref<T, 1> Y2(y2.data(), iextensions<1u>(y2.size()));
+    array_ref<T, 1> Y2(y2.data(), extents_t<1u>(y2.size()));
     verify_approx(Y, Y2);
   }
 }
@@ -554,8 +554,8 @@ void test_dense_gerf_gqr_device(Allocator& alloc)
     array<T, 2, Allocator> Id({3, 3}, alloc);
 
     auto sz = std::max(ma::geqrf_optimal_workspace_size(A), ma::gqr_optimal_workspace_size(A));
-    array<T, 1, Allocator> WORK(iextensions<1u>{sz}, alloc);
-    array<T, 1, Allocator> TAU(iextensions<1u>{3}, alloc);
+    array<T, 1, Allocator> WORK(extents_t<1u>{sz}, alloc);
+    array<T, 1, Allocator> TAU(extents_t<1u>{3}, alloc);
 
     ma::geqrf(A, TAU, WORK);
     ma::gqr(A, TAU, WORK);
@@ -577,8 +577,8 @@ void test_dense_gerf_gqr_device(Allocator& alloc)
     array<T, 2, Allocator> Id({3, 3}, alloc);
 
     auto sz = std::max(ma::geqrf_optimal_workspace_size(A), ma::gqr_optimal_workspace_size(A));
-    array<T, 1, Allocator> WORK(iextensions<1u>{sz}, alloc);
-    array<T, 1, Allocator> TAU(iextensions<1u>{3}, alloc);
+    array<T, 1, Allocator> WORK(extents_t<1u>{sz}, alloc);
+    array<T, 1, Allocator> TAU(extents_t<1u>{3}, alloc);
 
     ma::geqrf(A, TAU, WORK);
     ma::gqr(A, TAU, WORK);
@@ -604,10 +604,10 @@ void test_dense_gerf_gqr_strided_device(Allocator& alloc)
     REQUIRE(A.num_elements() == 2 * a.size());
 
     auto sz = std::max(ma::geqrf_optimal_workspace_size(A[0]), ma::gqr_optimal_workspace_size(A[0]));
-    array<T, 1, Allocator> WORK(iextensions<1u>{sz}, alloc);
+    array<T, 1, Allocator> WORK(extents_t<1u>{sz}, alloc);
     array<T, 2, Allocator> Id({3, 3}, alloc);
     using IAllocator = typename Allocator::template rebind<int>::other;
-    array<int, 1, IAllocator> info(iextensions<1u>{2}, IAllocator{alloc});
+    array<int, 1, IAllocator> info(extents_t<1u>{2}, IAllocator{alloc});
     array<T, 2, Allocator> TAU({2, 4}, alloc);
 
     geqrfStrided(4, 3, A.base(), 4, 12, TAU.base(), 4, info.base(), 2);
@@ -672,13 +672,13 @@ void test_dense_geqrf_getri_batched_device(Allocator& alloc)
     Ai_array.emplace_back(Ai[i].base());
   }
 
-  array<T, 1, Allocator> WORK(iextensions<1u>{9}, alloc);
+  array<T, 1, Allocator> WORK(extents_t<1u>{9}, alloc);
   array<T, 2, Allocator> Id({3, 3}, alloc);
   using IAllocator = typename Allocator::template rebind<int>::other;
-  array<int, 1, IAllocator> info(iextensions<1u>{2}, IAllocator{alloc});
-  array<int, 1, IAllocator> piv(iextensions<1u>{2 * (3 + 1)}, IAllocator{alloc});
+  array<int, 1, IAllocator> info(extents_t<1u>{2}, IAllocator{alloc});
+  array<int, 1, IAllocator> piv(extents_t<1u>{2 * (3 + 1)}, IAllocator{alloc});
   array<T, 2, Allocator> B({3, 3}, 0.0, alloc), Bi({3, 3}, 0.0, alloc);
-  array<int, 1, IAllocator> spiv(iextensions<1u>{4}, IAllocator{alloc});
+  array<int, 1, IAllocator> spiv(extents_t<1u>{4}, IAllocator{alloc});
   int status;
   //SECTION("getrf_batched")
   {

--- a/src/AFQMC/Numerics/tests/test_determinant.cpp
+++ b/src/AFQMC/Numerics/tests/test_determinant.cpp
@@ -29,7 +29,7 @@
 
 using boost::multi::array;
 using boost::multi::array_ref;
-using boost::multi::iextensions;
+using boost::multi::extents_t;
 using std::copy_n;
 
 namespace qmcplusplus

--- a/src/AFQMC/Numerics/tests/test_ma_blas.cpp
+++ b/src/AFQMC/Numerics/tests/test_ma_blas.cpp
@@ -30,7 +30,7 @@ using boost::multi::array;
 using boost::multi::array_ref;
 using std::vector;
 template<std::ptrdiff_t D>
-using iextensions = typename boost::multi::iextensions<D>;
+using extents_t = typename boost::multi::extents_t<D>;
 
 namespace qmcplusplus
 {
@@ -38,11 +38,11 @@ void ma_blas_tests()
 {
   vector<double> v = {1., 2., 3.};
   {
-    array_ref<double, 1> V(v.data(), iextensions<1u>(v.size()));
+    array_ref<double, 1> V(v.data(), extents_t<1u>(v.size()));
     ma::scal(2., V);
     {
       vector<double> v2 = {2., 4., 6.};
-      array_ref<double, 1> V2(v2.data(), iextensions<1u>(v2.size()));
+      array_ref<double, 1> V2(v2.data(), extents_t<1u>(v2.size()));
       verify_approx(V, V2);
     }
   }
@@ -80,13 +80,13 @@ void ma_blas_tests()
     array_ref<double, 2> M(m.data(), {3, 4});
     REQUIRE(M[2][0] == 14.);
     vector<double> x = {1., 2., 3., 4.};
-    array_ref<double, 1> X(x.data(), iextensions<1u>(x.size()));
+    array_ref<double, 1> X(x.data(), extents_t<1u>(x.size()));
     vector<double> y = {4., 5., 6.};
-    array_ref<double, 1> Y(y.data(), iextensions<1u>(y.size()));
+    array_ref<double, 1> Y(y.data(), extents_t<1u>(y.size()));
     ma::gemv<'T'>(1., M, X, 0., Y); // y := M x
 
     vector<double> y2 = {183., 88., 158.};
-    array_ref<double, 1> Y2(y2.data(), iextensions<1u>(y2.size()));
+    array_ref<double, 1> Y2(y2.data(), extents_t<1u>(y2.size()));
     verify_approx(Y, Y2);
   }
   {
@@ -94,15 +94,15 @@ void ma_blas_tests()
     array_ref<double, 2> M(m.data(), {3, 4});
 
     vector<double> x = {1., 2.};
-    array_ref<double, 1> X(x.data(), iextensions<1u>(x.size()));
+    array_ref<double, 1> X(x.data(), extents_t<1u>(x.size()));
     vector<double> y = {4., 5.};
-    array_ref<double, 1> Y(y.data(), iextensions<1u>(y.size()));
+    array_ref<double, 1> Y(y.data(), extents_t<1u>(y.size()));
 
     auto const& mm = M({0, 2}, {0, 2});
     ma::gemv<'T'>(1., M({0, 2}, {0, 2}), X, 0., Y); // y := M x
 
     vector<double> y2 = {57., 24.};
-    array_ref<double, 1> Y2(y2.data(), iextensions<1u>(y2.size()));
+    array_ref<double, 1> Y2(y2.data(), extents_t<1u>(y2.size()));
     verify_approx(Y, Y2);
   }
   {
@@ -110,12 +110,12 @@ void ma_blas_tests()
     array_ref<double, 2> M(m.data(), {4, 3});
     REQUIRE(M[2][0] == 14.);
     vector<double> x = {1., 2., 3.};
-    array_ref<double, 1> X(x.data(), iextensions<1u>(x.size()));
+    array_ref<double, 1> X(x.data(), extents_t<1u>(x.size()));
     vector<double> y = {4., 5., 6., 7.};
-    array_ref<double, 1> Y(y.data(), iextensions<1u>(y.size()));
+    array_ref<double, 1> Y(y.data(), extents_t<1u>(y.size()));
     ma::gemv<'T'>(1., M, X, 0., Y); // y := M x
     vector<double> y2 = {147., 60., 154., 25.};
-    array_ref<double, 1> Y2(y2.data(), iextensions<1u>(y2.size()));
+    array_ref<double, 1> Y2(y2.data(), extents_t<1u>(y2.size()));
     verify_approx(Y, Y2);
   }
   {
@@ -123,12 +123,12 @@ void ma_blas_tests()
     array_ref<double, 2> M(m.data(), {3, 4});
     REQUIRE(M[2][0] == 14.);
     vector<double> x = {1., 2., 3.};
-    array_ref<double, 1> X(x.data(), iextensions<1u>(x.size()));
+    array_ref<double, 1> X(x.data(), extents_t<1u>(x.size()));
     vector<double> y = {4., 5., 6., 7.};
-    array_ref<double, 1> Y(y.data(), iextensions<1u>(y.size()));
+    array_ref<double, 1> Y(y.data(), extents_t<1u>(y.size()));
     ma::gemv<'N'>(1., M, X, 0., Y); // y := M^T x
     vector<double> y2 = {59., 92., 162., 26.};
-    array_ref<double, 1> Y2(y2.data(), iextensions<1u>(y2.size()));
+    array_ref<double, 1> Y2(y2.data(), extents_t<1u>(y2.size()));
     verify_approx(Y, Y2);
   }
   {

--- a/src/AFQMC/Numerics/tests/test_ma_blas_extensions.cpp
+++ b/src/AFQMC/Numerics/tests/test_ma_blas_extensions.cpp
@@ -29,7 +29,7 @@
 
 using boost::multi::array;
 using boost::multi::array_ref;
-using boost::multi::iextensions;
+using boost::multi::extents_t;
 using std::copy_n;
 
 namespace qmcplusplus

--- a/src/AFQMC/Numerics/tests/test_misc_kernels.cpp
+++ b/src/AFQMC/Numerics/tests/test_misc_kernels.cpp
@@ -33,7 +33,7 @@
 
 using boost::multi::array;
 using boost::multi::array_ref;
-using boost::multi::iextensions;
+using boost::multi::extents_t;
 using std::copy_n;
 
 namespace qmcplusplus
@@ -64,7 +64,7 @@ TEST_CASE("axpyBatched", "[Numerics][misc_kernels]")
   Alloc<std::complex<double>> alloc{};
   Tensor2D<std::complex<double>> y({3, 4}, 1.0, alloc);
   Tensor2D<std::complex<double>> x({3, 4}, 1.0, alloc);
-  Tensor1D<std::complex<double>> a(iextensions<1u>{3}, 2.0, alloc);
+  Tensor1D<std::complex<double>> a(extents_t<1u>{3}, 2.0, alloc);
   std::vector<pointer<std::complex<double>>> x_batched, y_batched;
   using std::get;
   for (int i = 0; i < get<0>(x.sizes()); i++)
@@ -91,7 +91,7 @@ TEST_CASE("construct_X", "[Numerics][misc_kernels]")
   double sqrtdt           = 0.002;
   double vbound           = 40.0;
   std::complex<double> im = std::complex<double>(0.0, 1.0);
-  Tensor1D<std::complex<double>> vmf(iextensions<1U>{ncv}, im, alloc);
+  Tensor1D<std::complex<double>> vmf(extents_t<1U>{ncv}, im, alloc);
   Tensor2D<std::complex<double>> vbias({ncv, nwalk}, 1.0, alloc);
   Tensor2D<std::complex<double>> hws({nsteps, nwalk}, -0.2, alloc);
   Tensor2D<std::complex<double>> mf({nsteps, nwalk}, 2.0, alloc);
@@ -111,7 +111,7 @@ TEST_CASE("batchedDot", "[Numerics][misc_kernels]")
   Alloc<std::complex<double>> alloc{};
   std::complex<double> im = std::complex<double>(0.0, 1.0);
   int dim                 = 3;
-  Tensor1D<std::complex<double>> y(iextensions<1U>{dim}, im, alloc);
+  Tensor1D<std::complex<double>> y(extents_t<1U>{dim}, im, alloc);
   Tensor2D<std::complex<double>> A({dim, dim}, 1.0, alloc);
   Tensor2D<std::complex<double>> B({dim, dim}, -0.2, alloc);
   std::complex<double> alpha(2.0);
@@ -121,7 +121,7 @@ TEST_CASE("batchedDot", "[Numerics][misc_kernels]")
              1);
   // from numpy.
   std::complex<double> ref_val(-1.2, -1.0);
-  Tensor1D<std::complex<double>> ref(iextensions<1U>{dim}, ref_val, alloc);
+  Tensor1D<std::complex<double>> ref(extents_t<1U>{dim}, ref_val, alloc);
   verify_approx(ref, y);
 }
 #endif

--- a/src/AFQMC/Numerics/tests/test_sparse_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_sparse_numerics.cpp
@@ -40,7 +40,7 @@ using boost::multi::array;
 using boost::multi::array_ref;
 using std::vector;
 template<std::ptrdiff_t D>
-using iextensions = typename boost::multi::iextensions<D>;
+using extents_t = typename boost::multi::extents_t<D>;
 
 namespace qmcplusplus
 {
@@ -91,18 +91,18 @@ void test_sparse_matrix_mult(Allocator const& alloc = {})
   //// matrix-vector
   {
     vector<double> b = {1., 2., 1., 4.};
-    array<double, 1, Allocator> B(iextensions<1u>{4}, alloc);
+    array<double, 1, Allocator> B(extents_t<1u>{4}, alloc);
     using std::copy_n;
     copy_n(b.data(), b.size(), B.base());
     REQUIRE(B.num_elements() == b.size());
 
-    array<double, 1, Allocator> C(iextensions<1u>{4}, alloc);
+    array<double, 1, Allocator> C(extents_t<1u>{4}, alloc);
     REQUIRE(C.num_elements() == 4);
 
     ma::product(A, B, C); // C = A*B
 
     vector<double> c2 = {18., 0., 6., 4.};
-    array_ref<double, 1> C2(c2.data(), iextensions<1u>{4});
+    array_ref<double, 1> C2(c2.data(), extents_t<1u>{4});
     REQUIRE(C2.num_elements() == c2.size());
     verify_approx(C, C2);
 
@@ -110,7 +110,7 @@ void test_sparse_matrix_mult(Allocator const& alloc = {})
     ma::product(T(A), B, C); // D = T(A)*B
 
     vector<double> d2 = {0., 12., 0., 4.};
-    array_ref<double, 1> D2(d2.data(), iextensions<1u>{4});
+    array_ref<double, 1> D2(d2.data(), extents_t<1u>{4});
     REQUIRE(D2.num_elements() == d2.size());
     verify_approx(C, D2);
   }
@@ -149,25 +149,25 @@ void test_sparse_matrix_mult(Allocator const& alloc = {})
   // matrix-vector
   {
     vector<double> b = {1., 2., 1., 4.};
-    array<double, 1, Allocator> B(iextensions<1u>{4}, alloc);
+    array<double, 1, Allocator> B(extents_t<1u>{4}, alloc);
     using std::copy_n;
     copy_n(b.data(), b.size(), B.base());
     REQUIRE(B.num_elements() == b.size());
 
-    array<double, 1, Allocator> C(iextensions<1u>{4}, alloc);
+    array<double, 1, Allocator> C(extents_t<1u>{4}, alloc);
     REQUIRE(C.num_elements() == 4);
 
     ma::product(A, B, C); // C = A*B
 
     vector<double> c2 = {18., 0., 6., 4.};
-    array_ref<double, 1> C2(c2.data(), iextensions<1u>{4});
+    array_ref<double, 1> C2(c2.data(), extents_t<1u>{4});
     verify_approx(C, C2);
 
     using ma::T;
     ma::product(T(A), B, C); // D = T(A)*B
 
     vector<double> d2 = {0., 12., 0., 4.};
-    array_ref<double, 1> D2(d2.data(), iextensions<1u>{4});
+    array_ref<double, 1> D2(d2.data(), extents_t<1u>{4});
     REQUIRE(D2.num_elements() == d2.size());
     verify_approx(C, D2);
   }

--- a/src/AFQMC/Numerics/tests/test_sparse_numerics_native.cpp
+++ b/src/AFQMC/Numerics/tests/test_sparse_numerics_native.cpp
@@ -39,7 +39,7 @@ using boost::multi::array_ref;
 using std::vector;
 using csr_matrix = ma::sparse::csr_matrix<double, int, int>;
 template<std::ptrdiff_t D>
-using iextensions = typename boost::multi::iextensions<D>;
+using extents_t = typename boost::multi::extents_t<D>;
 
 namespace qmcplusplus
 {
@@ -83,28 +83,28 @@ void test_sparse_matrix_mult_native()
   // matrix-vector
   {
     vector<double> b = {1., 2., 1., 4.};
-    array_ref<double, 1> B(b.data(), iextensions<1u>{4});
+    array_ref<double, 1> B(b.data(), extents_t<1u>{4});
     REQUIRE(B.num_elements() == b.size());
 
     vector<double> c(4);
-    array_ref<double, 1> C(c.data(), iextensions<1u>{4});
+    array_ref<double, 1> C(c.data(), extents_t<1u>{4});
     REQUIRE(C.num_elements() == c.size());
 
     ma::product(A, B, C); // C = A*B
 
     vector<double> c2 = {18., 0., 6., 4.};
-    array_ref<double, 1> C2(c2.data(), iextensions<1u>{4});
+    array_ref<double, 1> C2(c2.data(), extents_t<1u>{4});
     REQUIRE(C2.num_elements() == c2.size());
     verify_approx(C, C2);
 
     vector<double> d(4);
-    array_ref<double, 1> D(d.data(), iextensions<1u>{4});
+    array_ref<double, 1> D(d.data(), extents_t<1u>{4});
     REQUIRE(D.num_elements() == d.size());
 
     using ma::T;
     ma::product(T(A), B, D); // D = T(A)*B
     vector<double> d2 = {0., 12., 0., 4.};
-    array_ref<double, 1> D2(d2.data(), iextensions<1u>{4});
+    array_ref<double, 1> D2(d2.data(), extents_t<1u>{4});
     REQUIRE(D2.num_elements() == d2.size());
     verify_approx(D2, D);
   }

--- a/src/AFQMC/Numerics/tests/test_tensor_contraction.cpp
+++ b/src/AFQMC/Numerics/tests/test_tensor_contraction.cpp
@@ -27,7 +27,7 @@ using boost::multi::array;
 using boost::multi::array_ref;
 using std::vector;
 template<std::ptrdiff_t D>
-using iextensions = typename boost::multi::iextensions<D>;
+using extents_t = typename boost::multi::extents_t<D>;
 
 namespace qmcplusplus
 {
@@ -35,11 +35,11 @@ void ma_tensor_tests()
 {
   vector<double> v = {1., 2., 3.};
   {
-    array_ref<double, 1> V(v.data(), iextensions<1u>{v.size()});
+    array_ref<double, 1> V(v.data(), extents_t<1u>{v.size()});
     ma::scal(2., V);
     {
       vector<double> v2 = {2., 4., 6.};
-      array_ref<double, 1> V2(v2.data(), iextensions<1u>{v2.size()});
+      array_ref<double, 1> V2(v2.data(), extents_t<1u>{v2.size()});
       verify_approx(V, V2);
     }
   }

--- a/src/AFQMC/Numerics/tests/test_tensor_operations.cpp
+++ b/src/AFQMC/Numerics/tests/test_tensor_operations.cpp
@@ -27,7 +27,7 @@
 
 using boost::multi::array;
 using boost::multi::array_ref;
-using boost::multi::iextensions;
+using boost::multi::extents_t;
 using std::copy_n;
 
 namespace qmcplusplus
@@ -150,7 +150,7 @@ TEST_CASE("term_by_term_matrix_vector", "[Numerics][tensor_operations]")
   int nrow = 3;
   int ncol = 3;
   Tensor2D<ComplexType> A({nrow, ncol}, alloc);
-  Tensor1D<ComplexType> x(iextensions<1u>{ncol}, alloc);
+  Tensor1D<ComplexType> x(extents_t<1u>{ncol}, alloc);
   std::vector<ComplexType> buffer(nrow * ncol);
   create_data(buffer, ComplexType(1.0));
   copy_n(buffer.data(), buffer.size(), A.base());
@@ -211,7 +211,7 @@ TEST_CASE("transpose_wabn_to_wban", "[Numerics][tensor_operations]")
   // Twban = numpy.transpose(Twabn, (0,2,1,3))
   using ma::transpose_wabn_to_wban;
   transpose_wabn_to_wban(nwalk, na, nb, nchol, Twabn.base(), Twban.base());
-  Tensor1D_ref<ComplexType> chunk(Twban.base() + 10, iextensions<1u>{10});
+  Tensor1D_ref<ComplexType> chunk(Twban.base() + 10, extents_t<1u>{10});
   // From Twban.copy().ravel()[10:20].
   Tensor1D<ComplexType> ref = {10, 55, 56, 57, 58, 59, 60, 61, 62, 63};
   verify_approx(chunk, ref);

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.icc
@@ -45,16 +45,16 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
   int localnCV     = wfn.local_number_of_cholesky_vectors();
   // if transposed_XXX_=true  --> XXX[nwalk][...],
   // if transposed_XXX_=false --> XXX[...][nwalk]
-  auto vhs_ext   = iextensions<2u>{NMO * NMO, nwalk * nsteps};
-  auto vhs3d_ext = iextensions<3u>{NMO, NMO, nwalk * nsteps};
-  auto G_ext     = iextensions<2u>{Gsize, nwalk};
+  auto vhs_ext   = extents_t<2u>{NMO * NMO, nwalk * nsteps};
+  auto vhs3d_ext = extents_t<3u>{NMO, NMO, nwalk * nsteps};
+  auto G_ext     = extents_t<2u>{Gsize, nwalk};
   if (transposed_vHS_)
   {
-    vhs_ext   = iextensions<2u>{nwalk * nsteps, NMO * NMO};
-    vhs3d_ext = iextensions<3u>{nwalk * nsteps, NMO, NMO};
+    vhs_ext   = extents_t<2u>{nwalk * nsteps, NMO * NMO};
+    vhs3d_ext = extents_t<3u>{nwalk * nsteps, NMO, NMO};
   }
   if (transposed_G_)
-    G_ext = iextensions<2u>{nwalk, Gsize};
+    G_ext = extents_t<2u>{nwalk, Gsize};
 
   using std::get;
   if (get<0>(MFfactor.sizes()) != nsteps || get<1>(MFfactor.sizes()) != nwalk)
@@ -62,7 +62,7 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
   if (get<0>(hybrid_weight.sizes()) != nsteps || get<1>(hybrid_weight.sizes()) != nwalk)
     hybrid_weight = CMatrix({long(nsteps), long(nwalk)});
   if (get<0>(new_overlaps.sizes()) != nwalk)
-    new_overlaps = CVector(iextensions<1u>{nwalk});
+    new_overlaps = CVector(extents_t<1u>{nwalk});
   if (get<0>(new_energies.sizes()) != nwalk || get<1>(new_energies.sizes()) != 3)
     new_energies = CMatrix({long(nwalk), 3});
 
@@ -267,12 +267,12 @@ void AFQMCBasePropagator::BackPropagate(int nbpsteps, int nStabalize, WlkSet& ws
   int nwalk        = wset.size();
   int globalnCV    = wfn.global_number_of_cholesky_vectors();
 
-  auto vhs_ext   = iextensions<2u>{NMO * NMO, nwalk};
-  auto vhs3d_ext = iextensions<3u>{NMO, NMO, nwalk};
+  auto vhs_ext   = extents_t<2u>{NMO * NMO, nwalk};
+  auto vhs3d_ext = extents_t<3u>{NMO, NMO, nwalk};
   if (transposed_vHS_)
   {
-    vhs_ext   = iextensions<2u>{nwalk, NMO * NMO};
-    vhs3d_ext = iextensions<3u>{nwalk, NMO, NMO};
+    vhs_ext   = extents_t<2u>{nwalk, NMO * NMO};
+    vhs3d_ext = extents_t<3u>{nwalk, NMO, NMO};
   }
 
   DynamicMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
@@ -652,7 +652,7 @@ void AFQMCBasePropagator::Orthogonalize_batched(WlkSet& wset, CMat&& detR)
   int nbatch = std::min(nw, (nbatched_qr < 0 ? nw : nbatched_qr));
   if (local_vHS.num_elements() < nbatch)
     local_vHS.reextent({nbatch, 1});
-  stdCVector detR_(iextensions<1u>{nbatch});
+  stdCVector detR_(extents_t<1u>{nbatch});
   std::vector<CMatrix_ptr> Ai;
   Ai.reserve(nbatch);
   if (walker_type != COLLINEAR)

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagator.icc
@@ -49,16 +49,16 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
   const int node_number = TG.getLocalGroupNumber();
   // if transposed_XXX_=true  --> XXX[nwalk][...],
   // if transposed_XXX_=false --> XXX[...][nwalk]
-  auto vhs_ext   = iextensions<2u>{NMO * NMO, nwalk * nsteps};
-  auto vhs3d_ext = iextensions<3u>{NMO, NMO, nwalk * nsteps};
-  auto G_ext     = iextensions<2u>{Gsize, nwalk};
+  auto vhs_ext   = extents_t<2u>{NMO * NMO, nwalk * nsteps};
+  auto vhs3d_ext = extents_t<3u>{NMO, NMO, nwalk * nsteps};
+  auto G_ext     = extents_t<2u>{Gsize, nwalk};
   if (transposed_vHS_)
   {
-    vhs_ext   = iextensions<2u>{nwalk * nsteps, NMO * NMO};
-    vhs3d_ext = iextensions<3u>{nwalk * nsteps, NMO, NMO};
+    vhs_ext   = extents_t<2u>{nwalk * nsteps, NMO * NMO};
+    vhs3d_ext = extents_t<3u>{nwalk * nsteps, NMO, NMO};
   }
   if (transposed_G_)
-    G_ext = iextensions<2u>{nwalk, Gsize};
+    G_ext = extents_t<2u>{nwalk, Gsize};
 
   using std::get;
   if (get<1>(MFfactor.sizes()) != nsteps || get<2>(MFfactor.sizes()) != nwalk)
@@ -67,7 +67,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
     hybrid_weight = C3Tensor({2, nsteps, nwalk});
 
   if (get<0>(new_overlaps.sizes()) != nwalk)
-    new_overlaps = CVector(iextensions<1u>{nwalk});
+    new_overlaps = CVector(extents_t<1u>{nwalk});
   if (get<0>(new_energies.sizes()) != nwalk || get<1>(new_energies.sizes()) != 3)
     new_energies = CMatrix({nwalk, 3});
 

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.h
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.h
@@ -58,7 +58,7 @@ public:
                                    CVector&& vmf_,
                                    RandomBase<RealType>& r)
       : base(info, cur, tg_, wfn_, std::move(h1_), std::move(vmf_), r),
-        bpX(iextensions<1u>{1}, shared_allocator<ComplexType>{TG.TG_local()}),
+        bpX(extents_t<1u>{1}, shared_allocator<ComplexType>{TG.TG_local()}),
         req_Gsend(MPI_REQUEST_NULL),
         req_Grecv(MPI_REQUEST_NULL),
         req_vsend(MPI_REQUEST_NULL),

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
@@ -55,16 +55,16 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
   const int node_number   = TG.getLocalGroupNumber();
   // if transposed_XXX_=true  --> XXX[nwalk][...],
   // if transposed_XXX_=false --> XXX[...][nwalk]
-  auto vhs_ext   = iextensions<2u>{NMO * NMO, nwalk * nsteps};
-  auto vhs3d_ext = iextensions<3u>{NMO, NMO, nwalk * nsteps};
-  auto G_ext     = iextensions<2u>{Gsize, nwalk};
+  auto vhs_ext   = extents_t<2u>{NMO * NMO, nwalk * nsteps};
+  auto vhs3d_ext = extents_t<3u>{NMO, NMO, nwalk * nsteps};
+  auto G_ext     = extents_t<2u>{Gsize, nwalk};
   if (transposed_vHS_)
   {
-    vhs_ext   = iextensions<2u>{nwalk * nsteps, NMO * NMO};
-    vhs3d_ext = iextensions<3u>{nwalk * nsteps, NMO, NMO};
+    vhs_ext   = extents_t<2u>{nwalk * nsteps, NMO * NMO};
+    vhs3d_ext = extents_t<3u>{nwalk * nsteps, NMO, NMO};
   }
   if (transposed_G_)
-    G_ext = iextensions<2u>{nwalk, Gsize};
+    G_ext = extents_t<2u>{nwalk, Gsize};
 
   using std::get;
   if (get<0>(MFfactor.sizes()) != nsteps || get<1>(MFfactor.sizes()) != nwalk)
@@ -72,7 +72,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
   if (get<0>(hybrid_weight.sizes()) != nsteps || get<1>(hybrid_weight.sizes()) != nwalk)
     hybrid_weight = CMatrix({long(nsteps), long(nwalk)});
   if (get<0>(new_overlaps.sizes()) != nwalk)
-    new_overlaps = CVector(iextensions<1u>{nwalk});
+    new_overlaps = CVector(extents_t<1u>{nwalk});
   if (get<0>(new_energies.sizes()) != nwalk || get<1>(new_energies.sizes()) != 3)
     new_energies = CMatrix({long(nwalk), 3});
 
@@ -154,7 +154,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       size_t m_(globalnCV * nwalk * nsteps * 2);
       if (bpX.num_elements() < m_)
       {
-        bpX = mpi3SPCVector(iextensions<1u>(m_), shared_allocator<SPComplexType>{TG.TG_local()});
+        bpX = mpi3SPCVector(extents_t<1u>(m_), shared_allocator<SPComplexType>{TG.TG_local()});
         if (TG.TG_local().root())
           fill_n(bpX.base(), bpX.num_elements(), SPComplexType(0.0));
       }
@@ -425,16 +425,16 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
   const int node_number   = TG.getLocalGroupNumber();
   // if transposed_XXX_=true  --> XXX[nwalk][...],
   // if transposed_XXX_=false --> XXX[...][nwalk]
-  auto vhs_ext   = iextensions<2u>{NMO * NMO, nwalk * nsteps};
-  auto vhs3d_ext = iextensions<3u>{NMO, NMO, nwalk * nsteps};
-  auto G_ext     = iextensions<2u>{Gsize, nwalk};
+  auto vhs_ext   = extents_t<2u>{NMO * NMO, nwalk * nsteps};
+  auto vhs3d_ext = extents_t<3u>{NMO, NMO, nwalk * nsteps};
+  auto G_ext     = extents_t<2u>{Gsize, nwalk};
   if (transposed_vHS_)
   {
-    vhs_ext   = iextensions<2u>{nwalk * nsteps, NMO * NMO};
-    vhs3d_ext = iextensions<3u>{nwalk * nsteps, NMO, NMO};
+    vhs_ext   = extents_t<2u>{nwalk * nsteps, NMO * NMO};
+    vhs3d_ext = extents_t<3u>{nwalk * nsteps, NMO, NMO};
   }
   if (transposed_G_)
-    G_ext = iextensions<2u>{nwalk, Gsize};
+    G_ext = extents_t<2u>{nwalk, Gsize};
 
   using std::get;
   if (get<0>(MFfactor.sizes()) != nsteps || get<1>(MFfactor.sizes()) != nwalk)
@@ -442,7 +442,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
   if (get<0>(hybrid_weight.sizes()) != nsteps || get<1>(hybrid_weight.sizes()) != nwalk)
     hybrid_weight = CMatrix({long(nsteps), long(nwalk)});
   if (get<0>(new_overlaps.sizes()) != nwalk)
-    new_overlaps = CVector(iextensions<1u>{nwalk});
+    new_overlaps = CVector(extents_t<1u>{nwalk});
   if (get<0>(new_energies.sizes()) != nwalk || get<1>(new_energies.sizes()) != 3)
     new_energies = CMatrix({long(nwalk), 3});
 
@@ -512,7 +512,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
       size_t m_(globalnCV * nwalk * nsteps);
       if (bpX.num_elements() < m_)
       {
-        bpX = mpi3SPCVector(iextensions<1u>(m_), shared_allocator<SPComplexType>{TG.TG_local()});
+        bpX = mpi3SPCVector(extents_t<1u>(m_), shared_allocator<SPComplexType>{TG.TG_local()});
         if (TG.TG_local().root())
           fill_n(bpX.base(), bpX.num_elements(), SPComplexType(0.0));
       }
@@ -788,12 +788,12 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps,
   const int global_origin = wfn.global_origin_cholesky_vector();
   const int nnodes        = TG.getNGroupsPerTG();
 
-  auto vhs_ext   = iextensions<2u>{NMO * NMO, nwalk};
-  auto vhs3d_ext = iextensions<3u>{NMO, NMO, nwalk};
+  auto vhs_ext   = extents_t<2u>{NMO * NMO, nwalk};
+  auto vhs3d_ext = extents_t<3u>{NMO, NMO, nwalk};
   if (transposed_vHS_)
   {
-    vhs_ext   = iextensions<2u>{nwalk, NMO * NMO};
-    vhs3d_ext = iextensions<3u>{nwalk, NMO, NMO};
+    vhs_ext   = extents_t<2u>{nwalk, NMO * NMO};
+    vhs3d_ext = extents_t<3u>{nwalk, NMO, NMO};
   }
 
   //  Shared buffer used for:

--- a/src/AFQMC/Propagators/PropagatorFactory.cpp
+++ b/src/AFQMC/Propagators/PropagatorFactory.cpp
@@ -67,7 +67,7 @@ Propagator PropagatorFactory::buildAFQMCPropagator(TaskGroup_& TG,
     app_log() << " Using mean-field subtraction in propagator: " << name << "\n";
 
   // buld mean field expectation value of the Cholesky matrix
-  CVector vMF(iextensions<1u>{wfn.local_number_of_cholesky_vectors()}, allocator{});
+  CVector vMF(extents_t<1u>{wfn.local_number_of_cholesky_vectors()}, allocator{});
   using std::fill_n;
   fill_n(vMF.base(), vMF.num_elements(), ComplexType(0));
   if (substractMF)

--- a/src/AFQMC/Propagators/store/AFQMCDistributedPropagatorDistCV.icc
+++ b/src/AFQMC/Propagators/store/AFQMCDistributedPropagatorDistCV.icc
@@ -80,7 +80,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     app_log() << " Resizing buffer space in AFQMCDistributedPropagatorDistCV to "
               << memory_needs * sizeof(ComplexType) / 1024.0 / 1024.0 << " MBs. \n";
     {
-      buffer = std::move(sharedCVector(iextensions<1u>{memory_needs}, aux_alloc_));
+      buffer = std::move(sharedCVector(extents_t<1u>{memory_needs}, aux_alloc_));
     }
     memory_report();
     fill_n(buffer.base(), buffer.num_elements(), ComplexType(0.0));
@@ -96,9 +96,9 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
               << memory_needs * sizeof(ComplexType) / 1024.0 / 1024.0 << " MBs. \n";
     {
 #ifdef ENABLE_CUDA
-      comm_buffer = std::move(stdCVector(iextensions<1u>{memory_needs}));
+      comm_buffer = std::move(stdCVector(extents_t<1u>{memory_needs}));
 #else
-      comm_buffer = std::move(sharedCVector(iextensions<1u>{memory_needs}, aux_alloc_));
+      comm_buffer = std::move(sharedCVector(extents_t<1u>{memory_needs}, aux_alloc_));
 #endif
     }
     memory_report();
@@ -175,7 +175,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
   if (hybrid_weight.size(0) != nnodes * nsteps || hybrid_weight.size(1) != nwalk)
     hybrid_weight = std::move(CMatrix({nnodes * nsteps, nwalk}));
   if (new_overlaps.size(0) != nwalk)
-    new_overlaps = std::move(CVector(iextensions<1u>{nwalk}));
+    new_overlaps = std::move(CVector(extents_t<1u>{nwalk}));
   if (new_energies.size(0) != nwalk || new_energies.size(1) != 3)
     new_energies = std::move(CMatrix({nwalk, 3}));
 

--- a/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_base.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_base.hpp
@@ -87,8 +87,8 @@ public:
     int NAEA = (herm ? get<0>(hermA.sizes()) : get<1>(hermA.sizes()));
     TMatrix TNN({NAEA, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
     TMatrix TNM({NAEA, NMO}, buffer_manager.get_generator().template get_allocator<T>());
-    TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    TVector WORK(extents_t<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
+    IVector IWORK(extents_t<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::base::MixedDensityMatrix<T>(hermA, B, std::forward<MatC>(C), LogOverlapFactor,
                                                                     TNN, TNM, IWORK, WORK, compact, herm);
   }
@@ -102,8 +102,8 @@ public:
     int NAEA = get<1>(A.sizes());
     TMatrix TNN({NAEA, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
     TMatrix TNM({NAEA, NMO}, buffer_manager.get_generator().template get_allocator<T>());
-    TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    TVector WORK(extents_t<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
+    IVector IWORK(extents_t<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::base::MixedDensityMatrix<T>(A, A, std::forward<MatC>(C), LogOverlapFactor, TNN,
                                                                     TNM, IWORK, WORK, compact, false);
   }
@@ -125,9 +125,9 @@ public:
       TMatrix TNN2({NAEA, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
       TMatrix TNM({NAEA, NMO}, buffer_manager.get_generator().template get_allocator<T>());
       TMatrix TMN({NMO, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
-      TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
-      RVector RWORK(iextensions<1u>{6 * NAEA + 1}, buffer_manager.get_generator().template get_allocator<R>());
-      IVector IWORK(iextensions<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
+      TVector WORK(extents_t<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
+      RVector RWORK(extents_t<1u>{6 * NAEA + 1}, buffer_manager.get_generator().template get_allocator<R>());
+      IVector IWORK(extents_t<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
       return SlaterDeterminantOperations::base::MixedDensityMatrix_noHerm_wSVD<T>(A, B, std::forward<MatC>(C),
                                                                                   LogOverlapFactor, RWORK, TNN1, TNN2,
                                                                                   TMN, TNM, IWORK, WORK, compact);
@@ -136,8 +136,8 @@ public:
     {
       TMatrix TNN({NAEA, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
       TMatrix TNM({NAEA, NMO}, buffer_manager.get_generator().template get_allocator<T>());
-      TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
-      IVector IWORK(iextensions<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
+      TVector WORK(extents_t<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
+      IVector IWORK(extents_t<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
       return SlaterDeterminantOperations::base::MixedDensityMatrix_noHerm<T>(A, B, std::forward<MatC>(C),
                                                                              LogOverlapFactor, TNN, TNM, IWORK, WORK,
                                                                              compact);
@@ -163,8 +163,8 @@ public:
     TMatrix TNN({NEL, NEL}, buffer_manager.get_generator().template get_allocator<T>());
     TMatrix TAB({Nact, NEL}, buffer_manager.get_generator().template get_allocator<T>());
     TMatrix TNM({NEL, NMO}, buffer_manager.get_generator().template get_allocator<T>());
-    TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    TVector WORK(extents_t<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
+    IVector IWORK(extents_t<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::base::MixedDensityMatrixForWoodbury<T>(hermA, B, std::forward<MatC>(C),
                                                                                LogOverlapFactor,
                                                                                std::forward<MatQ>(QQ0), ref, TNN, TAB,
@@ -187,8 +187,8 @@ public:
     TMatrix TNN({NEL, NEL}, buffer_manager.get_generator().template get_allocator<T>());
     TMatrix TAB({Nact, NEL}, buffer_manager.get_generator().template get_allocator<T>());
     TMatrix TNM({NEL, NMO}, buffer_manager.get_generator().template get_allocator<T>());
-    TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    TVector WORK(extents_t<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
+    IVector IWORK(extents_t<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::base::MixedDensityMatrixFromConfiguration<T>(hermA, B, std::forward<MatC>(C),
                                                                                      LogOverlapFactor, ref, TNN, TAB,
                                                                                      TNM, IWORK, WORK, compact);
@@ -201,7 +201,7 @@ public:
     int NAEA = get<1>(A.sizes());
     TMatrix TNN({NAEA, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
     TMatrix TNN2({NAEA, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{NAEA + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    IVector IWORK(extents_t<1u>{NAEA + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::base::Overlap<T>(A, A, LogOverlapFactor, TNN, IWORK, TNN2.elements(), false);
   }
 
@@ -212,7 +212,7 @@ public:
     int NAEA = (herm ? get<0>(hermA.sizes()) : get<1>(hermA.sizes()));
     TMatrix TNN({NAEA, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
     TMatrix TNN2({NAEA, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{NAEA + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    IVector IWORK(extents_t<1u>{NAEA + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::base::Overlap<T>(hermA, B, LogOverlapFactor, TNN, IWORK, TNN2.elements(), herm);
   }
 
@@ -223,7 +223,7 @@ public:
     int NAEA = get<1>(A.sizes());
     TMatrix TNN({NAEA, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
     TMatrix TNN2({NAEA, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{NAEA + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    IVector IWORK(extents_t<1u>{NAEA + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::base::Overlap<T>(A, B, LogOverlapFactor, TNN, IWORK, TNN2.elements(), false);
   }
 
@@ -239,8 +239,8 @@ public:
     assert(get<1>(QQ0.sizes()) == NEL);
     TMatrix TNN({NEL, NEL}, buffer_manager.get_generator().template get_allocator<T>());
     TMatrix TMN({Nact, NEL}, buffer_manager.get_generator().template get_allocator<T>());
-    TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{Nact + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    TVector WORK(extents_t<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
+    IVector IWORK(extents_t<1u>{Nact + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::base::OverlapForWoodbury<T>(hermA, B, LogOverlapFactor, std::forward<MatC>(QQ0),
                                                                     ref, TNN, TMN, IWORK, WORK);
   }
@@ -299,10 +299,10 @@ public:
     int NMO  = get<0>(A.sizes());
     int NAEA = get<1>(A.sizes());
     TMatrix AT({NAEA, NMO}, buffer_manager.get_generator().template get_allocator<T>());
-    TVector scl(iextensions<1u>{NMO}, buffer_manager.get_generator().template get_allocator<T>());
-    TVector TAU(iextensions<1u>{NMO}, buffer_manager.get_generator().template get_allocator<T>());
-    TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    TVector scl(extents_t<1u>{NMO}, buffer_manager.get_generator().template get_allocator<T>());
+    TVector TAU(extents_t<1u>{NMO}, buffer_manager.get_generator().template get_allocator<T>());
+    TVector WORK(extents_t<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
+    IVector IWORK(extents_t<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
     ma::transpose(A, AT);
     ma::geqrf(AT, TAU, WORK);
     using ma::determinant_from_geqrf;
@@ -313,9 +313,9 @@ public:
     scale_columns(get<0>(A.sizes()), get<1>(A.sizes()), A.base(), A.stride(), scl.base());
 #else
     int NMO = A.size();
-    TVector TAU(iextensions<1u>{NMO}, buffer_manager.get_generator().template get_allocator<T>());
-    TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    TVector TAU(extents_t<1u>{NMO}, buffer_manager.get_generator().template get_allocator<T>());
+    TVector WORK(extents_t<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
+    IVector IWORK(extents_t<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
     ma::gelqf(std::forward<Mat>(A), TAU, WORK);
     T res(0.0);
 

--- a/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_serial.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_serial.hpp
@@ -251,7 +251,7 @@ public:
     }
     TTensor TNN3D({nbatch, NAEA, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
     TTensor TNM3D({n1, n2, n3}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{nbatch * (NMO + 1)}, buffer_manager.get_generator().template get_allocator<int>());
+    IVector IWORK(extents_t<1u>{nbatch * (NMO + 1)}, buffer_manager.get_generator().template get_allocator<int>());
     SlaterDeterminantOperations::batched::MixedDensityMatrix(hermA, Bi, std::forward<MatC>(C), LogOverlapFactor,
                                                              std::forward<TVec>(ovlp), TNN3D, TNM3D, IWORK, compact,
                                                              herm);
@@ -290,7 +290,7 @@ public:
     }
     TTensor TNN3D({nbatch, NAEA, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
     TTensor TNM3D({n1, n2, n3}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{nbatch * (NMO + 1)}, buffer_manager.get_generator().template get_allocator<int>());
+    IVector IWORK(extents_t<1u>{nbatch * (NMO + 1)}, buffer_manager.get_generator().template get_allocator<int>());
     SlaterDeterminantOperations::batched::DensityMatrices(Left, Right, G, LogOverlapFactor, std::forward<TVec>(ovlp),
                                                           TNN3D, TNM3D, IWORK, compact, herm);
   }
@@ -316,7 +316,7 @@ public:
     int nbatch = Bi.size();
     assert(ovlp.size() == nbatch);
     TTensor TNN3D({nbatch, NAEA, NAEA}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{nbatch * (NMO + 1)}, buffer_manager.get_generator().template get_allocator<int>());
+    IVector IWORK(extents_t<1u>{nbatch * (NMO + 1)}, buffer_manager.get_generator().template get_allocator<int>());
     SlaterDeterminantOperations::batched::Overlap(hermA, Bi, LogOverlapFactor, std::forward<TVec>(ovlp), TNN3D, IWORK,
                                                   herm);
   }
@@ -338,8 +338,8 @@ public:
     TMatrix T_({nbatch, NMO}, buffer_manager.get_generator().template get_allocator<T>());
     TMatrix scl({nbatch, NMO}, buffer_manager.get_generator().template get_allocator<T>());
     int sz = ma::gqr_optimal_workspace_size(AT[0]);
-    TVector WORK(iextensions<1u>{nbatch * sz}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{nbatch * (NMO + 1)}, buffer_manager.get_generator().template get_allocator<int>());
+    TVector WORK(extents_t<1u>{nbatch * sz}, buffer_manager.get_generator().template get_allocator<T>());
+    IVector IWORK(extents_t<1u>{nbatch * (NMO + 1)}, buffer_manager.get_generator().template get_allocator<int>());
     for (int i = 0; i < nbatch; i++)
       ma::transpose(*Ai[i], AT[i]);
     // careful, expects fortran order
@@ -377,8 +377,8 @@ public:
     TMatrix T_({nbatch, NMO}, buffer_manager.get_generator().template get_allocator<T>());
     TMatrix scl({nbatch, NMO}, buffer_manager.get_generator().template get_allocator<T>());
     int sz = ma::gqr_optimal_workspace_size(AT[0]);
-    TVector WORK(iextensions<1u>{nbatch * sz}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{nbatch * (NMO + 1)}, buffer_manager.get_generator().template get_allocator<int>());
+    TVector WORK(extents_t<1u>{nbatch * sz}, buffer_manager.get_generator().template get_allocator<T>());
+    IVector IWORK(extents_t<1u>{nbatch * (NMO + 1)}, buffer_manager.get_generator().template get_allocator<int>());
     for (int i = 0; i < nbatch; i++)
       ma::transpose(*Ai[i], AT[i]);
     // careful, expects fortran order

--- a/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_shared.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_shared.hpp
@@ -82,8 +82,8 @@ public:
     assert(SM_TMats->num_elements() >= NAEA * (NAEA + NMO));
     boost::multi::array_ref<T, 2> TNN(to_address(SM_TMats->base()), {NAEA, NAEA});
     boost::multi::array_ref<T, 2> TNM(to_address(SM_TMats->base()) + NAEA * NAEA, {NAEA, NMO});
-    TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    TVector WORK(extents_t<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
+    IVector IWORK(extents_t<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::shm::MixedDensityMatrix<T>(hermA, B, std::forward<MatC>(C), LogOverlapFactor,
                                                                    TNN, TNM, IWORK, WORK, comm, compact, herm);
   }
@@ -115,8 +115,8 @@ public:
     boost::multi::array_ref<T, 2> TAB(to_address(SM_TMats->base()) + cnt, {Nact, NEL});
     cnt += TAB.num_elements();
     boost::multi::array_ref<T, 2> TNM(to_address(SM_TMats->base()) + cnt, {NEL, NMO});
-    TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    TVector WORK(extents_t<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
+    IVector IWORK(extents_t<1u>{NMO + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::shm::MixedDensityMatrixForWoodbury<T>(hermA, B, std::forward<MatC>(C),
                                                                               LogOverlapFactor, std::forward<MatQ>(QQ0),
                                                                               ref, TNN, TAB, TNM, IWORK, WORK, comm,
@@ -132,7 +132,7 @@ public:
     assert(SM_TMats->num_elements() >= 2 * NAEA * NAEA);
     boost::multi::array_ref<T, 2> TNN(to_address(SM_TMats->base()), {NAEA, NAEA});
     boost::multi::array_ref<T, 2> TNN2(to_address(SM_TMats->base()) + NAEA * NAEA, {NAEA, NAEA});
-    IVector IWORK(iextensions<1u>{NAEA + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    IVector IWORK(extents_t<1u>{NAEA + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::shm::Overlap<T>(hermA, B, LogOverlapFactor, TNN, IWORK, TNN2.elements(), comm, herm);
   }
 
@@ -155,8 +155,8 @@ public:
     assert(SM_TMats->num_elements() >= NEL * (Nact + NEL));
     boost::multi::array_ref<T, 2> TNN(to_address(SM_TMats->base()), {NEL, NEL});
     boost::multi::array_ref<T, 2> TMN(to_address(SM_TMats->base()) + NEL * NEL, {Nact, NEL});
-    TVector WORK(iextensions<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
-    IVector IWORK(iextensions<1u>{Nact + 1}, buffer_manager.get_generator().template get_allocator<int>());
+    TVector WORK(extents_t<1u>{work_size}, buffer_manager.get_generator().template get_allocator<T>());
+    IVector IWORK(extents_t<1u>{Nact + 1}, buffer_manager.get_generator().template get_allocator<int>());
     return SlaterDeterminantOperations::shm::OverlapForWoodbury<T>(hermA, B, LogOverlapFactor, std::forward<MatC>(QQ0),
                                                                    ref, TNN, TMN, IWORK, WORK, comm);
   }
@@ -294,10 +294,10 @@ protected:
   {
     if (SM_TMats == nullptr || SM_TMats->get_allocator() != shared_allocator<T>{comm})
     {
-      SM_TMats = std::move(std::make_unique<shmTVector>(iextensions<1u>(N), shared_allocator<T>{comm}));
+      SM_TMats = std::move(std::make_unique<shmTVector>(extents_t<1u>(N), shared_allocator<T>{comm}));
     }
     else if (SM_TMats->num_elements() < N)
-      SM_TMats = std::move(std::make_unique<shmTVector>(iextensions<1u>(N), shared_allocator<T>{comm}));
+      SM_TMats = std::move(std::make_unique<shmTVector>(extents_t<1u>(N), shared_allocator<T>{comm}));
   }
 };
 

--- a/src/AFQMC/SlaterDeterminantOperations/rotate.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/rotate.hpp
@@ -119,7 +119,7 @@ void halfRotateCholeskyMatrix(WALKER_TYPES type,
   if (type == NONCOLLINEAR)
     APP_ABORT(" GHF not yet implemented. \n");
 
-  boost::multi::array<SPComplexType, 1> vec(iextensions<1u>{nvec});
+  boost::multi::array<SPComplexType, 1> vec(extents_t<1u>{nvec});
   if (reserve_to_fit_)
   {
     std::vector<std::size_t> sz_per_row(Qdim);
@@ -323,7 +323,7 @@ SpCType_shm_csr_matrix halfRotateCholeskyMatrixForBias(WALKER_TYPES type,
   if (type == NONCOLLINEAR)
     APP_ABORT(" GHF not yet implemented. \n");
 
-  boost::multi::array<SPComplexType, 1> vec(iextensions<1u>{nvec});
+  boost::multi::array<SPComplexType, 1> vec(extents_t<1u>{nvec});
   std::vector<std::size_t> sz_per_row(nvec);
   std::size_t cnt = 0;
   for (int a = 0; a < NAEA; a++)

--- a/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
+++ b/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
@@ -308,7 +308,7 @@ TEST_CASE("SDetOps_double_mpi3", "[sdet_ops]")
   array_ref g_ref_2(v_ref_2.data(),{3,3});
   array_ref gc_ref_2(vc_ref_2.data(),{2,3});
 
-  boost::multi::array<Type,1,shared_allocator<Type>> SMbuff(iextensions<1u>{NMO*(NMO+NEL)},
+  boost::multi::array<Type,1,shared_allocator<Type>> SMbuff(extents_t<1u>{NMO*(NMO+NEL)},
                                                             shared_allocator<Type>{node});  
 
   array_ref G(to_address(SMbuff.base()),{NMO,NMO});
@@ -350,7 +350,7 @@ TEST_CASE("SDetOps_double_mpi3", "[sdet_ops]")
                           Gc({0,2},{0,3}),node,true);
   check(Gc({0,2},{0,3}),gc_ref_2);
 
-  boost::multi::array<Type,1,shared_allocator<Type>> SMbuff2(iextensions<1u>{NMO*(NMO+NEL)},
+  boost::multi::array<Type,1,shared_allocator<Type>> SMbuff2(extents_t<1u>{NMO*(NMO+NEL)},
                                                             shared_allocator<Type>{node_});
 
   array_ref G2(to_address(SMbuff2.base()),{NMO,NMO});
@@ -545,7 +545,7 @@ void SDetOps_complex_serial(Allocator alloc, BufferManager b)
     RA.reserve(3);
     RB.reserve(3);
     Gwv.reserve(3);
-    boost::multi::array<Type, 1, Allocator> ovlp(iextensions<1u>{3});
+    boost::multi::array<Type, 1, Allocator> ovlp(extents_t<1u>{3});
     for (int i = 0; i < 3; i++)
     {
       RA.emplace_back(&Aref);
@@ -592,7 +592,7 @@ void SDetOps_complex_serial(Allocator alloc, BufferManager b)
     std::vector<decltype(&Bref)> RB;
     RA.reserve(3);
     RB.reserve(3);
-    boost::multi::array<Type, 1, Allocator> ovlp(iextensions<1u>{3});
+    boost::multi::array<Type, 1, Allocator> ovlp(extents_t<1u>{3});
     for (int i = 0; i < 3; i++)
     {
       RA.emplace_back(&Aref);
@@ -738,7 +738,7 @@ TEST_CASE("SDetOps_complex_mpi3", "[sdet_ops]")
   boost::multi::array_ref<Type, 2> g_ref_2(v_ref_2.data(), {3, 3});
   boost::multi::array_ref<Type, 2> gc_ref_2(vc_ref_2.data(), {2, 3});
 
-  boost::multi::array<Type, 1, shared_allocator<Type>> SMbuff(iextensions<1u>{NMO * (NMO + NEL)},
+  boost::multi::array<Type, 1, shared_allocator<Type>> SMbuff(extents_t<1u>{NMO * (NMO + NEL)},
                                                               shared_allocator<Type>{node});
 
   array_ref G(to_address(SMbuff.base()), {NMO, NMO});
@@ -776,7 +776,7 @@ TEST_CASE("SDetOps_complex_mpi3", "[sdet_ops]")
   ov_ = SDet.MixedDensityMatrix(A({0, 2}, {0, 3}), B_, Gc({0, 2}, {0, 3}), 0.0, node, true);
   check(Gc({0, 2}, {0, 3}), gc_ref_2);
 
-  boost::multi::array<Type, 1, shared_allocator<Type>> SMbuff2(iextensions<1u>{NMO * (NMO + NEL)},
+  boost::multi::array<Type, 1, shared_allocator<Type>> SMbuff2(extents_t<1u>{NMO * (NMO + NEL)},
                                                                shared_allocator<Type>{node_});
 
   array_ref G2(to_address(SMbuff2.base()), {NMO, NMO});
@@ -906,7 +906,7 @@ TEST_CASE("SDetOps_complex_csr", "[sdet_ops]")
   boost::multi::array_ref<Type, 2> g_ref_2(v_ref_2.data(), {3, 3});
   boost::multi::array_ref<Type, 2> gc_ref_2(vc_ref_2.data(), {2, 3});
 
-  boost::multi::array<Type, 1, shared_allocator<Type>> SMbuff(iextensions<1u>{NMO * (NMO + NEL)},
+  boost::multi::array<Type, 1, shared_allocator<Type>> SMbuff(extents_t<1u>{NMO * (NMO + NEL)},
                                                               shared_allocator<Type>{node});
 
   array_ref G(to_address(SMbuff.base()), {NMO, NMO});
@@ -932,7 +932,7 @@ TEST_CASE("SDetOps_complex_csr", "[sdet_ops]")
   ov_ = SDet.MixedDensityMatrix(Acsr[{0, 2, 0, 3}], B_, Gc({0, 2}, {0, 3}), 0.0, node, true);
   check(Gc({0, 2}, {0, 3}), gc_ref_2);
 
-  boost::multi::array<Type, 1, shared_allocator<Type>> SMbuff2(iextensions<1u>{NMO * (NMO + NEL)},
+  boost::multi::array<Type, 1, shared_allocator<Type>> SMbuff2(extents_t<1u>{NMO * (NMO + NEL)},
                                                                shared_allocator<Type>{node_});
 
   array_ref G2(to_address(SMbuff2.base()), {NMO, NMO});

--- a/src/AFQMC/Utilities/type_conversion.hpp
+++ b/src/AFQMC/Utilities/type_conversion.hpp
@@ -173,9 +173,9 @@ void emplace_back_array_ref(VType& V, MType&& M, bool device=true) {
   assert(M.stride() == M.size(1));
   assert(get<1>(M.strides()) == 1);
   if(device) {  
-    V.emplace_back(make_device_ptr(M.base()),iextensions<2u>{M.size(0),M.size(1)});
+    V.emplace_back(make_device_ptr(M.base()),extents_t<2u>{M.size(0),M.size(1)});
   } else {
-    V.emplace_back(to_address(M.base()),iextensions<2u>{M.size(0),M.size(1)});
+    V.emplace_back(to_address(M.base()),extents_t<2u>{M.size(0),M.size(1)});
   }
 } 
 */

--- a/src/AFQMC/Walkers/WalkerSetBase.h
+++ b/src/AFQMC/Walkers/WalkerSetBase.h
@@ -276,7 +276,7 @@ public:
           pos++;
         }
         // use operator= or assign when ready!!!
-        boost::multi::array<ComplexType, 1> buff(iextensions<1u>{n - tot_num_walkers}, ComplexType(1.0));
+        boost::multi::array<ComplexType, 1> buff(extents_t<1u>{n - tot_num_walkers}, ComplexType(1.0));
         ma::copy(buff, W({tot_num_walkers, n}, data_displ[WEIGHT]));
         ma::copy(buff, W({tot_num_walkers, n}, data_displ[OVLP]));
         ma::copy(buff, W({tot_num_walkers, n}, data_displ[PHASE]));
@@ -379,7 +379,7 @@ public:
     assert(get<1>(walker_buffer.sizes()) == walker_size);
     if (TG.TG_local().root())
     {
-      boost::multi::array<ComplexType, 1> buff(iextensions<1u>{tot_num_walkers});
+      boost::multi::array<ComplexType, 1> buff(extents_t<1u>{tot_num_walkers});
       getProperty(WEIGHT, buff);
       for (int i = 0; i < tot_num_walkers; i++)
         res += std::abs(buff[i]);
@@ -603,8 +603,8 @@ public:
       return;
     assert(walker_buffer.size(1) == walker_size);
     auto W(walker_buffer.template static_array_cast<element, pointer>());
-    boost::multi::array<ComplexType, 1> ov(iextensions<1u>{tot_num_walkers});
-    boost::multi::array<ComplexType, 1> buff(iextensions<1u>{tot_num_walkers});
+    boost::multi::array<ComplexType, 1> ov(extents_t<1u>{tot_num_walkers});
+    boost::multi::array<ComplexType, 1> buff(extents_t<1u>{tot_num_walkers});
     getProperty(OVLP, ov);
     for (int i = 0; i < tot_num_walkers; i++)
       buff[i] = ComplexType(1.0 / std::abs(ov[i]), 0.0);
@@ -683,7 +683,7 @@ public:
     TG.TG_local().barrier();
     if (TG.TG_local().root())
     {
-      boost::multi::array<element, 1> w_(iextensions<1u>{tot_num_walkers}, ComplexType(1.0));
+      boost::multi::array<element, 1> w_(extents_t<1u>{tot_num_walkers}, ComplexType(1.0));
       setProperty(WEIGHT, w_);
     }
     TG.TG_local().barrier();

--- a/src/AFQMC/Walkers/WalkerUtilities.hpp
+++ b/src/AFQMC/Walkers/WalkerUtilities.hpp
@@ -102,7 +102,7 @@ inline void getGlobalListOfWalkerWeights(WlkBucket& wlk,
     APP_ABORT(" Error in getGlobalListOfWalkerWeights(): size > target.\n");
   std::vector<Type> blocal(target);
   std::vector<Type>::iterator itv = blocal.begin();
-  boost::multi::array<ComplexType, 1> w_data(iextensions<1u>{nW});
+  boost::multi::array<ComplexType, 1> w_data(extents_t<1u>{nW});
   wlk.getProperty(WEIGHT, w_data);
   //  for(typename WlkBucket::iterator it=wlk.begin(); it!=wlk.end(); ++it, ++itv)
   //    *itv = {std::abs(*it->weight()),1};

--- a/src/AFQMC/Walkers/Walkers.hpp
+++ b/src/AFQMC/Walkers/Walkers.hpp
@@ -36,7 +36,7 @@ public:
 
   template<class ma>
   walker(ma&& a, const wlk_indices& i_, const wlk_descriptor& d_)
-      : w_(a.base(), iextensions<1u>{a.size()}), indx(i_), desc(d_)
+      : w_(a.base(), extents_t<1u>{a.size()}), indx(i_), desc(d_)
   {
     static_assert(std::decay<ma>::type::dimensionality == 1, "Wrong dimensionality");
   }
@@ -44,9 +44,9 @@ public:
   ~walker() {}
 
   /*
-      walker(walker&& other): w_(other.w_.base(), iextensions<1u>{other.w_.size()}), 
+      walker(walker&& other): w_(other.w_.base(), extents_t<1u>{other.w_.size()}), 
                               indx(other.indx),desc(other.desc)  {} 
-      walker(walker const& other): w_(other.w_.base(),iextensions<1u>{other.w_.size()}), 
+      walker(walker const& other): w_(other.w_.base(),extents_t<1u>{other.w_.size()}), 
                               indx(other.indx),desc(other.desc)  {} 
 */
   // no copy/move assignment

--- a/src/AFQMC/Wavefunctions/NOMSD.hpp
+++ b/src/AFQMC/Wavefunctions/NOMSD.hpp
@@ -304,7 +304,7 @@ public:
   void Energy(WlkSet& wset)
   {
     int nw = wset.size();
-    DynamicVector ovlp(iextensions<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector ovlp(extents_t<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     DynamicMatrix eloc({nw, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     Energy(wset, eloc, ovlp);
     TG.local_barrier();
@@ -343,7 +343,7 @@ public:
   void MixedDensityMatrix(const WlkSet& wset, MatG&& G, bool compact = true, bool transpose = false)
   {
     int nw = wset.size();
-    DynamicVector ovlp(iextensions<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector ovlp(extents_t<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     MixedDensityMatrix(wset, std::forward<MatG>(G), ovlp, compact, transpose);
   }
 
@@ -432,7 +432,7 @@ public:
   void MixedDensityMatrix_for_vbias(const WlkSet& wset, MatG&& G)
   {
     int nw = wset.size();
-    DynamicVector ovlp(iextensions<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector ovlp(extents_t<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     MixedDensityMatrix(wset, std::forward<MatG>(G), ovlp, compact_G_for_vbias, transposed_G_for_vbias_);
   }
 
@@ -455,7 +455,7 @@ public:
   void Overlap(WlkSet& wset)
   {
     int nw = wset.size();
-    DynamicVector ovlp(iextensions<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector ovlp(extents_t<1u>{nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     Overlap(wset, ovlp);
     TG.local_barrier();
     if (TG.getLocalTGRank() == 0)

--- a/src/AFQMC/Wavefunctions/NOMSD.icc
+++ b/src/AFQMC/Wavefunctions/NOMSD.icc
@@ -68,10 +68,10 @@ void NOMSD<devPsiT>::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
   int nr = Gsize, nc = nwalk;
   if (transposed_G_for_E_)
     std::swap(nr, nc);
-  DynamicSHMVector shmbuff(iextensions<1u>{(Gsize + 1) * nwalk},
+  DynamicSHMVector shmbuff(extents_t<1u>{(Gsize + 1) * nwalk},
                            shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
   CMatrix_ref G(make_device_ptr(shmbuff.base()), {nr, nc});
-  CVector_ref ov_(G.base() + G.num_elements(), iextensions<1u>{nwalk});
+  CVector_ref ov_(G.base() + G.num_elements(), extents_t<1u>{nwalk});
   DynamicMatrix eloc2({nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
 
   using std::fill_n;
@@ -131,7 +131,7 @@ void NOMSD<devPsiT>::Energy_distributed_singleDet(const WlkSet& wset, Mat&& E, T
   //  iii. energies[3] for all walkers on all nodes of TG (assume all nodes have same # of walkers)
   int nt = nwalk * (2 * Gsize + 1);
   // in case the number of walkers changes
-  DynamicSHMVector shmbuff(iextensions<1u>{nt},
+  DynamicSHMVector shmbuff(extents_t<1u>{nt},
                            shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
   assert(E.dimensionality == 2);
   assert(Ov.dimensionality == 1);
@@ -146,7 +146,7 @@ void NOMSD<devPsiT>::Energy_distributed_singleDet(const WlkSet& wset, Mat&& E, T
     std::swap(nr, nc);
   CMatrix_ref Gwork(make_device_ptr(shmbuff.base()), {nr, nc});
   CMatrix_ref Grecv(Gwork.base() + Gwork.num_elements(), {nr, nc});
-  CVector_ref overlaps(Grecv.base() + Grecv.num_elements(), iextensions<1u>{nwalk});
+  CVector_ref overlaps(Grecv.base() + Grecv.num_elements(), extents_t<1u>{nwalk});
   DynamicMatrix eloc2({ngroups * nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
   int nak0, nak1;
   std::tie(nak0, nak1) = FairDivideBoundary(TG.getLocalTGRank(), Gsize * nwalk, TG.getNCoresPerTG());
@@ -237,7 +237,7 @@ void NOMSD<devPsiT>::Energy_distributed_multiDet(const WlkSet& wset, Mat&& E, TV
   //  ii.  1 copy of G (always compact),
   //  iii. ovlps for local walkers
   int nt = nwalk * (3 * Gsize + 1);
-  DynamicSHMVector shmbuff(iextensions<1u>{nt},
+  DynamicSHMVector shmbuff(extents_t<1u>{nt},
                            shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
   assert(E.dimensionality == 2);
   assert(Ov.dimensionality == 1);
@@ -253,7 +253,7 @@ void NOMSD<devPsiT>::Energy_distributed_multiDet(const WlkSet& wset, Mat&& E, TV
   CMatrix_ref SMwork(make_device_ptr(shmbuff.base()), {nwalk, Gsize});
   CMatrix_ref SMrecv(SMwork.base() + SMwork.num_elements(), {nwalk, Gsize});
   CMatrix_ref Gwork(SMrecv.base() + SMrecv.num_elements(), {nr, nc});
-  CVector_ref overlaps(Gwork.base() + Gwork.num_elements(), iextensions<1u>{nwalk});
+  CVector_ref overlaps(Gwork.base() + Gwork.num_elements(), extents_t<1u>{nwalk});
   // used for temporary storage in ndet loop for local calculation
   DynamicMatrix eloc2({nnodes * nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
   DynamicMatrix eloc3({nwalk, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
@@ -377,7 +377,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_for_E_from_SM(const MatSM& SM,
     auto Gdims = dm_dims(false, Alpha);
     DynamicMatrix G2D_({Gdims.first, Gdims.second},
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref G1D_(G2D_.base(), iextensions<1u>{Gsize});
+    CVector_ref G1D_(G2D_.base(), extents_t<1u>{Gsize});
     // notice interchange of dimensions
     CTensor_cref A(SM.base(), {nw, Gdims.second, Gdims.first});
 
@@ -397,7 +397,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_for_E_from_SM(const MatSM& SM,
   else
   {
     // store overlaps locally to be able to split alpha/beta pairs
-    DynamicVector ovlp2(iextensions<1u>{2 * nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector ovlp2(extents_t<1u>{2 * nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     fill_n(ovlp2.base(), 2 * nw, ComplexType(0.0));
     auto GAdims = dm_dims(false, Alpha);
     auto GBdims = dm_dims(false, Beta);
@@ -405,8 +405,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_for_E_from_SM(const MatSM& SM,
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
     // can reuse space!!!
     CMatrix_ref GB2D_(GA2D_.base(), {GBdims.first, GBdims.second});
-    CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GA2D_.num_elements()});
-    CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GB2D_.num_elements()});
+    CVector_ref GA1D_(GA2D_.base(), extents_t<1u>{GA2D_.num_elements()});
+    CVector_ref GB1D_(GB2D_.base(), extents_t<1u>{GB2D_.num_elements()});
 
     for (int iw = 0; iw < 2 * nw; ++iw)
     {
@@ -501,7 +501,7 @@ void NOMSD<devPsiT>::DensityMatrix_shared(const WlkSet& wset,
     auto Gdims = dm_dims(not compact, Alpha);
     DynamicMatrix G2D_({Gdims.first, Gdims.second},
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref G1D_(G2D_.base(), iextensions<1u>{G2D_.num_elements()});
+    CVector_ref G1D_(G2D_.base(), extents_t<1u>{G2D_.num_elements()});
 
     for (int iw = 0; iw < nw; ++iw)
     {
@@ -540,15 +540,15 @@ void NOMSD<devPsiT>::DensityMatrix_shared(const WlkSet& wset,
     {
       assert(get<1>(RefB.sizes()) == dm_dims(false, Beta).first && get<0>(RefB.sizes()) == dm_dims(false, Beta).second);
     }
-    DynamicVector ovlp2(iextensions<1u>{2 * nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector ovlp2(extents_t<1u>{2 * nw}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     fill_n(ovlp2.base(), 2 * nw, ComplexType(0.0));
     auto GAdims = dm_dims(not compact, Alpha);
     auto GBdims = dm_dims(not compact, Beta);
     DynamicMatrix GA2D_({GAdims.first, GAdims.second},
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
     CMatrix_ref GB2D_(GA2D_.base(), {GBdims.first, GBdims.second});
-    CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GA2D_.num_elements()});
-    CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GB2D_.num_elements()});
+    CVector_ref GA1D_(GA2D_.base(), extents_t<1u>{GA2D_.num_elements()});
+    CVector_ref GB1D_(GB2D_.base(), extents_t<1u>{GB2D_.num_elements()});
 
     for (int iw = 0; iw < 2 * nw; ++iw)
     {
@@ -626,7 +626,7 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
   TG.local_barrier();
   fill_n(Ov.base(), nw, 0);
   fill_n(G.base(), G.num_elements(), ComplexType(0.0));
-  DynamicVector ovlp2(iextensions<1u>{2 * nbatch__},
+  DynamicVector ovlp2(extents_t<1u>{2 * nbatch__},
                       buffer_manager.get_generator().template get_allocator<ComplexType>());
   fill_n(ovlp2.base(), ovlp2.num_elements(), ComplexType(0.0));
 
@@ -636,7 +636,7 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
     APP_ABORT(" Error: FIX FIX FIX need strided fill_n\n");
   }
   double LogOverlapFactor(wset.getLogOverlapFactor());
-  stdCVector hvec(iextensions<1u>{2 * nbatch__});
+  stdCVector hvec(extents_t<1u>{2 * nbatch__});
   TG.local_barrier();
   auto GAdims = dm_dims(not compact, Alpha);
   auto Gsize  = GAdims.first * GAdims.second;
@@ -662,7 +662,7 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
     }
     Dynamic3Tensor G3D_({nbatch__, GAdims.first, GAdims.second},
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CMatrix_ref G2D_(G3D_.base(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
+    CMatrix_ref G2D_(G3D_.base(), extents_t<2u>{nbatch__, GAdims.first * GAdims.second});
 
     for (int iw = 0; iw < nw; iw += nbatch__)
     {
@@ -717,9 +717,9 @@ void NOMSD<devPsiT>::DensityMatrix_batched(const WlkSet& wset,
     auto GBdims = dm_dims(not compact, Beta);
     Dynamic3Tensor GA3D_({nbatch__, GAdims.first, GAdims.second},
                          buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CMatrix_ref GA2D_(GA3D_.base(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
+    CMatrix_ref GA2D_(GA3D_.base(), extents_t<2u>{nbatch__, GAdims.first * GAdims.second});
     CTensor_ref GB3D_(GA3D_.base(), {nbatch__, GBdims.first, GBdims.second});
-    CMatrix_ref GB2D_(GB3D_.base(), iextensions<2u>{nbatch__, GBdims.first * GBdims.second});
+    CMatrix_ref GB2D_(GB3D_.base(), extents_t<2u>{nbatch__, GBdims.first * GBdims.second});
 
     for (int iw = 0; iw < nw; iw += nbatch__)
     {
@@ -826,7 +826,7 @@ void NOMSD<devPsiT>::DensityMatrix_batched(std::vector<MatA>& Left,
   Li.reserve(nbatch__);
   Ri.reserve(nbatch__);
   Gi.reserve(nbatch__);
-  DynamicVector ovlp2(iextensions<1u>{nbatch__}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicVector ovlp2(extents_t<1u>{nbatch__}, buffer_manager.get_generator().template get_allocator<ComplexType>());
   fill_n(ovlp2.base(), ovlp2.num_elements(), ComplexType(0.0));
 
   for (int iw = 0; iw < nw; iw += nbatch__)
@@ -901,7 +901,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
     auto Gdims = dm_dims(not compact, Alpha);
     DynamicMatrix G2D_({Gdims.first, Gdims.second},
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref G1D_(G2D_.base(), iextensions<1u>{G2D_.num_elements()});
+    CVector_ref G1D_(G2D_.base(), extents_t<1u>{G2D_.num_elements()});
 
     const int ntasks_percore      = (nw * ndet) / TG.getNCoresPerTG();
     const int ntasks_total_serial = ntasks_percore * TG.getNCoresPerTG();
@@ -956,14 +956,14 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
         }
         // first setup
         local_group_comm = shared_communicator(TG.TG_local().split(last_task_index, TG.TG_local().rank()));
-        shmbuff_for_G    = std::make_unique<mpi3CVector>(iextensions<1u>{dm_size(true)},
+        shmbuff_for_G    = std::make_unique<mpi3CVector>(extents_t<1u>{dm_size(true)},
                                                          shared_allocator<ComplexType>{local_group_comm});
       }
       if (last_task_index < 0 || last_task_index > nextra)
         APP_ABORT("Error: Problems in NOMSD<devPsiT>::Overlap(WSet,Ov)");
       {
         boost::multi::array_ref<ComplexType, 2> G2D_2(to_address(shmbuff_for_G->base()), {Gdims.first, Gdims.second});
-        boost::multi::array_ref<ComplexType, 1> G1D_2(to_address(shmbuff_for_G->base()), iextensions<1u>{Gsize});
+        boost::multi::array_ref<ComplexType, 1> G1D_2(to_address(shmbuff_for_G->base()), extents_t<1u>{Gsize});
         int iw         = (last_task_index + ntasks_total_serial) / ndet;
         int nd         = (last_task_index + ntasks_total_serial) % ndet;
         ComplexType ov = SDetOp.MixedDensityMatrix(OrbMats[nd], *wset[iw].SlaterMatrix(Alpha), G2D_2, LogOverlapFactor,
@@ -997,8 +997,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
     DynamicMatrix GB2D_({GBdims.first, GBdims.second},
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GA2D_.num_elements()});
-    CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GB2D_.num_elements()});
+    CVector_ref GA1D_(GA2D_.base(), extents_t<1u>{GA2D_.num_elements()});
+    CVector_ref GB1D_(GB2D_.base(), extents_t<1u>{GB2D_.num_elements()});
 
     const int ntasks_percore      = (nw * ndet) / TG.getNCoresPerTG();
     const int ntasks_total_serial = ntasks_percore * TG.getNCoresPerTG();
@@ -1055,7 +1055,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
         // first setup
         //local_group_comm = std::make_unique<shared_communicator>(TG.TG_local().split(last_task_index));
         local_group_comm = shared_communicator(TG.TG_local().split(last_task_index, TG.TG_local().rank()));
-        shmbuff_for_G    = std::make_unique<mpi3CVector>(iextensions<1u>{dm_size(true)},
+        shmbuff_for_G    = std::make_unique<mpi3CVector>(extents_t<1u>{dm_size(true)},
                                                          shared_allocator<ComplexType>{local_group_comm});
       }
       if (last_task_index < 0 || last_task_index > nextra)
@@ -1066,9 +1066,9 @@ void NOMSD<devPsiT>::MixedDensityMatrix_shared(const WlkSet& wset, MatG&& G, TVe
         boost::multi::array_ref<ComplexType, 2> GB2D_2(to_address(shmbuff_for_G->base()) + GAdims.first * GAdims.second,
                                                        {GBdims.first, GBdims.second});
         boost::multi::array_ref<ComplexType, 1> GA1D_2(to_address(shmbuff_for_G->base()),
-                                                       iextensions<1u>{GAdims.first * GAdims.second});
+                                                       extents_t<1u>{GAdims.first * GAdims.second});
         boost::multi::array_ref<ComplexType, 1> GB1D_2(to_address(shmbuff_for_G->base()) + GAdims.first * GAdims.second,
-                                                       iextensions<1u>{GBdims.first * GBdims.second});
+                                                       extents_t<1u>{GBdims.first * GBdims.second});
         int task       = (last_task_index + ntasks_total_serial);
         int iw         = task / ndet;
         int nd         = task % ndet;
@@ -1157,7 +1157,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
   double LogOverlapFactor(wset.getLogOverlapFactor());
   assert(Ov.size() >= nw);
   fill_n(Ov.base(), nw, 0);
-  DynamicVector ovlp2(iextensions<1u>{2 * nbatch__},
+  DynamicVector ovlp2(extents_t<1u>{2 * nbatch__},
                       buffer_manager.get_generator().template get_allocator<ComplexType>());
   fill_n(ovlp2.base(), ovlp2.num_elements(), ComplexType(0.0));
   // need strided fill_n????
@@ -1168,8 +1168,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
     APP_ABORT(" Error: FIX FIX FIX need strided fill_n\n");
   }
   fill_n(G.base(), G.num_elements(), ComplexType(0.0));
-  stdCVector hvec(iextensions<1u>{2 * nbatch__});
-  stdCVector Ovl(iextensions<1u>{nw});
+  stdCVector hvec(extents_t<1u>{2 * nbatch__});
+  stdCVector Ovl(extents_t<1u>{nw});
   fill_n(Ovl.base(), nw, ComplexType(0.0));
   TG.local_barrier();
   auto Gsize = dm_size(not compact);
@@ -1183,7 +1183,7 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
     auto GAdims = dm_dims(not compact, Alpha);
     Dynamic3Tensor G3D_({nbatch__, GAdims.first, GAdims.second},
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CMatrix_ref G2D_(G3D_.base(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
+    CMatrix_ref G2D_(G3D_.base(), extents_t<2u>{nbatch__, GAdims.first * GAdims.second});
     std::vector<pointer> Gx;
     std::vector<pointer> Gy;
     Gx.reserve(nbatch__);
@@ -1234,8 +1234,8 @@ void NOMSD<devPsiT>::MixedDensityMatrix_batched(const WlkSet& wset, MatG&& G, TV
                          buffer_manager.get_generator().template get_allocator<ComplexType>());
     Dynamic3Tensor GB3D_({nbatch__, GBdims.first, GBdims.second},
                          buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CMatrix_ref GA2D_(GA3D_.base(), iextensions<2u>{nbatch__, GAdims.first * GAdims.second});
-    CMatrix_ref GB2D_(GB3D_.base(), iextensions<2u>{nbatch__, GBdims.first * GBdims.second});
+    CMatrix_ref GA2D_(GA3D_.base(), extents_t<2u>{nbatch__, GAdims.first * GAdims.second});
+    CMatrix_ref GB2D_(GB3D_.base(), extents_t<2u>{nbatch__, GBdims.first * GBdims.second});
     std::vector<pointer> Gxa;
     std::vector<pointer> Gya;
     std::vector<pointer> Gxb;
@@ -1345,10 +1345,10 @@ void NOMSD<devPsiT>::Overlap_batched(const WlkSet& wset, TVec&& Ov)
   double LogOverlapFactor(wset.getLogOverlapFactor());
   assert(Ov.size() >= nw);
   fill_n(Ov.base(), nw, 0);
-  DynamicVector ovlp2(iextensions<1u>{2 * ndet * nw},
+  DynamicVector ovlp2(extents_t<1u>{2 * ndet * nw},
                       buffer_manager.get_generator().template get_allocator<ComplexType>());
   fill_n(ovlp2.base(), ovlp2.num_elements(), ComplexType(0.0));
-  stdCVector hvec(iextensions<1u>{(2 * ndet + 1) * nw});
+  stdCVector hvec(extents_t<1u>{(2 * ndet + 1) * nw});
   fill_n(hvec.base(), hvec.num_elements(), ComplexType(0.0));
   int i0(2 * nw * ndet);
   TG.local_barrier();
@@ -1467,7 +1467,7 @@ void NOMSD<devPsiT>::Overlap_shared(const WlkSet& wset, TVec&& Ov)
         }
         // first setup
         local_group_comm = shared_communicator(TG.TG_local().split(last_task_index, TG.TG_local().rank()));
-        shmbuff_for_G    = std::make_unique<mpi3CVector>(iextensions<1u>{dm_size(true)},
+        shmbuff_for_G    = std::make_unique<mpi3CVector>(extents_t<1u>{dm_size(true)},
                                                          shared_allocator<ComplexType>{local_group_comm});
       }
       if (last_task_index < 0 || last_task_index > nextra)
@@ -1521,7 +1521,7 @@ void NOMSD<devPsiT>::Overlap_shared(const WlkSet& wset, TVec&& Ov)
         }
         // first setup
         local_group_comm = shared_communicator(TG.TG_local().split(last_task_index, TG.TG_local().rank()));
-        shmbuff_for_G    = std::make_unique<mpi3CVector>(iextensions<1u>{dm_size(true)},
+        shmbuff_for_G    = std::make_unique<mpi3CVector>(extents_t<1u>{dm_size(true)},
                                                          shared_allocator<ComplexType>{local_group_comm});
       }
       if (last_task_index < 0 || last_task_index > nextra)
@@ -1601,11 +1601,11 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared(const WlkSet& wset,
     // Temporaries for determinant component of walker rdm function.
     DynamicMatrix G2D_({Gdims.first, Gdims.second},
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref G1D_(G2D_.base(), iextensions<1u>{Gsize});
+    CVector_ref G1D_(G2D_.base(), extents_t<1u>{Gsize});
     // Accumulator for trial wavefunction sum.
-    DynamicVector G21D_(iextensions<1u>{Gsize}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+    DynamicVector G21D_(extents_t<1u>{Gsize}, buffer_manager.get_generator().template get_allocator<ComplexType>());
     // 1D view of walker averaged RDM
-    CVector_ref G1D(make_device_ptr(G.base()), iextensions<1u>{Gsize});
+    CVector_ref G1D(make_device_ptr(G.base()), extents_t<1u>{Gsize});
     for (int iw = 0; iw < nwalk; iw++)
     {
       if (iw % TG.TG_local().size() != TG.TG_local().rank())
@@ -1662,15 +1662,15 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared(const WlkSet& wset,
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
     DynamicMatrix GB2D_({GBdims.first, GBdims.second},
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GAdims.first * GAdims.second});
-    CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GBdims.first * GBdims.second});
-    DynamicVector GA21D_(iextensions<1u>{GAdims.first * GAdims.second},
+    CVector_ref GA1D_(GA2D_.base(), extents_t<1u>{GAdims.first * GAdims.second});
+    CVector_ref GB1D_(GB2D_.base(), extents_t<1u>{GBdims.first * GBdims.second});
+    DynamicVector GA21D_(extents_t<1u>{GAdims.first * GAdims.second},
                          buffer_manager.get_generator().template get_allocator<ComplexType>());
-    DynamicVector GB21D_(iextensions<1u>{GBdims.first * GBdims.second},
+    DynamicVector GB21D_(extents_t<1u>{GBdims.first * GBdims.second},
                          buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref GA1D(make_device_ptr(G.base()), iextensions<1u>{GAdims.first * GAdims.second});
+    CVector_ref GA1D(make_device_ptr(G.base()), extents_t<1u>{GAdims.first * GAdims.second});
     CVector_ref GB1D(make_device_ptr(G.base()) + GAdims.first * GAdims.second,
-                     iextensions<1u>{GBdims.first * GBdims.second});
+                     extents_t<1u>{GBdims.first * GBdims.second});
     for (int iw = 0; iw < nwalk; iw++)
     {
       if (iw % TG.TG_local().size() != TG.TG_local().rank())
@@ -1798,9 +1798,9 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared_single_det(const WlkSet&
     // Temporaries for determinant component of walker rdm function.
     DynamicMatrix G2D_({Gdims.first, Gdims.second},
                        buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref G1D_(G2D_.base(), iextensions<1u>{Gsize});
+    CVector_ref G1D_(G2D_.base(), extents_t<1u>{Gsize});
     // 1D view of walker averaged RDM
-    CVector_ref G1D(make_device_ptr(G.base()), iextensions<1u>{Gsize});
+    CVector_ref G1D(make_device_ptr(G.base()), extents_t<1u>{Gsize});
     for (int iw = 0; iw < nwalk; iw++)
     {
       if (iw % TG.TG_local().size() != TG.TG_local().rank())
@@ -1853,11 +1853,11 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_shared_single_det(const WlkSet&
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
     DynamicMatrix GB2D_({GBdims.first, GBdims.second},
                         buffer_manager.get_generator().template get_allocator<ComplexType>());
-    CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GAdims.first * GAdims.second});
-    CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GBdims.first * GBdims.second});
-    CVector_ref GA1D(make_device_ptr(G.base()), iextensions<1u>{GAdims.first * GAdims.second});
+    CVector_ref GA1D_(GA2D_.base(), extents_t<1u>{GAdims.first * GAdims.second});
+    CVector_ref GB1D_(GB2D_.base(), extents_t<1u>{GBdims.first * GBdims.second});
+    CVector_ref GA1D(make_device_ptr(G.base()), extents_t<1u>{GAdims.first * GAdims.second});
     CVector_ref GB1D(make_device_ptr(G.base()) + GAdims.first * GAdims.second,
-                     iextensions<1u>{GBdims.first * GBdims.second});
+                     extents_t<1u>{GBdims.first * GBdims.second});
     for (int iw = 0; iw < nwalk; iw++)
     {
       if (iw % TG.TG_local().size() != TG.TG_local().rank())
@@ -1992,11 +1992,11 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_batched(const WlkSet& wset,
       assert(wset.size() == (*detR).size());
       assert(OrbMats.size() == get<1>((*detR).sizes()) );
     }
-    stdCVector hvec(iextensions<1u>{2*nbatch__});
+    stdCVector hvec(extents_t<1u>{2*nbatch__});
     TG.local_barrier();
     auto Gsize = dm_size(not compact);
     if(localGbuff.size() < nbatch__*Gsize+1)
-      localGbuff.reextent(iextensions<1u>{nbatch__*Gsize+1});
+      localGbuff.reextent(extents_t<1u>{nbatch__*Gsize+1});
     pointer ov_(localGbuff.base()+nbatch__*Gsize);  
     std::vector<CMatrix_ref> Ai;
     Ai.reserve(nbatch__);
@@ -2005,7 +2005,7 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_batched(const WlkSet& wset,
 
       auto GAdims = dm_dims(not compact,Alpha); 
       CTensor_ref G3D_(localGbuff.base(),{nbatch__,GAdims.first,GAdims.second});
-      CMatrix_ref G2D_(G3D_.base(),iextensions<2u>{nbatch__,GAdims.first*GAdims.second});
+      CMatrix_ref G2D_(G3D_.base(),extents_t<2u>{nbatch__,GAdims.first*GAdims.second});
 
       for(int idet=0; idet<ndet; ++idet) {
         for(int iw=0; iw<nw; iw+=nbatch__) {
@@ -2034,9 +2034,9 @@ void NOMSD<devPsiT>::WalkerAveragedDensityMatrix_batched(const WlkSet& wset,
       auto GAdims = dm_dims(not compact,Alpha); 
       auto GBdims = dm_dims(not compact,Beta);
       CTensor_ref GA3D_(localGbuff.base(),{nbatch__,GAdims.first,GAdims.second});
-      CMatrix_ref GA2D_(GA3D_.base(),iextensions<2u>{nbatch__,GAdims.first*GAdims.second});
+      CMatrix_ref GA2D_(GA3D_.base(),extents_t<2u>{nbatch__,GAdims.first*GAdims.second});
       CTensor_ref GB3D_(GA3D_.base()+GA3D_.num_elements(),{nbatch__,GBdims.first,GBdims.second});
-      CMatrix_ref GB2D_(GB3D_.base(),iextensions<2u>{nbatch__,GBdims.first*GBdims.second});
+      CMatrix_ref GB2D_(GB3D_.base(),extents_t<2u>{nbatch__,GBdims.first*GBdims.second});
 
       for(int idet=0; idet<ndet; ++idet) {
         for(int iw=0; iw<nw; iw+=nbatch__) {
@@ -2162,10 +2162,10 @@ void NOMSD<devPsiT>::Orthogonalize_batched(WlkSet& wset, bool impSamp)
   const int nw = wset.size();
   double LogOverlapFactor(wset.getLogOverlapFactor());
   int nbatch__ = std::min(nw, (nbatch_qr < 0 ? nw : nbatch_qr));
-  stdCVector detR(iextensions<1u>{2 * nw});
+  stdCVector detR(extents_t<1u>{2 * nw});
   std::vector<CMatrix_ptr> Ai;
   Ai.reserve(nbatch__);
-  DynamicVector ov(iextensions<1u>{nbatch__}, buffer_manager.get_generator().template get_allocator<ComplexType>());
+  DynamicVector ov(extents_t<1u>{nbatch__}, buffer_manager.get_generator().template get_allocator<ComplexType>());
   if (walker_type != COLLINEAR)
   {
     for (int iw = 0; iw < nw; iw += nbatch__)
@@ -2336,20 +2336,20 @@ void NOMSD<devPsiT>::vMF(Vec&& v)
       ma::Matrix2MA('H', OrbMats[1], PsiT);
       SDetOp.MixedDensityMatrix(OrbMats[1], PsiT, G.sliced(NAEA, NAEA + NAEB), 0.0, true);
     }
-    CVector_ref G1D(G.base(), iextensions<1u>{G.num_elements()});
+    CVector_ref G1D(G.base(), extents_t<1u>{G.num_elements()});
     HamOp.vbias(G1D, std::forward<Vec>(v));
   }
   else
   {
     auto Gsize = dm_size(true);
     auto Gdims = dm_dims(true, Alpha);
-    CVector G1D(iextensions<1u>{Gsize});
+    CVector G1D(extents_t<1u>{Gsize});
     fill_n(G1D.base(), G1D.num_elements(), ComplexType(0));
     ComplexType ov(0);
     if (walker_type != COLLINEAR)
     {
       CMatrix G_({Gdims.first, Gdims.second});
-      CVector_ref G1D_(G_.base(), iextensions<1u>{Gdims.first * Gdims.second});
+      CVector_ref G1D_(G_.base(), extents_t<1u>{Gdims.first * Gdims.second});
       int n0, n1;
       std::tie(n0, n1) = FairDivideBoundary(TG.getGlobalRank(), ndets * (ndets + 1) / 2, TG.getGlobalSize());
       int last_p       = -1;
@@ -2379,7 +2379,7 @@ void NOMSD<devPsiT>::vMF(Vec&& v)
     else
     {
       CMatrix G_({2 * NMO, NMO});
-      CVector_ref G1D_(G_.base(), iextensions<1u>{2 * NMO * NMO});
+      CVector_ref G1D_(G_.base(), extents_t<1u>{2 * NMO * NMO});
       int n0, n1;
       std::tie(n0, n1) = FairDivideBoundary(TG.getGlobalRank(), ndets * (ndets + 1) / 2, TG.getGlobalSize());
       int last_p       = -1;
@@ -2464,14 +2464,14 @@ inline void NOMSD<devPsiT>::recompute_ci()
   else
   {
     auto nt = (1 + dm_size(false) + NMO * NAEA);
-    DynamicSHMVector shmbuff(iextensions<1u>{nt},
+    DynamicSHMVector shmbuff(extents_t<1u>{nt},
                              shm_buffer_manager.get_generator().template get_allocator<ComplexType>());
 
     boost::multi::array<ComplexType, 2, shared_allocator<ComplexType>> H({ndets, ndets},
                                                                          shared_allocator<ComplexType>(TG.Node()));
     boost::multi::array<ComplexType, 2, shared_allocator<ComplexType>> S({ndets, ndets},
                                                                          shared_allocator<ComplexType>(TG.Node()));
-    boost::multi::array<ComplexType, 1> energy(iextensions<1u>{2});
+    boost::multi::array<ComplexType, 1> energy(extents_t<1u>{2});
     CMatrix Psia({0, 0});
     CMatrix Psib({0, 0});
     if (TG.TG_local().root())
@@ -2491,7 +2491,7 @@ inline void NOMSD<devPsiT>::recompute_ci()
     int nr = Gsize, nc = 1;
     if (transposed_G_for_E_)
       std::swap(nr, nc);
-    CVector_ref ov_(make_device_ptr(shmbuff.base()), iextensions<1u>{1});
+    CVector_ref ov_(make_device_ptr(shmbuff.base()), extents_t<1u>{1});
     CMatrix_ref G(ov_.base() + 1, {nr, nc});
     DynamicMatrix eloc2({1, 3}, buffer_manager.get_generator().template get_allocator<ComplexType>());
 

--- a/src/AFQMC/Wavefunctions/PHMSD.hpp
+++ b/src/AFQMC/Wavefunctions/PHMSD.hpp
@@ -305,7 +305,7 @@ public:
     using std::get;
     int nw = wset.size();
     if (ovlp.num_elements() != nw)
-      ovlp.reextent(iextensions<1u>{nw});
+      ovlp.reextent(extents_t<1u>{nw});
     if (get<0>(eloc.sizes()) != nw || get<1>(eloc.sizes()) != 3)
       eloc.reextent({nw, 3});
     Energy(wset, eloc, ovlp);
@@ -350,7 +350,7 @@ public:
   {
     int nw = wset.size();
     if (ovlp.num_elements() != nw)
-      ovlp.reextent(iextensions<1u>{nw});
+      ovlp.reextent(extents_t<1u>{nw});
     MixedDensityMatrix(wset, std::forward<MatG>(G), ovlp, compact, transpose);
   }
 
@@ -422,7 +422,7 @@ public:
   {
     int nw = wset.size();
     if (ovlp.num_elements() != nw)
-      ovlp.reextent(iextensions<1u>{nw});
+      ovlp.reextent(extents_t<1u>{nw});
     MixedDensityMatrix(wset, std::forward<MatG>(G), ovlp, compact_G_for_vbias, transposed_G_for_vbias_);
   }
 
@@ -440,7 +440,7 @@ public:
   {
     int nw = wset.size();
     if (ovlp.num_elements() != nw)
-      ovlp.reextent(iextensions<1u>{nw});
+      ovlp.reextent(extents_t<1u>{nw});
     Overlap(wset, ovlp);
     TG.local_barrier();
     if (TG.getLocalTGRank() == 0)

--- a/src/AFQMC/Wavefunctions/PHMSD.icc
+++ b/src/AFQMC/Wavefunctions/PHMSD.icc
@@ -64,11 +64,11 @@ void PHMSD::Energy_shared(const WlkSet& wset, Mat&& E, TVec&& Ov)
 
   using std::get;
   if (wgt.size() != nwalk)
-    wgt.reextent(iextensions<1u>{nwalk});
+    wgt.reextent(extents_t<1u>{nwalk});
   if (opSpinEJ.size() != nwalk)
-    opSpinEJ.reextent(iextensions<1u>{nwalk});
+    opSpinEJ.reextent(extents_t<1u>{nwalk});
   if (localGbuff.size() < 2 * Gsize)
-    localGbuff.reextent(iextensions<1u>{2 * Gsize});
+    localGbuff.reextent(extents_t<1u>{2 * Gsize});
   if (get<0>(eloc2.sizes()) != nwalk || get<1>(eloc2.sizes()) != 3)
     eloc2.reextent({nwalk, 3});
 
@@ -354,7 +354,7 @@ void PHMSD::Energy_distributed(const WlkSet& wset, Mat&& E, TVec&& Ov)
                                                 {nr,nc});
       displ += Gsize*nwalk;
     boost::multi::array_ref<ComplexType,1> overlaps(to_address(shmbuff_for_E->base())+displ,
-                                                   iextensions<1u>{nwalk});
+                                                   extents_t<1u>{nwalk});
     if(eloc2.size(0) != nnodes*nwalk || eloc2.size(1) != 3) 
         eloc2.resize({nnodes*nwalk,3});
     auto elocal = eloc2[node_number*nwalk];
@@ -444,12 +444,12 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
   if (compact)
   {
     if (localGbuff.size() < 2 * Gsize) // 2 copies needed
-      localGbuff.reextent(iextensions<1u>{2 * Gsize});
+      localGbuff.reextent(extents_t<1u>{2 * Gsize});
   }
   else
   {
     if (localGbuff.size() < 3 * Gsize) // 3 copies needed
-      localGbuff.reextent(iextensions<1u>{3 * Gsize});
+      localGbuff.reextent(extents_t<1u>{3 * Gsize});
   }
   if (walker_type != COLLINEAR)
   {
@@ -482,8 +482,8 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
     cnt += GA2D_.num_elements();
     boost::multi::array_ref<ComplexType, 2> GB2D_(localGbuff.base() + cnt, {GBdims.first, GBdims.second});
     cnt += GB2D_.num_elements();
-    boost::multi::array_ref<ComplexType, 1> GA1D_(GA2D_.base(), iextensions<1u>{GAdims.first * GAdims.second});
-    boost::multi::array_ref<ComplexType, 1> GB1D_(GB2D_.base(), iextensions<1u>{GBdims.first * GBdims.second});
+    boost::multi::array_ref<ComplexType, 1> GA1D_(GA2D_.base(), extents_t<1u>{GAdims.first * GAdims.second});
+    boost::multi::array_ref<ComplexType, 1> GB1D_(GB2D_.base(), extents_t<1u>{GBdims.first * GBdims.second});
     // storage for full G in case compact=false
     boost::multi::array_ref<ComplexType, 2> Gfulla(localGbuff.base() + cnt, {GAdims_full.first, GAdims_full.second});
     cnt += Gfulla.num_elements();
@@ -541,7 +541,7 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
         }
         else
         {
-          boost::multi::array_ref<ComplexType, 1> G1D(Gfulla.base(), iextensions<1u>{long(Gfulla.num_elements())});
+          boost::multi::array_ref<ComplexType, 1> G1D(Gfulla.base(), extents_t<1u>{long(Gfulla.num_elements())});
           ma::product(T(Ra), GA2D0_, GA2D_);
           ma::product(T(OrbMats[0]), GA2D_, Gfulla);
           ma::copy(G1D, G({0, Gfulla.num_elements()}, iw));
@@ -578,7 +578,7 @@ void PHMSD::MixedDensityMatrix(const WlkSet& wset, MatG&& G, TVec&& Ov, bool com
         }
         else
         {
-          boost::multi::array_ref<ComplexType, 1> G1D(Gfullb.base(), iextensions<1u>{Gfullb.num_elements()});
+          boost::multi::array_ref<ComplexType, 1> G1D(Gfullb.base(), extents_t<1u>{Gfullb.num_elements()});
           ma::product(T(Rb), GB2D0_, GB2D_);
           ma::product(T(OrbMats.back()), GB2D_, Gfullb);
           //G({Gfulla.num_elements(),G.size(0)},iw) = G1D;
@@ -817,7 +817,7 @@ void PHMSD::DensityMatrix_shared(const WlkSet& wset,
   double LogOverlapFactor(wset.getLogOverlapFactor());
   auto Gsize = dm_size(not compact);
   if (localGbuff.size() < Gsize)
-    localGbuff.reextent(iextensions<1u>{Gsize});
+    localGbuff.reextent(extents_t<1u>{Gsize});
 
   if (walker_type != COLLINEAR)
   {
@@ -828,7 +828,7 @@ void PHMSD::DensityMatrix_shared(const WlkSet& wset,
 
     auto Gdims = dm_dims(not compact, Alpha);
     CMatrix_ref G2D_(localGbuff.base(), {Gdims.first, Gdims.second});
-    CVector_ref G1D_(G2D_.base(), iextensions<1u>{G2D_.num_elements()});
+    CVector_ref G1D_(G2D_.base(), extents_t<1u>{G2D_.num_elements()});
 
     for (int iw = 0; iw < nw; ++iw)
     {
@@ -855,14 +855,14 @@ void PHMSD::DensityMatrix_shared(const WlkSet& wset,
       assert(get<1>(RefB.sizes()) == dm_dims(false, Beta).first && RefB.size(0) == dm_dims(false, Beta).second);
 
     if (get<0>(ovlp2.sizes()) < 2 * nw)
-      ovlp2.reextent(iextensions<1u>{2 * nw});
+      ovlp2.reextent(extents_t<1u>{2 * nw});
     fill_n(ovlp2.base(), 2 * nw, ComplexType(0.0));
     auto GAdims = dm_dims(not compact, Alpha);
     auto GBdims = dm_dims(not compact, Beta);
     CMatrix_ref GA2D_(localGbuff.base(), {GAdims.first, GAdims.second});
     CMatrix_ref GB2D_(GA2D_.base() + GA2D_.num_elements(), {GBdims.first, GBdims.second});
-    CVector_ref GA1D_(GA2D_.base(), iextensions<1u>{GA2D_.num_elements()});
-    CVector_ref GB1D_(GB2D_.base(), iextensions<1u>{GB2D_.num_elements()});
+    CVector_ref GA1D_(GA2D_.base(), extents_t<1u>{GA2D_.num_elements()});
+    CVector_ref GB1D_(GB2D_.base(), extents_t<1u>{GB2D_.num_elements()});
 
     for (int iw = 0; iw < 2 * nw; ++iw)
     {
@@ -1269,7 +1269,7 @@ void PHMSD::vMF(Vec&& v)
   std::fill_n(v.base(), v.num_elements(), ComplexType(0));
   auto Gsize = dm_size(false);
   if (localGbuff.size() < Gsize)
-    localGbuff.reextent(iextensions<1u>{Gsize});
+    localGbuff.reextent(extents_t<1u>{Gsize});
 
   //shmCMatrix ovlps({2,maxn_unique_confg},shared_allocator<ComplexType>{TG.Node()});
   //boost::multi::array<ComplexType,2> ovlps({2,maxn_unique_confg});
@@ -1324,7 +1324,7 @@ void PHMSD::vMF(Vec&& v)
     auto Gdims     = dm_dims(false, SpinTypes(spin));
     auto Gdims_ref = dm_dims_ref(false, SpinTypes(spin));
     boost::multi::array_ref<ComplexType, 2> G2D_(localGbuff.base(), {Gdims_ref.first, Gdims_ref.second});
-    boost::multi::array_ref<ComplexType, 1> G1D_(G2D_.base(), iextensions<1u>{G2D_.num_elements()});
+    boost::multi::array_ref<ComplexType, 1> G1D_(G2D_.base(), extents_t<1u>{G2D_.num_elements()});
     boost::multi::array<ComplexType, 2> SM_({Gdims_ref.second, Gdims_ref.first});
     // store mean field G
     boost::multi::array<ComplexType, 2> G({Gdims.first, Gdims.second});
@@ -1389,7 +1389,7 @@ void PHMSD::vMF(Vec&& v)
         }
       }
     }
-    boost::multi::array_ref<ComplexType, 1> G1D(G.base(), iextensions<1u>{G.num_elements()});
+    boost::multi::array_ref<ComplexType, 1> G1D(G.base(), extents_t<1u>{G.num_elements()});
     TG.Global().all_reduce_in_place_n(to_address(G1D.base()), G1D.num_elements(), std::plus<>());
     ma::scal(ComplexType(1.0 / ov), G1D);
     HamOp.vbias(G1D, std::forward<Vec>(v), 0.5, 1.0);

--- a/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
+++ b/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
@@ -1081,7 +1081,7 @@ void WavefunctionFactory::computeVariationalEnergyPHMSD(TaskGroup_& TG,
   // Allocate H in Node's shared memory, but use as a raw array with proper synchronization
   int dim((recompute_ci ? ndets : 0));
   boost::multi::array<ComplexType, 2, shared_allocator<ComplexType>> H({dim, dim}, TG.Node());
-  boost::multi::array<ComplexType, 1> energy(iextensions<1u>{2});
+  boost::multi::array<ComplexType, 1> energy(extents_t<1u>{2});
   using std::fill_n;
   fill_n(H.base(), H.num_elements(), ComplexType(0.0));           // this call synchronizes
   fill_n(energy.base(), energy.num_elements(), ComplexType(0.0)); // this call synchronizes

--- a/src/AFQMC/Wavefunctions/phmsd_helpers.hpp
+++ b/src/AFQMC/Wavefunctions/phmsd_helpers.hpp
@@ -92,7 +92,7 @@ inline void calculate_overlaps(int rank, int ngrp, int spin, PH_EXCT const& abij
     {
       boost::multi::array_ref<ComplexType, 2> Qwork_(Qwork.base(), {nex, nex});
       boost::multi::array_ref<ComplexType, 1> Qwork2_(Qwork.base() + Qwork_.num_elements(),
-                                                      iextensions<1u>{nex * nex});
+                                                      extents_t<1u>{nex * nex});
       for (auto it = abij.unique_begin(nex)[spin]; it < abij.unique_end(nex)[spin]; ++it, ++nd)
         if (nd % ngrp == rank)
         {

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -280,7 +280,7 @@ void test_phmsd(boost::mpi3::communicator& world)
     //CHECK(imag(*it->energy()) == Approx(imag(energy)));
     //}
     //auto nCV = wfn.local_number_of_cholesky_vectors();
-    //boost::multi::array<ComplexType,1> vMF(iextensions<1u>{nCV});
+    //boost::multi::array<ComplexType,1> vMF(extents_t<1u>{nCV});
     //std::cout << "NCHOL : " << nCV << " " << NMO*NMO << std::endl;
     //wfn.vMF(vMF);
     //computeVariationalEnergy(wfn, occs, ham, NAEA, NAEB);

--- a/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
@@ -1003,7 +1003,7 @@ TEST_CASE("wfn_fac_collinear_phmsd", "[wavefunction_factory]")
       }
     }
 
-    boost::multi::array<ComplexType,1> vMF(iextensions<1u>{nCV});
+    boost::multi::array<ComplexType,1> vMF(extents_t<1u>{nCV});
     wfn.vMF(vMF);
     ComplexType vMFsum=0;
     {
@@ -1065,7 +1065,7 @@ TEST_CASE("wfn_fac_collinear_phmsd", "[wavefunction_factory]")
       app_log()<<" Vsum: " <<setprecision(12) <<Vsum <<std::endl;
     }
 
-    boost::multi::array<ComplexType,1> vMF2(iextensions<1u>{nCV});
+    boost::multi::array<ComplexType,1> vMF2(extents_t<1u>{nCV});
     nomsd.vMF(vMF2);
     vMFsum=0;
     {

--- a/src/AFQMC/config.h
+++ b/src/AFQMC/config.h
@@ -260,8 +260,8 @@ enum HamiltonianTypes
 };
 
 template<std::ptrdiff_t D>
-using iextensions = typename boost::multi::iextensions<D>;
-//using extensions = typename boost::multi::layout_t<D>::extents_type;
+using extents_t = typename boost::multi::extents_t<D>;
+//using extensions = typename boost::multi::extents_t<D>;
 
 // general matrix definitions
 template<class Alloc = std::allocator<int>>

--- a/src/io/hdf/hdf_multi.h
+++ b/src/io/hdf/hdf_multi.h
@@ -42,9 +42,9 @@ struct h5data_proxy<boost::multi::array<T, 1, Alloc>> : public h5_space_type<T, 
 
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    using iextensions = typename boost::multi::iextensions<1u>;
+    using extents_t = typename boost::multi::extents_t<1u>;
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
-      ref.reextent(iextensions{static_cast<boost::multi::ssize_t>(dims[0])});
+      ref.reextent(extents_t{static_cast<boost::multi::ssize_t>(dims[0])});
     return h5d_read(grp, aname, get_address(std::addressof(*ref.base())), xfer_plist);
   }
 
@@ -170,8 +170,8 @@ struct h5data_proxy<boost::multi::array<T, 1, device::device_allocator<T>>> : pu
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
       ref.reextent({dims[0]});
     auto sz           = ref.num_elements();
-    using iextensions = typename boost::multi::iextensions<1u>;
-    boost::multi::array<T, 1> buf(iextensions{sz});
+    using extents_t = typename boost::multi::extents_t<1u>;
+    boost::multi::array<T, 1> buf(extents_t{sz});
     auto ret = h5d_read(grp, aname, get_address(buf.data()), xfer_plist);
     device::copy_n(buf.data(), sz, ref.base());
     return ret;
@@ -203,8 +203,8 @@ struct h5data_proxy<boost::multi::array<T, 2, device::device_allocator<T>>> : pu
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
       ref.reextent({dims[0], dims[1]});
     auto sz           = ref.num_elements();
-    using iextensions = typename boost::multi::iextensions<1u>;
-    boost::multi::array<T, 1> buf(iextensions{sz});
+    using extents_t = typename boost::multi::extents_t<1u>;
+    boost::multi::array<T, 1> buf(extents_t{sz});
     auto ret = h5d_read(grp, aname, get_address(buf.data()), xfer_plist);
     device::copy_n(buf.data(), sz, ref.base());
     return ret;
@@ -239,8 +239,8 @@ struct h5data_proxy<boost::multi::array_ref<T, 1, device::device_pointer<T>>> : 
       return false;
     }
     auto sz           = ref.num_elements();
-    using iextensions = typename boost::multi::iextensions<1u>;
-    boost::multi::array<T, 1> buf(iextensions{sz});
+    using extents_t = typename boost::multi::extents_t<1u>;
+    boost::multi::array<T, 1> buf(extents_t{sz});
     auto ret = h5d_read(grp, aname, get_address(buf.data()), xfer_plist);
     device::copy_n(buf.data(), sz, ref.base());
     return ret;
@@ -281,8 +281,8 @@ struct h5data_proxy<boost::multi::array_ref<T, 2, device::device_pointer<T>>> : 
       return false;
     }
     auto sz           = ref.num_elements();
-    using iextensions = typename boost::multi::iextensions<1u>;
-    boost::multi::array<T, 1> buf(iextensions{sz});
+    using extents_t = typename boost::multi::extents_t<1u>;
+    boost::multi::array<T, 1> buf(extents_t{sz});
     auto ret = h5d_read(grp, aname, get_address(buf.data()), xfer_plist);
     device::copy_n(buf.data(), sz, ref.base());
     return ret;
@@ -309,7 +309,7 @@ struct h5data_proxy<hyperslab_proxy<boost::multi::array<T, 2, device::device_all
     {
       // later on specialize h5d_read for fancy pointers
       auto sz = ref.ref.num_elements();
-      boost::multi::array<T, 1> buf(typename boost::multi::layout_t<1u>::extents_type{sz});
+      boost::multi::array<T, 1> buf(boost::multi::extents_t<1u>{sz});
       auto ret = h5d_read(grp, aname.c_str(), ref.slab_rank, ref.slab_dims.data(), ref.slab_dims_local.data(),
                           ref.slab_offset.data(), buf.base(), xfer_plist);
       device::copy_n(buf.data(), sz, ref.ref.base());
@@ -348,7 +348,7 @@ struct h5data_proxy<hyperslab_proxy<boost::multi::array_ref<T, 2, device::device
     {
       // later on specialize h5d_read for fancy pointers
       auto sz = ref.ref.num_elements();
-      boost::multi::array<T, 1> buf(typename boost::multi::layout_t<1u>::extents_type{sz});
+      boost::multi::array<T, 1> buf(boost::multi::extents_t<1u>{sz});
       auto ret = h5d_read(grp, aname.c_str(), ref.slab_rank, ref.slab_dims.data(), ref.slab_dims_local.data(),
                           ref.slab_offset.data(), buf.base(), xfer_plist);
       device::copy_n(buf.data(), sz, ref.ref.base());

--- a/src/io/hdf/tests/test_hdf_multiarray.cpp
+++ b/src/io/hdf/tests/test_hdf_multiarray.cpp
@@ -23,7 +23,7 @@ using std::vector;
 using namespace qmcplusplus;
 
 template<std::ptrdiff_t D>
-using extensions = typename boost::multi::extents_t<D>;  // boost::multi::layout_t<D>::extents_type;
+using extensions = typename boost::multi::extents_t<D>;
 
 TEST_CASE("hdf_multiarray_one_dim", "[hdf]")
 {


### PR DESCRIPTION
modernize Multi usage

## Proposed changes

iextensions<D> -> extents_t<D>
layout_t<D>::extensions_type -> extents_t<D>

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?


Ubuntu 24.04


## Checklist

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
