### PR TITLE
Redirect remaining unit test output to app_log

### DIFF
--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -36,7 +36,6 @@
 
 using std::cerr;
 using std::complex;
-using std::cout;
 using std::endl;
 using std::ifstream;
 using std::setprecision;

--- a/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
+++ b/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
@@ -39,7 +39,6 @@
 
 using std::cerr;
 using std::complex;
-using std::cout;
 using std::endl;
 using std::ifstream;
 using std::setprecision;
@@ -324,16 +323,16 @@ void ham_ops_basic_serial(boost::mpi3::communicator& world)
     boost::multi::array<ComplexType, 3, Alloc> GFock({2, nwalk, dm_size}, alloc_);
     fill_n(GFock.base(), GFock.num_elements(), ComplexType(0.0));
     //for(int i = 0; i < nwalk; i++) {
-    //std::cout << Gw2_[i][0] << std::endl;
+    //app_log() << Gw2_[i][0] << std::endl;
     //}
-    //std::cout << "INIT: " << Gw2_[0][0] << " " << Gw2_[0][NMO*NMO] << std::endl;
+    //app_log() << "INIT: " << Gw2_[0][0] << " " << Gw2_[0][NMO*NMO] << std::endl;
     HOps.generalizedFockMatrix(Gw2_, GFock[0], GFock[1]);
     //boost::multi::array_ref<ComplexType,2,pointer> GR(make_device_ptr(GFock[0][0].base()), {NMO,NMO});
     //for(int i = 0; i < nwalk; i++) {
-    //std::cout << GFock[0][i][0] << std::endl;
+    //app_log() << GFock[0][i][0] << std::endl;
     //}
-    //std::cout << "GFOCK: " << GFock[0][0][0] << " " << GFock[1][0][0] << std::endl;
-    //std::cout << "Fm: " << std::endl;
+    //app_log() << "GFOCK: " << GFock[0][0][0] << " " << GFock[1][0][0] << std::endl;
+    //app_log() << "Fm: " << std::endl;
     std::fill_n(Mat.base(), Mat.num_elements(), 0.0);
     ref.readEntry(Mat, "Fha");
     for (int i = 0; i < NMO; i++)
@@ -342,27 +341,27 @@ void ham_ops_basic_serial(boost::mpi3::communicator& world)
       {
         if (auto gfock = ComplexType(GFock[1][0][i * NMO + j]); std::abs(Mat[i][j] - std::real(gfock)) > 1e-5)
         {
-          std::cout << "DELTAA: " << i << " " << j << " " << Mat[i][j] << " " << std::real(gfock) << std::endl;
+          app_log() << "DELTAA: " << i << " " << j << " " << Mat[i][j] << " " << std::real(gfock) << std::endl;
         }
         //if(std::abs(real(GFock[1][0][i*NMO+j]))>1e-6)
-        //std::cout << i << " " << j << " " << real(GFock[1][0][i*NMO+j]) << " " << std::endl;
+        //app_log() << i << " " << j << " " << real(GFock[1][0][i*NMO+j]) << " " << std::endl;
       }
     }
-    //std::cout << "Fp: " << std::endl;
+    //app_log() << "Fp: " << std::endl;
     std::fill_n(Mat.base(), Mat.num_elements(), 0.0);
     ref.readEntry(Mat, "Fpa");
     for (int i = 0; i < NMO; i++)
     {
       for (int j = 0; j < NMO; j++)
       {
-        //std::cout << Mat[i][j] << std::endl;
-        //std::cout << Mat[i][j]-real(GFock[0][0][i*NMO+j]) << std::endl;
+        //app_log() << Mat[i][j] << std::endl;
+        //app_log() << Mat[i][j]-real(GFock[0][0][i*NMO+j]) << std::endl;
         if (auto gfock = ComplexType(GFock[0][0][i * NMO + j]); std::abs(Mat[i][j] - std::real(gfock)) > 1e-5)
         {
-          std::cout << "DELTAB: " << i << " " << j << " " << Mat[i][j] << " " << std::real(gfock) << std::endl;
+          app_log() << "DELTAB: " << i << " " << j << " " << Mat[i][j] << " " << std::real(gfock) << std::endl;
         }
         //if(std::abs(real(GFock[0][0][i*NMO+j]))>1e-6)
-        //std::cout << i << " " << j << " " << real(GFock[0][0][i*NMO+j]) << " " << real(GFock[0][1][i*NMO+j]) << " " << real(GFock[0][2][i*NMO+j]) << std::endl;
+        //app_log() << i << " " << j << " " << real(GFock[0][0][i*NMO+j]) << " " << real(GFock[0][1][i*NMO+j]) << " " << real(GFock[0][2][i*NMO+j]) << std::endl;
       }
     }
   }

--- a/src/AFQMC/Hamiltonians/tests/test_hamiltonian_factory.cpp
+++ b/src/AFQMC/Hamiltonians/tests/test_hamiltonian_factory.cpp
@@ -34,7 +34,6 @@
 
 using std::cerr;
 using std::complex;
-using std::cout;
 using std::endl;
 using std::ifstream;
 using std::setprecision;

--- a/src/AFQMC/Matrix/tests/test_csr_matrix.cpp
+++ b/src/AFQMC/Matrix/tests/test_csr_matrix.cpp
@@ -28,7 +28,6 @@
 #endif
 
 using std::cerr;
-using std::cout;
 using std::endl;
 using std::get;
 using tp_ul_ul = std::tuple<std::size_t, std::size_t>;
@@ -689,9 +688,9 @@ TEST_CASE("csr_matrix_shm_large_memory", "[csr]")
   world.barrier();
   if (node.root())
   {
-    std::cout << " capacity: " << umat.capacity() << std::endl;
+    app_log() << " capacity: " << umat.capacity() << std::endl;
     umat.emplace({399999, 0}, Type(1));
-    std::cout << " pbegin[399999]: " << umat.pointers_begin()[399999] << std::endl;
+    app_log() << " pbegin[399999]: " << umat.pointers_begin()[399999] << std::endl;
   }
   world.barrier();
   Alloc B(node);
@@ -699,9 +698,9 @@ TEST_CASE("csr_matrix_shm_large_memory", "[csr]")
   world.barrier();
   if (node.root())
   {
-    std::cout << " capacity: " << umat2.capacity() << std::endl;
+    app_log() << " capacity: " << umat2.capacity() << std::endl;
     umat2.emplace({399999, 0}, Type(1));
-    std::cout << " pbegin[399999]: " << umat2.pointers_begin()[399999] << std::endl;
+    app_log() << " pbegin[399999]: " << umat2.pointers_begin()[399999] << std::endl;
   }
   world.barrier();
 }

--- a/src/AFQMC/Numerics/tests/test_batched_operations.cpp
+++ b/src/AFQMC/Numerics/tests/test_batched_operations.cpp
@@ -120,7 +120,7 @@ TEST_CASE("batched_Tab_to_Klr", "[batched_operations]")
   batched_Tab_to_Klr(nbatch, nwalk, nel, nchol_max, nchol, ncholQ, ncholQ0, dev_kdiag.base(), Tab.base(),
                      Kl.base(), Kr.base());
   copy_n(Kr.base(), Kr.num_elements(), buffer.data());
-  //std::cout << std::setprecision(16) << Kl[2][3] << " " << Kl[1][4] << " " << Kr[1][3] << " " << Kr[0][1] << std::endl;
+  //app_log() << std::setprecision(16) << Kl[2][3] << " " << Kl[1][4] << " " << Kr[1][3] << " " << Kr[0][1] << std::endl;
   CHECK(real(buffer[2 * nchol + 3]) == Approx(2262));
 }
 
@@ -141,10 +141,10 @@ TEST_CASE("Tanb_to_Kl", "[batched_operations]")
   using ma::Tanb_to_Kl;
   Tanb_to_Kl(nwalk, nel, nchol, nchol, Twanb.base(), Kl.base());
   array_ref<ComplexType, 1, pointer<ComplexType>> Kl_(Kl.base(), iextensions<1u>{nwalk * nchol});
-  //std::cout << "{";
+  //app_log() << "{";
   //for (auto i : Kl_)
-  //std::cout << "ComplexType(" << real(i) << ")," << std::endl;
-  //std::cout << "};" << std::endl;;
+  //app_log() << "ComplexType(" << real(i) << ")," << std::endl;
+  //app_log() << "};" << std::endl;;
   array<ComplexType, 1, Alloc<ComplexType>> ref = {ComplexType(66),  ComplexType(75),  ComplexType(84),
                                                    ComplexType(93),  ComplexType(102), ComplexType(111),
                                                    ComplexType(120), ComplexType(255), ComplexType(264),
@@ -174,7 +174,7 @@ TEST_CASE("batched_dot_wabn_wban", "[Numerics][batched_operations]")
                                                    ComplexType(2189.312510839587)};
   using ma::batched_dot_wabn_wban;
   batched_dot_wabn_wban(nbatch, nwalk, nocc, nchol, scal.base(), Twabn.base(), to_address(out.data()), 1);
-  //std::cout << std::setprecision(16) << "this: " <<  out[0] << " " << out[1] << " " << out[2] << std::endl;
+  //app_log() << std::setprecision(16) << "this: " <<  out[0] << " " << out[1] << " " << out[2] << std::endl;
   verify_approx(ref, out);
 }
 
@@ -198,7 +198,7 @@ TEST_CASE("batched_dot_wanb_wbna", "[Numerics][batched_operations]")
                                                    ComplexType(2189.107040119586)};
   using ma::batched_dot_wanb_wbna;
   batched_dot_wanb_wbna(nbatch, nwalk, nocc, nchol, scal.base(), Twabn.base(), to_address(out.data()), 1);
-  //std::cout << std::setprecision(16) << "this: " <<  out[0] << " " << out[1] << " " << out[2] << std::endl;
+  //app_log() << std::setprecision(16) << "this: " <<  out[0] << " " << out[1] << " " << out[2] << std::endl;
   verify_approx(ref, out);
 }
 
@@ -312,7 +312,7 @@ TEST_CASE("viwj_vwij", "[Numerics][batched_operations]")
   copy_n(buffer.data(), buffer.size(), B.base());
   using ma::viwj_vwij;
   //viwj_vwij(nw, ni, 0, nj, B.data(), A.data());
-  //std::cout << A[0][1][1] << " " << A[1][2][1] << std::endl;
+  //app_log() << A[0][1][1] << " " << A[1][2][1] << std::endl;
 }
 
 TEST_CASE("element_wise_Aij_Bjk_Ckij", "[Numerics][batched_operations]")

--- a/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
@@ -49,7 +49,6 @@
 using boost::multi::array;
 using boost::multi::array_ref;
 using std::complex;
-using std::cout;
 using std::endl;
 using std::string;
 using std::vector;

--- a/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
+++ b/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
@@ -41,7 +41,6 @@
 
 using std::cerr;
 using std::complex;
-using std::cout;
 using std::endl;
 using std::ifstream;
 using std::setprecision;
@@ -147,7 +146,7 @@ void propg_fac_shared(boost::mpi3::communicator& world)
     PropgFac.push(prop_name, doc4.getRoot());
     Propagator& prop = PropgFac.getPropagator(TG, prop_name, wfn, rng);
 
-    std::cout << setprecision(12);
+    app_log() << setprecision(12);
     wfn.Energy(wset);
     {
       ComplexType eav = 0, ov = 0;

--- a/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
+++ b/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
@@ -34,7 +34,6 @@
 #include "AFQMC/SlaterDeterminantOperations/mixed_density_matrix.hpp"
 
 using std::complex;
-using std::cout;
 using std::endl;
 using std::string;
 

--- a/src/AFQMC/Walkers/tests/test_sharedwset.cpp
+++ b/src/AFQMC/Walkers/tests/test_sharedwset.cpp
@@ -36,7 +36,6 @@
 #include "AFQMC/Walkers/WalkerIO.hpp"
 
 using std::complex;
-using std::cout;
 using std::endl;
 using std::string;
 

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -19,7 +19,6 @@
 #include "hdf/hdf_archive.h"
 #include "Utilities/RandomGenerator.h"
 #include "Utilities/Timer.h"
-#include "Platforms/Host/OutputManager.h"
 
 #include <string>
 #include <vector>
@@ -43,7 +42,6 @@
 
 using std::cerr;
 using std::complex;
-using std::cout;
 using std::endl;
 using std::ifstream;
 using std::setprecision;
@@ -281,12 +279,12 @@ void test_phmsd(boost::mpi3::communicator& world)
     //}
     //auto nCV = wfn.local_number_of_cholesky_vectors();
     //boost::multi::array<ComplexType,1> vMF(iextensions<1u>{nCV});
-    //std::cout << "NCHOL : " << nCV << " " << NMO*NMO << std::endl;
+    //app_log() << "NCHOL : " << nCV << " " << NMO*NMO << std::endl;
     //wfn.vMF(vMF);
     //computeVariationalEnergy(wfn, occs, ham, NAEA, NAEB);
     //std::vector<ComplexType> vMF_sc = computeMeanFieldShift(wfn, occs, coeffs, NAEA, NAEB);
     //for(int i=0; i < vMF.size(); i++) {
-    //std::cout << vMF[i] << std::endl;
+    //app_log() << vMF[i] << std::endl;
     //}
   }
 }

--- a/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
@@ -19,7 +19,6 @@
 #include "hdf/hdf_archive.h"
 #include "Utilities/RandomGenerator.h"
 #include "Utilities/Timer.h"
-#include "Platforms/Host/OutputManager.h"
 
 #include <string>
 #include <vector>
@@ -40,7 +39,6 @@
 
 using std::cerr;
 using std::complex;
-using std::cout;
 using std::endl;
 using std::ifstream;
 using std::setprecision;
@@ -913,11 +911,11 @@ TEST_CASE("wfn_fac_collinear_phmsd", "[wavefunction_factory]")
       shmCMatrix Gno({2*NMO*NMO,nwalk},alloc_);
       wfn.MixedDensityMatrix(wset,Gph,false,false);
       nomsd.MixedDensityMatrix(wset,Gno,false,false);
-      std::cout<<" Comparing G \n";
+      app_log()<<" Comparing G \n";
       for(int i=0; i<NMO; i++)
        for(int j=0; j<NMO; j++)
         if(std::abs(Gph[i*NMO+j][0]-Gno[i*NMO+j][0]) > 1e-8)
-          std::cout<<i <<" " <<j <<" " <<Gph[i*NMO+j][0] <<" " <<Gno[i*NMO+j][0] <<" "
+          app_log()<<i <<" " <<j <<" " <<Gph[i*NMO+j][0] <<" " <<Gno[i*NMO+j][0] <<" "
                    <<std::abs(Gph[i*NMO+j][0]-Gno[i*NMO+j][0]) <<std::endl;
 #endif
 

--- a/src/Concurrency/tests/test_ParallelExecutorOPENMP.cpp
+++ b/src/Concurrency/tests/test_ParallelExecutorOPENMP.cpp
@@ -10,6 +10,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include "Platforms/Host/OutputManager.h"
 
 #include "Concurrency/ParallelExecutor.hpp"
 
@@ -35,7 +36,7 @@ TEST_CASE("ParallelExecutor<OPENMP> function case", "[concurrency]")
 TEST_CASE("ParallelExecutor<OPENMP> lambda case", "[concurrency]")
 {
   const int num_threads = omp_get_max_threads();
-  std::cout << "omp_get_max_threads() == " << num_threads << '\n';
+  app_log() << "omp_get_max_threads() == " << num_threads << '\n';
   ParallelExecutor<Executor::OPENMP> test_block;
   int count(0);
   test_block(

--- a/src/Containers/Pools/tests/test_pooled_memory.cpp
+++ b/src/Containers/Pools/tests/test_pooled_memory.cpp
@@ -114,24 +114,24 @@ TEST_CASE("pack scalar", "[utilities]")
       pm_walker.Current = size;
       Timer PoolTimer;
       pm_walker.allocate();
-      std::cout << "PooledMemory Allocate " << pm_walker.byteSize() << " bytes Time " << PoolTimer.elapsed()
+      app_log() << "PooledMemory Allocate " << pm_walker.byteSize() << " bytes Time " << PoolTimer.elapsed()
                 << std::endl;
       PoolTimer.restart();
       PooledMemory<double> pm_walker_copy(pm_walker);
-      std::cout << "PooledMemory Copy Time " << PoolTimer.elapsed() << std::endl;
+      app_log() << "PooledMemory Copy Time " << PoolTimer.elapsed() << std::endl;
     }
 
     {
       PooledData<double> pd_walker;
       Timer PoolTimer;
       pd_walker.resize(size / 8);
-      std::cout << "PooledData Allocate " << pd_walker.byteSize() << " bytes Time " << PoolTimer.elapsed() << std::endl;
+      app_log() << "PooledData Allocate " << pd_walker.byteSize() << " bytes Time " << PoolTimer.elapsed() << std::endl;
       PoolTimer.restart();
       PooledData<double> pd_walker_copy(pd_walker);
-      std::cout << "PooledData Copy Time " << PoolTimer.elapsed() << std::endl;
+      app_log() << "PooledData Copy Time " << PoolTimer.elapsed() << std::endl;
     }
 
-    std::cout << std::endl;
+    app_log() << std::endl;
   }
 #endif
 }

--- a/src/Estimators/tests/test_EnergyDensityEstimator.cpp
+++ b/src/Estimators/tests/test_EnergyDensityEstimator.cpp
@@ -169,7 +169,7 @@ TEST_CASE("NEEnergyDensityEstimator::AccumulateIntegration", "[estimators]")
   buffer.clear();
   e_den_est.packData(buffer);
   CHECK(buffer[buffer.size() - 1] == Approx(0.0));
-  std::cout << "wrote success\n";
+  app_log() << "wrote success\n";
 }
 
 TEST_CASE("NEEnergyDensityEstimator::Collect", "[estimators]")
@@ -234,7 +234,7 @@ TEST_CASE("NEEnergyDensityEstimator::Collect", "[estimators]")
   CHECK(summed_grid == Approx(expected_sum));
 
   e_den_est.write(hd);
-  std::cout << "wrote success\n";
+  app_log() << "wrote success\n";
 }
 
 } // namespace qmcplusplus

--- a/src/Estimators/tests/test_EnergyDensityEstimatorIntegration.cpp
+++ b/src/Estimators/tests/test_EnergyDensityEstimatorIntegration.cpp
@@ -110,7 +110,7 @@ TEST_CASE("EnergyDensityEstimatorIntegration::multirank_reduction", "[estimators
   auto expected_sum = pph_logger.sumOverSome({"local_potential"s, "kinetic_energy"s, "ion_potential"s});
   //Here we check the sum of logged energies against the total energy in the grid.
 
-  std::cout << "summed_grid: " << summed_grid << "  expected_sum: " << expected_sum << '\n';
+  app_log() << "summed_grid: " << summed_grid << "  expected_sum: " << expected_sum << '\n';
 
   CHECK(summed_grid == Approx(expected_sum));
 }
@@ -234,7 +234,7 @@ TEST_CASE("EnergyDensityEstimatorIntegration::normalization", "[estimators]")
   using namespace std::string_literals;
   auto expected_sum = pph_logger.sumOverSome({"local_potential"s, "kinetic_energy"s, "ion_potential"s});
 
-  std::cout << "expected_sum: " << expected_sum << '\n';
+  app_log() << "expected_sum: " << expected_sum << '\n';
 
   auto pset_list = eden_emn_integration_test.getPSetList();
   auto twf_list  = eden_emn_integration_test.getTwfList();
@@ -258,7 +258,7 @@ TEST_CASE("EnergyDensityEstimatorIntegration::normalization", "[estimators]")
   CHECK(summed_grid == Approx(debug_sum));
 #endif
 
-  std::cout << "summed grid: " << summed_grid << '\n';
+  app_log() << "summed grid: " << summed_grid << '\n';
 
   int num_steps = 4;
 
@@ -274,7 +274,7 @@ TEST_CASE("EnergyDensityEstimatorIntegration::normalization", "[estimators]")
 
     expected_sum2 += pph_logger.sumOverSome({"local_potential"s, "kinetic_energy"s, "ion_potential"s});
 
-    std::cout << "expected sum2: " << expected_sum2 << '\n';
+    app_log() << "expected sum2: " << expected_sum2 << '\n';
     emc.accumulate(walker_list, pset_list, twf_list, ham_list, rng);
 
     summed_grid = 0;
@@ -287,7 +287,7 @@ TEST_CASE("EnergyDensityEstimatorIntegration::normalization", "[estimators]")
   }
 
   auto block_weight = emc.get_block_weight();
-  std::cout << "block weight: " << block_weight << '\n';
+  app_log() << "block weight: " << block_weight << '\n';
   auto accept = num_walkers * pset_list[0].getTotalNum();
 
   RefVector<ScalarEstimatorBase> main_scalar_estimators;
@@ -309,12 +309,12 @@ TEST_CASE("EnergyDensityEstimatorIntegration::normalization", "[estimators]")
     summed_grid += *(app_grid.getDataVector().begin() + i * 3 + 2) + *(app_grid.getDataVector().begin() + i * 3 + 1);
   }
 
-  std::cout << "summed grid: " << summed_grid << '\n';
+  app_log() << "summed grid: " << summed_grid << '\n';
   CHECK(summed_grid == Approx(expected_sum + expected_sum2));
-  std::cout << "walkers weight: " << app_e_den_est.get_walkers_weight() << '\n';
+  app_log() << "walkers weight: " << app_e_den_est.get_walkers_weight() << '\n';
 
   emnta.stopBlockUpToWrite(accept, 0, block_weight);
-  std::cout << "walkers weight after reduction: " << app_e_den_est.get_walkers_weight() << '\n';
+  app_log() << "walkers weight after reduction: " << app_e_den_est.get_walkers_weight() << '\n';
 
   if (comm->rank() == 0)
   {
@@ -325,7 +325,7 @@ TEST_CASE("EnergyDensityEstimatorIntegration::normalization", "[estimators]")
     {
       summed_grid += *(app_grid.getDataVector().begin() + i * 3 + 2) + *(app_grid.getDataVector().begin() + i * 3 + 1);
     }
-    std::cout << "summed grid: " << summed_grid << '\n';
+    app_log() << "summed grid: " << summed_grid << '\n';
 
     // This is by 8 because expected_sum + expected_sum2 are only the local grids
     CHECK(summed_grid == Approx((expected_sum + expected_sum2) / (num_walkers * num_steps)));

--- a/src/Estimators/tests/test_EnergyDensityInput.cpp
+++ b/src/Estimators/tests/test_EnergyDensityInput.cpp
@@ -27,7 +27,7 @@ TEST_CASE("EnergyDensityInput::parseXML::valid", "[estimators]")
   int test_num = 0;
   for (auto input_xml : input)
   {
-    std::cout << "input number: " << test_num++ << '\n';
+    app_log() << "input number: " << test_num++ << '\n';
     Libxml2Document doc;
     REQUIRE(doc.parseFromString(input_xml));
     xmlNodePtr node = doc.getRoot();

--- a/src/Estimators/tests/test_InputSection.cpp
+++ b/src/Estimators/tests/test_InputSection.cpp
@@ -141,7 +141,7 @@ TEST_CASE("InputSection::readXML", "[estimators]")
     TestInputSection ti;
     ti.readXML(cur);
 
-    ti.report(std::cout);
+    ti.report(app_log());
 
     // assigned from xml
     CHECK(ti.has("full"));
@@ -194,7 +194,7 @@ TEST_CASE("InputSection::readXML", "[estimators]")
     TestInputSection ti;
     ti.readXML(cur);
 
-    ti.report(std::cout);
+    ti.report(app_log());
     // assigned from xml
     CHECK(ti.has("name"));
     CHECK(ti.has("samples"));
@@ -251,7 +251,7 @@ TEST_CASE("InputSection::readXML", "[estimators]")
 )"},
          {"invalid_section_name", R"(<not_test><parameter name="nothing"></parameter></not_test>)"}};
 
-    std::cout << "really going to try bad sections\n" << std::endl;
+    app_log() << "really going to try bad sections\n" << std::endl;
     for (auto& [label, xml] : invalid_inputs)
     {
       // parse xml doc
@@ -289,7 +289,7 @@ TEST_CASE("InputSection::init", "[estimators]")
     TestInputSection ti;
     ti.init({{"full", bool(false)}, {"count", int(15)}});
 
-    ti.report(std::cout);
+    ti.report(app_log());
 
     // assigned from initializer-list
     CHECK(ti.has("full"));
@@ -327,7 +327,7 @@ TEST_CASE("InputSection::init", "[estimators]")
              {"sposets", std::vector<std::string>{"spo1", "spo2"}},
              {"center", InputSection::Position(0.0, 0.0, 0.1)}});
 
-    ti.report(std::cout);
+    ti.report(app_log());
     // assigned from initializer-list
     CHECK(ti.has("name"));
     CHECK(ti.has("samples"));
@@ -486,7 +486,7 @@ TEST_CASE("InputSection::custom", "[estimators]")
   std::array<int, 3> exp_numbers{10, 20, 10};
   CHECK(ws.numbers == exp_numbers);
 
-  cti.report(std::cout);
+  cti.report(app_log());
   std::string custom_attribute = cti.get<std::string>("with_custom::custom_attribute");
   CHECK(custom_attribute == "This is a custom attribute.");
   custom_attribute = cti.get<std::string>("custom_attribute");

--- a/src/Estimators/tests/test_MomentumDistribution.cpp
+++ b/src/Estimators/tests/test_MomentumDistribution.cpp
@@ -192,10 +192,10 @@ TEST_CASE("MomentumDistribution::accumulate", "[estimators]")
               -9.4969045,    -9.470020717, -2.520417488,  -0.2024849597, -9.177741101, 21.82310933,   0.9716326509,
               0.08942598353, -5.130834919, 8.307662762,   4.78276286,    -5.752141485, 3.92261216};
 
-  //std::cout<<"\n\n\nn(k) data:\n{";
+  //app_log()<<"\n\n\nn(k) data:\n{";
   //for(int i=0;i<data.size();++i)
-  //  std::cout<<data[i]<<", ";
-  //std::cout<<"}\n\n\n";
+  //  app_log()<<data[i]<<", ";
+  //app_log()<<"}\n\n\n";
 
   for (size_t id = 0; id < ref_data.size(); ++id)
   {

--- a/src/Estimators/tests/test_NESpaceGrid.cpp
+++ b/src/Estimators/tests/test_NESpaceGrid.cpp
@@ -85,7 +85,7 @@ TEST_CASE("SpaceGrid::Construction", "[estimators]")
   NESpaceGrid<Real> space_grid(*(sge.sgi_), sge.ref_points_->get_points(), 1, false);
 
   using NES = testing::NESpaceGridTests<double>;
-  space_grid.write_description(std::cout, std::string(""));
+  space_grid.write_description(app_log(), std::string(""));
   auto& sgi = *(sge.sgi_);
   auto& agr = sgi.get_axis_grids();
   for (int id = 0; id < OHMMS_DIM; ++id)
@@ -105,7 +105,7 @@ TEST_CASE("SpaceGrid::CYLINDRICAL", "[estimators]")
   NESpaceGrid<Real> space_grid(*(sge.sgi_), sge.ref_points_->get_points(), 1, false);
 
   using NES = testing::NESpaceGridTests<double>;
-  space_grid.write_description(std::cout, std::string(""));
+  space_grid.write_description(app_log(), std::string(""));
   auto& sgi = *(sge.sgi_);
   auto& agr = sgi.get_axis_grids();
   for (int id = 0; id < OHMMS_DIM; ++id)
@@ -125,7 +125,7 @@ TEST_CASE("SpaceGrid::SPHERICAL", "[estimators]")
   NESpaceGrid<Real> space_grid(*(sge.sgi_), sge.ref_points_->get_points(), 1, false);
 
   using NES = testing::NESpaceGridTests<double>;
-  space_grid.write_description(std::cout, std::string(""));
+  space_grid.write_description(app_log(), std::string(""));
   auto& sgi = *(sge.sgi_);
   auto& agr = sgi.get_axis_grids();
   for (int id = 0; id < OHMMS_DIM; ++id)
@@ -142,7 +142,7 @@ TEST_CASE("SpaceGrid::Basic", "[estimators]")
   int num_values   = 3;
   NESpaceGrid<Real> space_grid(*(sge.sgi_), sge.ref_points_->get_points(), num_values, true);
   using NES = testing::NESpaceGridTests<double>;
-  space_grid.write_description(std::cout, std::string(""));
+  space_grid.write_description(app_log(), std::string(""));
   auto& sgi = *(sge.sgi_);
   auto& agr = sgi.get_axis_grids();
   for (int id = 0; id < OHMMS_DIM; ++id)
@@ -270,7 +270,7 @@ TEST_CASE("SpaceGrid::Accumulate::outside", "[estimators]")
   int num_values = 3;
   NESpaceGrid<Real> space_grid(*(sge.sgi_), sge.ref_points_->get_points(), num_values, false);
   using NES = testing::NESpaceGridTests<double>;
-  space_grid.write_description(std::cout, std::string(""));
+  space_grid.write_description(app_log(), std::string(""));
   auto& sgi = *(sge.sgi_);
   auto& agr = sgi.get_axis_grids();
   for (int id = 0; id < OHMMS_DIM; ++id)
@@ -301,12 +301,12 @@ TEST_CASE("SpaceGrid::Accumulate::outside", "[estimators]")
   sge.pset_elec_.R = min_R;
 
   sge.pset_elec_.update();
-  std::cout << NativePrint(p_outside) << '\n';
+  app_log() << NativePrint(p_outside) << '\n';
 
   std::vector<bool> p_outside_2(8, false);
   space_grid.accumulate(sge.pset_elec_.R, values, p_outside_2, sge.pset_elec_.getDistTableAB(ei_tid));
 
-  std::cout << NativePrint(p_outside_2) << '\n';
+  app_log() << NativePrint(p_outside_2) << '\n';
 }
 
 TEST_CASE("SpaceGrid::BadPeriodic", "[estimators]")
@@ -320,7 +320,7 @@ TEST_CASE("SpaceGrid::BadPeriodic", "[estimators]")
   NESpaceGrid<Real> space_grid(*(sge.sgi_), sge.ref_points_->get_points(), num_values, false);
 
   using NES = testing::NESpaceGridTests<double>;
-  space_grid.write_description(std::cout, std::string(""));
+  space_grid.write_description(app_log(), std::string(""));
   auto& sgi = *(sge.sgi_);
   auto& agr = sgi.get_axis_grids();
   for (int id = 0; id < OHMMS_DIM; ++id)
@@ -361,7 +361,7 @@ TEST_CASE("SpaceGrid::BadPeriodic", "[estimators]")
   }
   catch (const std::exception& exc)
   {
-    std::cout << exc.what() << '\n';
+    app_log() << exc.what() << '\n';
   }
 
 
@@ -395,16 +395,16 @@ TEST_CASE("SpaceGrid::WeirdCartesian", "[estimators]")
   int num_values = 3;
   NESpaceGrid<Real> space_grid(*(sge.sgi_), sge.ref_points_->get_points(), num_values, true);
   using NES = testing::NESpaceGridTests<double>;
-  space_grid.write_description(std::cout, std::string(""));
+  space_grid.write_description(app_log(), std::string(""));
   auto& sgi = *(sge.sgi_);
   auto& agr = sgi.get_axis_grids();
-  std::cout << "AxisGridDomains: ";
+  app_log() << "AxisGridDomains: ";
   for (int id = 0; id < OHMMS_DIM; ++id)
   {
     CHECK(NES::getOdu(space_grid)[id] == agr[id].odu);
-    std::cout << NativePrint(agr[id].ndom_int) << ',';
+    app_log() << NativePrint(agr[id].ndom_int) << ',';
   }
-  std::cout << '\n';
+  app_log() << '\n';
   //CHECK(buffer_start == 0);
   //CHECK(buffer_end == 23999);
 
@@ -484,7 +484,7 @@ TEST_CASE("SpaceGrid::hdf5", "[estimators]")
   int num_values   = 3;
   NESpaceGrid<Real> space_grid(*(sge.sgi_), sge.ref_points_->get_points(), num_values, false);
   using NES = testing::NESpaceGridTests<double>;
-  space_grid.write_description(std::cout, std::string(""));
+  space_grid.write_description(app_log(), std::string(""));
   auto& sgi = *(sge.sgi_);
   auto& agr = sgi.get_axis_grids();
   for (int id = 0; id < OHMMS_DIM; ++id)
@@ -616,10 +616,10 @@ TEST_CASE("SpaceGrid::collect", "[estimators]")
 
       //spot check
       auto grid_indexes = accumulating_space_grids[ia]->findGMapIndexes(pset_elec.R[0]);
-      std::cout << "grid_indexes: " << NativePrint(grid_indexes) << " value: " << val_for_part(0, 1, ia) << '\n';
+      app_log() << "grid_indexes: " << NativePrint(grid_indexes) << " value: " << val_for_part(0, 1, ia) << '\n';
       CHECK(tensorAccessor(*(accumulating_space_grids[ia]), grid_indexes, 2) == Approx(val_for_part(0, 2, ia)));
       grid_indexes = accumulating_space_grids[ia]->findGMapIndexes(pset_elec.R[3]);
-      std::cout << "grid_indexes: " << NativePrint(grid_indexes) << " value: " << val_for_part(3, 1, ia) << '\n';
+      app_log() << "grid_indexes: " << NativePrint(grid_indexes) << " value: " << val_for_part(3, 1, ia) << '\n';
       CHECK(tensorAccessor(*(accumulating_space_grids[ia]), grid_indexes, 2) == Approx(val_for_part(3, 2, ia)));
     }
   };

--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -222,7 +222,7 @@ public:
   }
 
   void dumpData(OneBodyDensityMatrices& obdm)
-  { std::cout << "Here is what is in your OneBodyDensityMatrices:\n" << NativePrint(obdm.data_) << '\n'; }
+  { app_log() << "Here is what is in your OneBodyDensityMatrices:\n" << NativePrint(obdm.data_) << '\n'; }
 
 private:
   Data getEvaluateMatrixData(OBDMI::Integrator integrator);
@@ -474,7 +474,7 @@ TEST_CASE("OneBodyDensityMatrices::evaluateMatrix", "[estimators]")
 
     std::string integrator_str =
         InputSection::reverseLookupInputEnumMap(obdmi.get_integrator(), testing::OBDMI::lookup_input_enum_value);
-    std::cout << "Test evaluateMatrix for: " << integrator_str << '\n';
+    app_log() << "Test evaluateMatrix for: " << integrator_str << '\n';
 
     auto particle_pool = MinimalParticlePool::make_diamondC_1x1x1(comm);
     auto wavefunction_pool =
@@ -524,7 +524,7 @@ TEST_CASE("OneBodyDensityMatrices::registerAndWrite", "[estimators]")
 
   std::string integrator_str =
       InputSection::reverseLookupInputEnumMap(obdmi.get_integrator(), testing::OBDMI::lookup_input_enum_value);
-  std::cout << "Test registerAndWrite for: " << integrator_str << '\n';
+  app_log() << "Test registerAndWrite for: " << integrator_str << '\n';
 
   auto particle_pool = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool =

--- a/src/Estimators/tests/test_ReferencePoints.cpp
+++ b/src/Estimators/tests/test_ReferencePoints.cpp
@@ -171,7 +171,7 @@ TEST_CASE("ReferencePoints::DefaultConstruction", "[estimators]")
   if (generate_test_data)
   {
     testing::TestableNEReferencePoints tref_points(ref_points);
-    std::cout << "expected_reference_points" << tref_points;
+    app_log() << "expected_reference_points" << tref_points;
   }
 
   typename NEReferencePoints::Points expected_reference_points;
@@ -193,7 +193,7 @@ TEST_CASE("ReferencePoints::Construction", "[estimators]")
   if (generate_test_data)
   {
     testing::TestableNEReferencePoints tref_points(ref_points);
-    std::cout << "expected_reference_points" << tref_points;
+    app_log() << "expected_reference_points" << tref_points;
   }
 
   typename NEReferencePoints::Points expected_reference_points;
@@ -279,7 +279,7 @@ TEST_CASE("ReferencePoints::Description", "[estimators]")
   std::string expected_testable_description;
   if constexpr (std::is_same_v<QMCTraits::RealType, float>)
   {
-    std::cout << "ParticleSet coords were float\n";
+    app_log() << "ParticleSet coords were float\n";
     expected_testable_description = R"({
  {"a1", {      3.37316115,3.37316115,0}},
  {"a2", {               0,3.37316115,3.37316115}},
@@ -309,7 +309,7 @@ TEST_CASE("ReferencePoints::Description", "[estimators]")
   }
   else
   {
-    std::cout << "ParticleSet coords were double\n";
+    app_log() << "ParticleSet coords were double\n";
     expected_testable_description = R"({
  {"a1", {      3.37316115,3.37316115,0}},
  {"a2", {               0,3.37316115,3.37316115}},

--- a/src/Estimators/tests/test_StructureFactorEstimator.cpp
+++ b/src/Estimators/tests/test_StructureFactorEstimator.cpp
@@ -162,7 +162,7 @@ TEST_CASE("StructureFactorEstimator::Accumulate", "[estimators]")
     // this is not an app_log() because generate_test_data should
     // never be true for merged production code. It is only for
     // developer use when the test data must be regenerated.
-    std::cout << "rng_reals = " << NativePrint(rng_reals) << '\n';
+    app_log() << "rng_reals = " << NativePrint(rng_reals) << '\n';
   }
   else
   {
@@ -276,7 +276,7 @@ TEST_CASE("StructureFactorEstimator::Accumulate", "[estimators]")
   };
   // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 
-  //std::cout << "kpoint_lists = " << NativePrint(sfe.getKLists().kpts) << '\n';
+  //app_log() << "kpoint_lists = " << NativePrint(sfe.getKLists().kpts) << '\n';
 
   double tolerance = 0.1;
   {
@@ -295,10 +295,10 @@ TEST_CASE("StructureFactorEstimator::Accumulate", "[estimators]")
 
   if constexpr (generate_test_data)
   {
-    std::cout << "sfk_e_e_expected = ";
-    std::cout << NativePrint(sfk_e_e) << '\n';
-    std::cout << "rhok_e_expected = ";
-    std::cout << NativePrint(rhok_e) << '\n';
+    app_log() << "sfk_e_e_expected = ";
+    app_log() << NativePrint(sfk_e_e) << '\n';
+    app_log() << "rhok_e_expected = ";
+    app_log() << NativePrint(rhok_e) << '\n';
     //    FAIL_CHECK("Test always fails when generating new test reference data.");
   }
 

--- a/src/Estimators/tests/test_accumulator.cpp
+++ b/src/Estimators/tests/test_accumulator.cpp
@@ -24,8 +24,8 @@ namespace qmcplusplus
 template<typename T>
 void test_real_accumulator_basic()
 {
-  //std::cout << "int eps = " << std::numeric_limits<T>::epsilon() << std::endl;
-  //std::cout << "int max = " << std::numeric_limits<T::max() << std::endl;
+  //app_log() << "int eps = " << std::numeric_limits<T>::epsilon() << std::endl;
+  //app_log() << "int max = " << std::numeric_limits<T::max() << std::endl;
   accumulator_set<T> a1;
   REQUIRE(a1.count() == 0);
   REQUIRE(a1.good() == false);

--- a/src/Numerics/tests/test_cartesian_tensor.cpp
+++ b/src/Numerics/tests/test_cartesian_tensor.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Cartesian Tensor", "[numerics]")
   ct.evaluate(pt);
 
   //for (int i = 0; i < 35; i++) {
-  //std::cout << "XYZ = " << i << " " << ct.getYlm(i) << std::endl;
+  //app_log() << "XYZ = " << i << " " << ct.getYlm(i) << std::endl;
   //}
   CHECK(ct.getYlm(0) == Approx(0.282094791774));
   CHECK(ct.getYlm(1) == Approx(0.635183265474));
@@ -130,7 +130,7 @@ TEST_CASE("Cartesian Tensor evaluateAll subset", "[numerics]")
   ct.evaluateAll(pt);
 
   //for (int i = 0; i < 35; i++) {
-  //  std::cout << "XYZ = " << i << " " << ct.getYlm(i) << " " << ct.getGradYlm(i) << "  " << ct.getLaplYlm(i) <<  std::endl;
+  //  app_log() << "XYZ = " << i << " " << ct.getYlm(i) << " " << ct.getGradYlm(i) << "  " << ct.getLaplYlm(i) <<  std::endl;
   //}
 
   CHECK(ct.getYlm(0) == Approx(0.282094791774));
@@ -184,7 +184,7 @@ TEST_CASE("Cartesian Tensor evaluateWithHessian subset", "[numerics]")
   ct.evaluateWithHessian(pt);
 
   //for (int i = 0; i < 35; i++) {
-  //  std::cout << "XYZ = " << i << " " << ct.getYlm(i) << " " << ct.getHessYlm(i) <<  std::endl;
+  //  app_log() << "XYZ = " << i << " " << ct.getYlm(i) << " " << ct.getHessYlm(i) <<  std::endl;
   //}
 
   CHECK(ct.getYlm(0) == Approx(0.282094791774));
@@ -291,7 +291,7 @@ TEST_CASE("Cartesian Tensor evaluateWithThirdDeriv subset", "[numerics]")
   ct.evaluateWithThirdDeriv(pt);
 
   //for (int i = 0; i < 35; i++) {
-  //  std::cout << "XYZ = " << i << " " << ct.getYlm(i) << " " << ct.getGGGYlm(i) <<  std::endl;
+  //  app_log() << "XYZ = " << i << " " << ct.getYlm(i) << " " << ct.getGGGYlm(i) <<  std::endl;
   //}
 
 

--- a/src/Numerics/tests/test_gaussian_basis.cpp
+++ b/src/Numerics/tests/test_gaussian_basis.cpp
@@ -31,17 +31,17 @@ TEST_CASE("Basic Gaussian", "[numerics]")
   real_type r = 1.2;
 
   real_type f = g1.f(r * r);
-  //std::cout << "f = " << f << std::endl << std::endl;
+  //app_log() << "f = " << f << std::endl << std::endl;
   CHECK(f == Approx(0.0132998835424438));
 
   real_type df = g1.df(r, r * r);
-  //std::cout << "df = " << df << std::endl << std::endl;
+  //app_log() << "df = " << df << std::endl << std::endl;
   CHECK(df == Approx(-0.0957591615055951));
 
   df            = 0.0;
   real_type ddf = 0.0;
   f             = g1.evaluate(r, r * r, df, ddf);
-  //std::cout << "f = " << f << " " << df << " " << ddf << std::endl;
+  //app_log() << "f = " << f << " " << df << " " << ddf << std::endl;
   CHECK(f == Approx(0.0132998835424438));
   CHECK(df == Approx(-0.0957591615055951));
   CHECK(ddf == Approx(0.609666661585622));
@@ -50,7 +50,7 @@ TEST_CASE("Basic Gaussian", "[numerics]")
   ddf           = 0.0;
   real_type d3f = 0.0;
   f             = g1.evaluate(r, r * r, df, ddf, d3f);
-  //std::cout << "f = " << f << " " << df << " " << ddf  << " " << d3f << std::endl;
+  //app_log() << "f = " << f << " " << df << " " << ddf  << " " << d3f << std::endl;
   CHECK(f == Approx(0.0132998835424438));
   CHECK(df == Approx(-0.0957591615055951));
   CHECK(ddf == Approx(0.609666661585622));
@@ -70,7 +70,7 @@ TEST_CASE("Gaussian Combo", "[numerics]")
 
   real_type r = 1.3;
   real_type f = gc.f(r);
-  //std::cout << "f = " << f << std::endl << std::endl;
+  //app_log() << "f = " << f << std::endl << std::endl;
   CHECK(f == Approx(0.556240444149480));
 
   f = gc.evaluate(r, 1.0 / r);

--- a/src/Numerics/tests/test_min_oned.cpp
+++ b/src/Numerics/tests/test_min_oned.cpp
@@ -34,10 +34,10 @@ public:
     RealType xa = bracket.a;
     RealType xb = bracket.b;
     RealType xc = bracket.c;
-    //std::cout << " xa = " << xa;
-    //std::cout << " xb = " << xb;
-    //std::cout << " xc = " << xc;
-    //std::cout << std::endl;
+    //app_log() << " xa = " << xa;
+    //app_log() << " xb = " << xb;
+    //app_log() << " xc = " << xc;
+    //app_log() << std::endl;
 
     REQUIRE(xa < xb);
     REQUIRE(xb < xc);

--- a/src/Numerics/tests/test_one_dim_cubic_spline.cpp
+++ b/src/Numerics/tests/test_one_dim_cubic_spline.cpp
@@ -144,7 +144,7 @@ TEST_CASE("one_dim_cubic_spline_1", "[numerics]")
     double val2 = cubic_spline.splint(r, du, d2u);
     check_yvals_d2u.push_back(D2U(val2, du, d2u));
 
-    //std::cout << i << " r = " << r << " val = " << val << " " << check_yvals[i] << std::endl;
+    //app_log() << i << " r = " << r << " val = " << val << " " << check_yvals[i] << std::endl;
   }
 
   CHECK(check_yvals[0] == Approx(1));

--- a/src/Particle/LongRange/tests/test_StructFact.cpp
+++ b/src/Particle/LongRange/tests/test_StructFact.cpp
@@ -64,7 +64,7 @@ TEST_CASE("StructFact", "[lrhandler]")
     for (int ik = 0; ik < simulation_cell.getKLists().getNumK(); ik++)
       rhok_sum += std::complex<QMCTraits::FullPrecRealType>(sk.rhok_r[i][ik], sk.rhok_i[i][ik]);
 
-    //std::cout << std::setprecision(14) << rhok_sum << std::endl;
+    //app_log() << std::setprecision(14) << rhok_sum << std::endl;
     CHECK(ComplexApprox(rhok_sum).epsilon(5e-5) == rhok_sum_ref[i]);
   }
 }

--- a/src/Particle/LongRange/tests/test_ewald3d.cpp
+++ b/src/Particle/LongRange/tests/test_ewald3d.cpp
@@ -44,7 +44,7 @@ TEST_CASE("ewald3d", "[lrhandler]")
   handler.initBreakup(ref);
   CHECK(handler.Sigma == Approx(std::sqrt(lattice.LR_kc / (2.0 * lattice.LR_rc))));
 
-  std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
+  app_log() << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
   CHECK(handler.MaxKshell == 78);
   CHECK(handler.LR_rc == Approx(2.5));
   CHECK(handler.LR_kc == Approx(12));
@@ -92,7 +92,7 @@ TEST_CASE("ewald3d df", "[lrhandler]")
   handler.initBreakup(ref);
   CHECK(handler.Sigma == Approx(std::sqrt(lattice.LR_kc / (2.0 * lattice.LR_rc))));
 
-  std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
+  app_log() << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
   CHECK(handler.MaxKshell == 78);
   CHECK(handler.LR_rc == Approx(2.5));
   CHECK(handler.LR_kc == Approx(12));

--- a/src/Particle/LongRange/tests/test_lrhandler.cpp
+++ b/src/Particle/LongRange/tests/test_lrhandler.cpp
@@ -46,7 +46,7 @@ TEST_CASE("dummy", "[lrhandler]")
 
   handler.initBreakup(ref);
 
-  std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
+  app_log() << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
   CHECK( handler.MaxKshell == 78);
   CHECK(handler.LR_kc == Approx(12));
   CHECK(handler.LR_rc == Approx(0));

--- a/src/Particle/LongRange/tests/test_srcoul.cpp
+++ b/src/Particle/LongRange/tests/test_srcoul.cpp
@@ -52,7 +52,7 @@ TEST_CASE("srcoul", "[lrhandler]")
 
   handler.initBreakup(ref);
 
-  std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
+  app_log() << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
   CHECK( handler.MaxKshell == 78);
   CHECK(Approx(handler.LR_rc) == 2.5);
   CHECK(Approx(handler.LR_kc) == 12);
@@ -96,7 +96,7 @@ TEST_CASE("srcoul df", "[lrhandler]")
 
   handler.initBreakup(ref);
 
-  std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
+  app_log() << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
   CHECK( handler.MaxKshell == 78);
   CHECK(Approx(handler.LR_rc) == 2.5);
   CHECK(Approx(handler.LR_kc) == 12);

--- a/src/Particle/LongRange/tests/test_temp.cpp
+++ b/src/Particle/LongRange/tests/test_temp.cpp
@@ -53,7 +53,7 @@ TEST_CASE("temp3d", "[lrhandler]")
 
   handler.initBreakup(ref);
 
-  std::cout << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
+  app_log() << "handler.MaxKshell is " << handler.MaxKshell << std::endl;
   CHECK( handler.MaxKshell == 78);
   CHECK(Approx(handler.LR_rc) == 2.5);
   CHECK(Approx(handler.LR_kc) == 12);

--- a/src/Particle/tests/test_SoaDistanceTableAA.cpp
+++ b/src/Particle/tests/test_SoaDistanceTableAA.cpp
@@ -43,7 +43,7 @@ TEST_CASE("SoaDistanceTableAA compute_size", "[distance_table]")
   // run checks
   if (Alignment == 4 || Alignment == 8)
   {
-    std::cout << "testing Alignment = " << Alignment << std::endl;
+    app_log() << "testing Alignment = " << Alignment << std::endl;
     for (int i = 0; i < ref_results.size(); i++)
       CHECK(dt_ee.compute_size(i) == ref_results[i]);
   }

--- a/src/Particle/tests/test_particle_pool.cpp
+++ b/src/Particle/tests/test_particle_pool.cpp
@@ -70,8 +70,8 @@ TEST_CASE("ParticleSetPool", "[qmcapp]")
 
   std::stringstream out;
   pp.get(out);
-  //std::cout << "ParticleSetPool::get returns  " << std::endl;
-  //std::cout << out.str() << std::endl;
+  //app_log() << "ParticleSetPool::get returns  " << std::endl;
+  //app_log() << out.str() << std::endl;
 }
 
 TEST_CASE("ParticleSetPool random", "[qmcapp]")

--- a/src/Platforms/tests/CPU/test_aligned_allocator.cpp
+++ b/src/Platforms/tests/CPU/test_aligned_allocator.cpp
@@ -9,6 +9,7 @@
 // File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Platforms/Host/OutputManager.h"
 
 #include <iostream>
 #include "config.h"
@@ -21,20 +22,20 @@ TEST_CASE("Aligned allocator", "[numerics]")
   bool not_aligned;
 
   aligned_vector<float> a(311);
-  std::cout << "address=" << a.data() << " require=" << (void*)(QMC_SIMD_ALIGNMENT - 1) << std::endl;
+  app_log() << "address=" << a.data() << " require=" << (void*)(QMC_SIMD_ALIGNMENT - 1) << std::endl;
   not_aligned = (size_t)a.data() & (QMC_SIMD_ALIGNMENT - 1);
   REQUIRE(!not_aligned);
   a.resize(829);
-  std::cout << "address=" << a.data() << " require=" << (void*)(QMC_SIMD_ALIGNMENT - 1) << std::endl;
+  app_log() << "address=" << a.data() << " require=" << (void*)(QMC_SIMD_ALIGNMENT - 1) << std::endl;
   not_aligned = (size_t)a.data() & (QMC_SIMD_ALIGNMENT - 1);
   REQUIRE(!not_aligned);
 
   aligned_vector<double> b(311);
-  std::cout << "address=" << b.data() << " require=" << (void*)(QMC_SIMD_ALIGNMENT - 1) << std::endl;
+  app_log() << "address=" << b.data() << " require=" << (void*)(QMC_SIMD_ALIGNMENT - 1) << std::endl;
   not_aligned = (size_t)b.data() & (QMC_SIMD_ALIGNMENT - 1);
   REQUIRE(!not_aligned);
   b.resize(829);
-  std::cout << "address=" << b.data() << " require=" << (void*)(QMC_SIMD_ALIGNMENT - 1) << std::endl;
+  app_log() << "address=" << b.data() << " require=" << (void*)(QMC_SIMD_ALIGNMENT - 1) << std::endl;
   not_aligned = (size_t)b.data() & (QMC_SIMD_ALIGNMENT - 1);
   REQUIRE(!not_aligned);
 }

--- a/src/Platforms/tests/OMPTarget/test_class_member.cpp
+++ b/src/Platforms/tests/OMPTarget/test_class_member.cpp
@@ -9,6 +9,7 @@
 // File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Platforms/Host/OutputManager.h"
 
 #include <memory>
 #include <vector>
@@ -44,7 +45,7 @@ struct maptest
         set_value(i, newdata, data);
     }
     PRAGMA_OFFLOAD("omp target exit data map(delete:data[0:6])")
-    std::cout << "data[5] = " << data[5] << std::endl;
+    app_log() << "data[5] = " << data[5] << std::endl;
   }
 };
 

--- a/src/Platforms/tests/OMPTarget/test_deep_copy.cpp
+++ b/src/Platforms/tests/OMPTarget/test_deep_copy.cpp
@@ -9,6 +9,7 @@
 // File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Platforms/Host/OutputManager.h"
 
 #include <memory>
 #include <vector>
@@ -60,11 +61,11 @@ TEST_CASE("OMPdeepcopy", "[OMP]")
     check_address3 = foo;
   }
 
-  std::cout << "foo->data value on the host " << foo->data << std::endl;
-  std::cout << "foo->data value on the device " << check_address2 << std::endl;
-  std::cout << "foo->data mapped address on the device " << check_address1 << std::endl;
-  std::cout << "foo value on the host " << foo << std::endl;
-  std::cout << "foo mapped address on the device " << check_address3 << std::endl;
+  app_log() << "foo->data value on the host " << foo->data << std::endl;
+  app_log() << "foo->data value on the device " << check_address2 << std::endl;
+  app_log() << "foo->data mapped address on the device " << check_address1 << std::endl;
+  app_log() << "foo value on the host " << foo << std::endl;
+  app_log() << "foo mapped address on the device " << check_address3 << std::endl;
 
   REQUIRE(check_data1 == 1.0);
   REQUIRE(check_size == MAX);

--- a/src/Platforms/tests/OMPTarget/test_ompBLAS.cpp
+++ b/src/Platforms/tests/OMPTarget/test_ompBLAS.cpp
@@ -10,6 +10,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
+#include "Platforms/Host/OutputManager.h"
 
 #include <memory>
 #include <vector>
@@ -150,28 +151,28 @@ TEST_CASE("ompBLAS gemm", "[OMP]")
   const int K = 23;
 
   // Non-batched test
-  std::cout << "Testing NN gemm" << std::endl;
+  app_log() << "Testing NN gemm" << std::endl;
   test_gemm<float>(M, N, K, 'N', 'N');
   test_gemm<double>(M, N, K, 'N', 'N');
 #if defined(QMC_COMPLEX)
   test_gemm<std::complex<float>>(N, M, K, 'N', 'N');
   test_gemm<std::complex<double>>(N, M, K, 'N', 'N');
 #endif
-  std::cout << "Testing NT gemm" << std::endl;
+  app_log() << "Testing NT gemm" << std::endl;
   test_gemm<float>(M, N, K, 'N', 'T');
   test_gemm<double>(M, N, K, 'N', 'T');
 #if defined(QMC_COMPLEX)
   test_gemm<std::complex<float>>(N, M, K, 'N', 'T');
   test_gemm<std::complex<double>>(N, M, K, 'N', 'T');
 #endif
-  std::cout << "Testing TN gemm" << std::endl;
+  app_log() << "Testing TN gemm" << std::endl;
   test_gemm<float>(M, N, K, 'T', 'N');
   test_gemm<double>(M, N, K, 'T', 'N');
 #if defined(QMC_COMPLEX)
   test_gemm<std::complex<float>>(N, M, K, 'T', 'N');
   test_gemm<std::complex<double>>(N, M, K, 'T', 'N');
 #endif
-  std::cout << "Testing TT gemm" << std::endl;
+  app_log() << "Testing TT gemm" << std::endl;
   test_gemm<float>(M, N, K, 'T', 'T');
   test_gemm<double>(M, N, K, 'T', 'T');
 #if defined(QMC_COMPLEX)
@@ -348,7 +349,7 @@ TEST_CASE("ompBLAS gemv", "[OMP]")
   const int batch_count = 23;
 
   // Non-batched test
-  std::cout << "Testing TRANS gemv" << std::endl;
+  app_log() << "Testing TRANS gemv" << std::endl;
   test_gemv<float>(M, N, 'T');
   test_gemv<double>(M, N, 'T');
 #if defined(QMC_COMPLEX)
@@ -356,7 +357,7 @@ TEST_CASE("ompBLAS gemv", "[OMP]")
   test_gemv<std::complex<double>>(N, M, 'T');
 #endif
   // Batched Test
-  std::cout << "Testing TRANS gemv_batched" << std::endl;
+  app_log() << "Testing TRANS gemv_batched" << std::endl;
   test_gemv_batched<float>(M, N, 'T', batch_count);
   test_gemv_batched<double>(M, N, 'T', batch_count);
 #if defined(QMC_COMPLEX)
@@ -372,7 +373,7 @@ TEST_CASE("ompBLAS gemv notrans", "[OMP]")
   const int batch_count = 23;
 
   // Non-batched test
-  std::cout << "Testing NOTRANS gemv" << std::endl;
+  app_log() << "Testing NOTRANS gemv" << std::endl;
   test_gemv<float>(M, N, 'N');
   test_gemv<double>(M, N, 'N');
 #if defined(QMC_COMPLEX)
@@ -380,7 +381,7 @@ TEST_CASE("ompBLAS gemv notrans", "[OMP]")
   test_gemv<std::complex<double>>(N, M, 'N');
 #endif
   // Batched Test
-  std::cout << "Testing NOTRANS gemv_batched" << std::endl;
+  app_log() << "Testing NOTRANS gemv_batched" << std::endl;
   test_gemv_batched<float>(M, N, 'N', batch_count);
   test_gemv_batched<double>(M, N, 'N', batch_count);
 #if defined(QMC_COMPLEX)
@@ -535,7 +536,7 @@ TEST_CASE("ompBLAS ger", "[OMP]")
   const int batch_count = 23;
 
   // Non-batched test
-  std::cout << "Testing ger" << std::endl;
+  app_log() << "Testing ger" << std::endl;
   test_ger<float>(M, N);
   test_ger<double>(M, N);
 #if defined(QMC_COMPLEX)
@@ -543,7 +544,7 @@ TEST_CASE("ompBLAS ger", "[OMP]")
   test_ger<std::complex<double>>(N, M);
 #endif
   // Batched Test
-  std::cout << "Testing ger_batched" << std::endl;
+  app_log() << "Testing ger_batched" << std::endl;
   test_ger_batched<float>(M, N, batch_count);
   test_ger_batched<double>(M, N, batch_count);
 #if defined(QMC_COMPLEX)

--- a/src/Platforms/tests/OMPTarget/test_runtime_mem.cpp
+++ b/src/Platforms/tests/OMPTarget/test_runtime_mem.cpp
@@ -9,6 +9,7 @@
 // File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Platforms/Host/OutputManager.h"
 
 #include <iostream>
 #include "config.h"
@@ -23,7 +24,7 @@ TEST_CASE("OMP runtime memory", "[OMP]")
     // intentional empty target to initialize offload runtime library.
   }
 
-  print_mem("OMP runtime memory", std::cout);
+  print_mem("OMP runtime memory", app_log());
 }
 
 } // namespace qmcplusplus

--- a/src/Platforms/tests/SYCL/test_SYCLallocator.cpp
+++ b/src/Platforms/tests/SYCL/test_SYCLallocator.cpp
@@ -53,7 +53,7 @@ TEST_CASE("SYCL_shared_allocator", "[SYCL]")
   sycl::queue m_queue = getSYCLDefaultDeviceDefaultQueue();
   Vector<double, SYCLSharedAllocator<double>> vec(1024);
 
-  std::cout << "Size " << vec.size() << std::endl;
+  app_log() << "Size " << vec.size() << std::endl;
   {
     double* V = vec.data();
     m_queue.parallel_for(sycl::range<1>{1024}, [=](sycl::id<1> item) { V[item] = item + 1; }).wait();

--- a/src/Platforms/tests/SYCL/test_syclBLAS.cpp
+++ b/src/Platforms/tests/SYCL/test_syclBLAS.cpp
@@ -192,7 +192,7 @@ TEST_CASE("OmpBLAS gemv", "[SYCL]")
   const int batch_count = 23;
 
   // Non-batched test
-  std::cout << "Testing TRANS gemv" << std::endl;
+  app_log() << "Testing TRANS gemv" << std::endl;
   test_gemv<float>(M, N, 'T');
   test_gemv<double>(M, N, 'T');
 #if defined(QMC_COMPLEX)
@@ -200,7 +200,7 @@ TEST_CASE("OmpBLAS gemv", "[SYCL]")
   test_gemv<std::complex<double>>(N, M, 'T');
 #endif
   // Batched Test
-  std::cout << "Testing TRANS gemv_batched" << std::endl;
+  app_log() << "Testing TRANS gemv_batched" << std::endl;
   test_gemv_batched<float>(M, N, 'T', batch_count);
   test_gemv_batched<double>(M, N, 'T', batch_count);
 #if defined(QMC_COMPLEX)
@@ -216,7 +216,7 @@ TEST_CASE("OmpBLAS gemv notrans", "[SYCL]")
   const int batch_count = 23;
 
   // Non-batched test
-  std::cout << "Testing NOTRANS gemv" << std::endl;
+  app_log() << "Testing NOTRANS gemv" << std::endl;
   test_gemv<float>(M, N, 'N');
   test_gemv<double>(M, N, 'N');
 #if defined(QMC_COMPLEX)
@@ -224,7 +224,7 @@ TEST_CASE("OmpBLAS gemv notrans", "[SYCL]")
   test_gemv<std::complex<double>>(N, M, 'N');
 #endif
   // Batched Test
-  std::cout << "Testing NOTRANS gemv_batched" << std::endl;
+  app_log() << "Testing NOTRANS gemv_batched" << std::endl;
   test_gemv_batched<float>(M, N, 'N', batch_count);
   test_gemv_batched<double>(M, N, 'N', batch_count);
 #if defined(QMC_COMPLEX)
@@ -335,7 +335,7 @@ TEST_CASE("OmpBLAS ger", "[SYCL]")
   const int batch_count = 23;
 
   // Batched Test
-  std::cout << "Testing ger_batched" << std::endl;
+  app_log() << "Testing ger_batched" << std::endl;
   test_ger_batched<float>(M, N, batch_count);
   test_ger_batched<double>(M, N, batch_count);
 #if defined(QMC_COMPLEX)

--- a/src/Platforms/tests/test_AccelBLAS.cpp
+++ b/src/Platforms/tests/test_AccelBLAS.cpp
@@ -10,6 +10,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
 #include "Utilities/for_testing/Catch2Approx.h"
+#include "Platforms/Host/OutputManager.h"
 
 #include <DualAllocatorAliases.hpp>
 #include <AccelBLAS.hpp>
@@ -144,28 +145,28 @@ void test_gemm_cases()
   const int K = 23;
 
   // Non-batched test
-  std::cout << "Testing NN gemm" << std::endl;
+  app_log() << "Testing NN gemm" << std::endl;
   test_one_gemm<PL, float>(M, N, K, 'N', 'N');
   test_one_gemm<PL, double>(M, N, K, 'N', 'N');
 #if defined(QMC_COMPLEX)
   test_one_gemm<PL, std::complex<float>>(N, M, K, 'N', 'N');
   test_one_gemm<PL, std::complex<double>>(N, M, K, 'N', 'N');
 #endif
-  std::cout << "Testing NT gemm" << std::endl;
+  app_log() << "Testing NT gemm" << std::endl;
   test_one_gemm<PL, float>(M, N, K, 'N', 'T');
   test_one_gemm<PL, double>(M, N, K, 'N', 'T');
 #if defined(QMC_COMPLEX)
   test_one_gemm<PL, std::complex<float>>(N, M, K, 'N', 'T');
   test_one_gemm<PL, std::complex<double>>(N, M, K, 'N', 'T');
 #endif
-  std::cout << "Testing TN gemm" << std::endl;
+  app_log() << "Testing TN gemm" << std::endl;
   test_one_gemm<PL, float>(M, N, K, 'T', 'N');
   test_one_gemm<PL, double>(M, N, K, 'T', 'N');
 #if defined(QMC_COMPLEX)
   test_one_gemm<PL, std::complex<float>>(N, M, K, 'T', 'N');
   test_one_gemm<PL, std::complex<double>>(N, M, K, 'T', 'N');
 #endif
-  std::cout << "Testing TT gemm" << std::endl;
+  app_log() << "Testing TT gemm" << std::endl;
   test_one_gemm<PL, float>(M, N, K, 'T', 'T');
   test_one_gemm<PL, double>(M, N, K, 'T', 'T');
 #if defined(QMC_COMPLEX)
@@ -298,14 +299,14 @@ void test_gemv_cases()
   const int M = 137;
   const int N = 79;
 
-  std::cout << "Testing NOTRANS gemv" << std::endl;
+  app_log() << "Testing NOTRANS gemv" << std::endl;
   test_one_gemv<PL, float>(M, N, 'N');
   test_one_gemv<PL, double>(M, N, 'N');
 #if defined(QMC_COMPLEX)
   test_one_gemv<PL, std::complex<float>>(N, M, 'N');
   test_one_gemv<PL, std::complex<double>>(N, M, 'N');
 #endif
-  std::cout << "Testing TRANS gemv" << std::endl;
+  app_log() << "Testing TRANS gemv" << std::endl;
   test_one_gemv<PL, float>(M, N, 'T');
   test_one_gemv<PL, double>(M, N, 'T');
 #if defined(QMC_COMPLEX)
@@ -438,7 +439,7 @@ void test_ger_cases()
   const int N = 79;
 
   // Batched Test
-  std::cout << "Testing ger_batched" << std::endl;
+  app_log() << "Testing ger_batched" << std::endl;
   test_one_ger<PL, float>(M, N);
   test_one_ger<PL, double>(M, N);
 #if defined(QMC_COMPLEX)
@@ -499,7 +500,7 @@ void test_copy_cases()
 {
   const int n = 137;
 
-  std::cout << "Testing copy_batched" << std::endl;
+  app_log() << "Testing copy_batched" << std::endl;
   test_one_copy<PL, float>(n);
   test_one_copy<PL, double>(n);
 #if defined(QMC_COMPLEX)
@@ -513,15 +514,15 @@ TEST_CASE("AccelBLAS", "[BLAS]")
   SECTION("gemm")
   {
 #if defined(ENABLE_CUDA)
-    std::cout << "Testing gemm<PlatformKind::CUDA>" << std::endl;
+    app_log() << "Testing gemm<PlatformKind::CUDA>" << std::endl;
     test_gemm_cases<PlatformKind::CUDA>();
 #endif
 #if defined(ENABLE_SYCL)
-    std::cout << "Testing gemm<PlatformKind::SYCL>" << std::endl;
+    app_log() << "Testing gemm<PlatformKind::SYCL>" << std::endl;
     test_gemm_cases<PlatformKind::SYCL>();
 #endif
 #if defined(ENABLE_OFFLOAD)
-    std::cout << "Testing gemm<PlatformKind::OMPTARGET>" << std::endl;
+    app_log() << "Testing gemm<PlatformKind::OMPTARGET>" << std::endl;
     test_gemm_cases<PlatformKind::OMPTARGET>();
 #endif
   }
@@ -529,15 +530,15 @@ TEST_CASE("AccelBLAS", "[BLAS]")
   SECTION("gemv")
   {
 #if defined(ENABLE_CUDA)
-    std::cout << "Testing gemm<PlatformKind::CUDA>" << std::endl;
+    app_log() << "Testing gemm<PlatformKind::CUDA>" << std::endl;
     test_gemv_cases<PlatformKind::CUDA>();
 #endif
 #if defined(ENABLE_SYCL)
-    std::cout << "Testing gemm<PlatformKind::SYCL>" << std::endl;
+    app_log() << "Testing gemm<PlatformKind::SYCL>" << std::endl;
     test_gemv_cases<PlatformKind::SYCL>();
 #endif
 #if defined(ENABLE_OFFLOAD)
-    std::cout << "Testing gemm<PlatformKind::OMPTARGET>" << std::endl;
+    app_log() << "Testing gemm<PlatformKind::OMPTARGET>" << std::endl;
     test_gemv_cases<PlatformKind::OMPTARGET>();
 #endif
   }
@@ -545,15 +546,15 @@ TEST_CASE("AccelBLAS", "[BLAS]")
   SECTION("ger")
   {
 #if defined(ENABLE_CUDA)
-    std::cout << "Testing ger<PlatformKind::CUDA>" << std::endl;
+    app_log() << "Testing ger<PlatformKind::CUDA>" << std::endl;
     test_ger_cases<PlatformKind::CUDA>();
 #endif
 #if defined(ENABLE_SYCL)
-    std::cout << "Testing ger<PlatformKind::SYCL>" << std::endl;
+    app_log() << "Testing ger<PlatformKind::SYCL>" << std::endl;
     test_ger_cases<PlatformKind::SYCL>();
 #endif
 #if defined(ENABLE_OFFLOAD)
-    std::cout << "Testing ger<PlatformKind::OMPTARGET>" << std::endl;
+    app_log() << "Testing ger<PlatformKind::OMPTARGET>" << std::endl;
     test_ger_cases<PlatformKind::OMPTARGET>();
 #endif
   }
@@ -561,15 +562,15 @@ TEST_CASE("AccelBLAS", "[BLAS]")
   SECTION("copy")
   {
 #if defined(ENABLE_CUDA)
-    std::cout << "Testing copy<PlatformKind::CUDA>" << std::endl;
+    app_log() << "Testing copy<PlatformKind::CUDA>" << std::endl;
     test_copy_cases<PlatformKind::CUDA>();
 #endif
 #if defined(ENABLE_SYCL)
-    std::cout << "Testing copy<PlatformKind::SYCL>" << std::endl;
+    app_log() << "Testing copy<PlatformKind::SYCL>" << std::endl;
     test_copy_cases<PlatformKind::SYCL>();
 #endif
 #if defined(ENABLE_OFFLOAD)
-    std::cout << "Testing copy<PlatformKind::OMPTARGET>" << std::endl;
+    app_log() << "Testing copy<PlatformKind::OMPTARGET>" << std::endl;
     test_copy_cases<PlatformKind::OMPTARGET>();
 #endif
   }

--- a/src/QMCDrivers/tests/test_MCPopulation.cpp
+++ b/src/QMCDrivers/tests/test_MCPopulation.cpp
@@ -143,7 +143,7 @@ TEST_CASE("MCPopulation::createWalkers_walker_ids", "[particle][population]")
     std::generate(rank_expected_ids.begin(), rank_expected_ids.end(),
                   [n = 0, rank, num_ranks]() mutable { return (n++) * num_ranks + rank + 1; });
     CHECK(per_rank_walker_ids[rank] == rank_expected_ids);
-    std::cout << NativePrint(rank_expected_ids) << '\n';
+    app_log() << NativePrint(rank_expected_ids) << '\n';
   }
 }
 

--- a/src/QMCDrivers/tests/test_QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/tests/test_QMCCostFunctionBase.cpp
@@ -47,8 +47,8 @@ public:
     char* buf;
     int out_buflen;
     xmlDocDumpFormatMemory(m_doc_out, (xmlChar**)&buf, &out_buflen, 1);
-    std::cout << "XML buffer length = " << out_buflen << std::endl;
-    std::cout << "XML: " << std::endl << buf << std::endl;
+    app_log() << "XML buffer length = " << out_buflen << std::endl;
+    app_log() << "XML: " << std::endl << buf << std::endl;
     xmlFree(buf);
   }
 

--- a/src/QMCDrivers/tests/test_WFOptDriverInput.cpp
+++ b/src/QMCDrivers/tests/test_WFOptDriverInput.cpp
@@ -40,7 +40,7 @@ TEST_CASE("WFOptDriverInput readXML", "[drivers]")
     }
     else
     {
-      std::cout << "Unknown opt method: " << wfoptdriver_input.get_opt_method() << std::endl;
+      app_log() << "Unknown opt method: " << wfoptdriver_input.get_opt_method() << std::endl;
       REQUIRE(false); // optimizer method name not one of the two options
     }
   };

--- a/src/QMCDrivers/tests/test_WalkerControl.cpp
+++ b/src/QMCDrivers/tests/test_WalkerControl.cpp
@@ -22,7 +22,6 @@
 #include "QMCDrivers/MCPopulation.h"
 #include "Utilities/MPIExceptionWrapper.hpp"
 #include "Utilities/for_testing/NativeInitializerPrint.hpp"
-#include "Platforms/Host/OutputManager.h"
 
 
 //#include "Concurrency/Info.hpp"
@@ -83,7 +82,7 @@ TEST_CASE("WalkerControl::determineNewWalkerPopulation", "[drivers][walker_contr
   int rank = test.getRank();
   app_log() << "rank:" << rank << " minus: " << NativePrint(minus) << std::endl;
 
-  std::cout << "rank:" << rank << " plus: " << NativePrint(plus) << std::endl;
+  app_log() << "rank:" << rank << " plus: " << NativePrint(plus) << std::endl;
   CHECK(minus.size() == num_ranks - 1);
   CHECK(plus.size() == num_ranks - 1);
   app_log() << "rank:" << rank << " plus: " << NativePrint(num_per_rank) << std::endl;
@@ -130,7 +129,7 @@ void testing::UnifiedDriverWalkerControlMPITest::testWalkerIDs(std::vector<std::
     walker_ids.push_back(pop_->get_walkers()[iw]->getWalkerID());
     parent_ids.push_back(pop_->get_walkers()[iw]->getParentID());
   }
-  std::cout << "rank: " << rank << "  walker ids: " << NativePrint(walker_ids)
+  app_log() << "rank: " << rank << "  walker ids: " << NativePrint(walker_ids)
             << " parent ids: " << NativePrint(parent_ids) << std::endl;
 #endif
   for (int iw = 0; iw < walker_ids_after[rank].size(); ++iw)

--- a/src/QMCDrivers/tests/test_walker_control.cpp
+++ b/src/QMCDrivers/tests/test_walker_control.cpp
@@ -32,15 +32,15 @@ namespace qmcplusplus
 {
 void output_vector(const std::string& name, std::vector<int>& vec)
 {
-  std::cout << name;
+  app_log() << name;
   for (int i = 0; i < vec.size(); i++)
   {
-    std::cout << vec[i] << " ";
+    app_log() << vec[i] << " ";
   }
-  std::cout << std::endl;
+  app_log() << std::endl;
 }
 
-// uncomment the std::cout and output_vector lines to see the walker assignments
+// uncomment the app_log() and output_vector lines to see the walker assignments
 TEST_CASE("Walker control assign walkers", "[drivers][walker_control]")
 {
   int Cur_pop     = 8;
@@ -58,7 +58,7 @@ TEST_CASE("Walker control assign walkers", "[drivers][walker_control]")
     std::vector<int> plus;
     std::vector<int> num_per_rank = NumPerRank;
 
-    //std::cout << "For processor number " << me << std::endl;
+    //app_log() << "For processor number " << me << std::endl;
     WalkerControlMPI::determineNewWalkerPopulation(Cur_pop, NumContexts, me, num_per_rank, FairOffset, minus, plus);
 
     REQUIRE(minus.size() == plus.size());
@@ -114,7 +114,7 @@ TEST_CASE("WalkerControl round trip index conversions", "[drivers][walker_contro
   REQUIRE(all_pass);
 }
 
-// uncomment the std::cout and output_vector lines to see the walker assignments
+// uncomment the app_log() and output_vector lines to see the walker assignments
 TEST_CASE("Walker control assign walkers odd ranks", "[drivers][walker_control]")
 {
   int Cur_pop                 = 9;
@@ -128,7 +128,7 @@ TEST_CASE("Walker control assign walkers odd ranks", "[drivers][walker_control]"
     std::vector<int> minus;
     std::vector<int> plus;
     std::vector<int> num_per_rank = NumPerRank;
-    //std::cout << "For processor number " << me << std::endl;
+    //app_log() << "For processor number " << me << std::endl;
     WalkerControlMPI::determineNewWalkerPopulation(Cur_pop, NumContexts, me, num_per_rank, FairOffset, minus, plus);
 
     REQUIRE(minus.size() == plus.size());
@@ -194,8 +194,8 @@ TEST_CASE("Walker control assign walkers many", "[drivers][walker_control][prope
       }
       NumPerRank[i] = p;
     }
-    //std::cout << "NumNodes = " << NumContexts << std::endl;
-    //std::cout << "TotalPop = " << Cur_pop << std::endl;
+    //app_log() << "NumNodes = " << NumContexts << std::endl;
+    //app_log() << "TotalPop = " << Cur_pop << std::endl;
     //output_vector("Start: ",NumPerRank);
 
     std::vector<int> NewNum = NumPerRank;
@@ -288,7 +288,7 @@ struct WalkerControlMPITest
 
       wc.swapWalkersSimple(W);
 
-      //std::cout << " Rank = " << c->rank() << " good size = " << wc.good_w.size() <<
+      //app_log() << " Rank = " << c->rank() << " good size = " << wc.good_w.size() <<
       //          " ID = " << wc.good_w[0]->ID << std::endl;
 
       if (c->rank() == c->size() - 2)
@@ -397,10 +397,10 @@ private:
     c->allreduce(rank_walker_count);
     if (c->rank() == 0)
     {
-      std::cout << "Walkers Per Rank (Total: " << wc.Cur_pop << ")\n";
+      app_log() << "Walkers Per Rank (Total: " << wc.Cur_pop << ")\n";
       for (int i = 0; i < rank_walker_count.size(); ++i)
       {
-        std::cout << " " << i << "  " << rank_walker_count[i] << "\n";
+        app_log() << " " << i << "  " << rank_walker_count[i] << "\n";
       }
     }
   }

--- a/src/QMCHamiltonians/tests/test_PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/tests/test_PairCorrEstimator.cpp
@@ -65,8 +65,8 @@ namespace qmcplusplus
 {
 TEST_CASE("Pair Correlation", "[hamiltonian]")
 {
-  std::cout << std::fixed;
-  std::cout << std::setprecision(8);
+  app_log() << std::fixed;
+  app_log() << std::setprecision(8);
   using RealType = QMCTraits::RealType;
 
   Communicate* c = OHMMS::Controller;
@@ -74,7 +74,7 @@ TEST_CASE("Pair Correlation", "[hamiltonian]")
   // XML parser
   Libxml2Document doc;
 
-  std::cout << "\n\n\ntest_paircorr:: START\n";
+  app_log() << "\n\n\ntest_paircorr:: START\n";
 
   // TEST new idea: ParticlesetPool to make a ParticleSet
   bool lat_okay = doc.parseFromString(lat_xml);
@@ -92,7 +92,7 @@ TEST_CASE("Pair Correlation", "[hamiltonian]")
   // Get the (now assembled) ParticleSet, do simple sanity checks, then print info
   ParticleSet* elec = pset_builder.getParticleSet("e");
 
-  std::cout << "cheeeee " << elec->getLattice().R << std::endl;
+  app_log() << "cheeeee " << elec->getLattice().R << std::endl;
   REQUIRE(elec->isSameMass());
   REQUIRE(elec->getName() == "e");
 
@@ -126,7 +126,7 @@ TEST_CASE("Pair Correlation", "[hamiltonian]")
   elec->R[7][1] = 1.0;
   elec->R[7][2] = 1.0;
 
-  elec->get(std::cout); // print particleset info to stdout
+  elec->get(app_log()); // print particleset info to stdout
 
   // Set up the distance table, match expected layout
   elec->addTable(*elec);
@@ -153,21 +153,21 @@ TEST_CASE("Pair Correlation", "[hamiltonian]")
   const RealType deltaR = Rmax / static_cast<RealType>(Nbins);
 
   auto gofr = elec->Collectables;
-  std::cout << "\n";
-  std::cout << "gofr:\n";
-  std::cout << std::fixed;
-  std::cout << std::setprecision(6);
-  std::cout << std::setw(4) << "i"
+  app_log() << "\n";
+  app_log() << "gofr:\n";
+  app_log() << std::fixed;
+  app_log() << std::setprecision(6);
+  app_log() << std::setw(4) << "i"
             << "  " << std::setw(12) << "r"
             << "  " << std::setw(12) << "uu"
             << "  " << std::setw(12) << "ud"
             << "  " << std::setw(12) << "dd"
             << "\n";
-  std::cout << "============================================================\n";
+  app_log() << "============================================================\n";
 
   for (int i = 0; i < Nbins; i++)
   {
-    std::cout << std::setw(4) << i << "  " << std::setw(12) << i * deltaR << "  " << std::setw(12) << gofr[i] << "  "
+    app_log() << std::setw(4) << i << "  " << std::setw(12) << i * deltaR << "  " << std::setw(12) << gofr[i] << "  "
               << std::setw(12) << gofr[i + Nbins] << "  " << std::setw(12) << gofr[i + 2 * Nbins] << "\n";
   }
 
@@ -196,7 +196,7 @@ TEST_CASE("Pair Correlation", "[hamiltonian]")
   REQUIRE(std::fabs(gofr[184] - 2.6408410) < eps);
   REQUIRE(std::fabs(gofr[283] - 0.0000000) < eps);
 
-  std::cout << "test_paircorr:: STOP\n";
+  app_log() << "test_paircorr:: STOP\n";
 }
 
 TEST_CASE("Pair Correlation Pair Index", "[hamiltonian]")

--- a/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
@@ -153,17 +153,17 @@ TEST_CASE("integrateListeners", "[hamiltonian]")
 
   if constexpr (generate_test_data)
   {
-    std::cout << "QMCHamiltonian-registerListeners initialize psets with:\n{";
+    app_log() << "QMCHamiltonian-registerListeners initialize psets with:\n{";
 
     for (int iw = 0; iw < num_walkers; ++iw)
     {
       //psets.emplace_back(pset_target);
-      std::cout << "{";
+      app_log() << "{";
       for (auto r : p_refs[iw].get().R)
-        std::cout << NativePrint(r) << ",";
-      std::cout << "},\n";
+        app_log() << NativePrint(r) << ",";
+      app_log() << "},\n";
     }
-    std::cout << "}\n";
+    app_log() << "}\n";
   }
   else
   {
@@ -233,18 +233,18 @@ TEST_CASE("integrateListeners", "[hamiltonian]")
   // {
   std::vector<Real> vector_kinetic;
   std::copy(kinetic.begin(), kinetic.end(), std::back_inserter(vector_kinetic));
-  std::cout << " size kinetic: " << vector_kinetic.size() << '\n';
-  std::cout << " std::vector<Real> kinetic_ref_vector = " << NativePrint(vector_kinetic) << ";\n";
+  app_log() << " size kinetic: " << vector_kinetic.size() << '\n';
+  app_log() << " std::vector<Real> kinetic_ref_vector = " << NativePrint(vector_kinetic) << ";\n";
 
   std::vector<Real> vector_pots;
   std::copy(local_pots.begin(), local_pots.end(), std::back_inserter(vector_pots));
-  std::cout << " size potentials: " << vector_pots.size() << '\n';
-  std::cout << " std::vector<Real> potential_ref_vector = " << NativePrint(vector_pots) << ";\n";
+  app_log() << " size potentials: " << vector_pots.size() << '\n';
+  app_log() << " std::vector<Real> potential_ref_vector = " << NativePrint(vector_pots) << ";\n";
 
   std::vector<Real> vector_ions;
   std::copy(ion_pots.begin(), ion_pots.end(), std::back_inserter(vector_ions));
-  std::cout << " size ion potentials: " << vector_ions.size() << '\n';
-  std::cout << " std::vector<Real> ion_potential_ref_vector = " << NativePrint(vector_ions) << ";\n";
+  app_log() << " size ion potentials: " << vector_ions.size() << '\n';
+  app_log() << " std::vector<Real> ion_potential_ref_vector = " << NativePrint(vector_ions) << ";\n";
   // }
   // else
   // {
@@ -342,7 +342,7 @@ TEST_CASE("integrateListeners", "[hamiltonian]")
   for (int iw = 0; iw < num_walkers; ++iw)
   {
     auto hamiltonian_local_energy = ham_list[iw].getLocalEnergy();
-    std::cout << "Walker: " << iw << " hamiltonian_local_energy (" << hamiltonian_local_energy
+    app_log() << "Walker: " << iw << " hamiltonian_local_energy (" << hamiltonian_local_energy
               << ") shadow_energy: " << shadow_ham_list[iw].getLocalEnergy() << "\n";
     hamiltonian_local_nrg_sum += ham_list[iw].getLocalEnergy();
     energies_sum += energies[iw];

--- a/src/QMCHamiltonians/tests/test_SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/tests/test_SkAllEstimator.cpp
@@ -39,8 +39,8 @@ namespace qmcplusplus
 TEST_CASE("SkAll", "[hamiltonian]")
 {
   // Boiler plate setup
-  std::cout << std::fixed;
-  std::cout << std::setprecision(8);
+  app_log() << std::fixed;
+  app_log() << std::setprecision(8);
   using RealType = QMCTraits::RealType;
 
   Communicate* c;
@@ -110,7 +110,7 @@ TEST_CASE("SkAll", "[hamiltonian]")
   REQUIRE(lat_okay);
   xmlNodePtr lat_xml_root = doc.getRoot();
 
-  std::cout << "\n\n\ntest_SkAllEstimator: START\n";
+  app_log() << "\n\n\ntest_SkAllEstimator: START\n";
 
   // Build a ParticleSetPool - makes ParticleSets
   ParticleSetPool pset_builder(c, "pset_builder");
@@ -159,7 +159,7 @@ TEST_CASE("SkAll", "[hamiltonian]")
   elec->R[7][1] = 1.0;
   elec->R[7][2] = 1.0;
 
-  elec->get(std::cout); // print particleset info to stdout
+  elec->get(app_log()); // print particleset info to stdout
 
 
   // Get the (now assembled) ion ParticleSet, sanity check, report
@@ -174,7 +174,7 @@ TEST_CASE("SkAll", "[hamiltonian]")
   ParticleSet* ion = pset_builder.getParticleSet("i");
   REQUIRE(ion->isSameMass());
   REQUIRE(ion->getName() == "i");
-  ion->get(std::cout); // print particleset info to stdout
+  ion->get(app_log()); // print particleset info to stdout
 
 
   // Set up the distance table, match expected layout
@@ -207,11 +207,11 @@ TEST_CASE("SkAll", "[hamiltonian]")
   // of k-vectors in cartesian coordinates.
   // Luckily, ParticleSet stores that in SK->getKLists().kpts_cart
   int nkpts = elec->getSimulationCell().getKLists().getNumK();
-  std::cout << "\n";
-  std::cout << "SkAll results:\n";
-  std::cout << std::fixed;
-  std::cout << std::setprecision(6);
-  std::cout << std::setw(4) << "i"
+  app_log() << "\n";
+  app_log() << "SkAll results:\n";
+  app_log() << std::fixed;
+  app_log() << std::setprecision(6);
+  app_log() << std::setw(4) << "i"
             << "  " << std::setw(8) << "kx"
             << "  " << std::setw(8) << "ky"
             << "  " << std::setw(8) << "kz"
@@ -219,12 +219,12 @@ TEST_CASE("SkAll", "[hamiltonian]")
             << "  " << std::setw(8) << "rhok_i"
             << "  " << std::setw(8) << "c.c."
             << "\n";
-  std::cout << "================================================================\n";
+  app_log() << "================================================================\n";
 
   // Extract rhok out of Collectables, print values
   auto rhok = elec->Collectables;
-  std::cout << std::fixed;
-  std::cout << std::setprecision(5);
+  app_log() << std::fixed;
+  app_log() << std::setprecision(5);
   for (int k = 0; k < nkpts; k++)
   {
     auto kvec      = elec->getSimulationCell().getKLists().getKptsCartWorking()[k];
@@ -234,7 +234,7 @@ TEST_CASE("SkAll", "[hamiltonian]")
     RealType rk_r  = rhok[nkpts + k];
     RealType rk_i  = rhok[2 * nkpts + k];
     RealType rk_cc = rhok[k];
-    std::cout << std::setw(4) << k << "  " << std::setw(8) << kx << "  " << std::setw(8) << ky << "  " << std::setw(8)
+    app_log() << std::setw(4) << k << "  " << std::setw(8) << kx << "  " << std::setw(8) << ky << "  " << std::setw(8)
               << kz << "  " << std::setw(8) << rk_r << "  " << std::setw(8) << rk_i << "  " << std::setw(8) << rk_cc
               << "\n";
   }
@@ -332,6 +332,6 @@ TEST_CASE("SkAll", "[hamiltonian]")
   REQUIRE(std::fabs(rhok[26 + 25] + 1.38359) < eps);
   REQUIRE(std::fabs(rhok[52 + 25] - 0.30687) < eps);
 
-  std::cout << "test_SkAllEstimator:: STOP\n";
+  app_log() << "test_SkAllEstimator:: STOP\n";
 }
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -77,7 +77,7 @@ TEST_CASE("Coulomb PBC A-A", "[hamiltonian]")
   CHECK(consts == Approx(-3.1151210154));
 
   double val = caa.evaluate(ions);
-  //std::cout << "val = " << val << std::endl;
+  //app_log() << "val = " << val << std::endl;
   CHECK(val == Approx(vmad_sc));
 
   // supercell Madelung energy
@@ -489,8 +489,8 @@ TEST_CASE("CoulombAA::mw_evaluatePerParticle", "[hamiltonian]")
   // Check that the sum of the particle energies == the total
   auto dump_particle_pots = [](const auto& local_pots, int row) {
     for (int i = 0; i < local_pots.cols(); ++i)
-      std::cout << *(local_pots[row] + i) << ", ";
-    std::cout << '\n';
+      app_log() << *(local_pots[row] + i) << ", ";
+    app_log() << '\n';
   };
 
   CHECK(std::accumulate(local_pots.begin(), local_pots.begin() + local_pots.cols(), 0.0) == Approx(-2.9332312765));
@@ -738,7 +738,7 @@ TEST_CASE("CoulombAA::mw_evaluatePerParticle_multimove", "[hamiltonian]")
   checkValuePotsMatch(caa2, local_pots, 1, expected_caa2);
   // Check that the sum of the particle energies == the total
 
-  // Nice to be able to change this to std::cout and not have to wade
+  // Nice to be able to change this to app_log() and not have to wade
   // through all the output we don't care about from everywhere else
   auto& local_ostream = app_log();
 

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -74,7 +74,7 @@ TEST_CASE("Bare Force", "[hamiltonian]")
 
   force.evaluate(elec);
 
-  //std::cout << " Force = " << force.getForces() << std::endl;
+  //app_log() << " Force = " << force.getForces() << std::endl;
   CHECK(force.getForces()[0][0] == Approx(3.2));
   CHECK(force.getForces()[0][1] == Approx(3.4));
   CHECK(force.getForces()[0][2] == Approx(0.0));
@@ -87,13 +87,13 @@ void check_force_copy(ForceChiesaPBCAA& force, ForceChiesaPBCAA& force2)
   REQUIRE(force2.N_basis == force.N_basis);
   REQUIRE(force2.getAddIonIon() == force.getAddIonIon());
   REQUIRE(force2.Sinv.size() == force.Sinv.size());
-  std::cout << force.Sinv << std::endl;
-  std::cout << force2.Sinv << std::endl;
+  app_log() << force.Sinv << std::endl;
+  app_log() << force2.Sinv << std::endl;
   for (int i = 0; i < force2.Sinv.rows(); i++)
   {
     for (int j = 0; j < force2.Sinv.cols(); j++)
     {
-      //std::cout << "Sinv " << i << "  " << j << " " << force2.Sinv(i,j) << " "  << force.Sinv(i,j) << std::endl;
+      //app_log() << "Sinv " << i << "  " << j << " " << force2.Sinv(i,j) << " "  << force.Sinv(i,j) << std::endl;
       CHECK(force2.Sinv(i, j) == Approx(force.Sinv(i, j)));
     }
   }
@@ -173,8 +173,8 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
 
   elec.update();
   force.evaluate(elec);
-  std::cout << " Force = " << force.getForces() << std::endl;
-  std::cout << " Forces_IonIon = " << force.getForcesIonIon() << std::endl;
+  app_log() << " Force = " << force.getForces() << std::endl;
+  app_log() << " Forces_IonIon = " << force.getForcesIonIon() << std::endl;
 
   // Unvalidated externally
   CHECK(force.getForces()[0][0] == Approx(3.186559306));
@@ -194,7 +194,7 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
 
   CoulombPBCAB elecIonForce(ions, elec, true);
   elecIonForce.evaluate(elec); // Not computed upon construction
-  std::cout << " CoulombElecIon = " << elecIonForce.getForces() << std::endl;
+  app_log() << " CoulombElecIon = " << elecIonForce.getForces() << std::endl;
   CHECK(elecIonForce.getForces()[0][0] == Approx(3.186558296));
   CHECK(elecIonForce.getForces()[0][1] == Approx(3.352572459));
   CHECK(elecIonForce.getForces()[1][0] == Approx(-0.3950094326));
@@ -298,8 +298,8 @@ TEST_CASE("Ceperley Force", "[hamiltonian]")
 
   force.setAddIonIon(true); // is true by default
   force.evaluate(elec);
-  std::cout << " Force ionion = " << force.getForcesIonIon() << std::endl;
-  std::cout << " Force = " << force.getForces() << std::endl;
+  app_log() << " Force ionion = " << force.getForcesIonIon() << std::endl;
+  app_log() << " Force = " << force.getForces() << std::endl;
   CHECK(force.getForces()[0][0] == Approx(8.99061106).epsilon(1e-4));
   CHECK(force.getForces()[0][1] == Approx(14.86091659).epsilon(1e-4));
   CHECK(force.getForces()[0][2] == Approx(0.0));
@@ -468,7 +468,7 @@ TEST_CASE("AC Force", "[hamiltonian]")
 
   CHECK(vold == Approx(0));
   CHECK(vnew == Approx(0));
-  REQUIRE(force_old.get(std::cout) == true);
+  REQUIRE(force_old.get(app_log()) == true);
 
   force_old.add2Hamiltonian(elec, psi, qmcHamiltonian);
 

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -85,7 +85,7 @@ void test_He(bool transform)
     OhmmsXPathObject slater_base("//determinant", doc.getXPathContext());
     auto sposet = bb.createSPOSet(slater_base[0]);
 
-    //std::cout << "basis set size = " << sposet->getBasisSetSize() << std::endl;
+    //app_log() << "basis set size = " << sposet->getBasisSetSize() << std::endl;
 
     SPOSet::ValueVector values;
     SPOSet::GradVector dpsi;
@@ -189,7 +189,7 @@ void test_He_mw(bool transform)
   OhmmsXPathObject slater_base("//determinant", doc.getXPathContext());
   auto sposet = bb.createSPOSet(slater_base[0]);
 
-  //std::cout << "basis set size = " << sposet->getBasisSetSize() << std::endl;
+  //app_log() << "basis set size = " << sposet->getBasisSetSize() << std::endl;
 
   SPOSet::ValueVector psi;
   SPOSet::GradVector dpsi;
@@ -340,7 +340,7 @@ void test_EtOH_mw(bool transform)
   auto sposet = bb.createSPOSet(slater_base[0]);
 
 
-  //std::cout << "basis set size = " << sposet->getBasisSetSize() << std::endl;
+  //app_log() << "basis set size = " << sposet->getBasisSetSize() << std::endl;
   size_t n_mo = sposet->getOrbitalSetSize();
   SPOSet::ValueVector psiref_0(n_mo);
   SPOSet::GradVector dpsiref_0(n_mo);
@@ -519,7 +519,7 @@ void test_Ne(bool transform)
     OhmmsXPathObject slater_base("//determinant", doc.getXPathContext());
     auto sposet = bb.createSPOSet(slater_base[0]);
 
-    //std::cout << "basis set size = " << sposet->getBasisSetSize() << std::endl;
+    //app_log() << "basis set size = " << sposet->getBasisSetSize() << std::endl;
 
     const int norbs = 5;
     SPOSet::ValueVector values;

--- a/src/QMCWaveFunctions/tests/test_counting_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_counting_jastrow.cpp
@@ -354,7 +354,7 @@ TEST_CASE("CountingJastrow", "[wavefunction]")
   optVars.resetIndex();
   cj->checkInVariablesExclusive(optVars);
   cj->checkOutVariables(optVars);
-  optVars.print(std::cout);
+  optVars.print(app_log());
 
   // test evaluateDerivatives
   cj->evaluateDerivatives(elec, optVars, dlogpsi, dhpsioverpsi);
@@ -378,7 +378,7 @@ TEST_CASE("CountingJastrow", "[wavefunction]")
   optVars2.resetIndex();
   cj2->checkInVariablesExclusive(optVars2);
   cj2->checkOutVariables(optVars2);
-  optVars2.print(std::cout);
+  optVars2.print(app_log());
 
   cj2->evaluateDerivatives(elec, optVars2, dlogpsi, dhpsioverpsi);
   for (int p = 0; p < num_derivs; ++p)

--- a/src/QMCWaveFunctions/tests/test_short_range_cusp_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_short_range_cusp_jastrow.cpp
@@ -127,7 +127,7 @@ TEST_CASE("ShortRangeCuspJastrowFunctor", "[wavefunction]")
   {
     const std::string var_name = var_param.name(i);
     const RealType old_param   = std::real(var_param[var_name]);
-    //std::cout << "checking parameter " << var_name << std::endl;
+    //app_log() << "checking parameter " << var_name << std::endl;
 
     RealType dudr_h     = 10000000.0; // initialize to a wrong value
     RealType d2udr2_h   = 10000000.0; // initialize to a wrong value

--- a/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
+++ b/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
@@ -305,7 +305,7 @@ TEST_CASE("HCN MO with cusp", "[wavefunction]")
 
   values = 0.0;
   sposet->evaluateValue(elec, 0, values);
-  //std::cout << "values = " << values << std::endl;
+  //app_log() << "values = " << values << std::endl;
   // Values from gen_cusp_corr.py
   CHECK(values[0] == Approx(9.5150713253));
   CHECK(values[1] == Approx(-0.0086731542));
@@ -319,9 +319,9 @@ TEST_CASE("HCN MO with cusp", "[wavefunction]")
   values = 0.0;
   sposet->evaluateVGL(elec, 0, values, dpsi, d2psi);
 
-  //std::cout << "values = " << values << std::endl;
-  //std::cout << "dpsi = " << dpsi << std::endl;
-  //std::cout << "d2psi = " << d2psi << std::endl;
+  //app_log() << "values = " << values << std::endl;
+  //app_log() << "dpsi = " << dpsi << std::endl;
+  //app_log() << "d2psi = " << d2psi << std::endl;
 
   // Values from gen_cusp_corr.py
   CHECK(values[0] == Approx(9.5150713253));

--- a/src/QMCWaveFunctions/tests/test_variable_set.cpp
+++ b/src/QMCWaveFunctions/tests/test_variable_set.cpp
@@ -47,12 +47,12 @@ TEST_CASE("VariableSet one", "[optimize]")
 
   std::ostringstream o;
   vs.print(o, 0, false);
-  //std::cout << o.str() << std::endl;
+  //app_log() << o.str() << std::endl;
   REQUIRE(o.str() == "first                 1.123457e+00 0  ON 0\n");
 
   std::ostringstream o2;
   vs.print(o2, 1, true);
-  //std::cout << o2.str() << std::endl;
+  //app_log() << o2.str() << std::endl;
 
   char formatted_output[] = "  Name                        Value Type Use Index\n"
                             " ----- ---------------------------- ---- --- -----\n"
@@ -87,7 +87,7 @@ TEST_CASE("VariableSet output", "[optimize]")
 
   std::ostringstream o;
   vs.print(o, 0, true);
-  //std::cout << o.str() << std::endl;
+  //app_log() << o.str() << std::endl;
 
   char formatted_output[] = "            Name                        Value Type Use Index\n"
                             "---------------- ---------------------------- ---- --- -----\n"

--- a/src/Utilities/tests/test_partition.cpp
+++ b/src/Utilities/tests/test_partition.cpp
@@ -9,6 +9,7 @@
 // File created by: Mark Dewing, mdewing@anl.gov Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 #include <catch2/catch_test_macros.hpp>
+#include "Platforms/Host/OutputManager.h"
 
 #include <iostream>
 #include "Utilities/FairDivide.h"
@@ -24,9 +25,9 @@ void print_vector(vector<int>& out)
 {
   for (int i = 0; i < out.size(); i++)
   {
-    std::cout << out[i] << " ";
+    app_log() << out[i] << " ";
   }
-  std::cout << std::endl;
+  app_log() << std::endl;
 }
 
 TEST_CASE("FairDivideLow_one", "[utilities]")

--- a/src/Utilities/tests/test_prime_set.cpp
+++ b/src/Utilities/tests/test_prime_set.cpp
@@ -25,7 +25,7 @@ namespace qmcplusplus
 TEST_CASE("prime number set 32 bit", "[utilities]")
 {
   PrimeNumberSet<std::uint32_t> pns;
-  //std::cout << "32 bit size = "<< pns.size() << std::endl;
+  //app_log() << "32 bit size = "<< pns.size() << std::endl;
   REQUIRE(pns.size() == 4097);
   REQUIRE(pns[0] == 3);
 
@@ -44,7 +44,7 @@ TEST_CASE("prime number set 32 bit", "[utilities]")
 TEST_CASE("prime number set 64 bit", "[utilities]")
 {
   PrimeNumberSet<uint64_t> pns;
-  //std::cout << "64 bit size = "<< pns.size() << std::endl;
+  //app_log() << "64 bit size = "<< pns.size() << std::endl;
   REQUIRE(pns.size() == 55109);
   REQUIRE(pns[0] == 3);
 


### PR DESCRIPTION
<!--
Please review the developer documentation on the wiki of this project that contains help and requirements.

https://github.com/QMCPACK/qmcpack/wiki/Development-workflow

Please also follow the GitHub Pull Request guidance.

https://qmcpack.readthedocs.io/en/develop/developing.html#github-pull-request-guidance

As much as possible, try to avoid the "Don't"s to help maintain a high development velocity.

https://qmcpack.readthedocs.io/en/develop/developing.html#don-t
-->
## Proposed changes
<!--
Describe what this PR changes and why.  If it closes an issue, link to it here
with a supported keyword.

https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Unit test should have output silenced by default.

## What type(s) of changes does this code introduce?
<!-- Delete the items that do not apply -->

- Bugfix

### Does this introduce a breaking change?
<!-- Delete one. If you are unsure, you can put "Maybe" or "Possibly" -->
- No

## What systems has this change been tested on?
<!--
You can be brief here, but it is strongly recommended to provide some information.

For example, if you are changing code in Nexus, list at least the following:

- Python w/ version (run `python --version`)
- NumPy w/ version (run `python -c "import numpy; print(numpy.__version__)"`)
- Pytest w/ version (run `pytest --version`)
-->

laptop

## Checklist
<!--
Update the following with an [x] where the items apply.
If you're unsure about any of them, don't hesitate to ask. 
This is simply a reminder of what we are going to look for before merging your code.
-->

* * [x] I have read the pull request guidance and develop docs
* * [x] This PR is up to date with the current state of 'develop'
* * [ ] Code added or changed in the PR has been clang-formatted
* * [ ] This PR adds tests to cover any new code, or to catch a bug that is being fixed
* * [ ] Documentation has been added (if appropriate)
